### PR TITLE
feat(orchestrator): budget governor for unattended dispatch (#1525)

### DIFF
--- a/.changeset/unattended-budget-governor.md
+++ b/.changeset/unattended-budget-governor.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/types': minor
+---
+
+Add a budget governor for unattended dispatch (#1525). A per-period spend
+envelope (`agent.budget`) is enforced on the real dispatch path: global envelope
+exhaustion stops dispatch cleanly at a lane boundary (in-flight lanes are never
+interrupted), and per-fleet sub-allocations let fleets sharing an envelope
+respect their split under contention. The remaining-budget signal is exposed via
+the orchestrator snapshot (`getSnapshot().budget`). The governor is off when
+`agent.budget` is not configured.

--- a/docs/changes/unattended-budget-governor/plans/plan.md
+++ b/docs/changes/unattended-budget-governor/plans/plan.md
@@ -1,0 +1,77 @@
+# Plan — Budget governor for unattended dispatch (#1525)
+
+## Problem
+
+Fleets currently run only while an operator is at the desk: of 1,866 commits in 90
+days, just 24 (1.3%) landed at a weekend, and the hour histogram collapses after
+18:00. All the observed 57x-median throughput comes from ~50 of 168 hours because
+dispatch is operator-triggered, not scheduled. Enabling naive 168-hour scheduling
+would need ~3.4x the quota. Before unattended operation is safe to turn on, the
+orchestrator needs a **spend envelope** that stops dispatch cleanly at a lane
+boundary when the budget is reached — never mid-write — with per-fleet allocation
+and an operator-visible remaining-budget signal.
+
+## Approach — smallest coherent slice
+
+Land the governor primitive + envelope enforcement on the real dispatch path +
+the remaining-budget signal. Denominate the envelope in **total tokens**
+(input + output) — the unit the orchestrator already accrues in `tokenTotals` —
+so envelope accounting reconciles with burn attribution without a separate cost
+model. Governor is **off** when no `agent.budget` is configured (unbounded,
+pre-#1525 behaviour).
+
+## Tasks
+
+1. **Governor primitive** — `packages/orchestrator/src/core/budget-governor.ts`.
+   Pure module over a `BudgetState { periodStartMs, spentTokens, perFleetSpent }`:
+   `createBudgetState`, `recordBudgetSpend` (rolls an elapsed window, immutable),
+   `isGlobalEnvelopeExhausted`, `isFleetAllocationExhausted`, `canAffordDispatch`,
+   `getBudgetStatus` (remaining-budget signal), `fleetKeyForIssue` (label
+   attribution), `rollBudgetPeriod`, `periodLengthMs`.
+
+2. **Config surface** — add `AgentBudgetConfig` + `budget?` to `AgentConfig`
+   (`packages/types/src/orchestrator.ts`), export via the types barrel, and add a
+   strict `AgentBudgetSchema` validated in `validateWorkflowConfig`
+   (`packages/orchestrator/src/workflow/{schema,config}.ts`).
+
+3. **State wiring** — add `budget: BudgetState | null` to `OrchestratorState`;
+   initialise from config in `createEmptyState`; deep-clone in the state machine's
+   `cloneState`.
+
+4. **Dispatch enforcement (WIRED)** — in the `applyEvent` tick dispatch loop
+   (`state-machine.ts`), consult the governor BEFORE each lane: global exhaustion
+   `break`s the whole loop (clean stop, in-flight lanes untouched); a single
+   fleet's exhaustion `continue`s (skip that fleet, siblings proceed). The retry
+   dispatch path uses `canDispatch(..., budgetOptions)`.
+
+5. **Accrual** — in `accrueUsage`, record `usage.totalTokens` against the envelope,
+   attributed to the lane's fleet.
+
+6. **Remaining-budget signal** — surface `getBudgetStatus(...)` as `budget` in
+   `Orchestrator.getSnapshot()` (feeds `GET /api/state`, TUI, dashboard).
+
+7. **Docs** — document `agent.budget`, clean-stop semantics, and the
+   remaining-budget signal in `docs/guides/orchestrator-api.md`; regenerate
+   `docs/reference/*`.
+
+8. **Tests** — governor unit behaviour, a WIRED integration proving
+   `applyEvent(tick)` stops dispatch at the envelope while leaving an in-flight
+   lane running (plus per-fleet contention and the accrual path), and config
+   validation.
+
+## Wiring (live call site)
+
+`applyEvent` → `handleTick` tick dispatch loop
+(`packages/orchestrator/src/core/state-machine.ts`) calls
+`isGlobalEnvelopeExhausted` / `isFleetAllocationExhausted` before dispatching each
+eligible lane; the retry path calls `canDispatch(..., dispatchBudgetOptions(...))`
+(`packages/orchestrator/src/core/concurrency.ts`). Adopters set
+`agent.budget.{period, envelopeTokens, perFleet}`.
+
+## Scope / deferral
+
+`Refs #1525`. Delivers the governor primitive, envelope enforcement on the live
+dispatch path, per-fleet allocation, and the remaining-budget signal. Deferred
+(follow-ups, not needed for safe-to-enable): the thin cron scheduler primitive
+(#1405), burn-attribution reconciliation to a dollar cost model, and dashboard
+UI rendering of the `budget` snapshot field.

--- a/docs/changes/unattended-budget-governor/provenance.json
+++ b/docs/changes/unattended-budget-governor/provenance.json
@@ -1,0 +1,31 @@
+{
+  "issue": 1525,
+  "slug": "unattended-budget-governor",
+  "title": "Budget governor for unattended dispatch",
+  "stages": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "plan_path": "docs/changes/unattended-budget-governor/plans/plan.md",
+  "closing_keyword": "Refs #1525",
+  "wiring": {
+    "live_dispatch_call_site": "packages/orchestrator/src/core/state-machine.ts — handleTick() tick dispatch loop calls isGlobalEnvelopeExhausted()/isFleetAllocationExhausted() before dispatching each eligible lane; the retry dispatch path calls canDispatch(..., dispatchBudgetOptions(issue)) in packages/orchestrator/src/core/concurrency.ts.",
+    "accrual": "packages/orchestrator/src/core/state-machine.ts — accrueUsage() calls recordBudgetSpend(state.budget, config.agent.budget, fleetKey, usage.totalTokens).",
+    "config_keys": [
+      "agent.budget.period",
+      "agent.budget.envelopeTokens",
+      "agent.budget.perFleet",
+      "agent.budget.fleetLabelPrefix"
+    ],
+    "remaining_budget_signal": "Orchestrator.getSnapshot().budget (BudgetEnvelopeStatus) — surfaced via GET /api/state, TUI, dashboard.",
+    "governor_primitive": "packages/orchestrator/src/core/budget-governor.ts"
+  },
+  "assumptions": [
+    "Envelope is denominated in total tokens (input + output), the unit already accrued in OrchestratorState.tokenTotals, so envelope accounting reconciles with burn attribution without introducing a separate token->dollar cost model (that reconciliation to cost-per-merged-pr is a deferred follow-up).",
+    "Envelope model = per-period global spend envelope + per-fleet sub-allocation. Global exhaustion stops the whole tick dispatch loop cleanly at a lane boundary; a single fleet's sub-allocation exhaustion skips only that fleet's lanes so sibling fleets sharing the envelope keep dispatching under contention. A lane already in flight is never interrupted (never mid-write).",
+    "A lane is attributed to a fleet via an issue label matching agent.budget.fleetLabelPrefix (default 'fleet:'), e.g. 'fleet:roadmap' -> fleet 'roadmap'. Lanes without a fleet label count only against the global envelope. The orchestrator core has no first-class per-issue fleet field, so the label is the attribution seam.",
+    "The governor is OFF when agent.budget is absent (unbounded dispatch, pre-#1525 behaviour). envelopeTokens and every per-fleet cap must be positive integers; a zero cap would stall all dispatch, so 'off' is expressed by omitting agent.budget rather than a zero.",
+    "The period window is a rolling window anchored at the first spend (or state creation); a fully-elapsed window resets spend to zero on the next spend or read. Not calendar-aligned to midnight/Monday.",
+    "Config lives in the orchestrator WorkflowConfig 'agent' section (alongside maxConcurrentAgents and the rate limits), not the top-level harness.config.json 'agent' (executor/timeout/skills), which is a different schema.",
+    "Refs #1525 (not Closes): the thin cron scheduler primitive (#1405), dollar-cost burn reconciliation, and dashboard UI rendering of the budget snapshot field are deferred follow-ups. The governor primitive + envelope enforcement + per-fleet allocation + remaining-budget signal (the safe-to-enable core) are delivered.",
+    "New exports live in @harness-engineering/orchestrator (core/index.ts), not @harness-engineering/core, so scripts/generate-core-barrel.mjs is not involved.",
+    "Shared-file coordination with sibling lanes #1524 / #1532: changes to concurrency.ts (added optional DispatchBudgetOptions param, backward-compatible) and state-machine.ts (added governor checks before the existing canDispatch call) are additive; the pre-existing canDispatch(state, issueState, byState) signature still works with the budget argument omitted."
+  ]
+}

--- a/docs/guides/orchestrator-api.md
+++ b/docs/guides/orchestrator-api.md
@@ -512,6 +512,76 @@ Setting a token limit to `0` disables that check.
 
 ---
 
+## Budget Governor
+
+The budget governor makes unattended (168-hour) operation safe to enable by enforcing a **spend envelope per period**. Where the rate limiter throttles the _pace_ of requests within a minute, the governor caps the _total_ spend over a day or week and stops dispatching new lanes once the envelope is reached. It lives in `packages/orchestrator/src/core/budget-governor.ts` and is consulted on the real dispatch path (`applyEvent` → the tick dispatch loop, alongside `canDispatch`) before any lane is started.
+
+### Clean-stop semantics
+
+When the period envelope is spent, the governor refuses to dispatch a **new** lane at the next lane boundary. Lanes already in flight are never interrupted — dispatch stops cleanly, never mid-write. Because accounting is denominated in **total tokens** (input + output), the same unit the orchestrator already accrues in `tokenTotals`, envelope accounting reconciles with burn attribution without a separate cost model.
+
+- **Global envelope exhausted** → the whole dispatch loop stops for every fleet (the clean, whole-run stop).
+- **A single fleet's sub-allocation exhausted** → only that fleet's lanes are skipped; sibling fleets sharing the envelope keep dispatching, so two fleets respect their split under contention.
+
+### Configuration
+
+The governor is configured under `agent.budget` in the orchestrator workflow config (the same `agent` section that holds `maxConcurrentAgents` and the rate limits). Omitting `agent.budget` leaves the governor **off** — dispatch is unbounded, the pre-governor behaviour.
+
+```typescript
+interface AgentBudgetConfig {
+  /** Accounting period. The envelope resets at the start of each new window. */
+  period: 'day' | 'week';
+  /** Global spend envelope for the period, in total tokens. */
+  envelopeTokens: number;
+  /** Optional per-fleet sub-allocations (fleet key → token cap). */
+  perFleet?: Record<string, number>;
+  /** Issue-label prefix used to attribute a lane to a fleet (default `fleet:`). */
+  fleetLabelPrefix?: string;
+}
+```
+
+```json
+{
+  "agent": {
+    "maxConcurrentAgents": 2,
+    "budget": {
+      "period": "week",
+      "envelopeTokens": 5000000,
+      "perFleet": { "roadmap": 2000000, "bug": 1000000 }
+    }
+  }
+}
+```
+
+A lane is attributed to a fleet via its issue label: an issue labelled `fleet:roadmap` counts against the `roadmap` sub-allocation (and the global envelope). Lanes without a fleet label count only against the global envelope. `envelopeTokens` and every per-fleet cap must be positive integers — a zero cap would stall all dispatch, so to turn the governor off you omit `agent.budget` entirely rather than setting a zero.
+
+### Remaining-budget signal
+
+The orchestrator snapshot (`GET /api/state`, the TUI, and the dashboard) exposes a `budget` field with the operator-visible remaining-budget signal, or `null` when the governor is off:
+
+```typescript
+interface BudgetEnvelopeStatus {
+  period: 'day' | 'week';
+  periodStartMs: number;
+  periodEndMs: number;
+  envelopeTokens: number;
+  spentTokens: number;
+  remainingTokens: number;
+  exhausted: boolean; // true once no new lane will be dispatched
+  perFleet: {
+    fleet: string;
+    allocatedTokens: number;
+    spentTokens: number;
+    remainingTokens: number;
+    exhausted: boolean;
+  }[];
+}
+```
+
+An elapsed window is reported as a fresh, fully-remaining period, matching the reset the next spend will apply.
+
+---
+
 ## Maintenance Scheduler
 
 The maintenance scheduler evaluates cron schedules on an interval timer, performs leader election via the claim manager, and invokes task execution for due tasks.

--- a/packages/orchestrator/src/core/budget-governor.ts
+++ b/packages/orchestrator/src/core/budget-governor.ts
@@ -1,0 +1,234 @@
+import type {
+  AgentBudgetConfig,
+  BudgetEnvelopeStatus,
+  FleetBudgetStatus,
+  Issue,
+} from '@harness-engineering/types';
+
+/**
+ * Budget governor for unattended dispatch (#1525).
+ *
+ * Makes 168-hour unattended operation safe to enable by enforcing a per-period
+ * **spend envelope** — denominated in total tokens (input + output), the same
+ * unit the orchestrator already accrues in `tokenTotals`. The governor is
+ * consulted BEFORE a lane is dispatched (see `canDispatch` in `concurrency.ts`)
+ * and refuses a NEW dispatch once the envelope is spent. Lanes already in flight
+ * are never touched, so dispatch stops cleanly at a lane boundary — never
+ * mid-write.
+ *
+ * All functions here are pure: the mutable {@link BudgetState} lives on
+ * `OrchestratorState.budget` and is threaded through the state machine's
+ * clone-per-event discipline. The governor is OFF when no
+ * {@link AgentBudgetConfig} is configured — `null` state ⇒ unbounded dispatch,
+ * the pre-#1525 behaviour.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+
+const DEFAULT_FLEET_LABEL_PREFIX = 'fleet:';
+
+/** Length of one accounting window, in ms. */
+export function periodLengthMs(period: AgentBudgetConfig['period']): number {
+  return period === 'week' ? WEEK_MS : DAY_MS;
+}
+
+/**
+ * Mutable per-period spend accumulator. Anchored at the first spend of a window;
+ * a window that has fully elapsed is rolled (reset) on the next spend or read.
+ */
+export interface BudgetState {
+  /** Epoch-ms anchor of the active window. */
+  periodStartMs: number;
+  /** Total tokens spent in the active window. */
+  spentTokens: number;
+  /** Per-fleet token spend in the active window (fleet key → tokens). */
+  perFleetSpent: Record<string, number>;
+}
+
+/** Fresh, empty budget state anchored at `nowMs`. */
+export function createBudgetState(nowMs: number): BudgetState {
+  return { periodStartMs: nowMs, spentTokens: 0, perFleetSpent: {} };
+}
+
+/** Deep clone (the state machine clones the whole {@link OrchestratorState} per event). */
+export function cloneBudgetState(state: BudgetState): BudgetState {
+  return {
+    periodStartMs: state.periodStartMs,
+    spentTokens: state.spentTokens,
+    perFleetSpent: { ...state.perFleetSpent },
+  };
+}
+
+/** True when the active window has fully elapsed by `nowMs`. */
+function windowElapsed(
+  state: BudgetState,
+  period: AgentBudgetConfig['period'],
+  nowMs: number
+): boolean {
+  return nowMs - state.periodStartMs >= periodLengthMs(period);
+}
+
+/**
+ * Roll the window if it has elapsed, returning a FRESH state anchored at
+ * `nowMs`; otherwise return `state` unchanged (referentially, so callers can
+ * cheaply detect a roll). Read paths use this to report a rolled window's spend
+ * as zero without mutating; the write path (`recordBudgetSpend`) rolls before
+ * accruing so a new window starts clean.
+ */
+export function rollBudgetPeriod(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  nowMs: number
+): BudgetState {
+  if (windowElapsed(state, config.period, nowMs)) {
+    return createBudgetState(nowMs);
+  }
+  return state;
+}
+
+/**
+ * Attribute an issue to a fleet for per-fleet accounting. Reads the first label
+ * matching the configured prefix (default `fleet:`) and returns the suffix.
+ * Returns `null` when no fleet label is present — the lane then counts only
+ * against the global envelope.
+ */
+export function fleetKeyForIssue(issue: Issue, config: AgentBudgetConfig): string | null {
+  const prefix = config.fleetLabelPrefix ?? DEFAULT_FLEET_LABEL_PREFIX;
+  for (const label of issue.labels ?? []) {
+    if (label.startsWith(prefix) && label.length > prefix.length) {
+      return label.slice(prefix.length);
+    }
+  }
+  return null;
+}
+
+/**
+ * Record `tokens` of spend against the global envelope and (when attributed) the
+ * `fleetKey` sub-allocation. Rolls an elapsed window first, so spend always
+ * accrues into the current period. Returns a NEW state (never mutates the
+ * argument). Non-positive token counts are ignored.
+ */
+export function recordBudgetSpend(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  fleetKey: string | null,
+  tokens: number,
+  nowMs: number
+): BudgetState {
+  const rolled = rollBudgetPeriod(state, config, nowMs);
+  const next = cloneBudgetState(rolled);
+  if (tokens > 0) {
+    next.spentTokens += tokens;
+    if (fleetKey) {
+      next.perFleetSpent[fleetKey] = (next.perFleetSpent[fleetKey] ?? 0) + tokens;
+    }
+  }
+  return next;
+}
+
+/** Effective spend for the active window, treating an elapsed window as zero. */
+function effectiveSpend(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  nowMs: number
+): { global: number; perFleet: Record<string, number> } {
+  if (windowElapsed(state, config.period, nowMs)) {
+    return { global: 0, perFleet: {} };
+  }
+  return { global: state.spentTokens, perFleet: state.perFleetSpent };
+}
+
+/**
+ * True once the GLOBAL envelope is spent. A breach here stops dispatch for
+ * EVERY fleet at the next lane boundary — the clean, whole-run stop.
+ */
+export function isGlobalEnvelopeExhausted(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  nowMs: number
+): boolean {
+  return effectiveSpend(state, config, nowMs).global >= config.envelopeTokens;
+}
+
+/**
+ * True once `fleetKey`'s sub-allocation is spent while the global envelope may
+ * still have room. A breach here skips only THIS fleet's lanes — sibling fleets
+ * keep dispatching — so two fleets sharing an envelope respect their split under
+ * contention. `null`/unconfigured fleet ⇒ never fleet-exhausted (bounded only by
+ * the global envelope).
+ */
+export function isFleetAllocationExhausted(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  fleetKey: string | null,
+  nowMs: number
+): boolean {
+  if (!fleetKey) return false;
+  const allocation = config.perFleet?.[fleetKey];
+  if (allocation === undefined) return false;
+  return (effectiveSpend(state, config, nowMs).perFleet[fleetKey] ?? 0) >= allocation;
+}
+
+/**
+ * The governor's dispatch verdict: may a NEW lane for `fleetKey` be dispatched
+ * without breaching the global envelope OR the fleet's sub-allocation?
+ *
+ * Read-only. Used where a single lane is redispatched (the retry path): a breach
+ * at either level parks the lane. The tick dispatch loop instead calls the two
+ * predicates above directly, because global vs. per-fleet exhaustion differ in
+ * whether they stop the whole loop or skip one lane.
+ */
+export function canAffordDispatch(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  fleetKey: string | null,
+  nowMs: number
+): boolean {
+  return (
+    !isGlobalEnvelopeExhausted(state, config, nowMs) &&
+    !isFleetAllocationExhausted(state, config, fleetKey, nowMs)
+  );
+}
+
+/**
+ * Operator-visible remaining-budget signal (#1525). Surfaced in the orchestrator
+ * snapshot so an operator sees how much of the envelope is left. Reports an
+ * elapsed window as a fresh (fully-remaining) period.
+ */
+export function getBudgetStatus(
+  state: BudgetState,
+  config: AgentBudgetConfig,
+  nowMs: number
+): BudgetEnvelopeStatus {
+  const elapsed = windowElapsed(state, config.period, nowMs);
+  const periodStartMs = elapsed ? nowMs : state.periodStartMs;
+  const spend = effectiveSpend(state, config, nowMs);
+
+  const allocations: Record<string, number> = config.perFleet ?? {};
+  const perFleet: FleetBudgetStatus[] = Object.entries(allocations).map(
+    ([fleet, allocatedTokens]) => {
+      const spentTokens = spend.perFleet[fleet] ?? 0;
+      const remainingTokens = Math.max(allocatedTokens - spentTokens, 0);
+      return {
+        fleet,
+        allocatedTokens,
+        spentTokens,
+        remainingTokens,
+        exhausted: spentTokens >= allocatedTokens,
+      };
+    }
+  );
+
+  const spentTokens = spend.global;
+  return {
+    period: config.period,
+    periodStartMs,
+    periodEndMs: periodStartMs + periodLengthMs(config.period),
+    envelopeTokens: config.envelopeTokens,
+    spentTokens,
+    remainingTokens: Math.max(config.envelopeTokens - spentTokens, 0),
+    exhausted: spentTokens >= config.envelopeTokens,
+    perFleet,
+  };
+}

--- a/packages/orchestrator/src/core/concurrency.ts
+++ b/packages/orchestrator/src/core/concurrency.ts
@@ -1,4 +1,18 @@
+import type { AgentBudgetConfig } from '@harness-engineering/types';
 import type { OrchestratorState, RunningEntry } from '../types/internal';
+import { canAffordDispatch } from './budget-governor';
+
+/**
+ * Budget-governor inputs threaded into {@link canDispatch} (#1525). Absent ⇒ the
+ * governor is off and dispatch is bounded only by concurrency/rate limits (the
+ * pre-#1525 behaviour).
+ */
+export interface DispatchBudgetOptions {
+  config: AgentBudgetConfig;
+  /** Fleet the candidate lane belongs to, for per-fleet sub-allocation. */
+  fleetKey: string | null;
+  nowMs: number;
+}
 
 /**
  * Get the number of available global concurrency slots.
@@ -26,8 +40,21 @@ export function getPerStateCount(running: ReadonlyMap<string, RunningEntry>): Ma
 export function canDispatch(
   state: OrchestratorState,
   issueState: string,
-  maxConcurrentAgentsByState: Record<string, number>
+  maxConcurrentAgentsByState: Record<string, number>,
+  budget?: DispatchBudgetOptions
 ): boolean {
+  // #1525: spend-envelope check. Refuse a NEW lane once the period envelope (or
+  // this fleet's sub-allocation) is spent. Lanes already in `running` are never
+  // touched, so dispatch stops cleanly at a lane boundary — never mid-write.
+  // Off (`state.budget === null` or no `budget` opts) ⇒ unbounded, pre-#1525.
+  if (
+    state.budget &&
+    budget &&
+    !canAffordDispatch(state.budget, budget.config, budget.fleetKey, budget.nowMs)
+  ) {
+    return false;
+  }
+
   // Global cooldown check
   if (state.globalCooldownUntilMs && Date.now() < state.globalCooldownUntilMs) {
     return false;

--- a/packages/orchestrator/src/core/index.ts
+++ b/packages/orchestrator/src/core/index.ts
@@ -1,6 +1,20 @@
 export { calculateRetryDelay } from './retry';
 export { sortCandidates, isEligible, selectCandidates } from './candidate-selection';
 export { getAvailableSlots, getPerStateCount, canDispatch } from './concurrency';
+export type { DispatchBudgetOptions } from './concurrency';
+export {
+  createBudgetState,
+  cloneBudgetState,
+  rollBudgetPeriod,
+  recordBudgetSpend,
+  canAffordDispatch,
+  isGlobalEnvelopeExhausted,
+  isFleetAllocationExhausted,
+  getBudgetStatus,
+  fleetKeyForIssue,
+  periodLengthMs,
+} from './budget-governor';
+export type { BudgetState } from './budget-governor';
 export { reconcile } from './reconciliation';
 export { detectScopeTier, routeIssue, artifactPresenceFromIssue } from './model-router';
 export type { ArtifactPresence } from './model-router';

--- a/packages/orchestrator/src/core/state-helpers.ts
+++ b/packages/orchestrator/src/core/state-helpers.ts
@@ -1,5 +1,6 @@
 import type { OrchestratorState } from '../types/internal';
 import type { WorkflowConfig } from '@harness-engineering/types';
+import { createBudgetState } from './budget-governor';
 
 const RATE_LIMIT_DEFAULTS = {
   globalCooldownMs: 60000,
@@ -49,5 +50,8 @@ export function createEmptyState(config: WorkflowConfig): OrchestratorState {
       tokensLimit: null,
     },
     claimRejections: 0,
+    // #1525: arm the spend-envelope accumulator only when a budget is configured;
+    // otherwise the governor is off and dispatch is unbounded (pre-#1525 behaviour).
+    budget: config.agent.budget ? createBudgetState(Date.now()) : null,
   };
 }

--- a/packages/orchestrator/src/core/state-machine.ts
+++ b/packages/orchestrator/src/core/state-machine.ts
@@ -14,7 +14,14 @@ import type {
   TickEvent,
 } from '../types/events';
 import { selectCandidates } from './candidate-selection';
-import { canDispatch } from './concurrency';
+import { canDispatch, type DispatchBudgetOptions } from './concurrency';
+import {
+  cloneBudgetState,
+  fleetKeyForIssue,
+  recordBudgetSpend,
+  isGlobalEnvelopeExhausted,
+  isFleetAllocationExhausted,
+} from './budget-governor';
 import { reconcile } from './reconciliation';
 import { calculateRetryDelay } from './retry';
 import { detectScopeTier, routeIssue, artifactPresenceFromIssue } from './model-router';
@@ -34,6 +41,24 @@ export interface ApplyEventResult {
 }
 
 /**
+ * Build the #1525 budget-governor inputs for a dispatch decision, or `undefined`
+ * when the governor is off. Attributes the candidate lane to its fleet (issue
+ * label) so `canDispatch` can honour the per-fleet sub-allocation.
+ */
+function dispatchBudgetOptions(
+  config: WorkflowConfig,
+  issue: Issue
+): DispatchBudgetOptions | undefined {
+  const budgetConfig = config.agent.budget;
+  if (!budgetConfig) return undefined;
+  return {
+    config: budgetConfig,
+    fleetKey: fleetKeyForIssue(issue, budgetConfig),
+    nowMs: Date.now(),
+  };
+}
+
+/**
  * Clone the state for immutable transitions.
  * Maps and Sets are shallow-cloned; entries within them are not deeply copied
  * since we only add/remove entries, not mutate them in place.
@@ -50,6 +75,7 @@ function cloneState(state: OrchestratorState): OrchestratorState {
     completed: new Map(state.completed),
     tokenTotals: { ...state.tokenTotals },
     rateLimits: { ...state.rateLimits },
+    budget: state.budget ? cloneBudgetState(state.budget) : null,
   };
 }
 
@@ -422,9 +448,25 @@ function handleTick(
 
   const escalationConfig = resolveEscalationConfig(config);
 
+  const budgetConfig = config.agent.budget;
   for (const issue of eligible) {
+    // #1525: consult the spend-envelope governor BEFORE dispatching this lane.
+    // Global exhaustion stops the whole loop cleanly (no lane started mid-write);
+    // a single fleet's sub-allocation exhaustion skips only that fleet's lanes so
+    // sibling fleets keep dispatching under a shared envelope.
+    if (next.budget && budgetConfig) {
+      const now = Date.now();
+      if (isGlobalEnvelopeExhausted(next.budget, budgetConfig, now)) {
+        break;
+      }
+      const fleetKey = fleetKeyForIssue(issue, budgetConfig);
+      if (isFleetAllocationExhausted(next.budget, budgetConfig, fleetKey, now)) {
+        continue;
+      }
+    }
+
     if (!canDispatch(next, issue.state, config.agent.maxConcurrentAgentsByState)) {
-      break; // No more slots available
+      break; // No more slots available (concurrency or rate limit)
     }
 
     const peslAbort = tryPeslAbort(issue, event);
@@ -569,7 +611,8 @@ function accrueUsage(
   session: LiveSession,
   issueId: string,
   usage: NonNullable<AgentEvent['usage']>,
-  effects: SideEffect[]
+  effects: SideEffect[],
+  config: WorkflowConfig
 ): void {
   session.inputTokens += usage.inputTokens;
   session.outputTokens += usage.outputTokens;
@@ -587,13 +630,25 @@ function accrueUsage(
   next.recentInputTokens = next.recentInputTokens.filter((t) => now - t.timestamp < 60000);
   next.recentOutputTokens = next.recentOutputTokens.filter((t) => now - t.timestamp < 60000);
 
+  // #1525: accrue the same token spend against the dispatch spend-envelope so a
+  // later dispatch is refused once the period is exhausted. Attribute to the
+  // lane's fleet (issue label) for per-fleet sub-allocation. No-op when the
+  // governor is off (`budget === null`).
+  const budgetConfig = config.agent.budget;
+  if (next.budget && budgetConfig) {
+    const issue = next.running.get(issueId)?.issue;
+    const fleetKey = issue ? fleetKeyForIssue(issue, budgetConfig) : null;
+    next.budget = recordBudgetSpend(next.budget, budgetConfig, fleetKey, usage.totalTokens, now);
+  }
+
   effects.push({ type: 'updateTokens', issueId, usage });
 }
 
 function handleAgentUpdate(
   state: OrchestratorState,
   issueId: string,
-  event: AgentEvent
+  event: AgentEvent,
+  config: WorkflowConfig
 ): ApplyEventResult {
   const next = cloneState(state);
   const effects: SideEffect[] = [];
@@ -616,7 +671,7 @@ function handleAgentUpdate(
   const entry = next.running.get(issueId);
   if (entry && entry.session) {
     const { session: updatedSession, nextPhase } = deriveSessionPatch(entry.session, event);
-    if (event.usage) accrueUsage(next, updatedSession, issueId, event.usage, effects);
+    if (event.usage) accrueUsage(next, updatedSession, issueId, event.usage, effects, config);
     next.running.set(issueId, {
       ...entry,
       phase: nextPhase ?? entry.phase,
@@ -673,7 +728,14 @@ function handleRetryFired(
   }
 
   // Check slots
-  if (!canDispatch(next, issue.state, config.agent.maxConcurrentAgentsByState)) {
+  if (
+    !canDispatch(
+      next,
+      issue.state,
+      config.agent.maxConcurrentAgentsByState,
+      dispatchBudgetOptions(config, issue)
+    )
+  ) {
     // Requeue with incremented attempt
     const nextAttempt = retryEntry.attempt + 1;
     const maxRetries = config.agent.maxRetries ?? 5;
@@ -819,7 +881,7 @@ export function applyEvent(
         config
       );
     case 'agent_update':
-      return handleAgentUpdate(state, event.issueId, event.event);
+      return handleAgentUpdate(state, event.issueId, event.event, config);
     case 'retry_fired':
       return handleRetryFired(
         state,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -33,6 +33,7 @@ import type { OrchestratorState, LiveSession, RunningEntry } from './types/inter
 import type { OrchestratorEvent, SideEffect } from './types/events';
 import { applyEvent } from './core/state-machine';
 import { createEmptyState } from './core/state-helpers';
+import { getBudgetStatus } from './core/budget-governor';
 import { detectStalledIssues } from './core/stall-detector';
 import { AnalysisArchive } from './core/analysis-archive';
 import { IntelligencePipelineRunner } from './intelligence/pipeline-runner';
@@ -5032,6 +5033,12 @@ export class Orchestrator extends EventEmitter {
       maxOutputTokensPerMinute: this.state.maxOutputTokensPerMinute,
       claimRejections: this.state.claimRejections,
       tickActivity: this.tickActivity,
+      // #1525: operator-visible remaining-budget signal. `null` when the
+      // unattended-dispatch governor is off (no `agent.budget` configured).
+      budget:
+        this.state.budget && this.config.agent.budget
+          ? getBudgetStatus(this.state.budget, this.config.agent.budget, now)
+          : null,
     };
   }
 

--- a/packages/orchestrator/src/types/internal.ts
+++ b/packages/orchestrator/src/types/internal.ts
@@ -1,4 +1,5 @@
 import type { Issue, WorkflowExecutionPlan, StageRun } from '@harness-engineering/types';
+import type { BudgetState } from '../core/budget-governor';
 
 /**
  * Run attempt lifecycle phases (internal to orchestrator).
@@ -131,4 +132,10 @@ export interface OrchestratorState {
   rateLimits: RateLimitSnapshot;
   /** Running count of claim rejections (another orchestrator won the race). */
   claimRejections: number;
+  /**
+   * Unattended-dispatch spend envelope accumulator (#1525), or `null` when no
+   * `agent.budget` is configured (governor off — unbounded dispatch). When
+   * present, `canDispatch` refuses a NEW lane once the period envelope is spent.
+   */
+  budget: BudgetState | null;
 }

--- a/packages/orchestrator/src/workflow/config.ts
+++ b/packages/orchestrator/src/workflow/config.ts
@@ -15,6 +15,7 @@ import {
   RoutingConfigSchema,
   StagedWorkflowDeclSchema,
   RoadmapConfigSchema,
+  AgentBudgetSchema,
 } from './schema.js';
 
 const REQUIRED_SECTIONS = ['tracker', 'polling', 'workspace', 'hooks', 'agent', 'server'] as const;
@@ -223,6 +224,14 @@ export function validateWorkflowConfig(
     agent.backends !== undefined && typeof agent.backends === 'object' && agent.backends !== null;
   if (!hasLegacyBackend && !hasModernBackends) {
     return Err(new Error('Config must define agent.backend or agent.backends.'));
+  }
+
+  // #1525: validate the unattended-dispatch spend envelope when present. Absent ⇒
+  // governor off (unchanged). A malformed field is rejected at config-load (the
+  // strict schema) rather than silently disabling the budget (the AMR trap).
+  if (agent.budget !== undefined) {
+    const parsed = AgentBudgetSchema.safeParse(agent.budget);
+    if (!parsed.success) return Err(new Error(`agent.budget: ${parsed.error.message}`));
   }
 
   // Modern path: validate the new shape via Phase 0's Zod schemas + the

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -7,6 +7,7 @@ import type {
   RoadmapConfig,
   RoadmapAutoTriageConfig,
   McpServerSpec,
+  AgentBudgetConfig,
 } from '@harness-engineering/types';
 
 /**
@@ -347,6 +348,26 @@ const _roadmapGuard = (r: RoadmapConfig): z.infer<typeof RoadmapConfigSchema> =>
 const _autoTriageGuard = (t: RoadmapAutoTriageConfig): z.infer<typeof RoadmapAutoTriageSchema> => t;
 void _roadmapGuard;
 void _autoTriageGuard;
+
+/**
+ * #1525 unattended-dispatch spend envelope. `.strict()` so a typo'd field fails
+ * at config-load rather than silently disabling the governor (the AMR trap).
+ * `envelopeTokens` and every per-fleet allocation must be positive integers —
+ * a zero or negative cap would stop all dispatch, which is a misconfiguration,
+ * not a valid "off" switch (omit `budget` entirely to turn the governor off).
+ */
+export const AgentBudgetSchema = z
+  .object({
+    period: z.enum(['day', 'week']),
+    envelopeTokens: z.number().int().positive(),
+    perFleet: z.record(z.string().min(1), z.number().int().positive()).optional(),
+    fleetLabelPrefix: z.string().min(1).optional(),
+  })
+  .strict();
+
+// Drift guard: schema output must be assignable to the canonical type.
+const _budgetGuard = (b: AgentBudgetConfig): z.infer<typeof AgentBudgetSchema> => b;
+void _budgetGuard;
 
 /**
  * split-routing D7: Zod schema for a workflow STEP (a stage in a declared

--- a/packages/orchestrator/tests/core/budget-governor.behavior.test.ts
+++ b/packages/orchestrator/tests/core/budget-governor.behavior.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentBudgetConfig, Issue } from '@harness-engineering/types';
+import {
+  createBudgetState,
+  recordBudgetSpend,
+  canAffordDispatch,
+  getBudgetStatus,
+  fleetKeyForIssue,
+  periodLengthMs,
+  rollBudgetPeriod,
+} from '../../src/core/budget-governor';
+
+const T0 = 1_700_000_000_000; // fixed epoch anchor
+
+function makeIssue(labels: string[]): Issue {
+  return {
+    id: 'i',
+    identifier: 'I-1',
+    title: 't',
+    description: null,
+    priority: null,
+    state: 'planned',
+    branchName: null,
+    url: null,
+    labels,
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: null,
+    updatedAt: null,
+    externalId: null,
+  };
+}
+
+const dayBudget: AgentBudgetConfig = { period: 'day', envelopeTokens: 1000 };
+
+describe('budget-governor: global envelope', () => {
+  it('affords dispatch while spend is below the envelope', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, dayBudget, null, 400, T0);
+    expect(canAffordDispatch(s, dayBudget, null, T0)).toBe(true);
+  });
+
+  it('refuses a NEW dispatch once spend reaches the envelope', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, dayBudget, null, 1000, T0);
+    expect(canAffordDispatch(s, dayBudget, null, T0)).toBe(false);
+  });
+
+  it('treats an exact overshoot as exhausted (>=, not >)', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, dayBudget, null, 999, T0);
+    expect(canAffordDispatch(s, dayBudget, null, T0)).toBe(true);
+    s = recordBudgetSpend(s, dayBudget, null, 1, T0);
+    expect(canAffordDispatch(s, dayBudget, null, T0)).toBe(false);
+  });
+
+  it('ignores non-positive spend', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, dayBudget, null, 0, T0);
+    s = recordBudgetSpend(s, dayBudget, null, -50, T0);
+    expect(s.spentTokens).toBe(0);
+  });
+
+  it('does not mutate the input state (immutable record)', () => {
+    const s = createBudgetState(T0);
+    const next = recordBudgetSpend(s, dayBudget, null, 100, T0);
+    expect(s.spentTokens).toBe(0);
+    expect(next.spentTokens).toBe(100);
+  });
+});
+
+describe('budget-governor: period roll', () => {
+  it('resets spend when the window has fully elapsed', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, dayBudget, null, 1000, T0);
+    expect(canAffordDispatch(s, dayBudget, null, T0)).toBe(false);
+
+    const afterWindow = T0 + periodLengthMs('day');
+    // Read path reports the elapsed window as fully remaining...
+    expect(canAffordDispatch(s, dayBudget, null, afterWindow)).toBe(true);
+    // ...and the next spend rolls into a fresh window.
+    const rolled = recordBudgetSpend(s, dayBudget, null, 200, afterWindow);
+    expect(rolled.spentTokens).toBe(200);
+    expect(rolled.periodStartMs).toBe(afterWindow);
+  });
+
+  it('rollBudgetPeriod returns the same ref when the window has not elapsed', () => {
+    const s = createBudgetState(T0);
+    expect(rollBudgetPeriod(s, dayBudget, T0 + 1000)).toBe(s);
+  });
+
+  it('week period uses a 7-day window', () => {
+    expect(periodLengthMs('week')).toBe(7 * periodLengthMs('day'));
+  });
+});
+
+describe('budget-governor: per-fleet sub-allocation', () => {
+  const perFleet: AgentBudgetConfig = {
+    period: 'day',
+    envelopeTokens: 10_000,
+    perFleet: { roadmap: 600, bug: 400 },
+  };
+
+  it('refuses a fleet whose sub-allocation is spent even when the global envelope has room', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, perFleet, 'roadmap', 600, T0);
+    // Global still has 9,400 left, but roadmap's 600 is spent.
+    expect(canAffordDispatch(s, perFleet, 'roadmap', T0)).toBe(false);
+    // A different fleet under the same global envelope still dispatches.
+    expect(canAffordDispatch(s, perFleet, 'bug', T0)).toBe(true);
+  });
+
+  it('two fleets sharing an envelope respect their split under contention', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, perFleet, 'roadmap', 600, T0);
+    s = recordBudgetSpend(s, perFleet, 'bug', 400, T0);
+    expect(canAffordDispatch(s, perFleet, 'roadmap', T0)).toBe(false);
+    expect(canAffordDispatch(s, perFleet, 'bug', T0)).toBe(false);
+    // An unlabelled lane is still bounded only by the (unspent) global envelope.
+    expect(canAffordDispatch(s, perFleet, null, T0)).toBe(true);
+  });
+
+  it('a fleet with no configured sub-allocation is bounded only by the global envelope', () => {
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, perFleet, 'unlisted', 5000, T0);
+    expect(canAffordDispatch(s, perFleet, 'unlisted', T0)).toBe(true);
+  });
+});
+
+describe('budget-governor: fleetKeyForIssue', () => {
+  it('extracts the fleet key from the default fleet: label prefix', () => {
+    expect(fleetKeyForIssue(makeIssue(['fleet:roadmap', 'p1']), dayBudget)).toBe('roadmap');
+  });
+
+  it('returns null when no fleet label is present', () => {
+    expect(fleetKeyForIssue(makeIssue(['p1', 'bug']), dayBudget)).toBeNull();
+  });
+
+  it('honours a custom fleetLabelPrefix', () => {
+    const cfg: AgentBudgetConfig = { ...dayBudget, fleetLabelPrefix: 'family/' };
+    expect(fleetKeyForIssue(makeIssue(['family/security']), cfg)).toBe('security');
+  });
+});
+
+describe('budget-governor: remaining-budget signal', () => {
+  it('reports remaining, spent, and per-fleet slices', () => {
+    const cfg: AgentBudgetConfig = {
+      period: 'week',
+      envelopeTokens: 10_000,
+      perFleet: { roadmap: 600 },
+    };
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, cfg, 'roadmap', 250, T0);
+
+    const status = getBudgetStatus(s, cfg, T0);
+    expect(status.period).toBe('week');
+    expect(status.envelopeTokens).toBe(10_000);
+    expect(status.spentTokens).toBe(250);
+    expect(status.remainingTokens).toBe(9_750);
+    expect(status.exhausted).toBe(false);
+    expect(status.periodEndMs - status.periodStartMs).toBe(periodLengthMs('week'));
+
+    const roadmap = status.perFleet.find((f) => f.fleet === 'roadmap');
+    expect(roadmap).toMatchObject({
+      allocatedTokens: 600,
+      spentTokens: 250,
+      remainingTokens: 350,
+      exhausted: false,
+    });
+  });
+
+  it('reports an elapsed window as a fresh, fully-remaining period', () => {
+    const cfg: AgentBudgetConfig = { period: 'day', envelopeTokens: 1000 };
+    let s = createBudgetState(T0);
+    s = recordBudgetSpend(s, cfg, null, 1000, T0);
+    const after = T0 + periodLengthMs('day') + 1;
+    const status = getBudgetStatus(s, cfg, after);
+    expect(status.spentTokens).toBe(0);
+    expect(status.remainingTokens).toBe(1000);
+    expect(status.exhausted).toBe(false);
+  });
+});

--- a/packages/orchestrator/tests/core/budget-governor.wired.test.ts
+++ b/packages/orchestrator/tests/core/budget-governor.wired.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { applyEvent } from '../../src/core/state-machine';
+import { createEmptyState } from '../../src/core/state-helpers';
+import { recordBudgetSpend } from '../../src/core/budget-governor';
+import type { AgentBudgetConfig, Issue, WorkflowConfig } from '@harness-engineering/types';
+import type { OrchestratorEvent, ClaimEffect } from '../../src/types/events';
+import type { RunningEntry } from '../../src/types/internal';
+
+/**
+ * WIRED verification for #1525: the budget governor is consulted on the REAL
+ * dispatch path (`applyEvent(tick)` → `canDispatch`), stops dispatch cleanly at a
+ * lane boundary when the envelope is spent, and never touches a lane already in
+ * flight. Also proves the accrual path (`agent_update` usage → envelope spend).
+ */
+
+function makeConfig(budget?: AgentBudgetConfig): WorkflowConfig {
+  return {
+    tracker: {
+      kind: 'roadmap',
+      activeStates: ['planned', 'in-progress'],
+      terminalStates: ['done'],
+    },
+    polling: { intervalMs: 30000 },
+    workspace: { root: '/tmp/ws' },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 60000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 5,
+      maxTurns: 20,
+      maxRetryBackoffMs: 300000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: {},
+      turnTimeoutMs: 3600000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 300000,
+      ...(budget ? { budget } : {}),
+    },
+    server: { port: null },
+  } as WorkflowConfig;
+}
+
+function makeIssue(id: string, labels: string[] = ['scope:quick-fix']): Issue {
+  return {
+    id,
+    identifier: `A-${id}`,
+    title: `Issue ${id}`,
+    description: null,
+    priority: Number(id),
+    state: 'planned',
+    branchName: null,
+    url: null,
+    labels,
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: null,
+    externalId: null,
+  };
+}
+
+function tick(candidates: Issue[], nowMs = 1_706_745_600_000): OrchestratorEvent {
+  return { type: 'tick', candidates, runningStates: new Map(), nowMs };
+}
+
+function claims(effects: { type: string }[]): ClaimEffect[] {
+  return effects.filter((e) => e.type === 'claim') as ClaimEffect[];
+}
+
+describe('#1525 wired: governor gates the real dispatch path', () => {
+  it('governor off (no budget) dispatches normally', () => {
+    const config = makeConfig();
+    const state = createEmptyState(config);
+    expect(state.budget).toBeNull();
+    const { effects } = applyEvent(state, tick([makeIssue('1'), makeIssue('2')]), config);
+    expect(claims(effects)).toHaveLength(2);
+  });
+
+  it('dispatches while the envelope has room', () => {
+    const budget: AgentBudgetConfig = { period: 'day', envelopeTokens: 10_000 };
+    const config = makeConfig(budget);
+    const state = createEmptyState(config);
+    const { effects } = applyEvent(state, tick([makeIssue('1'), makeIssue('2')]), config);
+    expect(claims(effects)).toHaveLength(2);
+  });
+
+  it('stops dispatch cleanly once the envelope is spent — zero new claims', () => {
+    const budget: AgentBudgetConfig = { period: 'day', envelopeTokens: 1000 };
+    const config = makeConfig(budget);
+    const state = createEmptyState(config);
+    // Simulate a prior spend that exhausts the envelope.
+    state.budget = recordBudgetSpend(state.budget!, budget, null, 1000, Date.now());
+
+    const { effects, nextState } = applyEvent(
+      state,
+      tick([makeIssue('1'), makeIssue('2')]),
+      config
+    );
+    expect(claims(effects)).toHaveLength(0);
+    expect(nextState.claimed.size).toBe(0);
+  });
+
+  it('never touches a lane already in flight when the envelope is spent', () => {
+    const budget: AgentBudgetConfig = { period: 'day', envelopeTokens: 1000 };
+    const config = makeConfig(budget);
+    const state = createEmptyState(config);
+    state.budget = recordBudgetSpend(state.budget!, budget, null, 1000, Date.now());
+
+    // A lane already running.
+    const running: RunningEntry = {
+      issueId: 'running-1',
+      identifier: 'A-running',
+      issue: makeIssue('running-1'),
+      attempt: null,
+      workspacePath: '/tmp/ws/running-1',
+      startedAt: '2026-01-01T00:00:00Z',
+      phase: 'StreamingTurn',
+      session: null,
+    };
+    state.running.set('running-1', running);
+
+    const { nextState } = applyEvent(state, tick([makeIssue('2')]), config);
+    // In-flight lane survives; no new lane dispatched.
+    expect(nextState.running.has('running-1')).toBe(true);
+    expect(nextState.claimed.size).toBe(0);
+  });
+
+  it('honours per-fleet sub-allocation under contention on the dispatch path', () => {
+    const budget: AgentBudgetConfig = {
+      period: 'day',
+      envelopeTokens: 100_000,
+      perFleet: { roadmap: 500 },
+    };
+    const config = makeConfig(budget);
+    const state = createEmptyState(config);
+    // Exhaust roadmap's sub-allocation; global still has ample room.
+    state.budget = recordBudgetSpend(state.budget!, budget, 'roadmap', 500, Date.now());
+
+    const roadmapIssue = makeIssue('1', ['scope:quick-fix', 'fleet:roadmap']);
+    const bugIssue = makeIssue('2', ['scope:quick-fix', 'fleet:bug']);
+
+    const { effects } = applyEvent(state, tick([roadmapIssue, bugIssue]), config);
+    const claimed = claims(effects).map((c) => c.issue.id);
+    // roadmap is gated; bug (no exhausted allocation) still dispatches.
+    expect(claimed).toContain('2');
+    expect(claimed).not.toContain('1');
+  });
+});
+
+describe('#1525 wired: usage accrues against the envelope', () => {
+  it('agent_update usage records spend into the budget accumulator', () => {
+    const budget: AgentBudgetConfig = { period: 'day', envelopeTokens: 10_000 };
+    const config = makeConfig(budget);
+    const state = createEmptyState(config);
+
+    // Put a running lane with a live session so accrueUsage has an entry.
+    const running: RunningEntry = {
+      issueId: 'run-1',
+      identifier: 'A-run',
+      issue: makeIssue('run-1', ['fleet:roadmap']),
+      attempt: null,
+      workspacePath: '/tmp/ws/run-1',
+      startedAt: '2026-01-01T00:00:00Z',
+      phase: 'StreamingTurn',
+      session: {
+        sessionId: 's1',
+        backendName: 'mock',
+        agentPid: null,
+        startedAt: '2026-01-01T00:00:00Z',
+        lastEvent: null,
+        lastTimestamp: null,
+        lastMessage: null,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        lastReportedInputTokens: 0,
+        lastReportedOutputTokens: 0,
+        lastReportedTotalTokens: 0,
+        turnCount: 0,
+      },
+    };
+    state.running.set('run-1', running);
+
+    const event: OrchestratorEvent = {
+      type: 'agent_update',
+      issueId: 'run-1',
+      event: {
+        type: 'assistant',
+        usage: {
+          inputTokens: 300,
+          outputTokens: 200,
+          totalTokens: 500,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    };
+
+    const { nextState } = applyEvent(state, event, config);
+    expect(nextState.budget?.spentTokens).toBe(500);
+    // Attributed to the lane's fleet.
+    expect(nextState.budget?.perFleetSpent.roadmap).toBe(500);
+  });
+});

--- a/packages/orchestrator/tests/workflow/config.test.ts
+++ b/packages/orchestrator/tests/workflow/config.test.ts
@@ -1,6 +1,53 @@
 import { describe, it, expect } from 'vitest';
 import { validateWorkflowConfig, getDefaultConfig } from '../../src/workflow/config.js';
 
+describe('validateWorkflowConfig — #1525 budget governor', () => {
+  it('accepts a valid day/week envelope with per-fleet allocations', () => {
+    const cfg = getDefaultConfig();
+    (cfg.agent as Record<string, unknown>).budget = {
+      period: 'week',
+      envelopeTokens: 5_000_000,
+      perFleet: { roadmap: 2_000_000, bug: 1_000_000 },
+    };
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(true);
+  });
+
+  it('leaves the governor off when no budget is configured', () => {
+    const cfg = getDefaultConfig();
+    expect((cfg.agent as Record<string, unknown>).budget).toBeUndefined();
+    expect(validateWorkflowConfig(cfg).ok).toBe(true);
+  });
+
+  it('rejects a non-positive envelope (a zero cap would stall all dispatch)', () => {
+    const cfg = getDefaultConfig();
+    (cfg.agent as Record<string, unknown>).budget = { period: 'day', envelopeTokens: 0 };
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/agent\.budget/);
+  });
+
+  it('rejects an unknown period', () => {
+    const cfg = getDefaultConfig();
+    (cfg.agent as Record<string, unknown>).budget = { period: 'month', envelopeTokens: 100 };
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/agent\.budget/);
+  });
+
+  it('rejects a typo’d field (strict schema, not silently dropped)', () => {
+    const cfg = getDefaultConfig();
+    (cfg.agent as Record<string, unknown>).budget = {
+      period: 'day',
+      envelopeTokens: 100,
+      envelopTokens: 999, // typo
+    };
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/agent\.budget/);
+  });
+});
+
 describe('validateWorkflowConfig — backend requirement (Spec 2 SC15)', () => {
   it('rejects a config with neither agent.backend nor agent.backends set', () => {
     const cfg = getDefaultConfig();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -141,6 +141,10 @@ export type {
   WorkspaceConfig,
   HooksConfig,
   AgentConfig,
+  // --- #1525: unattended-dispatch budget governor ---
+  AgentBudgetConfig,
+  BudgetEnvelopeStatus,
+  FleetBudgetStatus,
   ServerConfig,
   WorkflowConfig,
   RoadmapConfig,

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -1099,6 +1099,76 @@ export interface AgentConfig {
   container?: ContainerConfig;
   /** Secret injection configuration */
   secrets?: SecretConfig;
+  /**
+   * Unattended-dispatch spend envelope (#1525). When set, the orchestrator
+   * refuses to dispatch a NEW lane once the period's token envelope is spent —
+   * lanes already in flight run to completion, so dispatch stops cleanly at a
+   * lane boundary, never mid-write. Unset ⇒ the governor is off (unbounded,
+   * the pre-#1525 behaviour). See {@link AgentBudgetConfig}.
+   */
+  budget?: AgentBudgetConfig;
+}
+
+/**
+ * Spend-envelope configuration for unattended dispatch (#1525).
+ *
+ * The envelope is denominated in **total tokens** (input + output), the same
+ * unit the orchestrator already accrues in `tokenTotals`, so envelope
+ * accounting reconciles with burn attribution without a separate cost model.
+ * A `week` period is aligned to a rolling window anchored at first spend.
+ */
+export interface AgentBudgetConfig {
+  /** Accounting period. Envelope resets at the start of each new window. */
+  period: 'day' | 'week';
+  /** Global spend envelope for the period, in total tokens. */
+  envelopeTokens: number;
+  /**
+   * Optional per-fleet sub-allocations (fleet key → token cap). A fleet whose
+   * sub-allocation is spent stops dispatching even while the global envelope has
+   * room, so two fleets sharing one envelope respect their split under
+   * contention. Fleets absent from this map are bounded only by the global
+   * envelope.
+   */
+  perFleet?: Record<string, number>;
+  /**
+   * Issue-label prefix used to attribute a lane to a fleet for per-fleet
+   * accounting. An issue labelled `fleet:roadmap` is attributed to fleet
+   * `roadmap`. Defaults to `fleet:`.
+   */
+  fleetLabelPrefix?: string;
+}
+
+/**
+ * Per-fleet slice of a {@link BudgetEnvelopeStatus}.
+ */
+export interface FleetBudgetStatus {
+  /** Fleet key (the label suffix after {@link AgentBudgetConfig.fleetLabelPrefix}). */
+  fleet: string;
+  allocatedTokens: number;
+  spentTokens: number;
+  remainingTokens: number;
+  /** True once `spentTokens >= allocatedTokens` — this fleet stops dispatching. */
+  exhausted: boolean;
+}
+
+/**
+ * Operator-visible remaining-budget signal for the unattended-dispatch governor
+ * (#1525). Surfaced in the orchestrator snapshot (CLI + dashboard) so an
+ * operator can see how much of the period envelope is left before enabling
+ * unattended operation.
+ */
+export interface BudgetEnvelopeStatus {
+  period: 'day' | 'week';
+  /** Epoch-ms start of the active window. */
+  periodStartMs: number;
+  /** Epoch-ms end of the active window (`periodStartMs + period length`). */
+  periodEndMs: number;
+  envelopeTokens: number;
+  spentTokens: number;
+  remainingTokens: number;
+  /** True once `spentTokens >= envelopeTokens` — no new lane will be dispatched. */
+  exhausted: boolean;
+  perFleet: FleetBudgetStatus[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a **budget governor for unattended dispatch** (#1525) so 168-hour operation is safe to enable. The orchestrator now enforces a per-period **spend envelope** on the real dispatch path and stops dispatching new lanes cleanly at a lane boundary once the envelope is reached — a lane already in flight is never interrupted (never mid-write).

Denominated in **total tokens** (input + output), the unit already accrued in `OrchestratorState.tokenTotals`, so envelope accounting reconciles with burn attribution without a separate cost model. The governor is **off** when `agent.budget` is not configured (unbounded dispatch, pre-#1525 behaviour).

- **Global envelope exhausted** → the whole tick dispatch loop stops for every fleet (clean, whole-run stop).
- **A single fleet's sub-allocation exhausted** → only that fleet's lanes are skipped; sibling fleets sharing the envelope keep dispatching, so two fleets respect their split under contention.

## Wiring

- **Live dispatch call site:** `packages/orchestrator/src/core/state-machine.ts` — the `applyEvent` → `handleTick` **tick dispatch loop** consults the governor before dispatching each eligible lane (`isGlobalEnvelopeExhausted` → `break`; `isFleetAllocationExhausted` → `continue`). The retry dispatch path calls `canDispatch(..., dispatchBudgetOptions(issue))` in `packages/orchestrator/src/core/concurrency.ts`. Spend accrues in `accrueUsage()` via `recordBudgetSpend(...)`.
- **Config keys adopters set** (orchestrator workflow config `agent` section, next to `maxConcurrentAgents` / rate limits): `agent.budget.period` (`day`|`week`), `agent.budget.envelopeTokens`, `agent.budget.perFleet` (fleet → token cap), `agent.budget.fleetLabelPrefix` (default `fleet:`). Strict-validated via `AgentBudgetSchema` in `validateWorkflowConfig`.
- **Remaining-budget signal:** `Orchestrator.getSnapshot().budget` (`BudgetEnvelopeStatus`) — surfaced via `GET /api/state`, the TUI, and the dashboard.
- Fleet attribution is by issue label (`fleet:roadmap` → fleet `roadmap`).
- New exports live in `@harness-engineering/orchestrator` (not `@harness-engineering/core`), so `generate-core-barrel.mjs` is not involved.

## Tests

- `budget-governor.behavior.test.ts` — envelope exhaustion, per-fleet contention, period roll, immutability, fleet-key attribution, remaining-budget signal.
- `budget-governor.wired.test.ts` — WIRED: `applyEvent(tick)` stops dispatch at the envelope while an in-flight lane keeps running; per-fleet contention on the real dispatch path; usage accrual against the envelope.
- `config.test.ts` — `agent.budget` validation (valid, off, non-positive, unknown period, typo'd field).

## Artifacts

- Plan: `docs/changes/unattended-budget-governor/plans/plan.md`
- Provenance: `docs/changes/unattended-budget-governor/provenance.json`
- Docs: Budget Governor section added to `docs/guides/orchestrator-api.md`; `docs/reference/*` regenerated.

## Scope

`Refs #1525` — delivers the safe-to-enable core (governor primitive + envelope enforcement + per-fleet allocation + remaining-budget signal). Deferred follow-ups: the thin cron scheduler primitive (#1405), dollar-cost burn reconciliation, and dashboard UI rendering of the `budget` snapshot field.

## Assumptions made

See `docs/changes/unattended-budget-governor/provenance.json` `assumptions[]`. Key ones:
- Envelope unit is total tokens (reconciles with existing `tokenTotals`); dollar-cost reconciliation is deferred.
- Governor off = omit `agent.budget`; caps must be positive integers (a zero cap would stall all dispatch).
- Rolling window anchored at first spend (not calendar-aligned).
- Coordination with sibling lanes #1524 / #1532: `concurrency.ts` gains an **optional** `DispatchBudgetOptions` param and `state-machine.ts` adds governor checks *before* the existing `canDispatch` call — both additive and backward-compatible.

Refs #1525
