### PR TITLE
feat(graph): bound detailed-mode output on hub nodes (#1591)

### DIFF
--- a/.changeset/bound-detailed-graph-output.md
+++ b/.changeset/bound-detailed-graph-output.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/cli': minor
+'@harness-engineering/core': minor
+---
+
+Bound detailed-mode output of the graph retrieval MCP tools on hub (high-degree) nodes (issue #1591). The token-savings benchmark (#1271) found `get_impact` / `query_graph` / `compute_blast_radius` detailed-mode payloads on hub nodes were unbounded — serializing to ~293M / ~4.47M tokens and able to overflow an agent's context. Each detailed-mode response array is now capped by a configurable item ceiling (`graph.detailedMode.maxItems`, default `DEFAULT_GRAPH_DETAIL_CEILING = 200`). When output is truncated the response fails soft with `truncated: true` plus a `continuation` signal (naming the ceiling, totals available, and how to page or scope down) instead of silently returning a giant payload. Small nodes below the ceiling are unchanged. Adds the `boundItems` helper to `@harness-engineering/core`.

--- a/docs/changes/bound-detailed-graph-output/plans/plan.md
+++ b/docs/changes/bound-detailed-graph-output/plans/plan.md
@@ -1,0 +1,44 @@
+# Plan: Bound detailed-mode graph output on hub nodes (#1591)
+
+Spec: `docs/changes/bound-detailed-graph-output/proposal.md`
+
+## Phase 1 — Core helper
+
+- **T1.1** Add `packages/core/src/compaction/detail-ceiling.ts`: `DEFAULT_GRAPH_DETAIL_CEILING = 200`,
+  `BoundedItems<T>` interface, `boundItems<T>(items, ceiling?)` — slices to ceiling, reports
+  `truncated`/`totalAvailable`/`returned`. Non-positive/absent ceiling → default.
+- **T1.2** Export from `packages/core/src/compaction/index.ts`; verify core barrel picks it up
+  (edit `scripts/generate-core-barrel.mjs` allowlist if the generator drops it).
+- **T1.3** Unit test `detail-ceiling.test.ts`: over-ceiling truncates + flags; under-ceiling
+  passthrough; custom ceiling; empty array; ceiling<=0 falls back to default.
+
+## Phase 2 — Config
+
+- **T2.1** Add `detailedMode: { maxItems: positive int }` to the `graph` object in
+  `packages/cli/src/config/schema.ts` (optional, no default at schema level — handler falls back to
+  the constant).
+
+## Phase 3 — Handler wiring
+
+- **T3.1** `get-impact.ts`: resolve ceiling from config; in detailed branch bound the flattened
+  impacted nodes and `edges`; regroup bounded nodes; add `truncated` + `continuation` to response.
+- **T3.2** `query-graph.ts`: bound the filtered `edges` array; set response `truncated` = node
+  `hasMore` OR edges truncated; extend `pagination`/add `continuation`.
+- **T3.3** `compute-blast-radius.ts`: in detailed branch bound `flatSummary` and each layer's nodes;
+  add `truncated` + `continuation`.
+- Helper `resolveDetailCeiling(path)` (local to graph tools or shared) reading `resolveConfig`,
+  fail-open to `DEFAULT_GRAPH_DETAIL_CEILING`.
+
+## Phase 4 — Behavior test (WIRED proof)
+
+- **T4.1** `detail-ceiling.behavior.test.ts`: build a synthetic hub-node graph store (1 hub with
+  > 200 incident nodes/edges) + a small node. Call `handleGetImpact` / `handleQueryGraph` /
+  > `handleComputeBlastRadius` in detailed mode. Assert hub responses bounded to ceiling + `truncated:true`
+  - continuation present; small-node response unchanged (`truncated` falsy, all items present).
+
+## Phase 5 — Ship
+
+- **T5.1** `pnpm run generate-docs` (reference-docs freshness gate).
+- **T5.2** Rebuild CLI (`npm run build-release` / turbo build) before commit (pre-commit arch gate).
+- **T5.3** Run graph tool tests + core compaction tests + typecheck.
+- **T5.4** Changeset, commit, push, open PR vs `main` with `Closes #1591`, Wiring section.

--- a/docs/changes/bound-detailed-graph-output/proposal.md
+++ b/docs/changes/bound-detailed-graph-output/proposal.md
@@ -1,0 +1,202 @@
+---
+title: Bound detailed-mode output for graph retrieval tools on hub nodes
+issue: 1591
+status: planned
+keywords:
+  - graph-tools
+  - detailed-mode
+  - pagination
+  - token-ceiling
+  - hub-nodes
+  - fail-soft-truncation
+  - get_impact
+  - query_graph
+  - compute_blast_radius
+---
+
+# Bound detailed-mode output for graph retrieval tools on hub nodes
+
+## Overview
+
+The reproducible graph token-savings benchmark (#1271, `docs/benchmarks/graph-token-savings/RESULTS.md`)
+measured graph-scoped retrieval at 26.5× fewer tokens overall — but recorded a sharp exception
+(caveat 3): the **detailed-mode** payloads of `get_impact` and `query_graph`, when run against the
+graph's **hub (high-degree) nodes**, are **unbounded**. On this repo's own graph they serialized to
+**≈293M tokens** (5 `impact` anchors, full bidirectional 3-hop neighborhood) and **≈4.47M tokens**
+(5 `dependencies` anchors). A single such call can dwarf every saving the graph tools otherwise
+deliver and can overflow an agent's entire context window.
+
+This change bounds detailed-mode output for the affected graph retrieval handlers so that **no
+detailed call can return an unbounded payload**, while preserving the drill-in usefulness of
+detailed mode for small/normal nodes.
+
+### Goals
+
+- No `get_impact` / `query_graph` / `compute_blast_radius` detailed-mode response can exceed a
+  bounded, configurable item ceiling.
+- Truncation is **fail-soft and explicit**: a truncated response carries `truncated: true` plus a
+  continuation signal so a caller can page — never a silent 293M-token dump.
+- The default ceiling is derived from the benchmark's own numbers and exposed as configuration.
+- The behavior of small nodes (below the ceiling) is unchanged.
+
+### Out of scope
+
+- Changing summary/compact modes (they are already bounded — that is the whole point of scoping).
+- Changing traversal depth defaults or graph ingestion.
+- The answer-quality axis (LLM-judge comparator) — a separate deferred slice of #1271.
+
+## Decisions made
+
+1. **Count-based item ceiling, not a serialized-byte/token meter.** Cap the number of items in each
+   otherwise-unbounded array (impacted nodes, edges, cascade layers) at a fixed ceiling.
+   - _Rationale:_ deterministic and cheap — no need to serialize-then-measure a 293M-token payload
+     to discover it is too big (defeating the purpose). It is consistent with the pagination
+     `query_graph` detailed mode already uses (`offset`/`limit`, `paginate()` from
+     `@harness-engineering/core`, `packages/core/src/compaction/pagination.ts`). Node serialized
+     size is roughly uniform, so an item count is a good proxy for token cost.
+
+2. **Default ceiling = 200 items per array, derived from the benchmark.** The 293M-token blowup
+   comes from materializing tens-of-thousands of nodes/edges. At a rough ~125 tokens per serialized
+   graph item, a 200-item ceiling holds a detailed response near ~25k tokens — a >4-orders-of-magnitude
+   reduction from 293M, while still returning far more than the summary surface (which returns only
+   counts + top items). `query_graph`'s existing node page default (`limit: 50`) sits comfortably
+   under this ceiling and is preserved.
+
+3. **Expose the ceiling as configuration with a sane default.** New optional
+   `graph.detailedMode.maxItems` key in `harness.config.json` (schema in
+   `packages/cli/src/config/schema.ts`), falling back to the exported
+   `DEFAULT_GRAPH_DETAIL_CEILING` constant. Zero-config projects are bounded by default.
+
+4. **Fail-soft continuation contract.** A bounded array is produced by a shared core helper
+   `boundItems(items, ceiling)` returning `{ items, truncated, totalAvailable, returned }`. When
+   `truncated` is true the handler response carries a top-level `truncated: true` and a
+   `continuation` hint that names the ceiling, the total available, and how to retrieve more
+   (page via `offset`/`limit` for `query_graph`; narrow the anchor or use summary mode for
+   `get_impact` / `compute_blast_radius`).
+
+5. **Bound all three named handlers → `Closes #1591`.** `compute_blast_radius` detailed mode
+   (`layers` + `flatSummary`) exhibits the same unbounded class and is bounded here too, so the
+   issue is fully resolved rather than partially (`Refs`).
+
+## Technical design
+
+### New shared core helper (`@harness-engineering/core`, compaction module)
+
+`packages/core/src/compaction/detail-ceiling.ts`:
+
+```ts
+export const DEFAULT_GRAPH_DETAIL_CEILING = 200;
+
+export interface BoundedItems<T> {
+  items: T[];
+  /** True when the input exceeded the ceiling and was truncated. */
+  truncated: boolean;
+  /** Total items available before truncation. */
+  totalAvailable: number;
+  /** Number of items actually returned (<= ceiling). */
+  returned: number;
+}
+
+export function boundItems<T>(items: readonly T[], ceiling?: number): BoundedItems<T>;
+```
+
+Re-exported from `packages/core/src/compaction/index.ts` (already `export *`-ed by the core
+barrel) and added to the `scripts/generate-core-barrel.mjs` allowlist if required.
+
+### Config
+
+`graph.detailedMode.maxItems` — optional positive integer. Added to the existing `graph` object in
+`HarnessConfigSchema` (`packages/cli/src/config/schema.ts`). Handlers resolve it via
+`resolveConfig(path)` and fall back to `DEFAULT_GRAPH_DETAIL_CEILING` when absent or on any config
+error (fail-open to the safe default — the ceiling still applies).
+
+### Handler wiring (`packages/cli/src/mcp/tools/graph/`)
+
+- **`get-impact.ts` (`handleGetImpact` → tool `get_impact`)** — detailed branch: bound the flattened
+  impacted-node set and the `edges` array via `boundItems`. Response gains `truncated` +
+  `continuation` when either array is truncated. Summary mode unchanged.
+- **`query-graph.ts` (`handleQueryGraph` → tool `query_graph`)** — nodes remain offset/limit
+  paginated (already bounded). The `edges` array — currently `result.edges.filter(...)`, unbounded
+  when a hub node is on the page — is bounded via `boundItems`. Response `truncated` becomes true if
+  node pagination `hasMore` OR edges were truncated; `continuation` merges the existing `pagination`.
+- **`compute-blast-radius.ts` (`handleComputeBlastRadius` → tool `compute_blast_radius`)** — detailed
+  branch: bound `flatSummary` and the per-layer node arrays inside `layers` via `boundItems`.
+  Response gains `truncated` + `continuation`. Compact mode (default) unchanged.
+
+### File layout
+
+| File                                                               | Change                                   |
+| ------------------------------------------------------------------ | ---------------------------------------- |
+| `packages/core/src/compaction/detail-ceiling.ts`                   | **new** — helper + default constant      |
+| `packages/core/src/compaction/index.ts`                            | export new symbols                       |
+| `packages/core/src/compaction/detail-ceiling.test.ts`              | **new** — unit tests for helper          |
+| `scripts/generate-core-barrel.mjs`                                 | allowlist entry if barrel requires       |
+| `packages/cli/src/config/schema.ts`                                | `graph.detailedMode.maxItems`            |
+| `packages/cli/src/mcp/tools/graph/get-impact.ts`                   | bound detailed output                    |
+| `packages/cli/src/mcp/tools/graph/query-graph.ts`                  | bound edges                              |
+| `packages/cli/src/mcp/tools/graph/compute-blast-radius.ts`         | bound detailed output                    |
+| `packages/cli/src/mcp/tools/graph/detail-ceiling.behavior.test.ts` | **new** — hub-node bounding proof        |
+| `docs/reference/*`                                                 | regenerated via `pnpm run generate-docs` |
+
+## Integration points
+
+### Entry points
+
+Three existing MCP tools (`get_impact`, `query_graph`, `compute_blast_radius`) registered in
+`packages/cli/src/mcp/server.ts`. No new entry points; behavior of existing ones is bounded.
+
+### Registrations required
+
+- New core exports (`boundItems`, `DEFAULT_GRAPH_DETAIL_CEILING`, `BoundedItems`) via
+  `packages/core/src/compaction/index.ts` and the core barrel allowlist
+  (`scripts/generate-core-barrel.mjs`) if the generator requires it.
+- `docs/reference/*` regenerated for the new config key.
+
+### Documentation updates
+
+`docs/reference/*` regenerated. The benchmark caveat 3 in
+`docs/benchmarks/graph-token-savings/RESULTS.md` is now addressed by this bound (no edit required —
+it records the finding, which remains historically accurate).
+
+### Architectural decisions
+
+None rise to a standalone ADR — this is a bounded, localized guardrail on three existing handlers,
+consistent with the existing pagination pattern.
+
+### Knowledge impact
+
+Concept: "graph detailed-mode responses are bounded by a configurable item ceiling with fail-soft
+truncation." Relationship: the three graph retrieval tools depend on the shared `boundItems` helper.
+
+## Success criteria
+
+1. **When** `get_impact` runs in detailed mode against a hub node whose impacted set exceeds the
+   ceiling, **the** response **shall** contain at most `maxItems` nodes and at most `maxItems` edges,
+   and **shall** set `truncated: true` with a `continuation` signal. (observable in the JSON payload)
+2. **When** `get_impact` runs in detailed mode against a small node (below the ceiling), **the**
+   response **shall** be unchanged (`truncated` absent/false, all items present).
+3. **When** `query_graph` detailed mode returns a hub node whose incident edges exceed the ceiling,
+   **the** `edges` array **shall** be bounded and `truncated: true` set.
+4. **When** `compute_blast_radius` runs in detailed mode against a hub node, **the** cascade payload
+   (`flatSummary` / `layers`) **shall** be bounded and `truncated: true` set.
+5. The ceiling **shall** be overridable via `graph.detailedMode.maxItems` and **shall** default to
+   `DEFAULT_GRAPH_DETAIL_CEILING` (200) when unconfigured.
+6. All existing graph-tool tests pass; new behavior test proves the hub-node bound + small-node
+   passthrough; all-OS CI green.
+
+## Implementation order
+
+1. Core helper `boundItems` + `DEFAULT_GRAPH_DETAIL_CEILING` + unit tests; export + barrel.
+2. Config schema `graph.detailedMode.maxItems`.
+3. Wire `get_impact`, then `query_graph` edges, then `compute_blast_radius`.
+4. Behavior test: synthetic hub-node graph proves bound + truncated flag; small node unchanged.
+5. `pnpm run generate-docs`; build CLI; run graph tests + typecheck; ship.
+
+## Assumptions made
+
+- Count-based ceiling (200 items/array) is an acceptable proxy for the token ceiling the issue asks
+  for; a byte/token meter is intentionally rejected as it would require materializing the very
+  payload we are trying not to build.
+- Fail-open on config read error (apply the default ceiling) is safer than failing the tool call.
+- `query_graph`'s existing node pagination is retained; only its unbounded `edges` array needed
+  bounding.

--- a/docs/changes/bound-detailed-graph-output/provenance.json
+++ b/docs/changes/bound-detailed-graph-output/provenance.json
@@ -1,0 +1,64 @@
+{
+  "issue": 1591,
+  "slug": "bound-detailed-graph-output",
+  "fleet": "roadmap-fleet",
+  "pipeline": ["brainstorming", "autopilot"],
+  "stages": [
+    {
+      "stage": "explore",
+      "skill": "harness-brainstorming",
+      "artifacts": [
+        "read get-impact.ts, query-graph.ts, compute-blast-radius.ts, pagination.ts, config schema, benchmark RESULTS.md"
+      ]
+    },
+    {
+      "stage": "evaluate",
+      "skill": "harness-brainstorming",
+      "artifacts": [
+        "confirmed decisions folded from fleet task (count-based ceiling, fail-soft, config-driven, bound all three)"
+      ]
+    },
+    {
+      "stage": "prioritize",
+      "skill": "harness-brainstorming",
+      "artifacts": ["chose count-based item ceiling over token/byte meter"]
+    },
+    {
+      "stage": "validate",
+      "skill": "harness-brainstorming",
+      "artifacts": ["docs/changes/bound-detailed-graph-output/proposal.md"]
+    },
+    {
+      "stage": "plan",
+      "skill": "harness-autopilot",
+      "artifacts": ["docs/changes/bound-detailed-graph-output/plans/plan.md"]
+    },
+    {
+      "stage": "execute",
+      "skill": "harness-autopilot",
+      "artifacts": [
+        "packages/core/src/compaction/detail-ceiling.ts",
+        "packages/cli/src/mcp/tools/graph/get-impact.ts",
+        "packages/cli/src/mcp/tools/graph/query-graph.ts",
+        "packages/cli/src/mcp/tools/graph/compute-blast-radius.ts",
+        "packages/cli/src/config/schema.ts"
+      ]
+    },
+    {
+      "stage": "verify",
+      "skill": "harness-autopilot",
+      "artifacts": [
+        "packages/cli/src/mcp/tools/graph/detail-ceiling.behavior.test.ts",
+        "packages/core/src/compaction/detail-ceiling.test.ts"
+      ]
+    }
+  ],
+  "plan_path": "docs/changes/bound-detailed-graph-output/plans/plan.md",
+  "closing_keyword": "Closes #1591",
+  "assumptions": [
+    "Count-based ceiling (200 items/array) is an acceptable proxy for the token ceiling; a byte/token meter is rejected because it would require materializing the payload we are avoiding.",
+    "Fail-open on config read error (apply the default ceiling) is safer than failing the tool call.",
+    "query_graph's existing node offset/limit pagination is retained; only its unbounded edges array needed bounding.",
+    "Default ceiling of 200 derived from benchmark: ~125 tokens/item keeps a detailed response near ~25k tokens vs the ~293M unbounded worst case."
+  ]
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1217,6 +1217,19 @@ export const HarnessConfigSchema = z.object({
     .object({
       /** Per-connector configuration (keyed by connector name: jira, slack, ci, confluence, figma, miro) */
       connectors: z.record(z.string(), z.record(z.string(), z.unknown())).default({}),
+      /**
+       * Detailed-mode response bounds for graph retrieval tools (get_impact,
+       * query_graph, compute_blast_radius). Caps the number of items returned
+       * per array so a detailed call on a hub (high-degree) node cannot dump an
+       * unbounded payload (issue #1591). Omitted → the tools use
+       * `DEFAULT_GRAPH_DETAIL_CEILING` from `@harness-engineering/core`.
+       */
+      detailedMode: z
+        .object({
+          /** Max items returned per array in a detailed-mode response. */
+          maxItems: z.number().int().positive().optional(),
+        })
+        .optional(),
     })
     .optional(),
   /**

--- a/packages/cli/src/mcp/tools/graph/compute-blast-radius.ts
+++ b/packages/cli/src/mcp/tools/graph/compute-blast-radius.ts
@@ -1,6 +1,7 @@
+import { boundItems } from '@harness-engineering/core';
 import { loadGraphStore } from '../../utils/graph-loader.js';
 import { sanitizePath } from '../../utils/sanitize-path.js';
-import { graphNotFoundError } from './shared.js';
+import { graphNotFoundError, resolveDetailCeiling } from './shared.js';
 
 export const computeBlastRadiusDefinition = {
   name: 'compute_blast_radius',
@@ -112,6 +113,20 @@ export async function handleComputeBlastRadius(input: {
     });
 
     if (input.mode === 'detailed') {
+      // Bound the cascade payload so a hub (high-degree) node cannot return an
+      // unbounded flat summary or layer node list (issue #1591). Each array is
+      // capped to the detailed-mode ceiling; the per-layer categoryBreakdown is
+      // preserved as the true full-layer summary.
+      const ceiling = resolveDetailCeiling(projectPath);
+      const boundedFlat = boundItems(result.flatSummary, ceiling);
+      let layerNodesTruncated = false;
+      const boundedLayers = result.layers.map((layer) => {
+        const boundedNodes = boundItems(layer.nodes, ceiling);
+        if (boundedNodes.truncated) layerNodesTruncated = true;
+        return { ...layer, nodes: boundedNodes.items };
+      });
+      const truncated = boundedFlat.truncated || layerNodesTruncated || result.summary.truncated;
+
       return {
         content: [
           {
@@ -120,9 +135,20 @@ export async function handleComputeBlastRadius(input: {
               mode: 'detailed',
               sourceNodeId: result.sourceNodeId,
               sourceName: result.sourceName,
-              layers: result.layers,
-              flatSummary: result.flatSummary,
+              layers: boundedLayers,
+              flatSummary: boundedFlat.items,
               summary: result.summary,
+              truncated,
+              ...((boundedFlat.truncated || layerNodesTruncated) && {
+                continuation: {
+                  maxItems: ceiling,
+                  flatSummary: {
+                    returned: boundedFlat.returned,
+                    totalAvailable: boundedFlat.totalAvailable,
+                  },
+                  hint: 'Cascade truncated to the detailed-mode item ceiling. Use mode:"compact" for the top risks, or raise probabilityFloor to shrink the cascade. Configure via graph.detailedMode.maxItems.',
+                },
+              }),
             }),
           },
         ],

--- a/packages/cli/src/mcp/tools/graph/detail-ceiling.behavior.test.ts
+++ b/packages/cli/src/mcp/tools/graph/detail-ceiling.behavior.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { GraphStore, resolveGraphDir } from '@harness-engineering/graph';
+import { handleGetImpact } from './get-impact.js';
+import { handleQueryGraph } from './query-graph.js';
+import { handleComputeBlastRadius } from './compute-blast-radius.js';
+import { clearGraphStoreCache } from '../../utils/graph-loader.js';
+
+/**
+ * WIRED proof for issue #1591: detailed-mode output of the graph retrieval
+ * handlers is bounded on hub (high-degree) nodes.
+ *
+ * A hub file node is wired to 10 neighbors (above the configured ceiling of 3);
+ * a small file node in a separate component has 2 neighbors (below it). The
+ * ceiling is set via `graph.detailedMode.maxItems` in harness.config.json, which
+ * also proves the config → resolveDetailCeiling wiring is live.
+ */
+
+const CEILING = 3;
+const HUB_DEGREE = 10;
+
+let projectDir: string;
+
+function parse(res: { content: Array<{ text: string }> }): Record<string, unknown> {
+  return JSON.parse(res.content[0]!.text) as Record<string, unknown>;
+}
+
+beforeEach(async () => {
+  clearGraphStoreCache();
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'detail-ceiling-'));
+
+  fs.writeFileSync(
+    path.join(projectDir, 'harness.config.json'),
+    JSON.stringify({ version: 1, graph: { detailedMode: { maxItems: CEILING } } })
+  );
+
+  const store = new GraphStore();
+  const fileNode = (id: string, name: string, p: string) => ({
+    id,
+    type: 'file' as const,
+    name,
+    path: p,
+    metadata: {},
+  });
+  // Hub component: file:hub.ts imports HUB_DEGREE neighbors (above the ceiling).
+  store.addNode(fileNode('file:hub.ts', 'hub.ts', 'hub.ts'));
+  for (let i = 0; i < HUB_DEGREE; i++) {
+    store.addNode(fileNode(`file:nbr${i}.ts`, `nbr${i}.ts`, `nbr${i}.ts`));
+    store.addEdge({ from: 'file:hub.ts', to: `file:nbr${i}.ts`, type: 'imports' });
+  }
+  // Small component: file:small.ts imports 2 neighbors (below the ceiling).
+  store.addNode(fileNode('file:small.ts', 'small.ts', 'small.ts'));
+  for (let i = 0; i < 2; i++) {
+    store.addNode(fileNode(`file:s${i}.ts`, `s${i}.ts`, `s${i}.ts`));
+    store.addEdge({ from: 'file:small.ts', to: `file:s${i}.ts`, type: 'imports' });
+  }
+  await store.save(resolveGraphDir(projectDir, 'write'));
+  clearGraphStoreCache();
+});
+
+afterEach(() => {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe('get_impact detailed mode is bounded on hub nodes (#1591)', () => {
+  it('truncates node + edge arrays and flags truncated with a continuation signal', async () => {
+    const res = await handleGetImpact({
+      path: projectDir,
+      filePath: 'hub.ts',
+      mode: 'detailed',
+    });
+    const body = parse(res);
+    const impact = body['impact'] as Record<string, unknown[]>;
+    const totalNodes = Object.values(impact).reduce((n, arr) => n + arr.length, 0);
+
+    expect(totalNodes).toBeLessThanOrEqual(CEILING);
+    expect((body['edges'] as unknown[]).length).toBeLessThanOrEqual(CEILING);
+    expect(body['truncated']).toBe(true);
+    const continuation = body['continuation'] as Record<string, unknown>;
+    expect(continuation).toBeDefined();
+    expect(continuation['maxItems']).toBe(CEILING);
+  });
+
+  it('leaves a small node (below the ceiling) unchanged', async () => {
+    const res = await handleGetImpact({
+      path: projectDir,
+      filePath: 'small.ts',
+      mode: 'detailed',
+    });
+    const body = parse(res);
+    const impact = body['impact'] as Record<string, unknown[]>;
+    const totalNodes = Object.values(impact).reduce((n, arr) => n + arr.length, 0);
+
+    expect(totalNodes).toBe(2);
+    expect(body['truncated']).toBe(false);
+    expect(body['continuation']).toBeUndefined();
+  });
+});
+
+describe('query_graph detailed mode bounds the edge array on hub nodes (#1591)', () => {
+  it('truncates edges and flags truncated', async () => {
+    const res = await handleQueryGraph({
+      path: projectDir,
+      rootNodeIds: ['file:hub.ts'],
+      bidirectional: true,
+      mode: 'detailed',
+    });
+    const body = parse(res);
+    expect((body['edges'] as unknown[]).length).toBeLessThanOrEqual(CEILING);
+    expect(body['truncated']).toBe(true);
+    expect(body['continuation']).toBeDefined();
+  });
+
+  it('leaves a small node unchanged', async () => {
+    const res = await handleQueryGraph({
+      path: projectDir,
+      rootNodeIds: ['file:small.ts'],
+      bidirectional: true,
+      mode: 'detailed',
+    });
+    const body = parse(res);
+    expect((body['edges'] as unknown[]).length).toBe(2);
+    expect(body['truncated']).toBe(false);
+  });
+});
+
+describe('compute_blast_radius detailed mode is bounded on hub nodes (#1591)', () => {
+  it('truncates the cascade payload and flags truncated', async () => {
+    const res = await handleComputeBlastRadius({
+      path: projectDir,
+      nodeId: 'file:hub.ts',
+      mode: 'detailed',
+    });
+    const body = parse(res);
+    expect((body['flatSummary'] as unknown[]).length).toBeLessThanOrEqual(CEILING);
+    for (const layer of body['layers'] as Array<{ nodes: unknown[] }>) {
+      expect(layer.nodes.length).toBeLessThanOrEqual(CEILING);
+    }
+    expect(body['truncated']).toBe(true);
+    expect(body['continuation']).toBeDefined();
+  });
+
+  it('leaves a small node unchanged', async () => {
+    const res = await handleComputeBlastRadius({
+      path: projectDir,
+      nodeId: 'file:small.ts',
+      mode: 'detailed',
+    });
+    const body = parse(res);
+    expect((body['flatSummary'] as unknown[]).length).toBe(2);
+    expect(body['truncated']).toBe(false);
+    expect(body['continuation']).toBeUndefined();
+  });
+});

--- a/packages/cli/src/mcp/tools/graph/get-impact.ts
+++ b/packages/cli/src/mcp/tools/graph/get-impact.ts
@@ -1,6 +1,7 @@
+import { boundItems } from '@harness-engineering/core';
 import { loadGraphStore } from '../../utils/graph-loader.js';
 import { sanitizePath } from '../../utils/sanitize-path.js';
-import { graphNotFoundError } from './shared.js';
+import { graphNotFoundError, resolveDetailCeiling } from './shared.js';
 
 export const getImpactDefinition = {
   name: 'get_impact',
@@ -145,15 +146,53 @@ export async function handleGetImpact(input: {
       };
     }
 
+    // Detailed mode: bound both the impacted-node set and the edge list so a
+    // hub (high-degree) node cannot return an unbounded payload (issue #1591).
+    const ceiling = resolveDetailCeiling(projectPath);
+
+    // Flatten nodes in priority order (tests → docs → code → other), bound the
+    // combined set to the ceiling, then regroup the retained nodes.
+    const flatNodes = [
+      ...(groups['tests'] as Array<{ type: string }>),
+      ...(groups['docs'] as Array<{ type: string }>),
+      ...(groups['code'] as Array<{ type: string }>),
+      ...(groups['other'] as Array<{ type: string }>),
+    ];
+    const boundedNodes = boundItems(flatNodes, ceiling);
+    const groupOf = (t: string): keyof typeof groups =>
+      testTypes.has(t) ? 'tests' : docTypes.has(t) ? 'docs' : codeTypes.has(t) ? 'code' : 'other';
+    const boundedGroups: Record<string, unknown[]> = { tests: [], docs: [], code: [], other: [] };
+    for (const node of boundedNodes.items) {
+      boundedGroups[groupOf(node.type)]!.push(node);
+    }
+
+    const boundedEdges = boundItems(result.edges, ceiling);
+    const truncated = boundedNodes.truncated || boundedEdges.truncated;
+
     return {
       content: [
         {
           type: 'text' as const,
           text: JSON.stringify({
             targetNodeId,
-            impact: groups,
+            impact: boundedGroups,
             stats: result.stats,
-            edges: result.edges,
+            edges: boundedEdges.items,
+            truncated,
+            ...(truncated && {
+              continuation: {
+                maxItems: ceiling,
+                nodes: {
+                  returned: boundedNodes.returned,
+                  totalAvailable: boundedNodes.totalAvailable,
+                },
+                edges: {
+                  returned: boundedEdges.returned,
+                  totalAvailable: boundedEdges.totalAvailable,
+                },
+                hint: 'Result truncated to the detailed-mode item ceiling. Use mode:"summary" for counts, or narrow the anchor node. Configure via graph.detailedMode.maxItems.',
+              },
+            }),
           }),
         },
       ],

--- a/packages/cli/src/mcp/tools/graph/query-graph.ts
+++ b/packages/cli/src/mcp/tools/graph/query-graph.ts
@@ -1,7 +1,7 @@
-import { paginate } from '@harness-engineering/core';
+import { boundItems, paginate } from '@harness-engineering/core';
 import { loadGraphStore } from '../../utils/graph-loader.js';
 import { sanitizePath } from '../../utils/sanitize-path.js';
-import { graphNotFoundError } from './shared.js';
+import { graphNotFoundError, resolveDetailCeiling } from './shared.js';
 
 export const queryGraphDefinition = {
   name: 'query_graph',
@@ -158,11 +158,29 @@ export async function handleQueryGraph(input: {
       (e: { from: string; to: string }) => pagedNodeIds.has(e.from) || pagedNodeIds.has(e.to)
     );
 
+    // A hub node on the page can carry an unbounded number of incident edges;
+    // bound the edge array to the detailed-mode ceiling (issue #1591). Node
+    // pagination already bounds the node array via offset/limit.
+    const ceiling = resolveDetailCeiling(projectPath);
+    const boundedEdges = boundItems(filteredEdges, ceiling);
+    const truncated = paged.pagination.hasMore || boundedEdges.truncated;
+
     const response = {
       nodes: paged.items,
-      edges: filteredEdges,
+      edges: boundedEdges.items,
       stats: result.stats,
       pagination: paged.pagination,
+      truncated,
+      ...(boundedEdges.truncated && {
+        continuation: {
+          maxItems: ceiling,
+          edges: {
+            returned: boundedEdges.returned,
+            totalAvailable: boundedEdges.totalAvailable,
+          },
+          hint: 'Edges truncated to the detailed-mode item ceiling. Page nodes via offset/limit or use mode:"summary". Configure via graph.detailedMode.maxItems.',
+        },
+      }),
     };
     return { content: [{ type: 'text' as const, text: JSON.stringify(response) }] };
   } catch (error) {

--- a/packages/cli/src/mcp/tools/graph/shared.ts
+++ b/packages/cli/src/mcp/tools/graph/shared.ts
@@ -1,3 +1,7 @@
+import path from 'node:path';
+import { DEFAULT_GRAPH_DETAIL_CEILING } from '@harness-engineering/core';
+import { resolveConfig } from '../../../config/loader.js';
+
 export function graphNotFoundError() {
   return {
     content: [
@@ -8,4 +12,25 @@ export function graphNotFoundError() {
     ],
     isError: true,
   };
+}
+
+/**
+ * Resolve the detailed-mode item ceiling for graph retrieval tools from
+ * `graph.detailedMode.maxItems` in the project's harness.config.json.
+ *
+ * Fail-open: any failure (missing file, invalid config, unset key) yields
+ * {@link DEFAULT_GRAPH_DETAIL_CEILING} so detailed-mode output is always
+ * bounded even in zero-config projects (issue #1591).
+ */
+export function resolveDetailCeiling(projectPath: string): number {
+  try {
+    const resolved = resolveConfig(path.join(projectPath, 'harness.config.json'));
+    if (!resolved.ok) return DEFAULT_GRAPH_DETAIL_CEILING;
+    const maxItems = resolved.value.graph?.detailedMode?.maxItems;
+    return typeof maxItems === 'number' && Number.isFinite(maxItems) && maxItems > 0
+      ? maxItems
+      : DEFAULT_GRAPH_DETAIL_CEILING;
+  } catch {
+    return DEFAULT_GRAPH_DETAIL_CEILING;
+  }
 }

--- a/packages/core/src/compaction/detail-ceiling.test.ts
+++ b/packages/core/src/compaction/detail-ceiling.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_GRAPH_DETAIL_CEILING, boundItems } from './detail-ceiling';
+
+describe('boundItems', () => {
+  it('passes through an array below the ceiling unchanged', () => {
+    const input = [1, 2, 3];
+    const result = boundItems(input, 10);
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.truncated).toBe(false);
+    expect(result.totalAvailable).toBe(3);
+    expect(result.returned).toBe(3);
+  });
+
+  it('truncates an array above the ceiling and flags truncated', () => {
+    const input = Array.from({ length: 500 }, (_, i) => i);
+    const result = boundItems(input, 200);
+    expect(result.items).toHaveLength(200);
+    expect(result.items[0]).toBe(0);
+    expect(result.items[199]).toBe(199);
+    expect(result.truncated).toBe(true);
+    expect(result.totalAvailable).toBe(500);
+    expect(result.returned).toBe(200);
+  });
+
+  it('applies the default ceiling when none is provided', () => {
+    const input = Array.from({ length: DEFAULT_GRAPH_DETAIL_CEILING + 50 }, (_, i) => i);
+    const result = boundItems(input);
+    expect(result.items).toHaveLength(DEFAULT_GRAPH_DETAIL_CEILING);
+    expect(result.truncated).toBe(true);
+    expect(result.totalAvailable).toBe(DEFAULT_GRAPH_DETAIL_CEILING + 50);
+  });
+
+  it('falls back to the default ceiling for a non-positive ceiling', () => {
+    const input = Array.from({ length: DEFAULT_GRAPH_DETAIL_CEILING + 1 }, (_, i) => i);
+    expect(boundItems(input, 0).items).toHaveLength(DEFAULT_GRAPH_DETAIL_CEILING);
+    expect(boundItems(input, -5).items).toHaveLength(DEFAULT_GRAPH_DETAIL_CEILING);
+    expect(boundItems(input, Number.NaN).items).toHaveLength(DEFAULT_GRAPH_DETAIL_CEILING);
+  });
+
+  it('handles an empty array', () => {
+    const result = boundItems([], 200);
+    expect(result.items).toEqual([]);
+    expect(result.truncated).toBe(false);
+    expect(result.totalAvailable).toBe(0);
+    expect(result.returned).toBe(0);
+  });
+
+  it('does not mutate or alias the input array', () => {
+    const input = [1, 2, 3];
+    const result = boundItems(input, 10);
+    expect(result.items).not.toBe(input);
+    result.items.push(4);
+    expect(input).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/src/compaction/detail-ceiling.ts
+++ b/packages/core/src/compaction/detail-ceiling.ts
@@ -1,0 +1,59 @@
+/**
+ * Detail-mode item ceiling for graph retrieval tools.
+ *
+ * The graph token-savings benchmark (#1271) found that `get_impact` /
+ * `query_graph` / `compute_blast_radius` detailed-mode payloads on hub
+ * (high-degree) nodes are unbounded — serializing to hundreds of millions of
+ * tokens. `boundItems` caps an otherwise-unbounded array to a ceiling and
+ * reports whether it truncated so the tool can fail soft (emit `truncated: true`
+ * plus a continuation signal) instead of dumping the whole neighborhood.
+ */
+
+/**
+ * Default maximum number of items returned per array in a graph detailed-mode
+ * response. Derived from the #1271 benchmark: at roughly ~125 tokens per
+ * serialized graph item, a 200-item ceiling holds a detailed response near
+ * ~25k tokens — a >4-orders-of-magnitude reduction from the ~293M-token
+ * unbounded worst case, while still returning far more than the summary surface.
+ * Overridable via `graph.detailedMode.maxItems` in `harness.config.json`.
+ */
+export const DEFAULT_GRAPH_DETAIL_CEILING = 200;
+
+/**
+ * Result of bounding an array to a ceiling.
+ */
+export interface BoundedItems<T> {
+  /** The items actually returned (length <= ceiling). */
+  items: T[];
+  /** True when the input exceeded the ceiling and was truncated. */
+  truncated: boolean;
+  /** Total items available before truncation. */
+  totalAvailable: number;
+  /** Number of items actually returned (<= ceiling). */
+  returned: number;
+}
+
+/**
+ * Bounds an array to at most `ceiling` items, reporting whether truncation
+ * occurred. A non-positive, non-finite, or absent ceiling falls back to
+ * {@link DEFAULT_GRAPH_DETAIL_CEILING} so a caller can never accidentally
+ * disable the bound by passing `0` or `NaN`.
+ *
+ * @param items   - The full (already relevance-sorted) array to bound.
+ * @param ceiling - Maximum items to keep. Defaults to the graph detail ceiling.
+ */
+export function boundItems<T>(
+  items: readonly T[],
+  ceiling: number = DEFAULT_GRAPH_DETAIL_CEILING
+): BoundedItems<T> {
+  const cap =
+    Number.isFinite(ceiling) && ceiling > 0 ? Math.floor(ceiling) : DEFAULT_GRAPH_DETAIL_CEILING;
+  const totalAvailable = items.length;
+  const bounded = totalAvailable > cap ? items.slice(0, cap) : [...items];
+  return {
+    items: bounded,
+    truncated: totalAvailable > cap,
+    totalAvailable,
+    returned: bounded.length,
+  };
+}

--- a/packages/core/src/compaction/index.ts
+++ b/packages/core/src/compaction/index.ts
@@ -14,3 +14,6 @@ export { serializeEnvelope, estimateTokens } from './envelope';
 
 export type { PaginationMeta, PaginatedSlice } from './pagination';
 export { paginate } from './pagination';
+
+export type { BoundedItems } from './detail-ceiling';
+export { boundItems, DEFAULT_GRAPH_DETAIL_CEILING } from './detail-ceiling';


### PR DESCRIPTION
## Summary

Detailed-mode payloads of the graph retrieval MCP tools (`get_impact`, `query_graph`, `compute_blast_radius`) on **hub (high-degree) nodes** were **unbounded**. The reproducible graph token-savings benchmark (#1271, `docs/benchmarks/graph-token-savings/RESULTS.md` caveat 3) measured them serializing to **~293M tokens** (impact anchors, full bidirectional 3-hop neighborhood) and **~4.47M tokens** (dependencies anchors) — enough to dwarf every saving the graph tools deliver and overflow an agent's context.

This bounds every detailed-mode response array at a **configurable item ceiling** and **fails soft**: when output is truncated the response carries `truncated: true` plus a `continuation` signal (the ceiling, totals available, and how to page or scope down) instead of silently returning a giant payload. Small nodes below the ceiling are unchanged.

`Closes #1591` — all three named handlers are bounded.

## Wiring

- **Config key:** `graph.detailedMode.maxItems` (`packages/cli/src/config/schema.ts`), default `DEFAULT_GRAPH_DETAIL_CEILING = 200` (`@harness-engineering/core`).
- **Shared helper:** `boundItems(items, ceiling?)` → `{ items, truncated, totalAvailable, returned }` (`packages/core/src/compaction/detail-ceiling.ts`, re-exported via the compaction barrel — star-exported, no allowlist edit needed).
- **Ceiling resolver:** `resolveDetailCeiling(projectPath)` in `packages/cli/src/mcp/tools/graph/shared.ts` reads config, fail-open to the default.
- **Handlers wired** (live MCP entry points registered in `packages/cli/src/mcp/server.ts`):
  - `get_impact` (`handleGetImpact`, `get-impact.ts`) — bounds the flattened impacted-node set (regrouped) and the `edges` array.
  - `query_graph` (`handleQueryGraph`, `query-graph.ts`) — nodes stay offset/limit paginated; the previously-unbounded `edges` array is now bounded.
  - `compute_blast_radius` (`handleComputeBlastRadius`, `compute-blast-radius.ts`) — bounds `flatSummary` and each layer's `nodes`.

A reviewer can trace a live `get_impact` call on a hub node → `handleGetImpact` detailed branch → `boundItems` → bounded `impact`/`edges` + `truncated`/`continuation`.

## Default ceiling rationale

Derived from the benchmark: at ~125 tokens per serialized graph item, a 200-item cap holds a detailed response near ~25k tokens — a >4-orders-of-magnitude reduction from ~293M, while still returning far more than the summary surface. `query_graph`'s existing node page default (`limit: 50`) sits under this ceiling and is preserved.

## Tests

- `packages/core/src/compaction/detail-ceiling.test.ts` — unit (truncate/passthrough/default/empty/non-mutation).
- `packages/cli/src/mcp/tools/graph/detail-ceiling.behavior.test.ts` — WIRED proof: a synthetic hub node (10 neighbors) with a configured ceiling of 3 → all three detailed handlers return bounded arrays + `truncated: true` + `continuation`; a small node (2 neighbors) is unchanged. Also proves the `graph.detailedMode.maxItems` config → resolver path is live.

All graph-tool + config tests pass (43), core compaction tests pass, typecheck clean, `generate-docs` fresh.

## Assumptions made

- Count-based ceiling (200 items/array) is an acceptable proxy for the token ceiling; a byte/token meter is intentionally rejected because it would require materializing the very payload we are avoiding.
- Fail-open on config read error (apply the default ceiling) is safer than failing the tool call.
- `query_graph`'s existing node pagination is retained; only its unbounded `edges` array needed bounding.

## Artifacts

`docs/changes/bound-detailed-graph-output/` — `proposal.md`, `plans/plan.md`, `provenance.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
