### PR TITLE
feat(validate): scope `harness validate` to the changed surface (#1523)

### DIFF
--- a/.changeset/scope-validate-changed-surface.md
+++ b/.changeset/scope-validate-changed-surface.md
@@ -19,3 +19,8 @@ pre-merge/scheduled/release gates. Every affected run prints what it scoped and 
 staleness caveat, and the scoped-vs-full split is recorded on the `cli/validate`
 adoption record (`variant` field). The orchestrator package's `validate` dev-loop
 script is rewired to `--changed`.
+
+The same affected-mode is exposed to skills/agents through the MCP `validate_project`
+tool via an opt-in `scope: "affected" | "full"` / `changed` / `since` param — it
+delegates to the same `runValidate` (validate-scope is shared, not forked), and the
+default path stays byte-identical.

--- a/.changeset/scope-validate-changed-surface.md
+++ b/.changeset/scope-validate-changed-surface.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/cli': minor
+'@harness-engineering/orchestrator': patch
+---
+
+feat(validate): scope `harness validate` to the changed surface (`--changed`/`--affected`/`--since`)
+
+Adds an opt-in affected-only mode to `harness validate`. The design audits
+(detect-drift, audit-brand) walk the whole source tree on every run, which is the
+dominant cost of the most-invoked CLI command (adoption telemetry: `cli/validate` =
+68% of all harness CLI calls). `--changed` (alias `--affected`) derives the changed
+surface from git — the merge-base with the default branch, or an explicit
+`--since <ref>` — and hands just those files to the walkers. The surface is narrowed
+to the source extensions and exclude globs a full sweep would scan, so a scoped run is
+always a subset of a full run (it never reports a finding a full sweep would not). If
+the surface cannot be derived, the run falls back to a full sweep and reports why.
+Bare `harness validate` is unchanged (full sweep) — non-breaking for adopters and
+pre-merge/scheduled/release gates. Every affected run prints what it scoped and the
+staleness caveat, and the scoped-vs-full split is recorded on the `cli/validate`
+adoption record (`variant` field). The orchestrator package's `validate` dev-loop
+script is rewired to `--changed`.

--- a/docs/changes/scope-validate-changed-surface/plans/2026-08-26-scope-validate-changed-surface-plan.md
+++ b/docs/changes/scope-validate-changed-surface/plans/2026-08-26-scope-validate-changed-surface-plan.md
@@ -1,0 +1,52 @@
+# Plan: Scope `harness validate` to the changed surface
+
+**Issue:** #1523 · **Proposal:** `../proposal.md` · **Approach:** TDD, additive, non-breaking.
+
+## Tasks
+
+### T1 — Changed-surface derivation module (test-first)
+
+- `packages/cli/src/commands/validate-scope.ts`:
+  - `deriveChangedSurface(cwd, { since?, defaultBranch? })` → merge-base (or `since`)
+    diff ∪ untracked, existing files only, POSIX-normalized. Never throws; returns
+    `{ ok:false, reason }` on git failure.
+  - `filterToDesignSurface(cwd, files)` → keep only design-relevant extensions,
+    drop skip-dirs and `analysis.exclude` ∪ `design.exclude` matches (`scoped ⊆ full`).
+  - `SCOPED_WALKERS = ['driftDetection','brandCompliance']` (anatomy intentionally excluded).
+- Tests: `tests/commands/validate-scope.test.ts` — real temp git repos (branch diff,
+  uncommitted edit, untracked, deletion, `--since`, unknown-ref/no-repo fallback) +
+  filter parity (extensions, skip-dirs, exclude globs).
+
+### T2 — Wire scope into `runValidate`
+
+- `packages/cli/src/commands/validate.ts`:
+  - `ValidateOptions`: `changed?`, `since?`, `defaultBranch?`. `ValidateResult.scope`.
+  - Derive surface up front; on success pass `filterToDesignSurface(...)` as `files`
+    to detect-drift and audit-brand; on failure fall back to full sweep + record reason.
+  - `--changed` / `--affected` / `--since <ref>` / `--default-branch <name>` flags.
+  - Text + JSON scope reporting, including the staleness caveat.
+- Tests: `tests/commands/validate.changed.test.ts` — full default (no files), affected
+  (drift+brand get the filtered surface, anatomy left full), `--since` implies affected,
+  git-failure fallback.
+
+### T3 — Telemetry variant
+
+- `packages/cli/src/bin/command-telemetry.ts`: record `variant: 'affected'|'full'` on
+  the `cli/validate` adoption record (primary key stays `cli/validate`).
+- Tests: extend `tests/bin/command-telemetry.test.ts` (variant present/absent).
+
+### T4 — Call-site rewiring
+
+- `packages/orchestrator/package.json`: `validate` script → `harness validate --changed`.
+- Persona CI workflows + pre-commit `ci check` left full (see proposal audit + assumptions).
+
+### T5 — Docs + generated reference + changeset
+
+- `docs/guides/ci-cd-validation.md`: affected-only mode + staleness contract.
+- `pnpm run generate-docs` → `docs/reference/cli-commands.md` picks up the new flags.
+- `.changeset/scope-validate-changed-surface.md` (cli minor, orchestrator patch).
+
+### T6 — Verify
+
+- Build CLI (Node 22), typecheck, run the new/affected tests, and drive the built
+  binary to confirm `scoped ⊆ full` parity and the scope reporting end-to-end.

--- a/docs/changes/scope-validate-changed-surface/proposal.md
+++ b/docs/changes/scope-validate-changed-surface/proposal.md
@@ -1,0 +1,75 @@
+# Proposal: Scope `harness validate` to the changed surface
+
+**Issue:** [#1523](https://github.com/Intense-Visions/harness-engineering/issues/1523)
+**Milestone:** v5.0 — Telemetry & Effectiveness · **Priority:** P1
+**Stage:** brainstorming → planning → execution → review
+
+## Problem
+
+Adoption telemetry from a dogfood consumer (`.harness/metrics/adoption.jsonl`)
+shows `cli/validate` accounts for **2,097 invocations — 68% of every harness CLI
+call**. `harness validate` runs a set of project checks; most are fixed-scope and
+cheap (AGENTS.md, roadmap health, ADR numbers, STRATEGY.md, pulse), but the design
+audits — **detect-drift** and **audit-brand** — walk the _entire_ source tree on
+every run. Re-walking the whole tree for a one-file change, on the most-invoked
+command, is the single highest-leverage latency/cost fix available.
+
+## Call-site audit (part of scope, per operator request)
+
+Every place this repo invokes validation was audited:
+
+| Call site                                              | What it runs                                | Walks design surface?                                                                                                          | Disposition                                                                                                                                                                               |
+| ------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.husky/pre-commit`                                    | `harness ci check`                          | **No** — core `runValidateCheck` validates AGENTS.md only; the design walkers live in the CLI `runValidate`, not in `ci check` | Left full (already cheap; not the hot design-walker path)                                                                                                                                 |
+| `.husky/pre-push`                                      | —                                           | n/a (no validate)                                                                                                              | n/a                                                                                                                                                                                       |
+| `.github/workflows/persona-*.yml` (×3)                 | `harness validate` (advisory, non-blocking) | Yes                                                                                                                            | Left full — **generated** files (from `agents/personas/*.yaml`); advisory + once-per-PR low frequency; rewiring needs the persona-workflow generator + drift guard for negligible benefit |
+| `packages/orchestrator/package.json` `validate` script | `harness validate`                          | Yes                                                                                                                            | **Rewired to `--changed`** — the one direct per-change dev-loop `harness validate` call site                                                                                              |
+| MCP `validate_project` / `validate_cross_check`        | in-process                                  | validate_project walks design surface                                                                                          | No committed hot-loop caller in this repo; unchanged (opt-in remains available)                                                                                                           |
+
+**Finding:** the 2,097 telemetry invocations are overwhelmingly _interactive_
+agent/human `harness validate` calls, which no committed automation controls — those
+adopt `--changed` at the point of use (the new opt-in flag + docs). The one committed
+per-change dev-loop call site (the orchestrator `validate` script) is rewired.
+
+## Approach
+
+1. **Opt-in `--changed` / `--affected` flag** (plus `--since <ref>` and
+   `--default-branch <name>`). Bare `harness validate` keeps the full sweep —
+   non-breaking.
+2. **Derive the changed surface from git**: merge-base with the default branch (or
+   `--since` ref), union of tracked diffs + untracked files, existing files only.
+3. **Narrow to the design surface**: keep only files a full sweep would scan
+   (source extensions, skip-dirs, `analysis.exclude` ∪ `design.exclude`), so a
+   scoped run is a strict subset of a full run (`scoped ⊆ full`).
+4. **Hand the narrowed list to the walkers** via their existing `files` scoping
+   arg (detect-drift, audit-brand). Component-anatomy is _not_ scoped — it is
+   called with no file list in both modes today (a no-op in validate), so scoping
+   it would activate it in affected mode only and break parity.
+5. **Fail safe**: if the surface cannot be derived, fall back to a full sweep and
+   report why — never validate an empty surface (a false green).
+6. **Auditable**: every run records a `scope` block (mode, ref, changed count,
+   scoped checks) and prints it, including the staleness caveat.
+7. **Telemetry**: record scoped-vs-full via a `variant` field on the `cli/validate`
+   adoption record, keeping the primary `cli/validate` key stable.
+8. **Docs**: state the staleness contract — full sweep still required for
+   pre-merge, scheduled, and release runs.
+
+## Acceptance criteria (from the issue)
+
+- [x] On a repo where a subset of files changed, the design walkers scan only the
+      changed surface (verified: 125 changed design files → 28 findings vs 328 for the
+      full sweep).
+- [x] Affected-only and full-sweep agree — no finding present in full and absent in
+      scoped for the changed surface (verified: 0 affected findings absent from full;
+      `scoped ⊆ full`).
+- [x] Adoption telemetry records scoped vs. full invocations (`variant` field).
+- [x] Docs state the staleness contract (`docs/guides/ci-cd-validation.md`).
+
+## Non-goals
+
+- Changing bare `harness validate` default behavior (stays full sweep).
+- Turbo/task-cache integration — `harness validate` is an in-process check runner,
+  not a turbo task graph; the leverage here is scoping the file walkers, not riding
+  a task cache.
+- Scoping the fixed-scope checks (roadmap, ADR, AGENTS.md) — they are cheap and
+  correctness depends on their whole-project view.

--- a/docs/changes/scope-validate-changed-surface/provenance.json
+++ b/docs/changes/scope-validate-changed-surface/provenance.json
@@ -1,0 +1,64 @@
+{
+  "issue": 1523,
+  "title": "Scope `harness validate` to the changed surface",
+  "externalId": "github:Intense-Visions/harness-engineering#1523",
+  "slug": "scope-validate-changed-surface",
+  "branch": "feat/scope-validate-changed-surface",
+  "closing_keyword": "Closes #1523",
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "pipelineStages": [
+    {
+      "stage": "brainstorming",
+      "artifact": "docs/changes/scope-validate-changed-surface/proposal.md",
+      "summary": "Spec: opt-in --changed/--affected/--since mode scoping the design walkers (detect-drift, audit-brand) to the git-derived changed surface, narrowed to the design surface so scoped ⊆ full; full sweep stays the default; includes the required call-site audit."
+    },
+    {
+      "stage": "planning",
+      "artifact": "docs/changes/scope-validate-changed-surface/plans/2026-08-26-scope-validate-changed-surface-plan.md",
+      "summary": "6-task TDD plan: surface-derivation module, runValidate wiring, telemetry variant, call-site rewiring, docs+reference+changeset, verify."
+    },
+    {
+      "stage": "execution",
+      "artifact": "packages/cli/src/commands/validate-scope.ts",
+      "summary": "TDD implementation: deriveChangedSurface + filterToDesignSurface + SCOPED_WALKERS; wired into runValidate with flags, scope reporting, and full-sweep fallback; telemetry variant; orchestrator validate script rewired."
+    },
+    {
+      "stage": "review",
+      "artifact": "packages/cli/tests/commands/validate-scope.test.ts",
+      "summary": "Behavior + parity tests (39 across 3 files) plus end-to-end binary verification confirming scoped ⊆ full (0 affected findings absent from full; 28 vs 328 design findings)."
+    }
+  ],
+  "plan_path": "docs/changes/scope-validate-changed-surface/plans/2026-08-26-scope-validate-changed-surface-plan.md",
+  "planArtifact": "docs/changes/scope-validate-changed-surface/plans/2026-08-26-scope-validate-changed-surface-plan.md",
+  "sourceFiles": [
+    "packages/cli/src/commands/validate-scope.ts",
+    "packages/cli/src/commands/validate.ts",
+    "packages/cli/src/bin/command-telemetry.ts",
+    "packages/orchestrator/package.json"
+  ],
+  "testFiles": [
+    "packages/cli/tests/commands/validate-scope.test.ts",
+    "packages/cli/tests/commands/validate.changed.test.ts",
+    "packages/cli/tests/bin/command-telemetry.test.ts"
+  ],
+  "docs": ["docs/guides/ci-cd-validation.md", "docs/reference/cli-commands.md"],
+  "localChecks": {
+    "build": "pass (@harness-engineering/cli, Node 22)",
+    "typecheck": "pass (tsc --noEmit packages/cli)",
+    "test": "pass (39 tests: validate-scope + validate.changed + command-telemetry)",
+    "lint": "pass (src files; test files are not type-linted in this repo)",
+    "e2e": "pass — built binary: affected scope prints, scoped ⊆ full verified (0 affected design findings absent from full; 28 affected vs 328 full over 125 changed design files), full-sweep fallback on unknown ref"
+  },
+  "assumptions": [
+    "Default behavior is opt-in: bare `harness validate` keeps the full sweep; `--changed`/`--affected` are new opt-in flags (non-breaking for adopters and pre-merge/scheduled/release gates).",
+    "The changed surface is diffed against the merge-base with the default branch (default 'main', overridable via --default-branch), or an explicit --since <ref>; the surface unions tracked diffs + untracked files, filtered to files still on disk.",
+    "The design surface is narrowed to source extensions + skip-dirs + analysis.exclude ∪ design.exclude so a scoped run is a strict subset of a full run (scoped ⊆ full), satisfying the 'affected and full agree' criterion.",
+    "component-anatomy is deliberately NOT scoped: validate calls it with no file list in both modes (a no-op today), so scoping it would activate it only in affected mode and report findings a full sweep does not — breaking parity. Only detect-drift and audit-brand are scoped.",
+    "Call-site rewiring: the orchestrator package `validate` dev-loop script is rewired to `harness validate --changed` (the one direct per-change dev-loop call site).",
+    "Call-site left full — pre-commit/pre-push: they run `harness ci check`, whose validate step (core runValidateCheck) validates AGENTS.md only and does NOT walk the design surface, so there is nothing hot to scope there.",
+    "Call-site left full — the 3 persona CI workflows (persona-architecture-enforcer/documentation-maintainer/task-executor): they are GENERATED files (from agents/personas/*.yaml), run `harness validate` advisory/non-blocking once per PR (low frequency), and rewiring would require changing the persona-workflow generator + its drift guard for negligible benefit.",
+    "Telemetry: scoped-vs-full is recorded as an additive `variant` field on the `cli/validate` adoption record; the primary `skill: 'cli/validate'` key is unchanged so existing telemetry continuity and the version-guard bare-command matching are unaffected.",
+    "Turbo/task-cache integration is out of scope: `harness validate` is an in-process check runner, not a turbo task graph; the leverage is scoping the file walkers.",
+    "Changeset: @harness-engineering/cli minor (new feature flags), @harness-engineering/orchestrator patch (dev-script rewire)."
+  ]
+}

--- a/docs/changes/scope-validate-changed-surface/provenance.json
+++ b/docs/changes/scope-validate-changed-surface/provenance.json
@@ -34,14 +34,21 @@
     "packages/cli/src/commands/validate-scope.ts",
     "packages/cli/src/commands/validate.ts",
     "packages/cli/src/bin/command-telemetry.ts",
+    "packages/cli/src/mcp/tools/validate.ts",
     "packages/orchestrator/package.json"
   ],
   "testFiles": [
     "packages/cli/tests/commands/validate-scope.test.ts",
     "packages/cli/tests/commands/validate.changed.test.ts",
-    "packages/cli/tests/bin/command-telemetry.test.ts"
+    "packages/cli/tests/bin/command-telemetry.test.ts",
+    "packages/cli/tests/mcp/tools/validate.test.ts"
   ],
-  "docs": ["docs/guides/ci-cd-validation.md", "docs/reference/cli-commands.md"],
+  "docs": [
+    "docs/guides/ci-cd-validation.md",
+    "docs/reference/cli-commands.md",
+    "docs/reference/mcp-tools.md",
+    "docs/reference/tool-catalog.md"
+  ],
   "localChecks": {
     "build": "pass (@harness-engineering/cli, Node 22)",
     "typecheck": "pass (tsc --noEmit packages/cli)",
@@ -59,6 +66,9 @@
     "Call-site left full — the 3 persona CI workflows (persona-architecture-enforcer/documentation-maintainer/task-executor): they are GENERATED files (from agents/personas/*.yaml), run `harness validate` advisory/non-blocking once per PR (low frequency), and rewiring would require changing the persona-workflow generator + its drift guard for negligible benefit.",
     "Telemetry: scoped-vs-full is recorded as an additive `variant` field on the `cli/validate` adoption record; the primary `skill: 'cli/validate'` key is unchanged so existing telemetry continuity and the version-guard bare-command matching are unaffected.",
     "Turbo/task-cache integration is out of scope: `harness validate` is an in-process check runner, not a turbo task graph; the leverage is scoping the file walkers.",
-    "Changeset: @harness-engineering/cli minor (new feature flags), @harness-engineering/orchestrator patch (dev-script rewire)."
+    "MCP-consumer wiring: skills/agents validate through the MCP tool surface, so the affected-mode capability is exposed on `validate_project` (`packages/cli/src/mcp/tools/validate.ts`) via a new opt-in `scope: 'affected'|'full'` / `changed` / `since` / `defaultBranch` param. Affected mode delegates to the SAME `runValidate` the CLI uses (dynamic import, mirroring cross-check.ts) so validate-scope is shared, not forked; the default (omitted) path is byte-identical to the prior thin `{valid,checks,errors}` reimplementation. Verified end-to-end: full path has no `scope` block; affected path returns the scoped ValidateResult (127 changed design files -> 28 findings, scoped ⊆ full).",
+    "`validate_cross_check` (`packages/cli/src/mcp/tools/cross-check.ts`) is deliberately NOT given affected-mode: it validates spec->plan->impl coverage and staleness, not a design-file walk, so validate-scope's changed-CODE-surface derivation does not apply — scoping it to changed code files would wrongly skip linkage checks for specs whose impl files were untouched.",
+    "No new core export was needed (runValidate lives in @harness-engineering/cli, not core), so scripts/generate-core-barrel.mjs was untouched.",
+    "Changeset: @harness-engineering/cli minor (new feature flags + MCP affected-mode param), @harness-engineering/orchestrator patch (dev-script rewire)."
   ]
 }

--- a/docs/guides/ci-cd-validation.md
+++ b/docs/guides/ci-cd-validation.md
@@ -212,6 +212,62 @@ For Jenkins, CircleCI, Azure Pipelines, or any other platform:
 
 The shell script handles installation, running checks, and interpreting exit codes.
 
+## Scoping `harness validate` to the changed surface
+
+`harness validate` runs a set of project checks. Most are fixed-scope and cheap
+(AGENTS.md, roadmap health, ADR numbers, STRATEGY.md, pulse), but the design
+audits — detect-drift and audit-brand — walk the **whole** source tree on every
+run. On a large repo, re-walking the full tree for a one-file change is the
+dominant cost.
+
+Affected-only mode derives the changed surface from git and hands just those files
+to the walkers:
+
+```bash
+# Scope the design walkers to files changed vs the merge-base with the default branch
+harness validate --changed          # (--affected is an alias)
+
+# Scope to files changed since an explicit ref
+harness validate --since origin/main
+
+# Override the branch used for the merge-base (default: main)
+harness validate --changed --default-branch develop
+```
+
+The changed surface is the union of files that differ from the base ref (staged,
+unstaged, and committed-on-branch) plus untracked files, narrowed to the source
+extensions and exclude globs a full sweep would scan — so a scoped run is always a
+**subset** of a full run (it never reports a finding a full sweep would not). Every
+affected run prints what it scoped:
+
+```
+Scope: affected — 12 changed file(s) vs <base-sha>. Scoped checks: driftDetection,
+brandCompliance. Fixed-scope checks (roadmap, ADR, AGENTS.md, STRATEGY.md, pulse)
+always ran. Unchanged files were NOT re-validated — run a full `harness validate`
+before merge/release.
+```
+
+If the changed surface cannot be derived (not a git repo, unknown ref), the run
+**falls back to a full sweep** and reports why — it never validates an empty
+surface.
+
+### Staleness contract — when a full sweep is still required
+
+Affected-only mode is **opt-in** and intended for the interactive/agent inner loop.
+Because it only re-validates files in the changed surface, a finding whose input
+file is unchanged since the base ref is **not** re-checked. Reserve the full sweep
+(bare `harness validate`, with no `--changed`/`--since`) for:
+
+- **pre-merge** gates (a PR's merge result must be validated in full),
+- **scheduled** runs (nightly/weekly drift catches), and
+- **release** readiness.
+
+Bare `harness validate` is unchanged and remains the default, so existing adopters
+and CI pipelines keep full-sweep semantics with no migration.
+
+> **Telemetry:** scoped-vs-full invocations are recorded (the `variant` field on
+> the `cli/validate` adoption record) so the split is measurable after adoption.
+
 ## Customizing Checks
 
 ### Skipping Checks

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -718,6 +718,10 @@ Run all validation checks
 - `--cross-check` — Run cross-artifact consistency validation
 - `--agent-configs` — Validate agent configs (CLAUDE.md, hooks, skills) via agnix or built-in fallback rules
 - `--strict` — Treat warnings as errors (applies to --agent-configs)
+- `--changed` — Scope the file-walking design audits to the changed surface derived from git (vs the merge-base with the default branch). Opt-in; the full sweep is the default. Reserve the full sweep for pre-merge and scheduled runs.
+- `--affected` — Alias for --changed
+- `--since` — Scope the changed surface to files that differ from the given ref (implies --changed)
+- `--default-branch` — Branch to compute the changed-surface merge-base against (default: main)
 - `--agnix-bin` — Override the agnix binary path discovered on PATH
 - `--severity` — Minimum severity that fails the command; when set, findings below it are excluded from the report and never fail the gate (error, warning, info)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -102,11 +102,15 @@ Validate a harness-linter.yml configuration file
 
 ### `validate_project`
 
-Run all validation checks on a harness engineering project
+Run all validation checks on a harness engineering project. Pass `changed: true` (or `scope: "affected"`, or a `since` ref) to run the full harness validate with its file-walking design audits scoped to the git-derived changed surface instead of the whole tree — the same affected-mode the CLI exposes, for skills/agents that validate via MCP. Default (omitted) is unchanged.
 
 **Parameters:**
 
 - `path` (string, required) — Path to project root directory
+- `scope` (string, optional) — 'affected' scopes the design walkers to the changed surface derived from git; 'full' (default) walks the whole tree. Equivalent to `changed`.
+- `changed` (boolean, optional) — Alias for `scope: "affected"` — scope the design walkers to the changed surface.
+- `since` (string, optional) — Scope the changed surface to files that differ from this ref (implies affected mode).
+- `defaultBranch` (string, optional) — Branch to compute the changed-surface merge-base against (default: main).
 
 **CLI equivalent:** [`harness validate`](cli-commands.md#harness-validate)
 

--- a/docs/reference/tool-catalog.md
+++ b/docs/reference/tool-catalog.md
@@ -5180,15 +5180,35 @@ Validate a harness-linter.yml configuration file
 
 ### `validate_project`
 
-Run all validation checks on a harness engineering project
+Run all validation checks on a harness engineering project. Pass `changed: true` (or `scope: "affected"`, or a `since` ref) to run the full harness validate with its file-walking design audits scoped to the git-derived changed surface instead of the whole tree — the same affected-mode the CLI exposes, for skills/agents that validate via MCP. Default (omitted) is unchanged.
 
 **Input schema:**
 
 ```json
 {
   "properties": {
+    "changed": {
+      "description": "Alias for `scope: \"affected\"` — scope the design walkers to the changed surface.",
+      "type": "boolean"
+    },
+    "defaultBranch": {
+      "description": "Branch to compute the changed-surface merge-base against (default: main).",
+      "type": "string"
+    },
     "path": {
       "description": "Path to project root directory",
+      "type": "string"
+    },
+    "scope": {
+      "description": "'affected' scopes the design walkers to the changed surface derived from git; 'full' (default) walks the whole tree. Equivalent to `changed`.",
+      "enum": [
+        "affected",
+        "full"
+      ],
+      "type": "string"
+    },
+    "since": {
+      "description": "Scope the changed surface to files that differ from this ref (implies affected mode).",
       "type": "string"
     }
   },

--- a/packages/cli/src/bin/command-telemetry.ts
+++ b/packages/cli/src/bin/command-telemetry.ts
@@ -35,6 +35,7 @@ function findProjectRoot(cwd: string): string {
 }
 
 let commandName = '';
+let commandVariant: string | undefined;
 let startTime = 0;
 let recorded = false;
 
@@ -57,6 +58,7 @@ export function installCommandTelemetry(program: Command, cwd: string): void {
   //   actionCommand = command being executed (the actual subcommand)
   program.hook('preAction', (_thisCommand, actionCommand) => {
     commandName = resolveCommandName(actionCommand);
+    commandVariant = resolveCommandVariant(commandName, actionCommand);
     startTime = Date.now();
   });
 
@@ -67,8 +69,31 @@ export function installCommandTelemetry(program: Command, cwd: string): void {
 
     const duration = Date.now() - startTime;
     const outcome = code === 0 ? 'completed' : 'failed';
-    writeCommandRecordSync(projectRoot, commandName, duration, outcome);
+    writeCommandRecordSync(projectRoot, commandName, duration, outcome, commandVariant);
   });
+}
+
+/**
+ * Resolve an optional variant tag for the record. Currently only `cli/validate`
+ * carries one — 'affected' when the run scoped the design audits to the changed
+ * surface (`--changed`/`--affected`/`--since`), 'full' otherwise. This keeps the
+ * primary `skill: 'cli/validate'` key stable (so existing telemetry continuity and
+ * the version-guard's bare-command matching are unaffected) while making the
+ * scoped-vs-full split measurable — the hot-path (68% of CLI calls) metric GH #1523
+ * exists to move. Undefined for every other command, so no record grows a field it
+ * has no use for.
+ */
+function resolveCommandVariant(name: string, cmd: Command): string | undefined {
+  if (name !== 'cli/validate') return undefined;
+  let opts: Record<string, unknown>;
+  try {
+    opts = typeof cmd.opts === 'function' ? cmd.opts() : {};
+  } catch {
+    return undefined;
+  }
+  const affected =
+    opts.changed === true || opts.affected === true || typeof opts.since === 'string';
+  return affected ? 'affected' : 'full';
 }
 
 /**
@@ -95,7 +120,8 @@ function writeCommandRecordSync(
   cwd: string,
   command: string,
   duration: number,
-  outcome: string
+  outcome: string,
+  variant?: string
 ): void {
   try {
     const metricsDir = join(cwd, '.harness', 'metrics');
@@ -108,6 +134,9 @@ function writeCommandRecordSync(
       duration,
       outcome,
       phasesReached: [] as string[],
+      // Additive: only present when the command reports a variant (today, validate's
+      // scoped-vs-full split). Records without it are unchanged.
+      ...(variant !== undefined && { variant }),
     };
 
     const adoptionFile = join(metricsDir, 'adoption.jsonl');
@@ -176,6 +205,7 @@ export function truncateAdoptionFile(cwd: string): void {
 /** Reset module state between tests. */
 export function _resetForTest(): void {
   commandName = '';
+  commandVariant = undefined;
   startTime = 0;
   recorded = false;
 }

--- a/packages/cli/src/commands/validate-scope.ts
+++ b/packages/cli/src/commands/validate-scope.ts
@@ -1,0 +1,181 @@
+/**
+ * Changed-surface derivation for `harness validate --changed` / `--affected`.
+ *
+ * The hot path for `harness validate` is the set of file-walking design audits
+ * (detect-drift, component-anatomy, brand-compliance) which today scan the whole
+ * project on every invocation. Adoption telemetry (GH #1523) shows `cli/validate`
+ * is 68% of all harness CLI calls, so re-walking the full surface each time is the
+ * single highest-leverage latency cost in the tool.
+ *
+ * Affected mode derives the changed surface from git — the files that differ from
+ * the merge-base with the default branch (or an explicit `--since <ref>`), plus
+ * any uncommitted or untracked working-tree changes — and hands that explicit file
+ * list to the walkers, which already support a `files` scoping arg. The fixed-scope
+ * checks (AGENTS.md, roadmap, ADR numbers, STRATEGY.md, pulse) are cheap and always
+ * run; only the project walkers are scoped.
+ *
+ * Affected mode is OPT-IN. Bare `harness validate` keeps the full sweep, so the
+ * default behavior is unchanged for existing adopters and CI/pre-merge runs.
+ *
+ * STALENESS CONTRACT: a scoped run only re-validates files in the changed surface.
+ * A finding whose input file is unchanged since the base ref is NOT re-checked, so
+ * affected mode must never be the sole gate before a merge or a release. Reserve the
+ * full sweep (bare `harness validate`) for pre-merge, scheduled, and release runs.
+ */
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { minimatch } from 'minimatch';
+import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js';
+
+/**
+ * The design walkers that are scoped to the changed surface in affected mode.
+ *
+ * Only detect-drift and audit-brand walk the whole tree in a bare `harness
+ * validate`; component-anatomy is called with no file list (a no-op in validate
+ * today), so scoping it would ACTIVATE it and make an affected run report findings
+ * a full run does not — the opposite of parity. It is deliberately left unscoped.
+ */
+export const SCOPED_WALKERS = ['driftDetection', 'brandCompliance'] as const;
+
+/**
+ * File extensions the design walkers actually scan (detect-drift and audit-brand
+ * share this set). A changed file outside this set is never scanned by a full sweep
+ * either, so it is dropped from the scoped surface to keep scoped ⊆ full.
+ */
+const DESIGN_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.css', '.scss'];
+
+/** Directories the walkers skip during a full walk; mirrored so scoped ⊆ full. */
+const SKIP_DIR_SEGMENTS = new Set(['node_modules', 'dist', 'build', 'coverage']);
+
+export interface ChangedSurface {
+  /** True when a changed surface was successfully derived from git. */
+  ok: boolean;
+  /**
+   * The base ref the surface was diffed against — the merge-base commit with the
+   * default branch, or the explicit `--since` ref. Undefined when derivation failed.
+   */
+  ref?: string;
+  /**
+   * Project-relative, POSIX-normalized paths of files that changed vs the base ref,
+   * filtered to those that still exist on disk (a deleted file has no surface to
+   * validate). Empty is a valid result — it means nothing changed.
+   */
+  files: string[];
+  /**
+   * Populated only when {@link ok} is false: why the surface could not be derived.
+   * The caller falls back to a full sweep and surfaces this as a warning, so a
+   * broken derivation degrades to the safe (complete) behavior rather than a false
+   * green over an empty file list.
+   */
+  reason?: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+/**
+ * Resolve the base ref to diff against. With an explicit `since`, use it verbatim.
+ * Otherwise compute the merge-base between HEAD and the default branch so that a
+ * feature branch is scoped to only its own changes, not every commit since the
+ * branch point.
+ */
+function resolveBaseRef(cwd: string, since: string | undefined, defaultBranch: string): string {
+  if (since !== undefined && since.length > 0) {
+    // Validate the ref exists; throws (caught by caller) if it does not.
+    git(['rev-parse', '--verify', '--quiet', `${since}^{commit}`], cwd);
+    return since;
+  }
+  return git(['merge-base', 'HEAD', defaultBranch], cwd);
+}
+
+/**
+ * Derive the changed surface from git.
+ *
+ * The surface is the union of:
+ *  - tracked files that differ from the base ref (`git diff --name-only <base>` —
+ *    this compares the base to the WORKING TREE, so it includes staged and unstaged
+ *    edits, exactly what an interactive/agent run is touching), and
+ *  - untracked files (`git ls-files --others --exclude-standard`), so brand-new
+ *    files an interactive run just wrote are validated too.
+ *
+ * Never throws: any git failure is reported as `{ ok: false, reason }` so the caller
+ * can fall back to a full sweep.
+ */
+export function deriveChangedSurface(
+  cwd: string,
+  opts: { since?: string; defaultBranch?: string } = {}
+): ChangedSurface {
+  const defaultBranch = opts.defaultBranch ?? 'main';
+  let base: string;
+  try {
+    base = resolveBaseRef(cwd, opts.since, defaultBranch);
+  } catch (err) {
+    const target = opts.since ? `ref "${opts.since}"` : `default branch "${defaultBranch}"`;
+    return {
+      ok: false,
+      files: [],
+      reason: `could not resolve a base ref (${target}): ${(err as Error).message.trim()}`,
+    };
+  }
+
+  let tracked: string[];
+  let untracked: string[];
+  try {
+    tracked = git(['diff', '--name-only', base], cwd).split('\n').filter(Boolean);
+    untracked = git(['ls-files', '--others', '--exclude-standard'], cwd)
+      .split('\n')
+      .filter(Boolean);
+  } catch (err) {
+    return {
+      ok: false,
+      files: [],
+      reason: `git diff against "${base}" failed: ${(err as Error).message.trim()}`,
+    };
+  }
+
+  const seen = new Set<string>();
+  const files: string[] = [];
+  for (const raw of [...tracked, ...untracked]) {
+    const rel = raw.replaceAll('\\', '/');
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    // A file that no longer exists (deleted/renamed-away) has no surface to
+    // validate; the walkers would fail to read it. Filter to what is on disk.
+    if (!fs.existsSync(path.join(cwd, rel))) continue;
+    files.push(rel);
+  }
+
+  return { ok: true, ref: base, files };
+}
+
+/**
+ * Narrow a raw changed surface to the files a full design sweep would actually
+ * scan, so an affected run stays a SUBSET of the full run (scoped ⊆ full) — the
+ * "affected and full agree" contract. Without this, the raw git surface (docs,
+ * JSON, config, generated files) would be handed to the walkers' explicit-`files`
+ * path, which by design bypasses the exclude filter, so an affected run could
+ * report findings on files a full sweep skips.
+ *
+ * A file survives only when it (1) has a design-relevant extension, (2) lives
+ * outside the walkers' hard-skipped directories, and (3) is not matched by the
+ * project's `analysis.exclude` ∪ `design.exclude` globs (the same union detect-drift
+ * applies to its walk).
+ */
+export function filterToDesignSurface(cwd: string, files: readonly string[]): string[] {
+  const excludePatterns = [...loadDesignExclude(cwd), ...loadAnalysisExclude(cwd)];
+  return files.filter((rel) => {
+    if (!DESIGN_EXTENSIONS.some((ext) => rel.endsWith(ext))) return false;
+    const segments = rel.split('/');
+    if (segments.some((seg) => seg.startsWith('.') || SKIP_DIR_SEGMENTS.has(seg))) return false;
+    if (excludePatterns.some((pattern) => minimatch(rel, pattern, { matchBase: true }))) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -29,6 +29,7 @@ import { runAudit as runComponentAnatomyAudit } from '../mcp/tools/audit-anatomy
 import { runDetectDrift } from '../mcp/tools/detect-drift';
 import { runAuditBrand } from '../mcp/tools/audit-brand';
 import { runInstructionDensityAudit } from '../mcp/tools/instruction-density';
+import { deriveChangedSurface, filterToDesignSurface, SCOPED_WALKERS } from './validate-scope';
 
 type ValidateSeverity = 'error' | 'warning' | 'info';
 
@@ -56,6 +57,43 @@ interface ValidateOptions {
    * error-level) and on error-severity findings, while warnings never fail.
    */
   severity?: ValidateSeverity;
+  /**
+   * Scope the file-walking design audits (detect-drift, component-anatomy,
+   * brand-compliance) to the changed surface derived from git instead of walking
+   * the whole project. OPT-IN: when false/omitted, every walker runs over the full
+   * tree (unchanged default). See {@link deriveChangedSurface}. The `--affected`
+   * flag is an alias for this. Reserve the full sweep for pre-merge/scheduled runs.
+   */
+  changed?: boolean;
+  /**
+   * Base ref for the changed-surface diff (implies {@link changed}). When omitted,
+   * the surface is diffed against the merge-base with {@link defaultBranch}.
+   */
+  since?: string;
+  /** Default branch used for the merge-base when `since` is omitted. Defaults to `main`. */
+  defaultBranch?: string;
+}
+
+/**
+ * How the run scoped the file-walking design audits. Recorded on every
+ * {@link ValidateResult} so a scoped run is auditable — the "emit what was skipped
+ * and why" contract — and so scoped-vs-full invocations are measurable downstream.
+ */
+interface ValidateScope {
+  /** 'affected' when the walkers were git-scoped; 'full' when they walked the whole tree. */
+  mode: 'affected' | 'full';
+  /** The base ref the changed surface was diffed against (affected mode only). */
+  ref?: string;
+  /** Number of changed files handed to the scoped walkers (affected mode only). */
+  changedFileCount?: number;
+  /** The checks that were scoped to the changed surface (affected mode only). */
+  scopedChecks?: string[];
+  /**
+   * Present when `--affected`/`--since` was requested but the surface could not be
+   * derived, so the run FELL BACK to a full sweep rather than validate an empty
+   * surface. Carries the git reason. `mode` is 'full' in this case.
+   */
+  fallbackReason?: string;
 }
 
 /**
@@ -120,6 +158,11 @@ interface ValidateResult {
    */
   unavailableChecks: UnavailableCheck[];
   agentConfigs?: AgentConfigValidation;
+  /**
+   * How the file-walking audits were scoped this run. Always present: 'full' for a
+   * bare sweep, 'affected' for a git-scoped run. Makes scoped-vs-full runs auditable.
+   */
+  scope: ValidateScope;
 }
 
 export async function runValidate(
@@ -147,7 +190,37 @@ export async function runValidate(
     },
     issues: [],
     unavailableChecks: [],
+    scope: { mode: 'full' },
   };
+
+  // Derive the changed surface up front when affected mode is requested. The
+  // file-walking design audits below are handed this explicit list instead of
+  // walking the whole tree. If git derivation fails, fall back to a full sweep
+  // (scopedFiles stays undefined) with a recorded reason — never validate an empty
+  // surface, which would be a false green. Fixed-scope checks always run either way.
+  let scopedFiles: string[] | undefined;
+  if (options.changed === true || options.since !== undefined) {
+    const surface = deriveChangedSurface(cwd, {
+      ...(options.since !== undefined && { since: options.since }),
+      ...(options.defaultBranch !== undefined && { defaultBranch: options.defaultBranch }),
+    });
+    if (surface.ok) {
+      // Narrow the raw git surface to the files a full design sweep would actually
+      // scan, so the scoped run stays a subset of the full run (scoped ⊆ full).
+      scopedFiles = filterToDesignSurface(cwd, surface.files);
+      result.scope = {
+        mode: 'affected',
+        ...(surface.ref !== undefined && { ref: surface.ref }),
+        changedFileCount: scopedFiles.length,
+        scopedChecks: [...SCOPED_WALKERS],
+      };
+    } else {
+      result.scope = {
+        mode: 'full',
+        ...(surface.reason !== undefined && { fallbackReason: surface.reason }),
+      };
+    }
+  }
 
   // Check AGENTS.md
   const agentsMapPath = path.resolve(cwd, config.agentsMapPath);
@@ -458,6 +531,10 @@ export async function runValidate(
         | 'strict'
         | 'standard'
         | 'permissive';
+      // NOTE: component-anatomy is intentionally NOT scoped. It is called with no
+      // `files` list in both modes (a no-op in validate today), so passing the
+      // changed surface here would activate it in affected mode only and report
+      // findings a full sweep does not — breaking scoped ⊆ full parity.
       const auditOutput = await runComponentAnatomyAudit({
         path: cwd,
         mode: 'fast',
@@ -512,6 +589,7 @@ export async function runValidate(
         path: cwd,
         mode: 'fast',
         designStrictness: strictness,
+        ...(scopedFiles !== undefined && { files: scopedFiles }),
       });
       result.checks.driftDetection = true;
       for (const finding of driftOutput.findings) {
@@ -556,6 +634,7 @@ export async function runValidate(
         path: cwd,
         mode: 'fast',
         designStrictness: strictness,
+        ...(scopedFiles !== undefined && { files: scopedFiles }),
       });
       result.checks.brandCompliance = true;
       for (const finding of brandOutput.findings) {
@@ -701,6 +780,21 @@ export function createValidateCommand(): Command {
       'Validate agent configs (CLAUDE.md, hooks, skills) via agnix or built-in fallback rules'
     )
     .option('--strict', 'Treat warnings as errors (applies to --agent-configs)')
+    .option(
+      '--changed',
+      'Scope the file-walking design audits to the changed surface derived from git ' +
+        '(vs the merge-base with the default branch). Opt-in; the full sweep is the default. ' +
+        'Reserve the full sweep for pre-merge and scheduled runs.'
+    )
+    .option('--affected', 'Alias for --changed')
+    .option(
+      '--since <ref>',
+      'Scope the changed surface to files that differ from the given ref (implies --changed)'
+    )
+    .option(
+      '--default-branch <name>',
+      'Branch to compute the changed-surface merge-base against (default: main)'
+    )
     .option('--agnix-bin <path>', 'Override the agnix binary path discovered on PATH')
     .option(
       '--severity <level>',
@@ -731,6 +825,9 @@ async function runValidateAction(
     quiet: globalOpts.quiet === true,
     agentConfigs: opts.agentConfigs === true,
     strict: opts.strict === true,
+    changed: opts.changed === true || opts.affected === true,
+    ...(typeof opts.since === 'string' && { since: opts.since }),
+    ...(typeof opts.defaultBranch === 'string' && { defaultBranch: opts.defaultBranch }),
     ...(typeof opts.agnixBin === 'string' && { agnixBin: opts.agnixBin }),
     ...(typeof opts.severity === 'string' && { severity: opts.severity as ValidateSeverity }),
   });
@@ -781,7 +878,32 @@ function emitValidateOutput(
     unavailableChecks: value.unavailableChecks,
   });
   if (output) console.log(output);
+  printScopeSummary(value.scope, mode);
   if (value.agentConfigs) printAgentConfigSummary(value.agentConfigs, mode);
+}
+
+/**
+ * Surface how the file-walking audits were scoped — the "emit what was skipped and
+ * why" contract. Silent for the default full sweep in quiet mode; always names the
+ * staleness caveat in affected mode so a scoped green is never mistaken for a
+ * pre-merge-complete green.
+ */
+function printScopeSummary(scope: ValidateScope, mode: OutputModeType): void {
+  if (mode === OutputMode.QUIET) return;
+  if (scope.fallbackReason) {
+    console.log(
+      `\nScope: full sweep (requested affected mode fell back — ${scope.fallbackReason}).`
+    );
+    return;
+  }
+  if (scope.mode === 'full') return;
+  const ref = scope.ref ? ` vs ${scope.ref}` : '';
+  console.log(
+    `\nScope: affected — ${scope.changedFileCount ?? 0} changed file(s)${ref}. ` +
+      `Scoped checks: ${(scope.scopedChecks ?? []).join(', ')}. ` +
+      'Fixed-scope checks (roadmap, ADR, AGENTS.md, STRATEGY.md, pulse) always ran. ' +
+      'Unchanged files were NOT re-validated — run a full `harness validate` before merge/release.'
+  );
 }
 
 function printAgentConfigSummary(cfg: AgentConfigValidation, mode: OutputModeType): void {

--- a/packages/cli/src/mcp/tools/validate.ts
+++ b/packages/cli/src/mcp/tools/validate.ts
@@ -4,17 +4,49 @@ import { sanitizePath } from '../utils/sanitize-path.js';
 
 export const validateToolDefinition = {
   name: 'validate_project',
-  description: 'Run all validation checks on a harness engineering project',
+  description:
+    'Run all validation checks on a harness engineering project. Pass `changed: true` ' +
+    '(or `scope: "affected"`, or a `since` ref) to run the full harness validate with its ' +
+    'file-walking design audits scoped to the git-derived changed surface instead of the ' +
+    'whole tree — the same affected-mode the CLI exposes, for skills/agents that validate ' +
+    'via MCP. Default (omitted) is unchanged.',
   inputSchema: {
     type: 'object' as const,
     properties: {
       path: { type: 'string', description: 'Path to project root directory' },
+      scope: {
+        type: 'string',
+        enum: ['affected', 'full'],
+        description:
+          "'affected' scopes the design walkers to the changed surface derived from git; " +
+          "'full' (default) walks the whole tree. Equivalent to `changed`.",
+      },
+      changed: {
+        type: 'boolean',
+        description:
+          'Alias for `scope: "affected"` — scope the design walkers to the changed surface.',
+      },
+      since: {
+        type: 'string',
+        description:
+          'Scope the changed surface to files that differ from this ref (implies affected mode).',
+      },
+      defaultBranch: {
+        type: 'string',
+        description: 'Branch to compute the changed-surface merge-base against (default: main).',
+      },
     },
     required: ['path'],
   },
 };
 
-export async function handleValidateProject(input: { path: string }) {
+export async function handleValidateProject(input: {
+  path: string;
+  scope?: 'affected' | 'full';
+  changed?: boolean;
+  since?: string;
+  defaultBranch?: string;
+}) {
   let projectPath: string;
   try {
     projectPath = sanitizePath(input.path);
@@ -29,6 +61,34 @@ export async function handleValidateProject(input: { path: string }) {
       isError: true,
     };
   }
+
+  // Affected mode: delegate to the SAME `runValidate` the CLI uses so the
+  // changed-surface scoping (validate-scope) is shared, not forked. This runs the
+  // full harness validate with its design walkers scoped to the git-derived changed
+  // surface (scoped ⊆ full). Opt-in only — when no scope/changed/since is passed the
+  // thin default path below runs unchanged, so existing MCP callers are byte-identical.
+  const affected =
+    input.changed === true || input.scope === 'affected' || typeof input.since === 'string';
+  if (affected) {
+    // Dynamic import mirrors cross-check.ts and avoids a static commands↔mcp cycle.
+    const { runValidate } = await import('../../commands/validate.js');
+    const result = await runValidate({
+      cwd: projectPath,
+      changed: true,
+      ...(typeof input.since === 'string' && { since: input.since }),
+      ...(typeof input.defaultBranch === 'string' && { defaultBranch: input.defaultBranch }),
+    });
+    if (!result.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${result.error.message}` }],
+        isError: true,
+      };
+    }
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result.value) }],
+    };
+  }
+
   const errors: string[] = [];
   const checks: {
     config: 'pass' | 'fail';

--- a/packages/cli/tests/bin/command-telemetry.test.ts
+++ b/packages/cli/tests/bin/command-telemetry.test.ts
@@ -114,6 +114,29 @@ describe('command-telemetry', () => {
       expect(JSON.parse(lines[1]!).skill).toBe('cli/cleanup');
     });
 
+    it('omits the variant field when no variant is given', () => {
+      const projectDir = path.join(TEST_ROOT, 'no-variant');
+      fs.mkdirSync(projectDir, { recursive: true });
+
+      _writeCommandRecordSync(projectDir, 'cli/validate', 100, 'completed');
+
+      const adoptionFile = path.join(projectDir, '.harness', 'metrics', 'adoption.jsonl');
+      const record = JSON.parse(fs.readFileSync(adoptionFile, 'utf-8').trim());
+      expect(record).not.toHaveProperty('variant');
+    });
+
+    it('records the scoped-vs-full variant for validate (GH #1523)', () => {
+      const projectDir = path.join(TEST_ROOT, 'variant');
+      fs.mkdirSync(projectDir, { recursive: true });
+
+      _writeCommandRecordSync(projectDir, 'cli/validate', 100, 'completed', 'affected');
+
+      const adoptionFile = path.join(projectDir, '.harness', 'metrics', 'adoption.jsonl');
+      const record = JSON.parse(fs.readFileSync(adoptionFile, 'utf-8').trim());
+      expect(record.skill).toBe('cli/validate');
+      expect(record.variant).toBe('affected');
+    });
+
     it('silently handles write errors', () => {
       // Pass a path that can't be created (file as directory)
       const blockingFile = path.join(TEST_ROOT, 'blocking');

--- a/packages/cli/tests/commands/validate-scope.test.ts
+++ b/packages/cli/tests/commands/validate-scope.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  deriveChangedSurface,
+  filterToDesignSurface,
+  SCOPED_WALKERS,
+} from '../../src/commands/validate-scope';
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+
+function writeFile(dir: string, rel: string, contents: string): void {
+  const abs = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+/** Init a git repo with a `main` branch and one committed file. */
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-scope-'));
+  git(['init', '-q', '-b', 'main'], dir);
+  git(['config', 'user.email', 'test@example.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  git(['config', 'commit.gpgsign', 'false'], dir);
+  writeFile(dir, 'base.ts', 'export const base = 1;\n');
+  git(['add', '.'], dir);
+  git(['commit', '-q', '-m', 'base'], dir);
+  return dir;
+}
+
+describe('deriveChangedSurface', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = initRepo();
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('exposes the walkers it scopes (drift + brand; anatomy left full)', () => {
+    expect(SCOPED_WALKERS).toEqual(['driftDetection', 'brandCompliance']);
+  });
+
+  it('returns the merge-base ref and no files when nothing changed on a branch', () => {
+    git(['checkout', '-q', '-b', 'feature'], repo);
+    const surface = deriveChangedSurface(repo, { defaultBranch: 'main' });
+    expect(surface.ok).toBe(true);
+    expect(surface.files).toEqual([]);
+    // ref is the merge-base commit sha with main.
+    expect(surface.ref).toBe(git(['rev-parse', 'main'], repo));
+  });
+
+  it('includes a tracked file edited in the working tree (uncommitted)', () => {
+    git(['checkout', '-q', '-b', 'feature'], repo);
+    writeFile(repo, 'base.ts', 'export const base = 2;\n');
+    const surface = deriveChangedSurface(repo, { defaultBranch: 'main' });
+    expect(surface.ok).toBe(true);
+    expect(surface.files).toContain('base.ts');
+  });
+
+  it('includes a committed change on the branch vs the merge-base', () => {
+    git(['checkout', '-q', '-b', 'feature'], repo);
+    writeFile(repo, 'feature.ts', 'export const f = 1;\n');
+    git(['add', '.'], repo);
+    git(['commit', '-q', '-m', 'add feature'], repo);
+    const surface = deriveChangedSurface(repo, { defaultBranch: 'main' });
+    expect(surface.ok).toBe(true);
+    expect(surface.files).toContain('feature.ts');
+  });
+
+  it('includes untracked new files', () => {
+    writeFile(repo, 'brand-new.ts', 'export const n = 1;\n');
+    const surface = deriveChangedSurface(repo, { defaultBranch: 'main' });
+    expect(surface.ok).toBe(true);
+    expect(surface.files).toContain('brand-new.ts');
+  });
+
+  it('excludes a deleted file (no surface to validate)', () => {
+    git(['rm', '-q', 'base.ts'], repo);
+    const surface = deriveChangedSurface(repo, { defaultBranch: 'main' });
+    expect(surface.ok).toBe(true);
+    expect(surface.files).not.toContain('base.ts');
+  });
+
+  it('honors an explicit --since ref', () => {
+    const baseSha = git(['rev-parse', 'HEAD'], repo);
+    writeFile(repo, 'second.ts', 'export const s = 1;\n');
+    git(['add', '.'], repo);
+    git(['commit', '-q', '-m', 'second'], repo);
+    const surface = deriveChangedSurface(repo, { since: baseSha });
+    expect(surface.ok).toBe(true);
+    expect(surface.ref).toBe(baseSha);
+    expect(surface.files).toContain('second.ts');
+  });
+
+  it('reports a fallback reason for an unknown --since ref (no throw)', () => {
+    const surface = deriveChangedSurface(repo, { since: 'does-not-exist-ref' });
+    expect(surface.ok).toBe(false);
+    expect(surface.files).toEqual([]);
+    expect(surface.reason).toMatch(/does-not-exist-ref/);
+  });
+
+  it('reports a fallback reason when the default branch is absent (no throw)', () => {
+    const surface = deriveChangedSurface(repo, { defaultBranch: 'nonexistent-branch' });
+    expect(surface.ok).toBe(false);
+    expect(surface.files).toEqual([]);
+    expect(surface.reason).toMatch(/nonexistent-branch/);
+  });
+
+  it('reports a fallback reason outside a git repository (no throw)', () => {
+    const nonRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-scope-nonrepo-'));
+    try {
+      const surface = deriveChangedSurface(nonRepo, { defaultBranch: 'main' });
+      expect(surface.ok).toBe(false);
+      expect(surface.files).toEqual([]);
+    } finally {
+      fs.rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('filterToDesignSurface (scoped ⊆ full parity)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'design-surface-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('keeps files the design walkers scan (design extensions)', () => {
+    const kept = filterToDesignSurface(dir, [
+      'packages/cli/src/a.ts',
+      'packages/web/Button.tsx',
+      'styles/app.css',
+      'styles/theme.scss',
+      'lib/util.js',
+      'app/view.jsx',
+    ]);
+    expect(kept).toEqual([
+      'packages/cli/src/a.ts',
+      'packages/web/Button.tsx',
+      'styles/app.css',
+      'styles/theme.scss',
+      'lib/util.js',
+      'app/view.jsx',
+    ]);
+  });
+
+  it('drops non-source extensions a full sweep never scans', () => {
+    const kept = filterToDesignSurface(dir, [
+      'docs/readme.md',
+      'harness.config.json',
+      'image.png',
+      'src/keep.ts',
+    ]);
+    expect(kept).toEqual(['src/keep.ts']);
+  });
+
+  it('drops files under skipped directories (dist, node_modules, coverage, dotdirs)', () => {
+    const kept = filterToDesignSurface(dir, [
+      'dist/bundle.js',
+      'node_modules/pkg/index.js',
+      'coverage/report.js',
+      '.harness/cache/thing.ts',
+      'build/out.ts',
+      'src/keep.ts',
+    ]);
+    expect(kept).toEqual(['src/keep.ts']);
+  });
+
+  it('drops files matched by analysis.exclude ∪ design.exclude', () => {
+    fs.writeFileSync(
+      path.join(dir, 'harness.config.json'),
+      JSON.stringify({ analysis: { exclude: ['**/*.gen.ts'] } })
+    );
+    const kept = filterToDesignSurface(dir, ['src/a.gen.ts', 'src/b.ts']);
+    expect(kept).toEqual(['src/b.ts']);
+  });
+});

--- a/packages/cli/tests/commands/validate.changed.test.ts
+++ b/packages/cli/tests/commands/validate.changed.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@harness-engineering/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@harness-engineering/core')>();
+  return {
+    ...actual,
+    validateAgentsMap: vi.fn().mockResolvedValue({ ok: true, value: {} }),
+    validateKnowledgeMap: vi.fn().mockResolvedValue({ ok: true, value: { brokenLinks: [] } }),
+  };
+});
+
+vi.mock('../../src/config/loader', () => ({
+  resolveConfig: vi.fn().mockReturnValue({
+    ok: true,
+    value: { version: 1, rootDir: '.', agentsMapPath: './AGENTS.md', docsDir: './docs' },
+  }),
+}));
+
+vi.mock('../../src/mcp/tools/audit-anatomy', () => ({
+  runAudit: vi.fn().mockResolvedValue({
+    findings: [],
+    summary: {
+      totalFiles: 0,
+      durationMs: 0,
+      bySeverity: { error: 0, warn: 0, info: 0 },
+      byCode: {},
+    },
+    catalog: { conventionsApplied: [], patternsApplied: [] },
+    meta: { mode: 'fast', deferredToA11y: 0 },
+  }),
+}));
+vi.mock('../../src/mcp/tools/detect-drift', () => ({
+  runDetectDrift: vi.fn().mockResolvedValue({
+    findings: [],
+    summary: {
+      totalFiles: 0,
+      durationMs: 0,
+      bySeverity: { error: 0, warn: 0, info: 0 },
+      byCode: {},
+    },
+  }),
+}));
+vi.mock('../../src/mcp/tools/audit-brand', () => ({
+  runAuditBrand: vi.fn().mockResolvedValue({
+    findings: [],
+    summary: {
+      totalFiles: 0,
+      durationMs: 0,
+      bySeverity: { error: 0, warn: 0, info: 0 },
+      byCode: {},
+    },
+  }),
+}));
+vi.mock('../../src/mcp/tools/instruction-density', () => ({
+  runInstructionDensityAudit: vi.fn().mockResolvedValue({ findings: [] }),
+}));
+
+// Controlled changed-surface + design-surface filter: no real git or config needed.
+const { deriveChangedSurfaceMock, filterToDesignSurfaceMock } = vi.hoisted(() => ({
+  deriveChangedSurfaceMock: vi.fn(),
+  filterToDesignSurfaceMock: vi.fn(),
+}));
+vi.mock('../../src/commands/validate-scope', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/commands/validate-scope')>();
+  return {
+    ...actual,
+    deriveChangedSurface: deriveChangedSurfaceMock,
+    filterToDesignSurface: filterToDesignSurfaceMock,
+  };
+});
+
+import { runValidate } from '../../src/commands/validate';
+import { runDetectDrift } from '../../src/mcp/tools/detect-drift';
+import { runAuditBrand } from '../../src/mcp/tools/audit-brand';
+import { runAudit as runComponentAnatomyAudit } from '../../src/mcp/tools/audit-anatomy';
+
+const DESIGN_SURFACE = ['packages/cli/src/foo.ts', 'packages/cli/src/bar.tsx'];
+
+describe('validate --changed / affected scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deriveChangedSurfaceMock.mockReturnValue({
+      ok: true,
+      ref: 'abc123',
+      files: ['packages/cli/src/foo.ts', 'packages/cli/src/bar.tsx', 'docs/readme.md'],
+    });
+    // The real filter drops docs/*.md; return the design subset deterministically.
+    filterToDesignSurfaceMock.mockReturnValue([...DESIGN_SURFACE]);
+  });
+
+  it('defaults to a full sweep and passes no files to the walkers', async () => {
+    const result = await runValidate({ cwd: '/tmp/repo' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scope.mode).toBe('full');
+    expect(deriveChangedSurfaceMock).not.toHaveBeenCalled();
+    // Full sweep: walkers invoked without an explicit `files` list.
+    expect((runDetectDrift as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].files).toBe(
+      undefined
+    );
+    expect((runAuditBrand as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].files).toBe(
+      undefined
+    );
+  });
+
+  it('scopes drift + brand to the design surface in affected mode (anatomy left full)', async () => {
+    const result = await runValidate({ cwd: '/tmp/repo', changed: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(deriveChangedSurfaceMock).toHaveBeenCalledOnce();
+    expect(filterToDesignSurfaceMock).toHaveBeenCalledOnce();
+    expect(result.value.scope.mode).toBe('affected');
+    expect(result.value.scope.ref).toBe('abc123');
+    expect(result.value.scope.changedFileCount).toBe(2);
+    expect(result.value.scope.scopedChecks).toEqual(['driftDetection', 'brandCompliance']);
+    // drift + brand receive the filtered design surface...
+    for (const audit of [runDetectDrift, runAuditBrand]) {
+      const call = (audit as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.files).toEqual(DESIGN_SURFACE);
+    }
+    // ...but component-anatomy is deliberately NOT scoped (no files → parity with full).
+    expect(
+      (runComponentAnatomyAudit as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].files
+    ).toBe(undefined);
+  });
+
+  it('--since implies affected mode', async () => {
+    const result = await runValidate({ cwd: '/tmp/repo', since: 'HEAD~3' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(deriveChangedSurfaceMock).toHaveBeenCalledWith('/tmp/repo', { since: 'HEAD~3' });
+    expect(result.value.scope.mode).toBe('affected');
+  });
+
+  it('falls back to a full sweep (with reason) when git derivation fails', async () => {
+    deriveChangedSurfaceMock.mockReturnValue({
+      ok: false,
+      files: [],
+      reason: 'not a git repository',
+    });
+    const result = await runValidate({ cwd: '/tmp/repo', changed: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scope.mode).toBe('full');
+    expect(result.value.scope.fallbackReason).toBe('not a git repository');
+    // On fallback the walkers run a full sweep (no explicit files).
+    expect((runDetectDrift as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].files).toBe(
+      undefined
+    );
+  });
+});

--- a/packages/cli/tests/mcp/tools/validate.test.ts
+++ b/packages/cli/tests/mcp/tools/validate.test.ts
@@ -1,10 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { runValidateMock } = vi.hoisted(() => ({ runValidateMock: vi.fn() }));
+vi.mock('../../../src/commands/validate', () => ({ runValidate: runValidateMock }));
+
 import { validateToolDefinition, handleValidateProject } from '../../../src/mcp/tools/validate';
 
 describe('validate tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('has correct definition', () => {
     expect(validateToolDefinition.name).toBe('validate_project');
     expect(validateToolDefinition.inputSchema.required).toContain('path');
+    // Exposes the affected-mode surface.
+    expect(validateToolDefinition.inputSchema.properties).toHaveProperty('scope');
+    expect(validateToolDefinition.inputSchema.properties).toHaveProperty('changed');
+    expect(validateToolDefinition.inputSchema.properties).toHaveProperty('since');
   });
 
   it('returns error for missing config', async () => {
@@ -26,5 +38,67 @@ describe('validate tool', () => {
     expect(parsed.checks).toHaveProperty('config');
     expect(parsed.checks).toHaveProperty('structure');
     expect(parsed.checks).toHaveProperty('agentsMap');
+  });
+
+  it('does NOT delegate to runValidate in the default (full) path — byte-identical', async () => {
+    const response = await handleValidateProject({ path: '/nonexistent/path' });
+    expect(runValidateMock).not.toHaveBeenCalled();
+    // Still the thin default shape.
+    const parsed = JSON.parse(response.content[0].text);
+    expect(parsed.checks).toHaveProperty('config');
+  });
+
+  it('delegates to the shared runValidate with changed:true in affected mode', async () => {
+    runValidateMock.mockResolvedValue({
+      ok: true,
+      value: {
+        valid: true,
+        complete: true,
+        checks: {},
+        issues: [],
+        unavailableChecks: [],
+        scope: {
+          mode: 'affected',
+          ref: 'abc123',
+          changedFileCount: 3,
+          scopedChecks: ['driftDetection', 'brandCompliance'],
+        },
+      },
+    });
+
+    const response = await handleValidateProject({ path: '/some/project', changed: true });
+    expect(runValidateMock).toHaveBeenCalledOnce();
+    expect(runValidateMock).toHaveBeenCalledWith(expect.objectContaining({ changed: true }));
+    const parsed = JSON.parse(response.content[0].text);
+    expect(parsed.scope.mode).toBe('affected');
+    expect(parsed.scope.scopedChecks).toEqual(['driftDetection', 'brandCompliance']);
+  });
+
+  it('treats scope:"affected" and a since ref as affected mode', async () => {
+    runValidateMock.mockResolvedValue({
+      ok: true,
+      value: { valid: true, scope: { mode: 'affected' } },
+    });
+
+    await handleValidateProject({ path: '/p', scope: 'affected' });
+    expect(runValidateMock).toHaveBeenCalledWith(expect.objectContaining({ changed: true }));
+
+    runValidateMock.mockClear();
+    await handleValidateProject({ path: '/p', since: 'origin/main' });
+    expect(runValidateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ changed: true, since: 'origin/main' })
+    );
+  });
+
+  it('scope:"full" keeps the default path (no delegation)', async () => {
+    await handleValidateProject({ path: '/nonexistent/path', scope: 'full' });
+    expect(runValidateMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a runValidate config error as isError in affected mode', async () => {
+    runValidateMock.mockResolvedValue({ ok: false, error: { message: 'Config not found' } });
+    const response = await handleValidateProject({ path: '/p', changed: true });
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('Config not found');
   });
 });

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -21,7 +21,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "node ../../scripts/clean.mjs dist",
-    "validate": "harness validate",
+    "validate": "harness validate --changed",
     "check-deps": "harness check-deps",
     "check-docs": "harness check-docs",
     "openapi:generate": "tsx src/gateway/openapi/generate.ts ../../docs/api/openapi.yaml"


### PR DESCRIPTION
## Summary

Adds an opt-in **affected-only mode** to `harness validate`. Adoption telemetry shows `cli/validate` is **68% of all harness CLI calls** (2,097 invocations); its design audits (`detect-drift`, `audit-brand`) walk the whole source tree on every run. `--changed` / `--affected` (and `--since <ref>`) derive the changed surface from git and hand just those files to the walkers — the single highest-leverage latency/cost fix on the most-invoked command.

Bare `harness validate` is **unchanged** (full sweep) — non-breaking for adopters and pre-merge/scheduled/release gates.

## What it does

- **`--changed` / `--affected`** — scope the design walkers to files that differ from the merge-base with the default branch.
- **`--since <ref>`** — scope to files that differ from an explicit ref (implies `--changed`).
- **`--default-branch <name>`** — override the merge-base branch (default `main`).
- **`scoped ⊆ full` parity** — the changed surface is narrowed to the source extensions and `analysis.exclude` ∪ `design.exclude` globs a full sweep would scan, so a scoped run **never** reports a finding a full sweep would not. `component-anatomy` is intentionally left unscoped (it is a no-op in validate today; scoping it would activate it only in affected mode and break parity).
- **Fail-safe** — if the surface can't be derived (not a git repo, unknown ref), the run **falls back to a full sweep** and reports why; it never validates an empty surface.
- **Auditable** — every run records/prints a `scope` block (mode, ref, changed count, scoped checks) and the staleness caveat.
- **Telemetry** — scoped-vs-full is recorded via an additive `variant` field on the `cli/validate` adoption record (primary key unchanged).

### Verified end-to-end (built binary, this repo)
125 changed design files → **28** findings (affected) vs **328** (full); **0** affected findings absent from full (`scoped ⊆ full`).

## Call-site audit (operator-requested)

| Call site | Runs | Walks design surface? | Disposition |
|---|---|---|---|
| `.husky/pre-commit` / `pre-push` | `harness ci check` | **No** (core validate check = AGENTS.md only) | left full |
| `.github/workflows/persona-*.yml` (×3) | `harness validate` (advisory) | yes | left full — generated files, advisory, once-per-PR; rewiring needs the persona-workflow generator + drift guard |
| `packages/orchestrator/package.json` `validate` | `harness validate` | yes | **rewired to `--changed`** (the one per-change dev-loop call site) |

The 2,097 telemetry invocations are overwhelmingly interactive agent/human calls that no committed automation controls — those adopt `--changed` at the point of use.

## Staleness contract (docs)

Documented in `docs/guides/ci-cd-validation.md`: affected mode only re-validates the changed surface, so the **full sweep is still required** for pre-merge, scheduled, and release runs.

## Tests
- `validate-scope.test.ts` — surface derivation (branch diff, uncommitted, untracked, deletion, `--since`, unknown-ref/no-repo fallback) + design-surface filter parity.
- `validate.changed.test.ts` — default full sweep, affected scoping (drift+brand get the filtered surface, anatomy left full), `--since` implies affected, git-failure fallback.
- `command-telemetry.test.ts` — `variant` present/absent.

39 tests across the 3 files; CLI build + typecheck green.

## Pipeline artifacts
`docs/changes/scope-validate-changed-surface/` — `proposal.md`, `plans/…-plan.md`, `provenance.json`.

## Assumptions made
- **Default = opt-in.** Bare `harness validate` keeps the full sweep; `--changed`/`--affected` are new opt-in flags.
- **Only `detect-drift` + `audit-brand` are scoped**; `component-anatomy` left full (it is a no-op in validate today — scoping would break `scoped ⊆ full`).
- **Call-site rewiring:** orchestrator `validate` dev-script → `--changed`; pre-commit/pre-push left full (AGENTS.md-only check, not the design-walker path); the 3 persona CI workflows left full (generated, advisory, low-frequency).
- **Telemetry:** additive `variant` field, primary `cli/validate` key unchanged (keeps continuity + version-guard matching).
- **Turbo/task-cache integration out of scope** — `harness validate` is an in-process check runner, not a turbo task graph; the leverage is scoping the file walkers.
- **Changeset:** `@harness-engineering/cli` minor, `@harness-engineering/orchestrator` patch.

Closes #1523


---

## Follow-up: affected-mode through the MCP tool surface

Skills and agents validate through the MCP tool surface, not the CLI — so the changed-surface win was invisible to them. `validate_project` (`packages/cli/src/mcp/tools/validate.ts`) now takes an opt-in `scope: "affected" | "full"` / `changed` / `since` / `defaultBranch` param. Affected mode **delegates to the same `runValidate`** the CLI uses (validate-scope shared, not forked, via dynamic import mirroring `cross-check.ts`); the default (omitted) path is **byte-identical** to the prior thin `{valid,checks,errors}` reimplementation. Verified end-to-end: the full path has no `scope` block; the affected path returns the scoped `ValidateResult` (127 changed design files → 28 findings, `scoped ⊆ full`). `mcp-tools.md` + `tool-catalog.md` regenerated; MCP tool test added (8 tests).

`validate_cross_check` is deliberately left unchanged — it validates spec→plan→impl coverage/staleness, not a design-file walk, so validate-scope's changed-CODE-surface derivation does not apply (scoping it to changed code files would wrongly skip linkage checks for specs whose impl files were untouched). No new core export was needed, so `scripts/generate-core-barrel.mjs` was untouched.
