### PR TITLE
feat(core): fail loud on GitHub Search incomplete_results truncation (Refs #1532)

### DIFF
--- a/.changeset/search-incomplete-results-failloud.md
+++ b/.changeset/search-incomplete-results-failloud.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/core': minor
+---
+
+Fail loud on GitHub Search API truncation (Refs #1532). `GitHubHttp` gains a
+budget-aware `search()` method that throws the existing `TruncatedFetchError`
+when a search response reports `incomplete_results: true`, instead of returning
+the partial `items` as if complete — the search-API counterpart to the
+paginate-truncation guard landed in #1589. `GitHubIssuesTrackerAdapter.searchFeatures()`
+wires this into a real, `github.search`-budgeted call site: a truncated search
+is surfaced as `Err`, never a silently-short feature list. Byte-identical when
+`incomplete_results` is `false` or absent.

--- a/docs/changes/search-incomplete-results-failloud/plans/plan.md
+++ b/docs/changes/search-incomplete-results-failloud/plans/plan.md
@@ -1,0 +1,37 @@
+# Plan: Fail loud on GitHub Search `incomplete_results`
+
+Refs #1532. Proposal: `../proposal.md`.
+
+## Tasks
+
+1. **`GitHubHttp.search<T>()`** (`packages/core/src/roadmap/tracker/adapters/github-http.ts`)
+   - Add a paginating search method that goes through the existing `request()`
+     path (budget + throttle inherited).
+   - Parse `{ total_count, incomplete_results, items }`.
+   - `incomplete_results === true` → `throw new TruncatedFetchError(this.resource, url)`.
+   - `false`/absent → accumulate `items`, follow `Link: rel="next"` normally.
+   - Return `{ items, totalCount }`.
+
+2. **`GitHubIssuesTrackerAdapter.searchFeatures(query)`** (`.../adapters/github-issues.ts`)
+   - Add a `github.search`-budgeted `GitHubHttp` instance.
+   - Build repo-scoped query URL for `/search/issues`.
+   - Call `search<RawIssue>()`, filter out PRs, map to `TrackedFeature[]`.
+   - Wrap in try/catch → `Result`; `TruncatedFetchError` becomes `Err`.
+
+3. **Tests**
+   - `github-http.test.ts`: `search` throws `TruncatedFetchError` on
+     `incomplete_results: true`; returns items on `false`; identical on absent.
+   - `github-issues.test.ts`: `searchFeatures` returns `Err` on truncation;
+     returns mapped features on happy path; scopes the query to the repo.
+
+4. **Docs / gates**
+   - `pnpm run generate-docs` if any CLI/reference surface changed (none expected).
+   - Rebuild CLI before commit (pre-commit arch gate); `prettier --write`.
+
+## Verification
+
+- `incomplete_results: true` → throws (unit) and → `Err` (adapter).
+- `false`/absent → byte-identical returns.
+- Live trace: `searchFeatures` → `searchHttp.search` (resource `github.search`)
+  → `incomplete_results` check → `TruncatedFetchError` → `Err`.
+- All-OS CI green.

--- a/docs/changes/search-incomplete-results-failloud/proposal.md
+++ b/docs/changes/search-incomplete-results-failloud/proposal.md
@@ -1,0 +1,89 @@
+# Proposal: Fail loud on GitHub Search `incomplete_results` truncation
+
+Refs #1532 (deferred slice of the rate-limit-aware fan-out governor landed in PR #1589).
+
+## Problem
+
+PR #1589 made the GitHub fan-out rate-limit-aware and introduced a hard
+fail-on-truncation rule for the GitHub HTTP layer (`GitHubHttp`): a throttled
+fetch throws `ThrottledFetchError`, and a paginated GET that is server-truncated
+(a short page still advertising `Link: rel="next"`) throws `TruncatedFetchError`
+rather than returning a silently-short list.
+
+That work explicitly deferred one truncation channel: the **GitHub Search API**.
+Search endpoints (`/search/issues`, `/search/code`, …) return an envelope
+`{ total_count, incomplete_results, items }` and set `incomplete_results: true`
+when the query timed out or was truncated server-side. A consumer that reads
+`items` without inspecting `incomplete_results` treats a partial result as
+complete — the exact silent-under-fetch failure mode (287/430 repos read as
+zero) that motivated #1532, just on a different API family.
+
+At the time of this change there is **no live GitHub Search API call site** in
+the codebase — `github.search` exists only as a per-resource budget key
+(`limit: 10/min` in `workflow/config.ts`) reserved for the search family. The
+fix is therefore build-out: add the canonical search plumbing with the
+truncation check baked in, so the first (and every) consumer fails loud by
+construction rather than re-discovering the trap.
+
+## Goals
+
+- Detect `incomplete_results: true` on any GitHub Search response in the
+  fetch/search path and throw the **existing** `TruncatedFetchError`
+  (from `@harness-engineering/core` → `fleet/rate-budget`, landed in #1589) —
+  do NOT define a new error type.
+- Keep it consistent with how #1589 handles paginate-truncation: the truncated
+  operation FAILS instead of returning accumulated-so-far items.
+- Byte-identical behaviour when `incomplete_results` is `false` or absent.
+- Wire the check into a real, reachable search call site so a reviewer can
+  trace a live search → the `incomplete_results` check → `TruncatedFetchError`.
+
+## Non-goals (remaining deferred siblings of #1532)
+
+- Cross-process / cross-run cooldown sharing of the search budget.
+- Broader per-API truncation coverage beyond search + paginate.
+- Migrating the existing list-based `fetchAll()` onto the Search API (search
+  caps at 1000 results + 10 req/min; the label-list endpoint is correct there).
+
+## Design
+
+### 1. `GitHubHttp.search<T>()` — the search call site
+
+A new method on the existing budget-aware `GitHubHttp` (the same class #1589
+wired throttle/paginate-truncation into). It issues Search API GETs through the
+same `request()` path (so it inherits the shared per-resource budget, shared
+backoff, and throw-on-throttle for free), then:
+
+- Parses the search envelope `{ total_count, incomplete_results, items }`.
+- If `incomplete_results === true` → `throw new TruncatedFetchError(resource, url)`.
+- Otherwise accumulates `items` and paginates normally (search paginates via
+  `Link: rel="next"`; for search, a `rel="next"` link is _ordinary_ paging, NOT
+  truncation — `incomplete_results` is the truncation signal, so rel=next is
+  followed rather than treated as a failure).
+
+`incomplete_results` absent or `false` → the `=== true` guard is false → no
+throw → identical accumulation as before (byte-identical requirement).
+
+### 2. `GitHubIssuesTrackerAdapter.searchFeatures(query)` — the live consumer
+
+A real, reachable public capability: free-text search over harness-managed
+issues in the adapter's configured repo. It builds a repo-scoped query
+(`<query> repo:owner/repo`, confused-deputy-consistent with the rest of the
+adapter), issues it through a `github.search`-budgeted `GitHubHttp`, maps the
+result items to `TrackedFeature[]`, and returns a `Result`. A
+`TruncatedFetchError` thrown by the plumbing is caught by the adapter's
+try/catch and surfaced as `Err(...)` — fail-loud, never a silently-short list.
+
+The search request is budgeted under the `github.search` resource
+(10 req/min per #1532's measurement) via a dedicated `GitHubHttp` instance,
+distinct from the `github.core` client used by the list/CRUD path.
+
+## Acceptance criteria
+
+- [ ] A search response with `incomplete_results: true` throws
+      `TruncatedFetchError` (the existing type) — no partial `items` returned.
+- [ ] A search response with `incomplete_results: false` returns its items.
+- [ ] A search response with `incomplete_results` absent behaves identically to
+      `false` (byte-identical).
+- [ ] `searchFeatures()` surfaces the truncation as `Err`, and returns mapped
+      features on the happy path.
+- [ ] The search path is budgeted under `github.search`.

--- a/docs/changes/search-incomplete-results-failloud/provenance.json
+++ b/docs/changes/search-incomplete-results-failloud/provenance.json
@@ -1,0 +1,29 @@
+{
+  "issue": 1532,
+  "slug": "search-incomplete-results-failloud",
+  "title": "GitHub Search incomplete_results truncation → fail-loud",
+  "parent_pr": 1589,
+  "closing_keyword": "Refs #1532",
+  "plan_path": "docs/changes/search-incomplete-results-failloud/plans/plan.md",
+  "proposal_path": "docs/changes/search-incomplete-results-failloud/proposal.md",
+  "stages": ["brainstorming", "planning", "execution", "verification", "review"],
+  "wired_call_site": "GitHubIssuesTrackerAdapter.searchFeatures() -> GitHubHttp.search() (resource 'github.search') -> incomplete_results===true -> throw TruncatedFetchError -> Err",
+  "reused_error_type": "TruncatedFetchError (packages/core/src/fleet/rate-budget/errors.ts, landed in #1589)",
+  "changed_files": [
+    "packages/core/src/roadmap/tracker/adapters/github-http.ts",
+    "packages/core/src/roadmap/tracker/adapters/github-issues.ts",
+    "packages/core/src/roadmap/tracker/adapters/github-http.test.ts",
+    "packages/core/tests/roadmap/tracker/adapters/github-issues.test.ts"
+  ],
+  "tests": [
+    "github-http.test.ts: search throws TruncatedFetchError on incomplete_results:true; returns items on false; identical when absent; follows rel=next paging",
+    "github-issues.test.ts: searchFeatures returns Err on truncation; maps features + scopes q to repo on happy path; drops PRs"
+  ],
+  "assumptions": [
+    "No live GitHub Search API call site existed pre-change; 'github.search' was only a per-resource budget key. This slice adds the canonical search plumbing with the incomplete_results check baked in, wired into a real reachable adapter capability (searchFeatures).",
+    "For the Search API, a 'Link: rel=next' header is ordinary pagination (not truncation); 'incomplete_results:true' is the sole server-truncation signal — so rel=next is followed, incomplete_results throws.",
+    "Truncation is surfaced through the adapter's existing Result/try-catch convention as Err (fail-loud without partial data), mirroring how paginate-truncation reaches fetchAll callers as Err.",
+    "Search traffic is budgeted under 'github.search' (10 req/min per #1532 measurement) via a dedicated GitHubHttp instance, distinct from the 'github.core' list/CRUD client.",
+    "Deferred siblings of #1532 remain out of scope: cross-process/cross-run cooldown sharing and broader per-API truncation coverage."
+  ]
+}

--- a/packages/core/src/roadmap/tracker/adapters/github-http.test.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-http.test.ts
@@ -278,6 +278,45 @@ describe('GitHubHttp — rate-limit budget wiring (#1532)', () => {
     const out = await http(fetchFn).paginate<{ id: number }>(buildUrl, 2);
     expect(out.items).toEqual([{ id: 1 }]);
   });
+
+  it('search throws TruncatedFetchError when incomplete_results is true', async () => {
+    const { fetchFn } = queuedFetch([
+      res(200, { total_count: 5, incomplete_results: true, items: [{ id: 1 }] }),
+    ]);
+    // A server-truncated search must fail the leaf, NOT return the partial items.
+    await expect(http(fetchFn).search(buildUrl, 2)).rejects.toBeInstanceOf(TruncatedFetchError);
+  });
+
+  it('search returns items (no throw) when incomplete_results is false', async () => {
+    const { fetchFn } = queuedFetch([
+      res(200, { total_count: 2, incomplete_results: false, items: [{ id: 1 }] }),
+    ]);
+    const out = await http(fetchFn).search<{ id: number }>(buildUrl, 2);
+    expect(out.items).toEqual([{ id: 1 }]);
+    expect(out.totalCount).toBe(2);
+  });
+
+  it('search behaves identically when incomplete_results is absent (byte-identical to false)', async () => {
+    const { fetchFn } = queuedFetch([res(200, { total_count: 1, items: [{ id: 7 }] })]);
+    const out = await http(fetchFn).search<{ id: number }>(buildUrl, 2);
+    expect(out.items).toEqual([{ id: 7 }]);
+    expect(out.totalCount).toBe(1);
+  });
+
+  it('search follows rel="next" pagination (rel=next is paging, not truncation)', async () => {
+    const { fetchFn, count } = queuedFetch([
+      res(
+        200,
+        { total_count: 3, incomplete_results: false, items: [{ id: 1 }, { id: 2 }] },
+        { Link: '<https://api.github.com/search/issues?page=2>; rel="next"' }
+      ),
+      res(200, { total_count: 3, incomplete_results: false, items: [{ id: 3 }] }),
+    ]);
+    // perPage 2: page 1 is full AND advertises rel="next" → fetch page 2.
+    const out = await http(fetchFn).search<{ id: number }>(buildUrl, 2);
+    expect(out.items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(count()).toBe(2);
+  });
 });
 
 describe('re-exported External-ID helpers', () => {

--- a/packages/core/src/roadmap/tracker/adapters/github-http.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-http.ts
@@ -163,6 +163,63 @@ export class GitHubHttp {
     }
     return { items, lastEtag, status };
   }
+
+  /**
+   * Walk all pages of a GitHub **Search** API query (`/search/*`), which — unlike
+   * the list endpoints `paginate()` handles — returns an envelope
+   * `{ total_count, incomplete_results, items }` rather than a bare array.
+   *
+   * Fail-the-leaf on server truncation (#1532, search slice): the Search API sets
+   * `incomplete_results: true` when a query timed out or was truncated
+   * server-side. Reading `items` as if it were the complete set is the same
+   * silent under-fetch that `paginate()` guards against for rel="next" — so a
+   * page reporting `incomplete_results: true` throws `TruncatedFetchError`
+   * instead of returning the partial `items`.
+   *
+   * Distinct from paginate's truncation signal: for Search, a `Link: rel="next"`
+   * header is *ordinary* paging (the result set spans multiple pages), NOT
+   * truncation — `incomplete_results` is the truncation signal. So rel="next" is
+   * followed here rather than treated as a failure.
+   *
+   * Byte-identical when `incomplete_results` is `false` or absent: the `=== true`
+   * guard is false, nothing throws, and accumulation proceeds unchanged.
+   */
+  async search<T>(
+    buildUrl: (page: number) => string,
+    perPage = 100,
+    extraHeaders?: Record<string, string>
+  ): Promise<{ items: T[]; totalCount: number }> {
+    const items: T[] = [];
+    let page = 1;
+    let totalCount = 0;
+    for (;;) {
+      const init: RequestInit & { extraHeaders?: Record<string, string> } = { method: 'GET' };
+      if (extraHeaders) init.extraHeaders = extraHeaders;
+      const url = buildUrl(page);
+      const res = await this.request(url, init);
+      if (!res.ok) {
+        throw new Error(`GitHub ${res.status}: ${await res.text()}`);
+      }
+      const body = (await res.json()) as {
+        total_count?: number;
+        incomplete_results?: boolean;
+        items?: T[];
+      };
+      // Server-truncated search: fail the leaf (#1532) rather than return a
+      // partial `items` array a caller could mistake for the complete set.
+      if (body.incomplete_results === true) {
+        throw new TruncatedFetchError(this.resource, url);
+      }
+      const pageItems = body.items ?? [];
+      items.push(...pageItems);
+      totalCount = body.total_count ?? totalCount;
+      // A full page implies more may exist; Search paginates via rel="next".
+      if (pageItems.length < perPage) break;
+      if (!hasNextLink(res.headers.get('Link'))) break;
+      page++;
+    }
+    return { items, totalCount };
+  }
 }
 
 /**

--- a/packages/core/src/roadmap/tracker/adapters/github-issues.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-issues.ts
@@ -92,6 +92,14 @@ function buildCreateMeta(feature: NewFeatureInput): BodyMeta {
 
 export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
   private readonly http: GitHubHttp;
+  /**
+   * Dedicated client for the GitHub **Search** API, budgeted under the
+   * `github.search` resource family (measured cap: 10 req/min — much tighter
+   * than `github.core`'s 80, per #1532). Separate from `this.http` so search
+   * fan-out self-paces against its own budget and shares backoff only with
+   * sibling search leaves.
+   */
+  private readonly searchHttp: GitHubHttp;
   private readonly owner: string;
   private readonly repo: string;
   private readonly cache: ETagStore;
@@ -100,6 +108,7 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
 
   constructor(opts: GitHubIssuesTrackerOptions) {
     this.http = new GitHubHttp(opts);
+    this.searchHttp = new GitHubHttp({ ...opts, resource: 'github.search' });
     const [owner, repo] = opts.repo.split('/');
     if (!owner || !repo) throw new Error(`Invalid repo "${opts.repo}", expected "owner/repo"`);
     this.owner = owner;
@@ -203,6 +212,46 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
     const all = await this.fetchAll();
     if (!all.ok) return all;
     return Ok(all.value.features.filter((f) => statuses.includes(f.status)));
+  }
+
+  /**
+   * Free-text search over harness-managed issues in the configured repo via the
+   * GitHub Search API (`/search/issues`).
+   *
+   * The query is always scoped to the adapter's own `owner/repo` (appending
+   * `repo:owner/repo`), consistent with the confused-deputy guard on
+   * fetchById/update — the adapter never searches a repo it is not configured to
+   * manage.
+   *
+   * Fail-loud on truncation (#1532, search slice): the Search API sets
+   * `incomplete_results: true` when a query is truncated/timed-out server-side.
+   * `searchHttp.search()` throws `TruncatedFetchError` in that case, which this
+   * method's try/catch surfaces as `Err(...)` — a truncated search FAILS the
+   * operation rather than returning a silently-short feature list.
+   */
+  async searchFeatures(query: string): Promise<Result<TrackedFeature[], Error>> {
+    try {
+      // Scope every query to the configured repo. `q` is encoded once via
+      // URLSearchParams; the Search API reads a single space-joined `q` term.
+      const scopedQuery = `${query} repo:${this.owner}/${this.repo}`.trim();
+      const buildUrl = (page: number) => {
+        const params = new URLSearchParams({
+          q: scopedQuery,
+          per_page: '100',
+          page: String(page),
+        });
+        return `${this.searchHttp.apiBase}/search/issues?${params.toString()}`;
+      };
+
+      const { items } = await this.searchHttp.search<RawIssue>(buildUrl, 100);
+      // /search/issues returns PRs too; drop them, matching fetchAll.
+      const issues = items.filter((i) => !i.pull_request);
+      const features = issues.map((i) => this.mapIssue(i, new Map()));
+      features.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      return Ok(features);
+    } catch (err) {
+      return Err(err instanceof Error ? err : new Error(String(err)));
+    }
   }
 
   // --- Writes ---

--- a/packages/core/tests/roadmap/tracker/adapters/github-issues.test.ts
+++ b/packages/core/tests/roadmap/tracker/adapters/github-issues.test.ts
@@ -795,3 +795,59 @@ describe('GitHubIssuesTrackerAdapter — update', () => {
     expect((fetchFn as unknown as { mock?: { calls: unknown[] } }).mock?.calls.length ?? 0).toBe(0);
   });
 });
+
+describe('GitHubIssuesTrackerAdapter — searchFeatures (incomplete_results fail-loud)', () => {
+  it('returns Err when the Search API reports incomplete_results: true', async () => {
+    // A server-truncated search must NOT be surfaced as a (silently short)
+    // feature list — it fails the operation (#1532 search slice).
+    const fetchFn = mockFetchSequence({
+      status: 200,
+      body: { total_count: 42, incomplete_results: true, items: [rawIssue({ number: 1 })] },
+    });
+    const adapter = new GitHubIssuesTrackerAdapter({ token: 'tok', repo: 'o/r', fetchFn });
+    const r = await adapter.searchFeatures('label:harness-managed bug');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.name).toBe('TruncatedFetchError');
+  });
+
+  it('returns mapped features on a complete result and scopes the query to the repo', async () => {
+    const fetchFn = mockFetchSequence({
+      status: 200,
+      body: {
+        total_count: 2,
+        incomplete_results: false,
+        items: [rawIssue({ number: 1, title: 'F1' }), rawIssue({ number: 2, title: 'F2' })],
+      },
+    });
+    const adapter = new GitHubIssuesTrackerAdapter({ token: 'tok', repo: 'o/r', fetchFn });
+    const r = await adapter.searchFeatures('bug');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toHaveLength(2);
+      expect(r.value[0]!.externalId).toBe('github:o/r#1');
+    }
+    // The issued request must hit /search/issues with the repo appended to `q`.
+    const calls = (fetchFn as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls;
+    const url = calls[0]![0];
+    expect(url).toContain('/search/issues?');
+    expect(decodeURIComponent(url)).toContain('repo:o/r');
+  });
+
+  it('drops pull requests from search results (matching fetchAll)', async () => {
+    const fetchFn = mockFetchSequence({
+      status: 200,
+      body: {
+        total_count: 2,
+        incomplete_results: false,
+        items: [rawIssue({ number: 1 }), rawIssue({ number: 2, pull_request: { url: 'x' } })],
+      },
+    });
+    const adapter = new GitHubIssuesTrackerAdapter({ token: 'tok', repo: 'o/r', fetchFn });
+    const r = await adapter.searchFeatures('bug');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toHaveLength(1);
+      expect(r.value[0]!.externalId).toBe('github:o/r#1');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Deferred slice of #1532 (the rate-limit-aware fan-out governor landed in PR #1589). #1589 made the GitHub HTTP layer fail loud on **throttle** and **paginate-truncation** (`Link: rel="next"` on a short page), but explicitly deferred one truncation channel: the GitHub **Search API**.

Search endpoints return an envelope `{ total_count, incomplete_results, items }` and set `incomplete_results: true` when a query is truncated/timed-out server-side. A consumer reading `items` without checking that flag treats a partial result as complete — the same silent under-fetch (287/430 repos read as zero) that motivated #1532, on a different API family. This makes it fail loud too, reusing the existing `TruncatedFetchError` (no new error type).

`Refs #1532` (one slice; siblings — cross-process cooldown, broader per-API coverage — remain deferred).

## What changed

- **`GitHubHttp.search<T>()`** (`packages/core/src/roadmap/tracker/adapters/github-http.ts`) — the search call site. Issues Search API GETs through the same budget-aware `request()` path (inherits shared per-resource budget, shared backoff, throw-on-throttle). Parses the envelope and **throws `TruncatedFetchError` when `incomplete_results === true`** instead of returning partial `items`. For Search, `Link: rel="next"` is *ordinary paging* (followed), NOT truncation — `incomplete_results` is the truncation signal. Byte-identical when the flag is `false` or absent.
- **`GitHubIssuesTrackerAdapter.searchFeatures(query)`** (`.../github-issues.ts`) — the live, reachable consumer. Repo-scoped free-text search over harness-managed issues via a dedicated `github.search`-budgeted `GitHubHttp` (10 req/min per #1532's measurement, vs `github.core`'s 80). A `TruncatedFetchError` is surfaced as `Err(...)` — fail-loud, never a silently-short feature list.

## Wiring (live trace)

`GitHubIssuesTrackerAdapter.searchFeatures()` → `searchHttp.search()` (resource `github.search`) → `incomplete_results === true` → `throw new TruncatedFetchError(...)` → adapter try/catch → `Err(...)`.

## Context: no pre-existing search call site

There was no live GitHub Search API caller anywhere in the repo before this change — `github.search` existed only as a per-resource budget key. This slice adds the canonical search plumbing with the check baked in, wired into a genuine reachable adapter capability, so the first (and every) consumer fails loud by construction.

## Tests

- `github-http.test.ts`: `search` throws `TruncatedFetchError` on `incomplete_results:true`; returns items on `false`; identical when absent; follows `rel="next"` paging.
- `github-issues.test.ts`: `searchFeatures` returns `Err` on truncation; maps features + scopes `q` to the repo on happy path; drops PRs.
- Full roadmap + fleet suites: 776 passing.

## Assumptions made

- Truncation surfaces through the adapter's existing `Result`/try-catch convention as `Err` (mirrors how paginate-truncation reaches `fetchAll` callers).
- For the Search API, `rel="next"` = pagination (followed); `incomplete_results:true` = the sole server-truncation signal (throws).
- Search budgeted under `github.search` via a dedicated `GitHubHttp` instance, distinct from the `github.core` list/CRUD client.
- The existing list-based `fetchAll()` is intentionally NOT migrated onto Search (Search caps at 1000 results + 10 req/min; the label-list endpoint is correct there).

Artifacts: `docs/changes/search-incomplete-results-failloud/` (proposal.md, plans/plan.md, provenance.json).
