### PR TITLE
feat(burn): add invoking-skill attribution cut that reconciles with /usage

### DIFF
--- a/.changeset/burn-usage-skill-reconcile.md
+++ b/.changeset/burn-usage-skill-reconcile.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/burn': minor
+'@harness-engineering/cli': minor
+---
+
+Add an invoking-skill attribution cut to burn so its breakdown reconciles with Claude
+Code's `/usage`. burn previously grouped subagent spend only by agent TYPE
+(`attributionAgent`), while `/usage` groups the same spend by the SKILL that spawned it
+(`harness:roadmap-fleet`, `harness:autopilot`, …), so the two views could never
+reconcile — `/usage` showed rows burn had no equivalent for. Each turn now also records
+`invokingSkill` (derived from the transcript's `attributionSkill`, already a
+fully-qualified `plugin:skill` value), the summary carries a `skills` block alongside
+`agents`, and `harness burn report` leads with a `by invoking skill` section that states
+its window (week-to-date vs `/usage`'s last-24h) so a mismatch reads as a different
+question, not a wrong number. Both cuts coexist and partition the same weekly total. A
+turn with no readable skill is grouped honestly as `unattributed-skill` (never dropped,
+never fabricated); legacy rows are `pre-migration`. The `usage.tsv` store widened from
+nine to ten columns with a `STORE_VERSION` bump that forces one re-derivation from
+transcripts on disk. burn's default window is unchanged.

--- a/docs/changes/burn-usage-skill-reconcile/plans/plan.md
+++ b/docs/changes/burn-usage-skill-reconcile/plans/plan.md
@@ -1,0 +1,92 @@
+# Plan — reconcile burn attribution with `/usage` by adding an invoking-skill cut
+
+Issue: #1300 — "burn attribution groups by agent type while /usage groups by invoking
+skill, so the two can never reconcile"
+
+## Problem
+
+Per-subagent attribution (#1270, PR #1292) groups the week's spend by `attributionAgent`
+— the agent **type** that spent it (`harness-task-executor`, `general-purpose`, …).
+Claude Code's own `/usage` groups the _same_ spend by the **skill** that spawned the
+subagent (`harness:roadmap-fleet`, `harness:autopilot`, …). Both cuts are defensible,
+but they are not comparable: `/usage` shows a `harness:roadmap-fleet` row at 43% that
+burn has no equivalent for, because burn has no concept of the invoking skill. Anyone
+cross-checking one against the other concludes a number is broken.
+
+## Decision (confirmed, folded in — not re-litigated here)
+
+1. **ADD** an invoking-skill grouping dimension; do **not** replace the existing
+   agent-type grouping. Both coexist so the two views reconcile.
+2. Derive the invoking skill from the transcript field burn already scans
+   (`attributionSkill`, already carried per subagent turn alongside `attributionAgent`).
+   When a turn carries no readable skill, group it under `unattributed-skill` — never
+   drop, never fabricate — matching #1270's `unattributed` discipline for agents. Rows
+   that predate skill tracking (legacy store rows) group under `pre-migration`, mirroring
+   the agent dimension.
+3. The windows differ (`/usage` last-24h vs burn week-to-date). Make burn's window
+   explicit in the report so a reconciliation is apples-to-apples, and state which cut
+   each grouping shows. Do **not** change burn's default window.
+
+## Key finding from the transcripts (load-bearing)
+
+Real subagent transcripts on this machine already carry `attributionSkill` (values
+`harness:autopilot`, `harness:brainstorming`, …) and `attributionPlugin` (`harness`)
+right next to `attributionAgent`. The value is already fully-qualified `plugin:skill`,
+which is exactly the shape `/usage` reports — so the skill cut is directly derivable and
+directly reconcilable. Older transcripts predating the field carry `null`; those degrade
+to `unattributed-skill`.
+
+## Tasks
+
+1. **Data model** (`types.ts`)
+   - Add `invokingSkill: string` to `UsageRecord` (never empty; `unattributed-skill`
+     fallback, `pre-migration` for legacy rows).
+   - Add a `SkillBlock` interface (mirrors `AgentBlock`: requests, units, pct_of_week,
+     lanes).
+   - Add `skills: Record<string, SkillBlock>` to `Summary`.
+
+2. **Scan** (`scan.ts`)
+   - In `toRecord`, read `attributionSkill` with the same string type-guard used for
+     `attributionAgent`/`agentId` (undocumented internals may change type, must never
+     abort the scan). Derive `invokingSkill = trimmed skill || 'unattributed-skill'`.
+
+3. **Store** (`store.ts`)
+   - Widen `usage.tsv` to a 10th column (`invokingSkill`), written last so an older
+     reader still parses the first nine.
+   - Read the 10th column in `toStoredRecord`; a wide row missing it falls to
+     `pre-migration` (predates skill tracking), mirroring the agent fallback.
+   - Bump `STORE_VERSION` 2 → 3 so the migration is a stated one-time full rescan that
+     re-derives the skill from transcripts still on disk.
+   - Extend `tsvSafe` sanitisation to the new column.
+
+4. **Summary** (`summary.ts`)
+   - Roll records up per invoking skill exactly as per agent (same lane-union idiom),
+     and emit the sorted `skills` block. Partitions the week identically to `agents`.
+
+5. **Report** (`packages/cli/.../burn/report.ts`)
+   - Add a `by invoking skill` section that **leads** (renders before `by agent`), states
+     it is the cut `/usage` shows, and states the window is week-to-date vs `/usage`'s
+     last-24h so the discrepancy reads as "different question", not "wrong number".
+
+6. **Docs** (`packages/burn/README.md`)
+   - Document the skill cut, the `unattributed-skill`/`pre-migration` labels, and the
+     window/`/usage` reconciliation note. Note the 9→10 column widening.
+
+7. **Tests**
+   - Extend `agentLine` helper to carry `attributionSkill`.
+   - scan: a turn's skill is read; missing → `unattributed-skill`; non-string type
+     degrades without aborting.
+   - store: 10-column round-trip; wide-row-missing-skill → `pre-migration`; version 3;
+     sanitisation of the new column.
+   - summary: skills block partitions the week; `unattributed-skill` bucket present and
+     never dropped.
+   - report: `by invoking skill` renders, leads before `by agent`, states the window.
+
+## Non-goals
+
+- No change to burn's default window or to the existing agent-type cut.
+- No second degradation flag for skills — the existing agent-type `attribution.degraded`
+  already headlines a broken scanner; the skill cut degrades honestly to
+  `unattributed-skill`.
+- No dependency on the parallel #1522 cost-per-pr lane; build against current `main`,
+  keep changes additive.

--- a/docs/changes/burn-usage-skill-reconcile/provenance.json
+++ b/docs/changes/burn-usage-skill-reconcile/provenance.json
@@ -1,0 +1,34 @@
+{
+  "issue": 1300,
+  "slug": "burn-usage-skill-reconcile",
+  "closing_keyword": "Closes #1300",
+  "plan_path": "docs/changes/burn-usage-skill-reconcile/plans/plan.md",
+  "stages": [
+    {
+      "stage": "brainstorming",
+      "summary": "Confirmed the root cause: burn groups by attributionAgent (agent type) while /usage groups by invoking skill; the two cannot reconcile because burn has no skill dimension. Verified against real transcripts that attributionSkill is already carried per subagent turn as a fully-qualified plugin:skill value matching /usage's shape.",
+      "artifact": "docs/changes/burn-usage-skill-reconcile/plans/plan.md"
+    },
+    {
+      "stage": "planning",
+      "summary": "Broke the change into: data model (invokingSkill on UsageRecord, SkillBlock, skills on Summary), scan derivation from attributionSkill, store 9->10 column widening + STORE_VERSION 2->3, summary per-skill rollup, report by-invoking-skill section that leads and states the window, README + tests.",
+      "artifact": "docs/changes/burn-usage-skill-reconcile/plans/plan.md"
+    },
+    {
+      "stage": "execution",
+      "summary": "Added the invoking-skill cut additively alongside the agent-type cut. Derives from attributionSkill with the same type-guard discipline; unattributed-skill fallback (never drop/fabricate); pre-migration for legacy rows. Store widened one column with a version bump forcing a one-time re-derivation from transcripts. Report leads with the skill cut and makes the week-to-date vs /usage last-24h window explicit."
+    },
+    {
+      "stage": "verification",
+      "summary": "burn + cli unit tests (scan/store/summary/report attribution suites) extended and green; typecheck, lint, build, and reference-docs gates pass; all-OS CI green on the pushed branch."
+    }
+  ],
+  "assumptions": [
+    "The invoking skill is derived from the transcript's `attributionSkill` field, which real subagent transcripts on this machine already carry as a fully-qualified `plugin:skill` value (e.g. `harness:autopilot`) matching /usage's grouping. Turns predating the field carry null and degrade to `unattributed-skill`.",
+    "Main-thread and any turn without a readable `attributionSkill` group under `unattributed-skill` (honest degradation, never dropped, never fabricated), matching #1270's `unattributed` discipline for agents.",
+    "Legacy store rows that predate the skill column group under `pre-migration` for the skill dimension, mirroring the agent dimension's provenance-unknown label.",
+    "No second degradation flag was added for the skill cut: the existing agent-type `attribution.degraded` already headlines a broken scanner, and the skill cut degrades visibly to `unattributed-skill`.",
+    "burn's default window is unchanged; the report now states the window (week-to-date) and contrasts it with /usage's last-24h so a reconciliation is apples-to-apples.",
+    "Built against current main; no dependency on the parallel #1522 cost-per-pr lane."
+  ]
+}

--- a/packages/burn/README.md
+++ b/packages/burn/README.md
@@ -103,6 +103,38 @@ A `burn` older than this change reading a 9-column store discards every row. Tha
 accepted rather than mitigated: the integrity gate then re-reads every transcript, and
 this store is a rolling local cache reconstructible from source, not a system of record.
 
+### By invoking skill — reconciling with `/usage`
+
+The table above cuts the week by agent **type** (`attributionAgent`). Claude Code's own
+`/usage` cuts the _same_ spend by the **skill** that spawned the subagent — it shows a
+`harness:roadmap-fleet` row where the agent cut shows `general-purpose` and named harness
+agents. Both are honest; they are different questions, so cross-checking one against the
+other makes a correct number look broken. burn therefore carries **both** cuts.
+
+Every turn also records `invokingSkill`, derived from the transcript's `attributionSkill`
+(already carried per subagent turn, already a fully-qualified `plugin:skill` value like
+`harness:autopilot` — the exact shape `/usage` reports). The report leads with this cut,
+under `by invoking skill`, because it is the one that reconciles against `/usage`.
+
+| Skill label          | What it means                                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<plugin:skill>`     | The skill that spawned the turn, e.g. `harness:autopilot`. Reconciles directly with a `/usage` row.                                          |
+| `unattributed-skill` | A turn carrying no readable skill (main-thread work, or a subagent whose skill could not be read). Counted, never dropped, never fabricated. |
+| `pre-migration`      | A row written before this column existed; provenance unknown, re-derived on the first rescan.                                                |
+
+The skill cut partitions the week identically to the agent cut — both sum to the same
+weekly total — which is what makes the two views reconcile rather than compete. It has no
+separate degradation flag: the agent-type `attribution.degraded` already headlines a
+broken scanner, and a missing skill degrades visibly to `unattributed-skill`.
+
+**The windows still differ.** `/usage` reports the last 24h; burn reports week-to-date.
+The report states its window next to the skill cut so a mismatch reads as "a different
+span", not "a wrong number". Reconcile like for like; the default window is unchanged.
+
+The store widened from nine to ten columns to carry `invokingSkill`, with a `STORE_VERSION`
+bump that forces one full rescan so existing rows are re-derived from the transcripts
+still on disk rather than pinned to `pre-migration`.
+
 ## Design rules
 
 These come from the "check the denominator" habit: a green readout must never be

--- a/packages/burn/src/index.ts
+++ b/packages/burn/src/index.ts
@@ -9,6 +9,7 @@ export type {
   ModelBlock,
   ScanInfo,
   SessionBlock,
+  SkillBlock,
   Summary,
   UsageRecord,
   WeekReset,

--- a/packages/burn/src/scan.ts
+++ b/packages/burn/src/scan.ts
@@ -43,6 +43,8 @@ interface TranscriptLine {
   agentId?: string;
   /** The agent TYPE, e.g. `harness-task-executor`. */
   attributionAgent?: string;
+  /** The invoking SKILL, e.g. `harness:autopilot` — the cut `/usage` groups by. */
+  attributionSkill?: string;
   message?: {
     model?: string;
     usage?: {
@@ -98,6 +100,17 @@ function toRecord(
   // the lanes and overstate the human.
   const agent = named !== '' ? named : isSubagent ? 'unattributed' : 'main';
 
+  // The invoking-skill cut, orthogonal to the agent-type cut above. Same
+  // type-guard as `attributionAgent`/`agentId`: these are undocumented Claude
+  // Code internals, so a release may change a field's TYPE as easily as its
+  // name, and the store writer sanitises this column with `String.replace`,
+  // which throws on a non-string and aborts the whole scan. A shape change
+  // must degrade to an unattributed skill, never to a dead HUD. A turn with no
+  // readable skill is grouped honestly rather than dropped — the same
+  // discipline `unattributed` gives the agent cut.
+  const skillNamed = typeof obj.attributionSkill === 'string' ? obj.attributionSkill.trim() : '';
+  const invokingSkill = skillNamed !== '' ? skillNamed : 'unattributed-skill';
+
   return {
     id,
     record: {
@@ -109,6 +122,7 @@ function toRecord(
       cacheRead: Number(usage.cache_read_input_tokens) || 0,
       agent,
       agentId: agent === 'main' ? '' : lane,
+      invokingSkill,
     },
   };
 }

--- a/packages/burn/src/store.ts
+++ b/packages/burn/src/store.ts
@@ -138,7 +138,7 @@ export function withScanLock<T>(
  * forever. Dropping those fingerprints makes the migration a stated event
  * — one full rescan — rather than a silent, permanent mislabelling.
  */
-export const STORE_VERSION = 2;
+export const STORE_VERSION = 3;
 
 export interface Fingerprints {
   /** absolute transcript path -> [mtime seconds, size bytes] */
@@ -203,16 +203,18 @@ function num(field: string | undefined): number {
  *
  * A 7-field row predates attribution and is loaded as `pre-migration` rather
  * than discarded: discarding would delete the entire pre-migration store.
- * Nine or more fields carry the label and the lane id, and anything past the
- * ninth is ignored.
+ * Nine or more fields carry the agent label and the lane id; a tenth carries
+ * the invoking skill. Anything past the tenth is ignored.
  *
  * Exactly 8 fields is rejected on purpose, and that is what bounds the forward
  * tolerance here. A 7-column row with one trailing tab splits into 8 fields
  * and is indistinguishable from a genuine 8-column row, so 8 has to stay a
- * torn-write sentinel. The consequence is worth stating plainly: accepting
- * `>= 9` means a future addition of TWO OR MORE columns survives a reader that
- * predates it, but an addition of exactly one does not. A single-column
- * widening would need its own version bump rather than relying on this.
+ * torn-write sentinel. Accepting `>= 9` is what lets THIS reader still parse a
+ * 9-column store written before the skill column existed: its agent/lane are
+ * read and the absent skill falls to `pre-migration`. The `STORE_VERSION` bump
+ * that accompanies the widening then forces a one-time full rescan, so those
+ * 9-column rows are re-derived from the transcripts still on disk rather than
+ * being pinned to `pre-migration` forever.
  */
 function toStoredRecord(p: string[]): UsageRecord | null {
   const wide = p.length >= 9;
@@ -229,6 +231,11 @@ function toStoredRecord(p: string[]): UsageRecord | null {
     // `unattributed` — the latter is subagent spend and drives degradation.
     agent: (wide ? p[7]! : '') || 'pre-migration',
     agentId: wide ? p[8]! : '',
+    // The tenth column, added after the agent/lane pair. A wide row that lacks
+    // it is a pre-skill-tracking row, so its skill is unknown provenance —
+    // `pre-migration`, mirroring the agent fallback above — never
+    // `unattributed-skill`, which is a live "we looked and found none" reading.
+    invokingSkill: (wide ? (p[9] ?? '') : '') || 'pre-migration',
   };
 }
 
@@ -262,7 +269,7 @@ export function writeRecords(paths: BurnPaths, records: Map<string, UsageRecord>
   const lines: string[] = [];
   for (const [id, r] of records) {
     lines.push(
-      `${id}\t${r.ts}\t${r.model}\t${r.out}\t${r.in}\t${r.cacheWrite}\t${r.cacheRead}\t${tsvSafe(r.agent)}\t${tsvSafe(r.agentId)}\n`
+      `${id}\t${r.ts}\t${r.model}\t${r.out}\t${r.in}\t${r.cacheWrite}\t${r.cacheRead}\t${tsvSafe(r.agent)}\t${tsvSafe(r.agentId)}\t${tsvSafe(r.invokingSkill)}\n`
     );
   }
   atomicWrite(paths.usageTsv, lines.join(''));

--- a/packages/burn/src/summary.ts
+++ b/packages/burn/src/summary.ts
@@ -14,6 +14,7 @@ import type {
   ModelBlock,
   ScanInfo,
   SessionBlock,
+  SkillBlock,
   Summary,
 } from './types';
 import { units } from './units';
@@ -106,6 +107,7 @@ export function buildSummary(
   const buckets = new Map<number, { requests: number; out: number; units: number }>();
   const perModel = new Map<string, { requests: number; units: number }>();
   const perAgent = new Map<string, { requests: number; units: number; lanes: Set<string> }>();
+  const perSkill = new Map<string, { requests: number; units: number; lanes: Set<string> }>();
   let sessionUnits = 0;
   let sessionRequests = 0;
 
@@ -142,6 +144,16 @@ export function buildSummary(
       // `main` carries an empty agentId, so it counts zero lanes.
       if (rec.agentId) a.lanes.add(rec.agentId);
       perAgent.set(label, a);
+
+      // The orthogonal skill cut, folded up the same way so the two views
+      // reconcile against one shared week total. An empty column falls to
+      // `pre-migration` for the same reason the agent label does.
+      const skill = rec.invokingSkill || 'pre-migration';
+      const sk = perSkill.get(skill) ?? { requests: 0, units: 0, lanes: new Set<string>() };
+      sk.requests += 1;
+      sk.units += u;
+      if (rec.agentId) sk.lanes.add(rec.agentId);
+      perSkill.set(skill, sk);
     }
     if (t >= sessionCut) {
       sessionUnits += u;
@@ -243,6 +255,18 @@ export function buildSummary(
       units: Math.round(a.units),
       pct_of_week: cur.units ? roundTo((100 * a.units) / cur.units, 1) : 0,
       lanes: a.lanes.size,
+    };
+  }
+
+  // ---- per-skill. The cut `/usage` groups by; same shape as `agents`, sorted
+  // by units descending so the report can lead with it without re-sorting.
+  const skills: Record<string, SkillBlock> = {};
+  for (const [label, sk] of [...perSkill.entries()].sort((x, y) => y[1].units - x[1].units)) {
+    skills[label] = {
+      requests: sk.requests,
+      units: Math.round(sk.units),
+      pct_of_week: cur.units ? roundTo((100 * sk.units) / cur.units, 1) : 0,
+      lanes: sk.lanes.size,
     };
   }
 
@@ -360,6 +384,7 @@ export function buildSummary(
     models,
     models_exhausted: exhausted,
     agents,
+    skills,
     attribution,
     session,
     status,

--- a/packages/burn/src/types.ts
+++ b/packages/burn/src/types.ts
@@ -59,6 +59,15 @@ export interface UsageRecord {
   agent: string;
   /** The dispatch this turn belonged to — one fleet lane. Empty for the main thread. */
   agentId: string;
+  /**
+   * The invoking SKILL that spawned this turn, from `attributionSkill` (e.g.
+   * `harness:autopilot`). This is the cut `/usage` groups by; the `agent`
+   * column above is the orthogonal agent-TYPE cut. Never empty:
+   * `unattributed-skill` when a turn carries no readable skill, `pre-migration`
+   * for rows that predate skill tracking. See the reconciliation decision in
+   * the README.
+   */
+  invokingSkill: string;
 }
 
 export interface ScanInfo {
@@ -115,6 +124,25 @@ export interface AgentBlock {
    * Distinct non-empty `agentId`s seen this week under this label. `main`
    * records carry an empty `agentId`, so the empty id is excluded from the
    * count and `main` honestly reports 0.
+   */
+  lanes: number;
+}
+
+/**
+ * Where the week's units went, by invoking SKILL — the cut `/usage` shows.
+ *
+ * Same shape as `AgentBlock` on purpose: the two are orthogonal cuts of the
+ * same spend (skill vs agent type), so an existing consumer reads one without
+ * learning a second idiom, and the two views reconcile against a shared total.
+ */
+export interface SkillBlock {
+  requests: number;
+  units: number;
+  pct_of_week: number;
+  /**
+   * Distinct non-empty `agentId`s this skill dispatched this week. A turn that
+   * carries no lane id (the main thread) contributes 0, so a skill made up
+   * entirely of main-thread turns honestly reports 0 lanes.
    */
   lanes: number;
 }
@@ -183,6 +211,12 @@ export interface Summary {
   models: Record<string, ModelBlock>;
   models_exhausted: string[];
   agents: Record<string, AgentBlock>;
+  /**
+   * The same week's spend cut by invoking skill instead of agent type — the
+   * grouping `/usage` uses. Partitions the week identically to `agents`; the
+   * two are reconcilable views of one total, not a second number.
+   */
+  skills: Record<string, SkillBlock>;
   attribution: AttributionBlock;
   session: SessionBlock;
   status: BurnStatus;

--- a/packages/burn/tests/concurrency.test.ts
+++ b/packages/burn/tests/concurrency.test.ts
@@ -47,7 +47,7 @@ it('leaves a consistent store after six concurrent scans', async () => {
     .filter((l) => l.trim());
   expect(rows).toHaveLength(200);
   for (const row of rows) {
-    expect(row.split('\t')).toHaveLength(9); // no partial rows
+    expect(row.split('\t')).toHaveLength(10); // no partial rows
   }
 
   const header = readFileSync(hud.paths.filesTsv, 'utf8').split('\n')[0];

--- a/packages/burn/tests/helpers.ts
+++ b/packages/burn/tests/helpers.ts
@@ -134,7 +134,12 @@ export function utcIsoWeekday(d: Date): number {
 export function agentLine(
   requestId: string,
   when: Date,
-  fields: { isSidechain?: boolean; agentId?: string; attributionAgent?: string },
+  fields: {
+    isSidechain?: boolean;
+    agentId?: string;
+    attributionAgent?: string;
+    attributionSkill?: string;
+  },
   opts: { model?: string; out?: number; in?: number; cw?: number; cr?: number } = {}
 ): string {
   const base = JSON.parse(transcriptLine(requestId, when, opts)) as Record<string, unknown>;

--- a/packages/burn/tests/robustness.test.ts
+++ b/packages/burn/tests/robustness.test.ts
@@ -118,6 +118,7 @@ describe('transcript parsing', () => {
       cacheRead: 0,
       agent: 'main',
       agentId: '',
+      invokingSkill: 'unattributed-skill',
     });
   });
 

--- a/packages/burn/tests/scan-attribution.test.ts
+++ b/packages/burn/tests/scan-attribution.test.ts
@@ -140,6 +140,67 @@ describe('classification', () => {
   });
 });
 
+describe('invoking-skill classification', () => {
+  it('reads the invoking skill from attributionSkill, the cut /usage groups by', () => {
+    const h = newHud();
+    h.writeSubagentTranscript('agent-s.jsonl', [
+      agentLine('req_s1', hoursAgo(new Date(), 1), {
+        isSidechain: true,
+        agentId: 'lane-s1',
+        attributionAgent: 'harness-task-executor',
+        attributionSkill: 'harness:autopilot',
+      }),
+    ]);
+
+    const records = new Map<string, UsageRecord>();
+    parseTranscript(path.join(h.paths.projects, '-proj', SUB, 'agent-s.jsonl'), records);
+    const rec = records.get('req_s1')!;
+    // Orthogonal cuts: the agent TYPE and the invoking SKILL of one turn.
+    expect(rec.agent).toBe('harness-task-executor');
+    expect(rec.invokingSkill).toBe('harness:autopilot');
+  });
+
+  it('files a turn with no readable skill under unattributed-skill, never dropping it', () => {
+    // Same discipline `unattributed` gives the agent cut: a turn whose skill
+    // cannot be read is grouped honestly, never fabricated and never dropped.
+    const h = newHud();
+    h.writeSubagentTranscript('agent-s2.jsonl', [
+      agentLine(
+        'req_s2',
+        hoursAgo(new Date(), 1),
+        { isSidechain: true, agentId: 'lane-s2', attributionAgent: 'harness-task-executor' },
+        { out: 1000 }
+      ),
+    ]);
+
+    const records = new Map<string, UsageRecord>();
+    parseTranscript(path.join(h.paths.projects, '-proj', SUB, 'agent-s2.jsonl'), records);
+    const rec = records.get('req_s2')!;
+    expect(rec.invokingSkill).toBe('unattributed-skill');
+    expect(rec.out).toBe(1000);
+  });
+
+  it('degrades to unattributed-skill when attributionSkill is not a string, without aborting the scan', () => {
+    // These are undocumented internals; a release may change a field's TYPE as
+    // easily as its name. A non-string must never reach the store writer's
+    // `String.replace` and abort every future scan.
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeSubagentTranscript('agent-s3.jsonl', [
+      agentLine('req_s3', hoursAgo(new Date(), 1), {
+        isSidechain: true,
+        agentId: 'lane-s3',
+        attributionAgent: 'harness-task-executor',
+        // Deliberately the wrong type: the shape change under test.
+        attributionSkill: 12_345 as unknown as string,
+      }),
+    ]);
+
+    expect(() => refresh(h.paths)).not.toThrow();
+    expect(readRecords(h.paths).get('req_s3')!.invokingSkill).toBe('unattributed-skill');
+  });
+});
+
 describe('dedup with upgrade', () => {
   it('upgrades a pre-migration record when a later read finds the label', () => {
     const h = newHud();
@@ -163,6 +224,7 @@ describe('dedup with upgrade', () => {
           cacheRead: 0,
           agent: 'pre-migration',
           agentId: '',
+          invokingSkill: 'pre-migration',
         },
       ],
     ]);
@@ -198,6 +260,7 @@ describe('dedup with upgrade', () => {
           cacheRead: 0,
           agent: 'pre-migration',
           agentId: '',
+          invokingSkill: 'pre-migration',
         },
       ],
     ]);
@@ -231,6 +294,7 @@ describe('dedup with upgrade', () => {
           cacheRead: 0,
           agent: 'unattributed',
           agentId: 'lane-7',
+          invokingSkill: 'unattributed-skill',
         },
       ],
     ]);

--- a/packages/burn/tests/store-attribution.test.ts
+++ b/packages/burn/tests/store-attribution.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 
 const LEGACY_ROW = 'legacy\t2026-08-06T00:00:00Z\tclaude-opus-5\t1\t2\t3\t4';
 
-describe('store — 7-to-9 column migration', () => {
+describe('store — 7-to-10 column migration', () => {
   it('loads a legacy 7-column row as pre-migration rather than discarding it', () => {
     // Not `unattributed`: that label means SUBAGENT spend whose identity could
     // not be read, and most legacy rows are the main thread. Mislabelling
@@ -41,10 +41,13 @@ describe('store — 7-to-9 column migration', () => {
     expect(rec).toBeDefined();
     expect(rec!.agent).toBe('pre-migration');
     expect(rec!.agentId).toBe('');
+    // The skill column is absent from a legacy row, so its skill is unknown
+    // provenance too — `pre-migration`, mirroring the agent fallback.
+    expect(rec!.invokingSkill).toBe('pre-migration');
     expect(rec!.out).toBe(1);
   });
 
-  it('round-trips a 9-column row through write and read', () => {
+  it('round-trips a 10-column row through write and read', () => {
     const h = newHud();
     const rec: UsageRecord = {
       ts: '2026-08-06T00:00:00Z',
@@ -55,23 +58,38 @@ describe('store — 7-to-9 column migration', () => {
       cacheRead: 4,
       agent: 'harness-task-executor',
       agentId: 'a6bbff57161b6ebb2',
+      invokingSkill: 'harness:autopilot',
     };
     writeRecords(h.paths, new Map([['req_1', rec]]));
-    expect(readFileSync(h.paths.usageTsv, 'utf8').trim().split('\t')).toHaveLength(9);
+    expect(readFileSync(h.paths.usageTsv, 'utf8').trim().split('\t')).toHaveLength(10);
     expect(readRecords(h.paths).get('req_1')).toEqual(rec);
   });
 
-  it('loads a row with MORE than nine fields and ignores the extras', () => {
+  it('reads a 9-column row from the previous format, filing its absent skill as pre-migration', () => {
+    // A store written before the skill column existed still parses: its agent
+    // and lane are read, and the missing skill falls to `pre-migration` (a
+    // pre-skill-tracking row), never to `unattributed-skill`. The accompanying
+    // STORE_VERSION bump then re-derives it from the transcript on the next scan.
+    const h = newHud();
+    writeFileSync(h.paths.usageTsv, `${LEGACY_ROW}\tharness-task-executor\tlane-1\n`);
+    const rec = readRecords(h.paths).get('legacy')!;
+    expect(rec.agent).toBe('harness-task-executor');
+    expect(rec.agentId).toBe('lane-1');
+    expect(rec.invokingSkill).toBe('pre-migration');
+  });
+
+  it('loads a row with MORE than ten fields and ignores the extras', () => {
     // Forward tolerance: a future column addition must be survivable by a
     // reader that predates it, the same reversibility the wire contract has.
     const h = newHud();
     writeFileSync(
       h.paths.usageTsv,
-      `${LEGACY_ROW}\tharness-task-executor\tlane-1\tsomething-from-the-future\n`
+      `${LEGACY_ROW}\tharness-task-executor\tlane-1\tharness:autopilot\tsomething-from-the-future\n`
     );
     const rec = readRecords(h.paths).get('legacy')!;
     expect(rec.agent).toBe('harness-task-executor');
     expect(rec.agentId).toBe('lane-1');
+    expect(rec.invokingSkill).toBe('harness:autopilot');
   });
 
   it('still discards a row whose field count is neither 7 nor at least 9', () => {
@@ -114,6 +132,7 @@ describe('store — sanitising on write', () => {
             cacheRead: 0,
             agent: 'evil\tagent\nname\r',
             agentId: 'lane\t1',
+            invokingSkill: 'evil\tskill\nname\r',
           },
         ],
       ])
@@ -121,11 +140,12 @@ describe('store — sanitising on write', () => {
 
     const row = readFileSync(h.paths.usageTsv, 'utf8').trim();
     expect(row.split('\n')).toHaveLength(1);
-    expect(row.split('\t')).toHaveLength(9);
+    expect(row.split('\t')).toHaveLength(10);
 
     const rec = readRecords(h.paths).get('req_1')!;
     expect(rec.agent).toBe('evil agent name ');
     expect(rec.agentId).toBe('lane 1');
+    expect(rec.invokingSkill).toBe('evil skill name ');
   });
 });
 
@@ -142,7 +162,7 @@ describe('store — fingerprint version', () => {
     seed(h);
     const lines = readFileSync(h.paths.filesTsv, 'utf8').split('\n');
     expect(lines[0]).toBe('#count\t1');
-    expect(lines[1]).toBe('#version\t2');
+    expect(lines[1]).toBe('#version\t3');
   });
 
   it('re-reads every transcript when the version header is absent', () => {

--- a/packages/burn/tests/summary-attribution.test.ts
+++ b/packages/burn/tests/summary-attribution.test.ts
@@ -129,6 +129,88 @@ describe('summary — agents block', () => {
   });
 });
 
+describe('summary — skills block', () => {
+  it('partitions the week by invoking skill, the cut /usage groups by', () => {
+    // The skill cut and the agent cut are orthogonal views of ONE week total,
+    // so both must sum to the week within a unit of per-label rounding — that
+    // shared total is what makes the two views reconcile against /usage.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeTranscript('main.jsonl', [transcriptLine('m1', hoursAgo(now, 1), { out: 333 })]);
+    h.writeSubagentTranscript('agent-a.jsonl', [
+      agentLine(
+        's1',
+        hoursAgo(now, 1),
+        {
+          isSidechain: true,
+          agentId: 'lane-1',
+          attributionAgent: 'harness-task-executor',
+          attributionSkill: 'harness:autopilot',
+        },
+        { out: 777 }
+      ),
+      agentLine(
+        's2',
+        hoursAgo(now, 1),
+        {
+          isSidechain: true,
+          agentId: 'lane-2',
+          attributionAgent: 'harness-planner',
+          attributionSkill: 'harness:autopilot',
+        },
+        { out: 111 }
+      ),
+    ]);
+
+    const s = refresh(h.paths);
+    // Two subagent turns under one skill, plus the main-thread turn which has
+    // no readable skill and lands in the honest fallback bucket.
+    expect(Object.keys(s.skills).sort()).toEqual(['harness:autopilot', 'unattributed-skill']);
+    // Both subagent turns share one skill but ran as two distinct lanes.
+    expect(s.skills['harness:autopilot']!.lanes).toBe(2);
+    expect(s.skills['harness:autopilot']!.requests).toBe(2);
+    // main carries no lane id, so its skill bucket honestly reports 0 lanes.
+    expect(s.skills['unattributed-skill']!.lanes).toBe(0);
+
+    const labels = Object.keys(s.skills);
+    const summed = labels.reduce((acc, k) => acc + s.skills[k]!.units, 0);
+    expect(Math.abs(summed - s.wtd.units)).toBeLessThanOrEqual(labels.length);
+  });
+
+  it('keeps the unattributed-skill bucket rather than folding it into a real skill', () => {
+    // A subagent whose skill could not be read must not be silently attributed
+    // to a skill that did run — that would be the fleet-reads-as-free failure
+    // in the skill dimension.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeSubagentTranscript('agent-a.jsonl', [
+      agentLine(
+        's1',
+        hoursAgo(now, 1),
+        {
+          isSidechain: true,
+          agentId: 'lane-1',
+          attributionAgent: 'harness-task-executor',
+          attributionSkill: 'harness:autopilot',
+        },
+        { out: 500 }
+      ),
+      agentLine(
+        's2',
+        hoursAgo(now, 1),
+        { isSidechain: true, agentId: 'lane-2', attributionAgent: 'harness-task-executor' },
+        { out: 500 }
+      ),
+    ]);
+
+    const s = refresh(h.paths);
+    expect(s.skills['unattributed-skill']!.units).toBeGreaterThan(0);
+    expect(s.skills['harness:autopilot']!.units).toBeGreaterThan(0);
+  });
+});
+
 describe('summary — pre-migration rows', () => {
   /** Seed a 7-column store with a current-week row and roll it up without a scan. */
   function legacyOnly(h: Hud, extraRows: string[] = []): Summary {

--- a/packages/cli/src/commands/burn/report.test.ts
+++ b/packages/cli/src/commands/burn/report.test.ts
@@ -294,6 +294,64 @@ describe('report — by agent', () => {
   });
 });
 
+describe('report — by invoking skill', () => {
+  const skills = {
+    'unattributed-skill': { requests: 100, units: 41_200_000, pct_of_week: 58, lanes: 0 },
+    'harness:autopilot': { requests: 60, units: 18_900_000, pct_of_week: 27, lanes: 6 },
+  };
+
+  it('lists the week by invoking skill, the cut /usage groups by', () => {
+    const out = render({ skills });
+    expect(out).toContain('by invoking skill');
+    expect(out).toContain('the cut /usage shows');
+    expect(out).toContain('harness:autopilot');
+    expect(out).toContain('18.9M');
+    expect(out).toContain('27% of week, 6 lanes');
+  });
+
+  it('states its window so a /usage comparison is like-for-like', () => {
+    // The two tools measure different spans (burn week-to-date, /usage last-24h),
+    // so the window is stated to keep a mismatch reading as a different question.
+    const out = render({ skills });
+    expect(out).toContain('week-to-date');
+    expect(out).toContain('/usage last-24h');
+  });
+
+  it('leads with the skill cut, before the agent-type cut', () => {
+    const agents = {
+      'harness-task-executor': { requests: 60, units: 18_900_000, pct_of_week: 27, lanes: 6 },
+    };
+    const out = render({ skills, agents });
+    expect(out.indexOf('by invoking skill')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('by invoking skill')).toBeLessThan(out.indexOf('by agent'));
+  });
+
+  it('reads a summary written before the skill cut existed without a section or a throw', () => {
+    expect(() => render()).not.toThrow();
+    expect(render()).not.toContain('by invoking skill');
+  });
+
+  it('never elides the unattributed-skill bucket', () => {
+    // Same protection the agent cut gives `unattributed`: a bucket that can
+    // silently vanish cannot account for spend. Rank it below the cut and drop
+    // it below the floor and it must still render.
+    const ranked = Object.fromEntries(
+      Array.from({ length: 8 }, (_, i) => [
+        `skill-${i}`,
+        { requests: 1, units: 9_000_000 - i, pct_of_week: 10, lanes: 1 },
+      ])
+    );
+    const out = render({
+      skills: {
+        ...ranked,
+        'unattributed-skill': { requests: 1, units: 12, pct_of_week: 0, lanes: 0 },
+      },
+    });
+    expect(out).toContain('unattributed-skill');
+    expect(out).not.toContain('skill-7');
+  });
+});
+
 describe('report — unattributed is never elided', () => {
   // The two elisions `modelsSection` applies (top-6 slice, 1000-unit floor)
   // are exactly how a small or low-ranked unattributed bucket would vanish,

--- a/packages/cli/src/commands/burn/report.ts
+++ b/packages/cli/src/commands/burn/report.ts
@@ -4,6 +4,7 @@ import {
   refresh,
   resolvePaths,
   type AgentBlock,
+  type SkillBlock,
   type Summary,
 } from '@harness-engineering/burn';
 import chalk from 'chalk';
@@ -198,6 +199,61 @@ function attributionCaution(s: Summary): string[] {
 }
 
 /**
+ * Which skill labels earn a line.
+ *
+ * `unattributed-skill` is exempt from the top-N cut and the unit floor for the
+ * same reason `unattributed` is in the agent cut: a bucket that can silently
+ * vanish cannot be trusted to account for spend. `pre-migration` takes the
+ * ordinary cut and floor — it is history, not a live signal.
+ */
+function keptSkillLabels(s: Summary, all: [string, SkillBlock][]): Set<string> {
+  const kept = new Set(
+    all
+      .filter(([name]) => name !== 'unattributed-skill')
+      .slice(0, 6)
+      .filter(([, e]) => e.units >= 1000)
+      .map(([name]) => name)
+  );
+  if ((s.skills?.['unattributed-skill']?.units ?? 0) > 0) kept.add('unattributed-skill');
+  return kept;
+}
+
+/**
+ * Per invoking skill — the cut `/usage` groups by, so this is the section to
+ * hold next to a `/usage` reading. It LEADS the two attribution cuts on
+ * purpose: `/usage` shows `harness:roadmap-fleet` as a first-class row, and a
+ * reader reconciling the two needs the comparable cut first.
+ *
+ * The header states the window because the two tools measure different spans —
+ * burn is week-to-date, `/usage` is the last 24h — so a mismatch reads as "a
+ * different question", not "one of these numbers is wrong". Guarded like
+ * `agentsSection`: a summary written before this feature carries no `skills`
+ * key and must render without throwing.
+ */
+function skillsSection(s: Summary): string[] {
+  const all = Object.entries(s.skills ?? {});
+  if (all.length === 0) return [];
+
+  const kept = keptSkillLabels(s, all);
+
+  const out = [
+    '',
+    `  ${chalk.bold('by invoking skill')} ${chalk.dim('— the cut /usage shows')}`,
+    chalk.dim('  window: week-to-date (this section) vs /usage last-24h — reconcile like for like'),
+  ];
+  for (const [name, e] of all) {
+    if (!kept.has(name)) continue;
+    const lanes = e.lanes > 0 ? `, ${e.lanes} lane${e.lanes === 1 ? '' : 's'}` : '';
+    out.push(
+      `  ${pad(name)}${human(e.units).padStart(8)} ${chalk.dim(
+        `(${Math.round(e.pct_of_week)}% of week${lanes})`
+      )}`
+    );
+  }
+  return out;
+}
+
+/**
  * Per-agent. The pooled bar cannot tell you that a fleet run, not you, spent
  * the week — this is where a lane's cost becomes visible.
  *
@@ -212,7 +268,10 @@ function agentsSection(s: Summary): string[] {
 
   const kept = keptAgentLabels(s, all);
 
-  const out = ['', `  ${chalk.bold('by agent')}`];
+  const out = [
+    '',
+    `  ${chalk.bold('by agent')} ${chalk.dim('— agent-TYPE cut, a different question from /usage')}`,
+  ];
   // Iterate `all`, which summary.ts already sorted by units descending, so an
   // exempt row keeps its true rank rather than being appended at the bottom.
   for (const [name, e] of all) {
@@ -305,6 +364,7 @@ export function renderReport(s: Summary): string[] {
     ...spendSection(s),
     ...budgetSection(s, tz),
     ...modelsSection(s),
+    ...skillsSection(s),
     ...agentsSection(s),
     ...sessionSection(s),
     ...calibrationSection(s),


### PR DESCRIPTION
## Summary

burn's per-subagent attribution (#1270, PR #1292) grouped spend only by agent **type**
(`attributionAgent`), while Claude Code's own `/usage` groups the *same* spend by the
**skill** that spawned the subagent (`harness:roadmap-fleet`, `harness:autopilot`, …).
Both cuts are defensible, but they are not comparable — `/usage` shows a
`harness:roadmap-fleet` row that burn had no equivalent for, so anyone cross-checking one
against the other concluded a number was broken.

This **adds** an invoking-skill grouping dimension alongside the existing agent-type one
so the two views reconcile. Nothing about the agent cut changes.

## What changed

- **Data model** — `UsageRecord` carries `invokingSkill`; `Summary` carries a `skills`
  block (`SkillBlock`, same shape as `AgentBlock`).
- **Derivation** — `invokingSkill` comes from the transcript's `attributionSkill`, which
  real subagent transcripts already carry as a fully-qualified `plugin:skill` value — the
  exact shape `/usage` reports. Same type-guard discipline as `attributionAgent` so a
  shape change never aborts the scan.
- **Honest fallback** — a turn with no readable skill groups as `unattributed-skill`
  (never dropped, never fabricated), matching #1270's `unattributed` discipline; legacy
  rows group as `pre-migration`.
- **Store** — `usage.tsv` widened 9 → 10 columns (skill written last so older readers
  still parse the first nine), with a `STORE_VERSION` 2 → 3 bump that forces one full
  rescan re-deriving the skill from transcripts on disk.
- **Report** — `harness burn report` now **leads** with a `by invoking skill` section
  (the cut `/usage` shows) and states its window: **week-to-date, vs `/usage`'s last-24h**
  — so a mismatch reads as "a different question", not "a wrong number". The default
  window is unchanged. The `by agent` section follows, labelled as the agent-type cut.

Both cuts partition the same weekly total, so they reconcile against a shared denominator
rather than competing. No second degradation flag was added: the existing agent-type
`attribution.degraded` already headlines a broken scanner, and a missing skill degrades
visibly to `unattributed-skill`.

## Verified

- burn (129) and cli (6444) test suites green, including new scan/store/summary/report
  coverage for the skill cut, the `unattributed-skill` fallback, the non-string-type
  degrade, the 10-column round-trip + version bump, and the report leading/window text.
- End-to-end: rendered a real `harness burn report` against synthetic transcripts
  carrying `attributionSkill` — the skill cut leads with a `harness:roadmap-fleet` row
  (the row `/usage` shows and burn previously lacked), states the window, and both cuts
  partition identically. Store writes 10 columns; main-thread → `unattributed-skill`.
- typecheck, lint (0 errors), format, reference-docs, and tool-catalog gates pass.

## Assumptions made

- The invoking skill is derived from `attributionSkill`, verified present on real
  subagent transcripts as `harness:autopilot` / `harness:brainstorming` etc. Turns
  predating the field carry `null` and degrade to `unattributed-skill`.
- Main-thread and any turn without a readable skill group under `unattributed-skill`
  (honest degradation). Legacy store rows predating the column group under
  `pre-migration`, mirroring the agent dimension.
- No skill-specific degradation flag; the agent-type flag covers "scanner broke".
- burn's default window is unchanged; the report now states it for reconciliation.
- Built against current `main`; no dependency on the parallel #1522 cost-per-pr lane.

Artifacts: `docs/changes/burn-usage-skill-reconcile/plans/plan.md`,
`docs/changes/burn-usage-skill-reconcile/provenance.json`.

Closes #1300
