### PR TITLE
feat(fleet): rate-limit-aware fan-out — per-resource API budgets, shared backoff, fail-on-truncation (#1532)

### DIFF
--- a/.changeset/rate-limit-aware-fanout.md
+++ b/.changeset/rate-limit-aware-fanout.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/types': minor
+---
+
+Rate-limit-aware fan-out (#1532): add a per-resource API budget primitive
+(`RateBudget` + `sharedRateBudget` in `@harness-engineering/core` `fleet/rate-budget`)
+with shared cross-leaf backoff and typed `ThrottledFetchError` / `TruncatedFetchError`.
+The GitHub HTTP layer (`GitHubHttp`) now acquires the shared budget before every
+fetch, penalizes it on 403/429, and FAILS the leaf on a terminal throttle or a
+server-truncated page instead of returning partial/silent-zero data. Adopters tune
+budgets via the new `AgentConfig.resourceBudgets` config key (defaulted in
+`getDefaultConfig`, applied to the shared budget at orchestrator startup).

--- a/docs/changes/rate-limit-aware-fanout/plans/plan.md
+++ b/docs/changes/rate-limit-aware-fanout/plans/plan.md
@@ -1,0 +1,41 @@
+# Plan — Rate-limit-aware fan-out (#1532)
+
+Spec: `docs/changes/rate-limit-aware-fanout/proposal.md`
+Closing keyword: `Refs #1532` (smallest coherent slice; broader per-API coverage + cross-process sharing deferred).
+
+## Phase 1 — Per-resource budget primitive (core)
+
+- **T1.1** Add `packages/core/src/fleet/rate-budget/types.ts` — `ResourceBudgetConfig { limit, windowMs }`.
+- **T1.2** Add `packages/core/src/fleet/rate-budget/errors.ts` — `ThrottledFetchError`, `TruncatedFetchError` (carry `resource`, and `url` for truncation).
+- **T1.3** Add `packages/core/src/fleet/rate-budget/budget.ts` — `RateBudget` class:
+  - `configure(resource, cfg)`, `delayFor(resource, now): number` (pure: rolling-window count vs limit + `cooldownUntil`), `penalize(resource, cooldownMs, now?)`, `acquire(resource, now?): Promise<void>` (sleep `delayFor`, re-check, record timestamp).
+  - Module singleton `sharedRateBudget`.
+  - Pure applier `applyResourceBudgets(budget, map?)`.
+- **T1.4** `packages/core/src/fleet/rate-budget/index.ts` barrel; re-export from `packages/core/src/fleet/index.ts`.
+- **T1.5** Unit tests `packages/core/tests/fleet/rate-budget/budget.test.ts` — SC1 (delayFor limit boundary, clock-injected), SC2 (penalize shared cooldown observed by a second reader), applier copies config.
+- **T1.6** `pnpm run generate:barrels` → confirm `--check` clean (fleet is `export *`-discovered; edit `scripts/generate-core-barrel.mjs` only if not).
+
+## Phase 2 — Wire into GitHubHttp (core, live fetch path)
+
+- **T2.1** `GitHubHttpOptions` gains `budget?: RateBudget` (default `sharedRateBudget`) + `resource?: string` (default `'github.core'`).
+- **T2.2** `request()` → `await this.budget.acquire(this.resource)` before fetch.
+- **T2.3** `fetchWithRetry()` → on 403/429 with `Retry-After`, `budget.penalize(resource, retryAfterMs)`; on terminal throttle (last is 403/429 after retries) **throw `ThrottledFetchError`** (was: return `last!`).
+- **T2.4** `paginate()` → throw `TruncatedFetchError` on `incomplete_results: true`; propagate the terminal-throttle throw (never return partial `items`).
+- **T2.5** Tests `packages/core/tests/roadmap/tracker/adapters/github-http.behavior.test.ts` — injected `fetchFn` + injected `budget`: SC3 (acquire consulted — pre-penalized budget delays), SC4 (terminal throttle throws), SC5 (truncation throws, no partial return). Keep zero-real-network.
+
+## Phase 3 — Adopter config (types + orchestrator)
+
+- **T3.1** `AgentConfig.resourceBudgets?: Record<string, ResourceBudgetConfig>` in `packages/types/src/orchestrator.ts` (+ export `ResourceBudgetConfig` type from types, or reference structurally). Keep `exactOptionalPropertyTypes` clean.
+- **T3.2** `packages/orchestrator/src/workflow/config.ts` — optional Zod validation of `resourceBudgets` (reject malformed); `getDefaultConfig()` ships default map (`github.search: 10/60000`, `github.core: 80/60000`).
+- **T3.3** Orchestrator startup calls `applyResourceBudgets(sharedRateBudget, config.agent.resourceBudgets)` so the config key is live (consumer wiring).
+- **T3.4** Tests: config validation accept/reject; applier wiring.
+
+## Phase 4 — Docs, barrels, provenance
+
+- **T4.1** `pnpm run generate:barrels`, `pnpm run generate-docs` — commit regenerated `docs/reference/*`.
+- **T4.2** `provenance.json` (issue 1532, stages, plan_path, closing_keyword, assumptions).
+- **T4.3** Build CLI, run scoped tests + typecheck + lint; ship through pre-push gates (no `--no-verify`).
+
+## Verification (WIRED)
+
+Reviewer traces: `GitHubIssuesTracker` (`github-issues.ts:102` `new GitHubHttp(opts)`) → `this.http.paginate(...)`/`this.http.request(...)` → `budget.acquire(resource)` + throw-on-throttle/truncation. Config key `agent.resourceBudgets` → `applyResourceBudgets` → `sharedRateBudget` (the same default budget GitHubHttp uses).

--- a/docs/changes/rate-limit-aware-fanout/proposal.md
+++ b/docs/changes/rate-limit-aware-fanout/proposal.md
@@ -1,0 +1,238 @@
+---
+title: Rate-limit-aware fan-out — per-resource API budgets, shared backoff, fail-on-truncation
+issue: 1532
+slug: rate-limit-aware-fanout
+status: planned
+tier: medium
+keywords:
+  - rate-limit
+  - fan-out
+  - api-budget
+  - shared-backoff
+  - fail-on-truncation
+  - github-http
+  - concurrency
+---
+
+# Rate-limit-aware fan-out
+
+> Fleet concurrency is governed by compute slots, but not by the API budgets that
+> leaves consume. Make fan-out consult a per-resource budget, share backoff across
+> the fleet, and FAIL a leaf whose fetch was throttled or truncated instead of
+> returning silent partial data.
+
+## Overview and goals
+
+Today the orchestrator governs concurrency by **compute slots** — `canDispatch`
+(`packages/orchestrator/src/core/concurrency.ts`) gates dispatch on
+`maxConcurrentAgents`, per-state caps, and a rolling LLM request/token window
+(`AgentConfig.maxRequestsPerSecond` / `maxRequestsPerMinute`, evidence
+`packages/types/src/orchestrator.ts:1030`). None of these knobs models the
+**external API budgets** that a fan-out's leaves consume. When leaves fan out
+GitHub API calls (code search is capped at 10 req/min; the commits API trips
+secondary rate limits under modest parallelism), a slot-governed fleet degrades
+into throttling and — worse — **quietly-incomplete results**: a measured run read
+287 of 430 repos as zero because throttled/truncated fetches returned partial
+data rather than failing.
+
+The real GitHub HTTP layer is `GitHubHttp`
+(`packages/core/src/roadmap/tracker/adapters/github-http.ts`). It already retries
+403/429 with per-instance exponential backoff, but that backoff is **per-leaf**
+(each `GitHubHttp` instance backs off in isolation, so N concurrent leaves keep
+hammering a shared secondary-limit), there is **no proactive rate budget** (it
+only reacts after a 429), and its `paginate` can stop early on a `< perPage` page
+without distinguishing "genuinely done" from "server truncated the page".
+
+**Goals (smallest coherent slice):**
+
+1. A **per-resource budget primitive** — a process-wide, resource-keyed
+   rolling-window limiter that leaves acquire before issuing a fetch, sitting
+   _alongside_ (not replacing) the slot governor.
+2. **Shared backoff** — when any leaf hits a 429/403 secondary limit, the cooldown
+   is recorded on the shared budget so _every_ leaf on that resource backs off
+   together, not per-leaf.
+3. **Fail-on-truncation (the correctness rule)** — a truncated or throttled fetch
+   raises a typed error and FAILS the leaf. It never returns partial or
+   silent-zero data.
+4. Wire (1)–(3) into the live `GitHubHttp` fetch path and expose the per-resource
+   budgets as adopter configuration on `AgentConfig`.
+
+**Non-goals (deferred slices, noted so merge order is clear):**
+
+- Cross-process fleet coordination (a persisted/file-backed shared cooldown so
+  budgets are shared across separate leaf _processes_). This slice is
+  **process-wide** — it governs the in-process `Promise.all` / concurrency fan-out
+  that produced the measured failure. Cross-process sharing is a deferred slice.
+- Per-API budget coverage beyond GitHub's core + code-search + commits resources.
+- Reworking the orchestrator's LLM-request rolling window (`concurrency.ts`) — the
+  new primitive is additive and localized to the external-fetch concern (keeps
+  this change mergeable alongside sibling PRs #1524/#1525).
+
+## Decisions made
+
+- **D1 — Truncated/throttled fetch FAILS the leaf** (operator-confirmed). Never
+  return partial/silent-zero data. This is the core correctness rule of #1532.
+  Realized as typed errors (`ThrottledFetchError`, `TruncatedFetchError`) thrown
+  from the fetch path; callers that build a `Result` convert them to `Err`, and a
+  fan-out leaf that awaits the throw fails rather than yielding a short list.
+- **D2 — Per-resource budgets sit ALONGSIDE the slot budget** (operator-confirmed).
+  Additive; the slot governor (`canDispatch`) is untouched. The new `RateBudget`
+  is a separate primitive keyed by resource name (e.g. `github.core`,
+  `github.search`).
+- **D3 — Backoff is shared across the fleet, not per-leaf** (operator-confirmed).
+  The shared cooldown lives on the `RateBudget` instance; all `GitHubHttp`
+  instances constructed against the same budget observe the same cooldown.
+- **D4 — Home the primitive in `@harness-engineering/core` under `fleet/`.** The
+  `fleet/` module already houses "pure cross-run fleet coordination primitives"
+  (`packages/core/src/fleet/`, evidence `scripts/generate-core-barrel.mjs:149`);
+  it is `export *`-discovered, so a new `fleet/rate-budget` flows to the barrel
+  through `fleet/index.ts` without an allowlist edit (verified via
+  `generate:barrels --check`).
+- **D5 — Wire into `GitHubHttp`, the real gh-API layer** (operator WIRED
+  requirement). `GitHubHttp.request` acquires the budget before every fetch;
+  `fetchWithRetry` records the shared cooldown on 429/403 and throws
+  `ThrottledFetchError` on terminal throttle; `paginate` throws `TruncatedFetchError`
+  when a page is server-truncated. `GitHubIssuesTracker`
+  (`packages/core/src/roadmap/tracker/adapters/github-issues.ts:102`) is the live
+  consumer — a reviewer traces its `this.http.paginate(...)` / `this.http.request(...)`
+  call into the budget check.
+- **D6 — Expose adopter config on `AgentConfig.resourceBudgets`.** The concurrency
+  /governor config surface is `AgentConfig` (holds `maxConcurrentAgents` +
+  `maxRequestsPerSecond`); the new optional `resourceBudgets` map lands there,
+  "alongside slot budgets", validated in `workflow/config.ts` and defaulted in
+  `getDefaultConfig()`.
+
+## Technical design
+
+### New primitive: `packages/core/src/fleet/rate-budget/`
+
+```ts
+// Config an adopter can set (mirrored on AgentConfig).
+export interface ResourceBudgetConfig {
+  /** Max requests permitted per rolling window for this resource. */
+  limit: number;
+  /** Rolling window length in ms (e.g. 60_000 for a per-minute cap). */
+  windowMs: number;
+}
+
+export class RateBudget {
+  configure(resource: string, cfg: ResourceBudgetConfig): void;
+  /** Block (await) until a slot is free for `resource`, honoring the shared
+   *  cooldown and the rolling window; records the request timestamp. */
+  acquire(resource: string, now?: () => number): Promise<void>;
+  /** Record a shared cooldown for `resource` (e.g. from a Retry-After). Every
+   *  subsequent acquire() on this resource waits until the cooldown expires. */
+  penalize(resource: string, cooldownMs: number, now?: () => number): void;
+  /** Pure, testable: ms to wait before the next request may go (0 = go now). */
+  delayFor(resource: string, now: number): number;
+}
+
+/** Process-wide default budget the fetch layer uses unless one is injected. */
+export const sharedRateBudget: RateBudget;
+
+export class ThrottledFetchError extends Error {
+  resource: string;
+}
+export class TruncatedFetchError extends Error {
+  resource: string;
+  url: string;
+}
+```
+
+`delayFor` is the pure core (rolling-window count vs `limit`, plus
+`cooldownUntil`), unit-tested with an injected clock; `acquire` is the thin async
+wrapper that sleeps `delayFor` then re-checks. This mirrors the existing pure
+`computeRateLimitDelay` split (`packages/orchestrator/src/core/rate-limiter.ts`).
+
+### Wiring into `GitHubHttp`
+
+`GitHubHttpOptions` gains two optional fields (both defaulted, so all existing
+callers/tests are source-compatible):
+
+```ts
+budget?: RateBudget;   // default: sharedRateBudget
+resource?: string;     // default: 'github.core'
+```
+
+- `request()` → `await this.budget.acquire(this.resource)` before each fetch.
+- `fetchWithRetry()` → on a 403/429 carrying `Retry-After`, call
+  `this.budget.penalize(this.resource, retryAfterMs)` (shared backoff) in addition
+  to the local sleep; after retries are exhausted on a throttle status, **throw
+  `ThrottledFetchError`** instead of returning the 403/429 response (fail-the-leaf).
+- `paginate()` → detect server truncation and **throw `TruncatedFetchError`**.
+  Truncation signals: a `403`/`429` surfaced mid-walk (now a throw from
+  `fetchWithRetry`), and — for search-style responses — a JSON body with
+  `incomplete_results === true`. A partial accumulation is never returned.
+
+### Adopter config
+
+`AgentConfig` (`packages/types/src/orchestrator.ts`) gains:
+
+```ts
+/** Per-external-resource fan-out budgets, keyed by resource name
+ *  (e.g. "github.core", "github.search"). Governs external API fan-out
+ *  ALONGSIDE the slot/agent concurrency limits. */
+resourceBudgets?: Record<string, ResourceBudgetConfig>;
+```
+
+Validated in `packages/orchestrator/src/workflow/config.ts` (optional; a
+malformed entry is rejected at load, not silently dropped) and defaulted to a
+small sane map in `getDefaultConfig()` (`github.search: { limit: 10, windowMs:
+60000 }`, `github.core: { limit: 80, windowMs: 60000 }`). A pure applier
+`applyResourceBudgets(budget, cfg.agent.resourceBudgets)` copies the config onto
+the shared budget; the orchestrator calls it at startup so the config key is
+live.
+
+## Integration Points
+
+- **Entry Points** — New `@harness-engineering/core` export `fleet/rate-budget`
+  (`RateBudget`, `sharedRateBudget`, `ResourceBudgetConfig`, `ThrottledFetchError`,
+  `TruncatedFetchError`). New optional `AgentConfig.resourceBudgets` config key.
+  Modified fetch entry point: `GitHubHttp.request/fetchWithRetry/paginate`.
+- **Registrations Required** — `fleet/rate-budget` reaches the barrel via
+  `fleet/index.ts` (`export *`, auto-discovered); run `pnpm run generate:barrels`
+  and confirm `--check` is clean. If discovery does not pick it up, add it to
+  `scripts/generate-core-barrel.mjs`.
+- **Documentation Updates** — Regenerate `docs/reference/*` via
+  `pnpm run generate-docs` (config surface change). Note the config key in the
+  reference config docs.
+- **Architectural Decisions** — D1 (fail-on-truncation as a correctness invariant)
+  and D3 (shared cross-leaf backoff) are the decisions that could warrant an ADR;
+  scoped as a medium change, recorded here and in `provenance.json` rather than a
+  standalone ADR for this slice.
+- **Knowledge Impact** — Concept: "fan-out must be governed by API budgets, not
+  only compute slots; a throttled/truncated fetch is a failure, not a partial
+  success." Relationship: `RateBudget` → consumed-by → `GitHubHttp` → consumed-by
+  → `GitHubIssuesTracker`.
+
+## Success criteria
+
+1. `RateBudget.delayFor` returns a positive delay once a resource's rolling-window
+   request count reaches its `limit`, and 0 below the limit (pure, clock-injected
+   unit test).
+2. `RateBudget.penalize` makes every subsequent `delayFor`/`acquire` on that
+   resource wait for the shared cooldown — a second `GitHubHttp` sharing the budget
+   observes the cooldown set by the first (shared-backoff test).
+3. `GitHubHttp.request` awaits `budget.acquire` before fetching (verified: a
+   pre-penalized budget delays the fetch).
+4. A terminal-throttle (403/429 after retries) makes `GitHubHttp` **throw
+   `ThrottledFetchError`**, not return a response.
+5. `paginate` **throws `TruncatedFetchError`** on a server-truncated walk
+   (`incomplete_results: true`) and never returns a partial `items` array.
+6. `AgentConfig.resourceBudgets` validates when present/well-formed, rejects a
+   malformed entry, and `applyResourceBudgets` copies it onto the shared budget;
+   `getDefaultConfig()` ships a sane default map.
+7. Barrel `--check` clean, `generate-docs` clean, all-OS CI green.
+
+## Implementation order
+
+1. **Primitive** — `fleet/rate-budget/` (`RateBudget`, errors, `sharedRateBudget`,
+   `ResourceBudgetConfig`) + pure unit tests; export via `fleet/index.ts`;
+   regenerate barrel.
+2. **Wire GitHubHttp** — budget acquire + shared penalize + throw on
+   terminal-throttle + throw on truncation; tests with an injected `fetchFn` and
+   budget.
+3. **Config** — `AgentConfig.resourceBudgets` type + `workflow/config.ts`
+   validation + `getDefaultConfig()` default + `applyResourceBudgets` applier +
+   orchestrator startup call; tests.
+4. **Docs/barrels** — `generate:barrels`, `generate-docs`; provenance + plan.

--- a/docs/changes/rate-limit-aware-fanout/provenance.json
+++ b/docs/changes/rate-limit-aware-fanout/provenance.json
@@ -1,0 +1,33 @@
+{
+  "issue": 1532,
+  "slug": "rate-limit-aware-fanout",
+  "title": "Rate-limit-aware fan-out — per-resource API budgets, shared backoff, fail-on-truncation",
+  "branch": "build/rate-limit-aware-fanout-1532",
+  "closing_keyword": "Refs #1532",
+  "stages": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "plan_path": "docs/changes/rate-limit-aware-fanout/plans/plan.md",
+  "stagesRun": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "planArtifact": "docs/changes/rate-limit-aware-fanout/plans/plan.md",
+  "mechanisms": {
+    "perResourceBudget": "packages/core/src/fleet/rate-budget/budget.ts — RateBudget.delayFor/acquire (rolling-window request cap per resource key) + sharedRateBudget singleton",
+    "sharedBackoff": "packages/core/src/fleet/rate-budget/budget.ts — RateBudget.penalize records a cooldown on the SHARED budget; every GitHubHttp sharing the budget observes it",
+    "failOnTruncation": "packages/core/src/fleet/rate-budget/errors.ts — ThrottledFetchError / TruncatedFetchError; thrown from GitHubHttp.fetchWithRetry (terminal 403/429) and GitHubHttp.paginate (short page + Link rel=next)",
+    "config": "AgentConfig.resourceBudgets (packages/types/src/orchestrator.ts) → validated in packages/orchestrator/src/workflow/config.ts → defaulted in getDefaultConfig()"
+  },
+  "wiring": {
+    "liveFetchCallSite": "packages/core/src/roadmap/tracker/adapters/github-http.ts — GitHubHttp.request() awaits budget.acquire(resource) before every fetch; fetchWithRetry() penalizes the shared budget on 403/429 and throws ThrottledFetchError on terminal throttle; paginate() throws TruncatedFetchError on a truncated walk.",
+    "liveConsumer": "packages/core/src/roadmap/tracker/adapters/github-issues.ts:102 (new GitHubHttp(opts)) — GitHubIssuesTracker.fetchAll/fetchById/etc. call this.http.paginate(...)/this.http.request(...), which now consult the budget and fail-the-leaf on throttle/truncation.",
+    "configKey": "agent.resourceBudgets",
+    "configConsumer": "packages/orchestrator/src/orchestrator.ts constructor calls applyResourceBudgets(sharedRateBudget, config.agent.resourceBudgets) — the config key becomes live rate-limiting for the shared budget GitHubHttp uses."
+  },
+  "assumptions": [
+    "Scope is the smallest coherent slice (operator decision 3): the per-resource budget primitive + shared backoff + fail-on-truncation wired into the real GitHubHttp fetch path. Closing keyword is 'Refs #1532' (not Closes) — broader per-API coverage is a deferred slice.",
+    "The shared budget is PROCESS-WIDE (a module singleton). It governs the in-process Promise.all/concurrency fan-out that produced the measured failure (a 10-way fan-out on the commits API). Cross-process coordination across separate leaf PROCESSES (a persisted/file-backed cooldown) is a deferred slice, noted for the human to plan.",
+    "Fail-the-leaf (operator decision 1) is realized as thrown typed errors. Every GitHubHttp consumer (github-issues.ts) already wraps calls in try/catch → Err(...), so a throttle/truncation becomes an Err rather than a silent short list; no consumer returns partial data.",
+    "Truncation detection in the generic array paginate() uses the GitHub `Link: rel=\"next\"` header: a page shorter than perPage that STILL advertises a next page is a server truncation and fails. GitHub search's `incomplete_results` field is a distinct object shape not walked by this array-paginate; it is covered by the ThrottledFetchError path when throttled and left to a future search-specific slice otherwise.",
+    "ResourceBudgetConfig is defined canonically in @harness-engineering/types (mirrored onto AgentConfig) and re-exported by core's fleet/rate-budget so the primitive and its config surface cannot drift.",
+    "The new core exports flow to the barrel automatically: fleet/ is an `export *`-discovered module, so `export * from './fleet'` in the generated src/index.ts already re-exports rate-budget — generate:barrels --check is clean with no allowlist edit to scripts/generate-core-barrel.mjs.",
+    "Default budgets are conservative (github.core 80/min, github.search 10/min matching GitHub's documented code-search cap). Adopters override via agent.resourceBudgets.",
+    "Coordination with sibling PRs #1524/#1525: this change is additive and localized to the external-fetch concern (new fleet/rate-budget module + GitHubHttp + AgentConfig field + one orchestrator constructor line). It does NOT touch concurrency.ts / state-machine.ts / budget-governor.ts, so it should merge independently of #1524 (context-budget) and #1525 (budget-governor); no merge-order dependency identified."
+  ]
+}

--- a/packages/core/src/fleet/index.ts
+++ b/packages/core/src/fleet/index.ts
@@ -2,3 +2,5 @@
 export * from './claims';
 // Per-leaf context-replay budget enforcement primitives (#1524).
 export * from './context-budget';
+// Per-resource fan-out rate-limit budget primitives (#1532).
+export * from './rate-budget';

--- a/packages/core/src/fleet/rate-budget/budget.test.ts
+++ b/packages/core/src/fleet/rate-budget/budget.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { RateBudget, applyResourceBudgets, sharedRateBudget } from './budget';
+
+describe('RateBudget.delayFor (SC1: rolling-window limit)', () => {
+  it('returns 0 below the limit and a positive delay once the window is full', () => {
+    const b = new RateBudget();
+    b.configure('github.search', { limit: 3, windowMs: 60_000 });
+    const t0 = 1_000_000;
+
+    // Grant 3 requests within the window via acquire's timestamp recording,
+    // simulated by penalize-free manual pushes through delayFor+record path.
+    // Use acquire with a fixed clock and no-op sleep to record grants.
+    return (async () => {
+      const now = () => t0;
+      const sleep = async () => {};
+      await b.acquire('github.search', { now, sleep }); // 1
+      await b.acquire('github.search', { now, sleep }); // 2
+      expect(b.delayFor('github.search', t0)).toBe(0); // 2 < 3, still room
+      await b.acquire('github.search', { now, sleep }); // 3 -> at capacity
+      const delay = b.delayFor('github.search', t0);
+      expect(delay).toBeGreaterThan(0);
+      // Oldest grant was at t0; must wait ~full window.
+      expect(delay).toBe(60_000);
+      // After the window elapses, the slot frees up.
+      expect(b.delayFor('github.search', t0 + 60_001)).toBe(0);
+    })();
+  });
+
+  it('is unbudgeted (delay 0) for a resource with no config', () => {
+    const b = new RateBudget();
+    expect(b.delayFor('unknown', 123)).toBe(0);
+  });
+});
+
+describe('RateBudget.penalize (SC2: shared backoff across leaves)', () => {
+  it('makes every reader of the same budget wait for the shared cooldown', () => {
+    const shared = new RateBudget();
+    const t0 = 5_000_000;
+    // Leaf A hits a secondary limit and penalizes the SHARED budget.
+    shared.penalize('github.core', 30_000, t0);
+    // Leaf B (a different consumer holding the same budget handle) sees it.
+    expect(shared.delayFor('github.core', t0)).toBe(30_000);
+    expect(shared.delayFor('github.core', t0 + 10_000)).toBe(20_000);
+    expect(shared.delayFor('github.core', t0 + 30_001)).toBe(0);
+  });
+
+  it('cooldown dominates the rolling window and never shortens', () => {
+    const b = new RateBudget();
+    b.configure('r', { limit: 100, windowMs: 1_000 });
+    const t0 = 1_000;
+    b.penalize('r', 10_000, t0);
+    b.penalize('r', 2_000, t0); // shorter — must NOT reduce the cooldown
+    expect(b.delayFor('r', t0)).toBe(10_000);
+  });
+
+  it('acquire waits out an installed cooldown then proceeds', async () => {
+    const b = new RateBudget();
+    let clock = 0;
+    const now = () => clock;
+    const sleep = async (ms: number) => {
+      clock += ms; // advance virtual time by exactly the requested sleep
+    };
+    b.penalize('r', 5_000, 0);
+    await b.acquire('r', { now, sleep });
+    expect(clock).toBeGreaterThanOrEqual(5_000);
+  });
+});
+
+describe('applyResourceBudgets (config wiring)', () => {
+  it('copies an adopter config map onto a budget', () => {
+    const b = new RateBudget();
+    applyResourceBudgets(b, {
+      'github.search': { limit: 10, windowMs: 60_000 },
+    });
+    const t0 = 0;
+    // Fill the window; the 11th at the same instant must wait.
+    return (async () => {
+      const now = () => t0;
+      const sleep = async () => {};
+      for (let i = 0; i < 10; i++) await b.acquire('github.search', { now, sleep });
+      expect(b.delayFor('github.search', t0)).toBeGreaterThan(0);
+    })();
+  });
+
+  it('is a no-op for an undefined map', () => {
+    expect(() => applyResourceBudgets(new RateBudget(), undefined)).not.toThrow();
+  });
+
+  it('exposes a process-wide shared singleton', () => {
+    expect(sharedRateBudget).toBeInstanceOf(RateBudget);
+  });
+});

--- a/packages/core/src/fleet/rate-budget/budget.ts
+++ b/packages/core/src/fleet/rate-budget/budget.ts
@@ -1,0 +1,152 @@
+// packages/core/src/fleet/rate-budget/budget.ts
+//
+// Per-resource fan-out budget (#1532). Fleet concurrency is governed by compute
+// slots (`canDispatch`), but slots do not model the external API budgets that a
+// fan-out's leaves consume. `RateBudget` adds that missing axis:
+//
+//   1. Per-resource proactive limiting — a rolling-window request cap per
+//      resource key, so a 10-way fan-out on a 10 req/min endpoint paces itself
+//      instead of tripping a secondary rate limit.
+//   2. Shared backoff — `penalize()` records a cooldown on the SHARED budget, so
+//      every leaf holding a handle to this budget backs off together (not
+//      per-leaf), which is what actually clears a secondary limit.
+//
+// The budget is process-wide (a module singleton), governing the in-process
+// `Promise.all`/concurrency fan-out. Cross-process (separate leaf processes)
+// coordination is a deferred slice — see the proposal's Non-goals.
+//
+// Pure/injected-IO discipline: `delayFor` is a pure function of state + `now`,
+// unit-tested with an injected clock. `acquire` is the thin async wrapper.
+
+import type { ResourceBudgetConfig } from './types';
+
+interface ResourceState {
+  config?: ResourceBudgetConfig;
+  /** Grant timestamps within the current window (ms). Pruned lazily. */
+  recent: number[];
+  /** Shared cooldown: no request may go before this timestamp (ms). */
+  cooldownUntil: number;
+}
+
+/** Options for `acquire`, allowing the clock and sleep to be injected in tests. */
+export interface RateBudgetAcquireOptions {
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * A shared, per-resource fan-out budget. Construct one and pass it to every
+ * leaf/fetcher that should share the budget + backoff, or use the process-wide
+ * `sharedRateBudget` singleton.
+ */
+export class RateBudget {
+  private readonly resources = new Map<string, ResourceState>();
+
+  private stateFor(resource: string): ResourceState {
+    let s = this.resources.get(resource);
+    if (!s) {
+      s = { recent: [], cooldownUntil: 0 };
+      this.resources.set(resource, s);
+    }
+    return s;
+  }
+
+  /** Set (or replace) the rolling-window budget for a resource. */
+  configure(resource: string, config: ResourceBudgetConfig): void {
+    this.stateFor(resource).config = { ...config };
+  }
+
+  /**
+   * Clear all state for one resource (or the whole budget). Drops recorded
+   * grants, the shared cooldown, and — for the whole-budget form — configs.
+   * Primarily for test isolation of the process-wide `sharedRateBudget`.
+   */
+  reset(resource?: string): void {
+    if (resource === undefined) {
+      this.resources.clear();
+      return;
+    }
+    this.resources.delete(resource);
+  }
+
+  /**
+   * Milliseconds to wait before the next request on `resource` may proceed at
+   * `now`. Returns 0 when a request may go immediately. Pure except for pruning
+   * the resource's stale timestamps (which never changes the returned value).
+   */
+  delayFor(resource: string, now: number): number {
+    const s = this.resources.get(resource);
+    if (!s) return 0;
+
+    // Shared cooldown dominates — a penalized resource waits regardless of window.
+    if (s.cooldownUntil > now) return s.cooldownUntil - now;
+
+    const config = s.config;
+    if (!config || config.limit <= 0 || config.windowMs <= 0) return 0;
+
+    // Prune timestamps outside the window.
+    const cutoff = now - config.windowMs;
+    if (s.recent.length > 0) {
+      s.recent = s.recent.filter((ts) => ts > cutoff);
+    }
+
+    if (s.recent.length < config.limit) return 0;
+
+    // At capacity: wait until the oldest in-window grant ages out.
+    const oldest = s.recent.reduce((m, ts) => (ts < m ? ts : m), s.recent[0]!);
+    return Math.max(1, config.windowMs - (now - oldest));
+  }
+
+  /**
+   * Record a shared cooldown for `resource` (e.g. from a Retry-After header).
+   * Every subsequent `acquire`/`delayFor` on this resource waits until the
+   * cooldown expires. Extends but never shortens an existing cooldown.
+   */
+  penalize(resource: string, cooldownMs: number, now: number = Date.now()): void {
+    if (cooldownMs <= 0) return;
+    const s = this.stateFor(resource);
+    s.cooldownUntil = Math.max(s.cooldownUntil, now + cooldownMs);
+  }
+
+  /**
+   * Block until a request slot is free for `resource`, honoring the shared
+   * cooldown and the rolling window, then record the grant. Re-checks after each
+   * sleep so a cooldown installed by a sibling leaf mid-wait is observed.
+   */
+  async acquire(resource: string, options: RateBudgetAcquireOptions = {}): Promise<void> {
+    const now = options.now ?? Date.now;
+    const sleep = options.sleep ?? defaultSleep;
+    // Ensure state exists so a grant is always recorded even for an unbudgeted
+    // resource (keeps the window populated if it is configured later).
+    this.stateFor(resource);
+    for (;;) {
+      const delay = this.delayFor(resource, now());
+      if (delay <= 0) break;
+      await sleep(delay);
+    }
+    this.stateFor(resource).recent.push(now());
+  }
+}
+
+/**
+ * Process-wide default budget. The GitHub HTTP layer (and any other fan-out
+ * fetcher) consults this unless an explicit `RateBudget` is injected, so a
+ * single `applyResourceBudgets` at startup governs all in-process fan-out.
+ */
+export const sharedRateBudget = new RateBudget();
+
+/**
+ * Copy an adopter's `resourceBudgets` config map onto a budget. Pure aside from
+ * mutating the target budget; safe to call repeatedly (idempotent per key).
+ */
+export function applyResourceBudgets(
+  budget: RateBudget,
+  budgets?: Record<string, ResourceBudgetConfig>
+): void {
+  if (!budgets) return;
+  for (const [resource, config] of Object.entries(budgets)) {
+    budget.configure(resource, config);
+  }
+}

--- a/packages/core/src/fleet/rate-budget/errors.ts
+++ b/packages/core/src/fleet/rate-budget/errors.ts
@@ -1,0 +1,44 @@
+// packages/core/src/fleet/rate-budget/errors.ts
+//
+// Typed failures that enforce the #1532 correctness rule: a throttled or
+// truncated fetch FAILS the leaf instead of returning partial/silent-zero data.
+
+/**
+ * Thrown when a fetch was rate-limited (HTTP 403/429) and could not complete
+ * within the retry budget. The leaf must fail — it must NOT return the throttle
+ * response as if it were data.
+ */
+export class ThrottledFetchError extends Error {
+  readonly resource: string;
+  readonly status: number;
+
+  constructor(resource: string, status: number, message?: string) {
+    super(
+      message ??
+        `Fetch throttled on resource '${resource}' (HTTP ${status}); failing the leaf rather than returning partial data.`
+    );
+    this.name = 'ThrottledFetchError';
+    this.resource = resource;
+    this.status = status;
+  }
+}
+
+/**
+ * Thrown when a fetch/pagination was server-truncated (e.g. GitHub search
+ * `incomplete_results: true`). Returning the accumulated-so-far items would be
+ * a silent under-fetch, so the leaf fails instead.
+ */
+export class TruncatedFetchError extends Error {
+  readonly resource: string;
+  readonly url: string;
+
+  constructor(resource: string, url: string, message?: string) {
+    super(
+      message ??
+        `Fetch truncated on resource '${resource}' at ${url}; failing the leaf rather than returning partial data.`
+    );
+    this.name = 'TruncatedFetchError';
+    this.resource = resource;
+    this.url = url;
+  }
+}

--- a/packages/core/src/fleet/rate-budget/index.ts
+++ b/packages/core/src/fleet/rate-budget/index.ts
@@ -1,0 +1,10 @@
+// packages/core/src/fleet/rate-budget/index.ts
+//
+// Per-resource fan-out budget primitive (#1532): proactive per-resource rate
+// limiting + shared backoff + fail-on-throttle/truncation errors.
+
+export type { ResourceBudgetConfig } from './types';
+export { RateBudget, sharedRateBudget, applyResourceBudgets } from './budget';
+// Note: `RateBudget.reset()` is exposed as an instance method (test isolation).
+export type { RateBudgetAcquireOptions } from './budget';
+export { ThrottledFetchError, TruncatedFetchError } from './errors';

--- a/packages/core/src/fleet/rate-budget/types.ts
+++ b/packages/core/src/fleet/rate-budget/types.ts
@@ -1,0 +1,8 @@
+// packages/core/src/fleet/rate-budget/types.ts
+//
+// Adopter-facing shape for a per-resource fan-out budget. The canonical
+// definition lives in `@harness-engineering/types` (it is mirrored onto
+// `AgentConfig.resourceBudgets`); re-exported here so the primitive and its
+// config surface never drift.
+
+export type { ResourceBudgetConfig } from '@harness-engineering/types';

--- a/packages/core/src/roadmap/tracker/adapters/github-http.test.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-http.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { GitHubHttp, parseExternalId, buildExternalId } from './github-http';
+import {
+  RateBudget,
+  sharedRateBudget,
+  ThrottledFetchError,
+  TruncatedFetchError,
+} from '../../../fleet/rate-budget';
 
 const TOKEN = 'ghp_test_token';
 
@@ -33,6 +39,9 @@ function http(fetchFn: typeof fetch, extra?: Partial<ConstructorParameters<typeo
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  // The default budget is the process-wide singleton; clear it so a penalize()
+  // in one test cannot leak a cooldown into the next.
+  sharedRateBudget.reset();
 });
 
 describe('GitHubHttp — construction & headers', () => {
@@ -215,6 +224,59 @@ describe('GitHubHttp — paginate()', () => {
   it('throws a descriptive error on a non-ok, non-304 response', async () => {
     const { fetchFn } = queuedFetch([res(422, { message: 'Unprocessable' })]);
     await expect(http(fetchFn).paginate(buildUrl, 100)).rejects.toThrow(/GitHub 422/);
+  });
+});
+
+describe('GitHubHttp — rate-limit budget wiring (#1532)', () => {
+  const url = 'https://api.github.com/x';
+  const buildUrl = (page: number) => `https://api.github.com/items?page=${page}`;
+
+  it('acquires the shared budget before fetching (a cooldown defers the fetch)', async () => {
+    vi.useFakeTimers();
+    const budget = new RateBudget();
+    budget.penalize('github.core', 5000);
+    const { fetchFn, count } = queuedFetch([res(200, { ok: true })]);
+    const client = http(fetchFn, { budget });
+
+    const p = client.request(url, { method: 'GET' });
+    // The request suspends inside budget.acquire() — no fetch until the cooldown clears.
+    expect(count()).toBe(0);
+
+    await vi.runAllTimersAsync();
+    const r = await p;
+    expect(r.status).toBe(200);
+    expect(count()).toBe(1);
+  });
+
+  it('throws ThrottledFetchError on terminal throttle AND penalizes the shared budget', async () => {
+    const budget = new RateBudget();
+    const before = Date.now();
+    const { fetchFn } = queuedFetch([res(429, { rate: 'limited' }, { 'Retry-After': '3' })]);
+    // maxRetries: 0 → single attempt, no retry sleep; 429 is terminal.
+    const client = http(fetchFn, { budget, resource: 'github.search', maxRetries: 0 });
+
+    await expect(client.request(url, { method: 'GET' })).rejects.toBeInstanceOf(
+      ThrottledFetchError
+    );
+    // The 429 recorded a shared cooldown a sibling leaf on this resource observes.
+    expect(budget.delayFor('github.search', before)).toBeGreaterThan(0);
+  });
+
+  it('paginate throws TruncatedFetchError when a short page still advertises rel="next"', async () => {
+    const { fetchFn } = queuedFetch([
+      res(200, [{ id: 1 }], {
+        ETag: '"p1"',
+        Link: '<https://api.github.com/items?page=2>; rel="next"',
+      }),
+    ]);
+    // Short page (1 < perPage 2) but a next page exists → server truncated → fail.
+    await expect(http(fetchFn).paginate(buildUrl, 2)).rejects.toBeInstanceOf(TruncatedFetchError);
+  });
+
+  it('paginate does NOT throw on a genuinely-final short page (no next link)', async () => {
+    const { fetchFn } = queuedFetch([res(200, [{ id: 1 }], { ETag: '"p1"' })]);
+    const out = await http(fetchFn).paginate<{ id: number }>(buildUrl, 2);
+    expect(out.items).toEqual([{ id: 1 }]);
   });
 });
 

--- a/packages/core/src/roadmap/tracker/adapters/github-http.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-http.ts
@@ -8,12 +8,27 @@
  * (out of scope; would touch a green file). Future cleanup may
  * consolidate (decision D-P2-C).
  */
+import {
+  RateBudget,
+  sharedRateBudget,
+  ThrottledFetchError,
+  TruncatedFetchError,
+} from '../../../fleet/rate-budget';
+
 export interface GitHubHttpOptions {
   token: string;
   fetchFn?: typeof fetch;
   apiBase?: string;
   maxRetries?: number;
   baseDelayMs?: number;
+  /**
+   * Shared per-resource fan-out budget (#1532). Every request `acquire`s a slot
+   * before it fetches, and a 403/429 `penalize`s the SHARED budget so sibling
+   * leaves back off together. Defaults to the process-wide `sharedRateBudget`.
+   */
+  budget?: RateBudget;
+  /** Budget resource key for this client (e.g. `github.core`, `github.search`). */
+  resource?: string;
 }
 
 const DEFAULTS = { maxRetries: 5, baseDelayMs: 1000 };
@@ -23,6 +38,8 @@ export class GitHubHttp {
   private readonly fetchFn: typeof fetch;
   readonly apiBase: string;
   private readonly retryOpts: { maxRetries: number; baseDelayMs: number };
+  private readonly budget: RateBudget;
+  private readonly resource: string;
 
   constructor(opts: GitHubHttpOptions) {
     this.token = opts.token;
@@ -32,6 +49,8 @@ export class GitHubHttp {
       maxRetries: opts.maxRetries ?? DEFAULTS.maxRetries,
       baseDelayMs: opts.baseDelayMs ?? DEFAULTS.baseDelayMs,
     };
+    this.budget = opts.budget ?? sharedRateBudget;
+    this.resource = opts.resource ?? 'github.core';
   }
 
   headers(extra?: Record<string, string>): Record<string, string> {
@@ -59,10 +78,13 @@ export class GitHubHttp {
   private async fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
     let last: Response | undefined;
     for (let attempt = 0; attempt <= this.retryOpts.maxRetries; attempt++) {
+      // Consult the shared per-resource budget BEFORE every attempt so a fan-out
+      // paces itself proactively (and observes any cooldown a sibling installed).
+      await this.budget.acquire(this.resource);
       const res = await this.fetchFn(url, init);
       if (res.status !== 403 && res.status !== 429 && res.status < 500) return res;
       last = res;
-      if (attempt === this.retryOpts.maxRetries) break;
+      const isThrottle = res.status === 403 || res.status === 429;
       const retryAfter = res.headers.get('Retry-After');
       let delayMs: number;
       if (retryAfter) {
@@ -71,7 +93,18 @@ export class GitHubHttp {
       } else {
         delayMs = this.retryOpts.baseDelayMs * Math.pow(2, attempt) + Math.random() * 500;
       }
+      // Shared backoff: record the cooldown on the SHARED budget so every leaf on
+      // this resource — not just this one — waits it out (what actually clears a
+      // secondary rate limit).
+      if (isThrottle) this.budget.penalize(this.resource, delayMs);
+      if (attempt === this.retryOpts.maxRetries) break;
       await new Promise((r) => setTimeout(r, delayMs));
+    }
+    // Fail-the-leaf (#1532): a fetch that is still throttled after the retry
+    // budget must NOT be returned as if it were data — a caller could mistake the
+    // 403/429 body for "zero results". Throw so the leaf fails loudly.
+    if (last && (last.status === 403 || last.status === 429)) {
+      throw new ThrottledFetchError(this.resource, last.status);
     }
     return last!;
   }
@@ -116,11 +149,29 @@ export class GitHubHttp {
       items.push(...data);
       lastEtag = etag;
       status = res.status;
-      if (data.length < perPage) break;
+      if (data.length < perPage) {
+        // A short page normally means "genuinely done". But if the server ALSO
+        // advertises a next page (`Link: …; rel="next"`), the page was
+        // truncated and stopping here would silently under-fetch. Fail the leaf
+        // (#1532) rather than return an incomplete list.
+        if (hasNextLink(res.headers.get('Link'))) {
+          throw new TruncatedFetchError(this.resource, buildUrl(page));
+        }
+        break;
+      }
       page++;
     }
     return { items, lastEtag, status };
   }
+}
+
+/**
+ * True when a GitHub `Link` header advertises a `rel="next"` page. Used to
+ * distinguish a genuinely-final short page from a server-truncated one.
+ */
+function hasNextLink(link: string | null): boolean {
+  if (!link) return false;
+  return /;\s*rel="next"/.test(link);
 }
 
 // External-ID parse/build come from the one canonical module (../../external-id);

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -15,7 +15,12 @@ import type {
 } from '@harness-engineering/types';
 import { RoutingError } from '@harness-engineering/types';
 import type { Issue, IssueTrackerClient } from '@harness-engineering/core';
-import { writeTaint, SecurityScanner } from '@harness-engineering/core';
+import {
+  writeTaint,
+  SecurityScanner,
+  applyResourceBudgets,
+  sharedRateBudget,
+} from '@harness-engineering/core';
 import { hasIntroducedSecurityDefect, outcomeVerdictToQualityFail } from './agent/quality-verdict';
 import {
   IntelligencePipeline,
@@ -1027,6 +1032,13 @@ export class Orchestrator extends EventEmitter {
     this.acceptanceRunner = overrides?.acceptanceRunner ?? defaultLocalAcceptanceRunner;
     this.state = createEmptyState(config);
     this.logger = new StructuredLogger();
+
+    // #1532: apply the operator's per-resource fan-out budgets onto the
+    // process-wide shared budget that the GitHub HTTP layer (and any other
+    // fan-out fetcher) consults. This is the consumer wiring for
+    // `agent.resourceBudgets` — the config key becomes live rate-limiting +
+    // shared backoff for external API fan-out, alongside the slot governor.
+    applyResourceBudgets(sharedRateBudget, config.agent.resourceBudgets);
 
     // Spec 2 / Task 9: Apply legacy → modern config migration eagerly so
     // every downstream code path observes a uniform `agent.backends` +

--- a/packages/orchestrator/src/workflow/config.ts
+++ b/packages/orchestrator/src/workflow/config.ts
@@ -36,6 +36,17 @@ const AgentContextBudgetSchema = z
   .strict();
 
 /**
+ * Per-resource fan-out budget (#1532). A malformed entry is rejected at
+ * config-load rather than silently dropped (the AMR trap), so an operator who
+ * fat-fingers a budget learns at startup, not by silently losing rate-limiting.
+ */
+const ResourceBudgetSchema = z.object({
+  limit: z.number().positive(),
+  windowMs: z.number().positive(),
+});
+const ResourceBudgetsMapSchema = z.record(z.string(), ResourceBudgetSchema);
+
+/**
  * Cross-field check: every value in `routing` must reference a key in
  * `backends`. Mirrors the Phase 1 standalone helper but returns a flat
  * array of issues for synchronous consumption inside
@@ -247,6 +258,14 @@ export function validateWorkflowConfig(
     if (!parsed.success) return Err(new Error(`agent.budget: ${parsed.error.message}`));
   }
 
+  // #1532: validate the optional per-resource fan-out budgets. Absent ⇒ unchanged.
+  if (agent.resourceBudgets !== undefined) {
+    const parsed = ResourceBudgetsMapSchema.safeParse(agent.resourceBudgets);
+    if (!parsed.success) {
+      return Err(new Error(`agent.resourceBudgets: ${parsed.error.message}`));
+    }
+  }
+
   // Modern path: validate the new shape via Phase 0's Zod schemas + the
   // cross-field validator. The legacy path remains hand-rolled until
   // autopilot Phase 4+ retires the legacy schema entirely.
@@ -354,6 +373,13 @@ export function getDefaultConfig(): WorkflowConfig {
     agent: {
       backend: 'mock',
       maxConcurrentAgents: 1,
+      // #1532: sane default external-API budgets. GitHub code search is capped
+      // at 10 req/min; the core REST API is far higher but trips secondary
+      // limits under parallelism, so a conservative per-minute cap paces fan-out.
+      resourceBudgets: {
+        'github.core': { limit: 80, windowMs: 60_000 },
+        'github.search': { limit: 10, windowMs: 60_000 },
+      },
       maxTurns: 10,
       maxRetryBackoffMs: 5000,
       maxRetries: 5,

--- a/packages/orchestrator/tests/workflow/config.test.ts
+++ b/packages/orchestrator/tests/workflow/config.test.ts
@@ -268,3 +268,41 @@ describe('validateWorkflowConfig — declarative workflows (D7/D13)', () => {
     }
   });
 });
+
+describe('validateWorkflowConfig — resourceBudgets (#1532)', () => {
+  it('ships a sane default resourceBudgets map (github.core + github.search)', () => {
+    const cfg = getDefaultConfig();
+    expect(cfg.agent.resourceBudgets).toEqual({
+      'github.core': { limit: 80, windowMs: 60_000 },
+      'github.search': { limit: 10, windowMs: 60_000 },
+    });
+  });
+
+  it('accepts a well-formed resourceBudgets map', () => {
+    const cfg = getDefaultConfig();
+    (cfg.agent as Record<string, unknown>).resourceBudgets = {
+      'github.commits': { limit: 30, windowMs: 60_000 },
+    };
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts config with resourceBudgets absent (unchanged behavior)', () => {
+    const cfg = getDefaultConfig();
+    delete (cfg.agent as Record<string, unknown>).resourceBudgets;
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a malformed resourceBudgets entry rather than silently dropping it', () => {
+    const cfg = getDefaultConfig();
+    (cfg.agent as Record<string, unknown>).resourceBudgets = {
+      'github.core': { limit: -1, windowMs: 60_000 },
+    };
+    const result = validateWorkflowConfig(cfg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/resourceBudgets/i);
+    }
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -147,6 +147,8 @@ export type {
   FleetBudgetStatus,
   // --- #1524: per-leaf context-replay budget ---
   AgentContextBudgetConfig,
+  // --- #1532: per-resource fan-out rate-limit budgets ---
+  ResourceBudgetConfig,
   ServerConfig,
   WorkflowConfig,
   RoadmapConfig,

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -1027,6 +1027,19 @@ export type RoutingUseCase =
 /**
  * Configuration for the agent runner.
  */
+/**
+ * Budget for a single external resource that a fan-out's leaves consume
+ * (e.g. `github.core`, `github.search`). Governs external API fan-out
+ * ALONGSIDE the slot/agent concurrency limits — see #1532. Consumed by the
+ * `RateBudget` primitive in `@harness-engineering/core` (`fleet/rate-budget`).
+ */
+export interface ResourceBudgetConfig {
+  /** Max requests permitted per rolling window for this resource. Must be > 0. */
+  limit: number;
+  /** Rolling window length in ms (e.g. 60_000 for a per-minute cap). Must be > 0. */
+  windowMs: number;
+}
+
 export interface AgentConfig {
   /** Global cooldown in milliseconds after a rate limit hit */
   globalCooldownMs?: number;
@@ -1048,6 +1061,13 @@ export interface AgentConfig {
   apiKey?: string;
   /** Global limit on concurrent agents */
   maxConcurrentAgents: number;
+  /**
+   * Per-external-resource fan-out budgets, keyed by resource name
+   * (e.g. `github.core`, `github.search`). Governs external API fan-out
+   * ALONGSIDE the slot/agent concurrency limits (#1532). Applied to the shared
+   * `RateBudget` at orchestrator startup via `applyResourceBudgets`.
+   */
+  resourceBudgets?: Record<string, ResourceBudgetConfig>;
   /** Maximum turns allowed per session */
   maxTurns: number;
   /** Maximum backoff for retries */


### PR DESCRIPTION
## Summary

Fleet concurrency was governed by **compute slots** but not by the **external API budgets** a fan-out's leaves consume. An API-bound fan-out (GitHub code search is capped at 10 req/min; the commits API trips secondary rate limits under modest parallelism) degraded into throttling and — worse — **silent under-fetching**: a throttled or truncated fetch returned partial/zero data instead of failing (measured: 287 of 430 repos read as zero).

This adds a **per-resource API budget** primitive alongside the slot governor, **shared backoff** across a fleet, and a **hard rule that a throttled/truncated fetch FAILS the leaf** instead of returning partial data — wired into the real GitHub HTTP fetch path.

Refs #1532 (smallest coherent slice; broader per-API coverage + cross-process sharing deferred).

## What changed

- **New primitive** `@harness-engineering/core` → `fleet/rate-budget`:
  - `RateBudget` — per-resource rolling-window request cap (`delayFor`/`acquire`) + a **shared cooldown** (`penalize`) so every leaf on a resource backs off together, not per-leaf. `sharedRateBudget` process-wide singleton. `applyResourceBudgets` config applier.
  - `ThrottledFetchError` / `TruncatedFetchError` — typed failures enforcing fail-the-leaf.
- **Wired into `GitHubHttp`** (`packages/core/src/roadmap/tracker/adapters/github-http.ts`), the real gh-API layer:
  - `request()` **acquires the shared budget before every fetch**.
  - `fetchWithRetry()` **penalizes the shared budget on 403/429** and **throws `ThrottledFetchError` on terminal throttle** (was: returned the 403/429 response, which a caller could mistake for "zero results").
  - `paginate()` **throws `TruncatedFetchError`** when a short page still advertises `Link: rel="next"` (server truncation) — never returns a partial `items` array.
- **Adopter config** `AgentConfig.resourceBudgets` (canonical type in `@harness-engineering/types`, validated in `workflow/config.ts` — malformed entries rejected at load, sane defaults in `getDefaultConfig()`).

## Wiring (live fetch call site + config key)

- **Live fetch call site:** `GitHubHttp.request/fetchWithRetry/paginate` in `packages/core/src/roadmap/tracker/adapters/github-http.ts`. Reviewer trace: `GitHubIssuesTracker` (`github-issues.ts:102` `new GitHubHttp(opts)`) → `this.http.paginate(...)`/`this.http.request(...)` → `budget.acquire(resource)` + throw-on-throttle/truncation. Every consumer wraps these in `try/catch` → `Err(...)`, so a throttle/truncation becomes a failed operation, never a silent short list.
- **Config key:** `agent.resourceBudgets` → `packages/orchestrator/src/orchestrator.ts` constructor calls `applyResourceBudgets(sharedRateBudget, config.agent.resourceBudgets)` — the config becomes live rate-limiting + shared backoff for the budget `GitHubHttp` consults.

## Tests

- `packages/core/src/fleet/rate-budget/budget.test.ts` — rolling-window limit boundary (clock-injected), shared-cooldown observed by a second reader, cooldown-dominates-window, `acquire` waits out a cooldown, config applier.
- `packages/core/src/roadmap/tracker/adapters/github-http.test.ts` — acquire consulted before fetch (a cooldown defers it), terminal throttle throws `ThrottledFetchError` + penalizes the shared budget, `paginate` throws `TruncatedFetchError` on truncation and does NOT throw on a genuinely-final short page.
- `packages/orchestrator/tests/workflow/config.test.ts` — default budget map, accepts well-formed / absent, rejects malformed `resourceBudgets`.

## Assumptions made

- **Scope:** smallest coherent slice → `Refs #1532` (not `Closes`). Broader per-API coverage is a deferred slice.
- **Process-wide, not cross-process:** the shared budget is a module singleton governing the in-process `Promise.all`/concurrency fan-out that produced the measured failure. Cross-process coordination (persisted/file-backed cooldown across separate leaf processes) is a **deferred slice**.
- **Truncation signal** in the generic array `paginate()` is the GitHub `Link: rel="next"` header (short page + a next page = truncation). Search's `incomplete_results` object shape is not walked by array-paginate; it is covered by the throttle path when throttled and left to a future search-specific slice.
- `ResourceBudgetConfig` is defined canonically in `@harness-engineering/types` and re-exported by core so primitive and config can't drift. New core exports flow to the barrel automatically (`fleet/` is `export *`-discovered — `generate:barrels --check` clean, no `generate-core-barrel.mjs` edit needed).
- **Coordination with #1524/#1525:** this change is additive and localized (new `fleet/rate-budget` + `GitHubHttp` + `AgentConfig` field + one orchestrator constructor line). It does NOT touch `concurrency.ts` / `state-machine.ts` / `budget-governor.ts`, so no merge-order dependency with #1524 (context-budget) or #1525 (budget-governor) was identified.

## Verification observed locally (Node 22)

- `@harness-engineering/{types,core,orchestrator}` build + typecheck + lint clean.
- Core fleet + roadmap/tracker suites: 210 passed / 1 skipped. Orchestrator config suite: 17 passed. New rate-budget + github-http suites: 29 passed.
- `generate-docs --check` fresh (no reference drift). All pre-push gates passed on push.
