### PR TITLE
feat(graph): answer-quality axis for graph token-savings benchmark (Refs #1271)

### DIFF
--- a/.changeset/graph-bench-answer-quality-axis.md
+++ b/.changeset/graph-bench-answer-quality-axis.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Add the answer-quality axis to `harness graph bench` (deferred slice of #1271). The
+benchmark measured two objective axes — retrieval tokens and tool calls — but the
+comparator's third axis, **answer quality** (whether the retrieved payload actually
+suffices to answer the query), was deferred. It now ships as an opt-in `--judge` flag:
+an LLM judge grades each strategy's payload for retrieval sufficiency, reusing the shared
+harness eval/judge plumbing (`resolveAnalysisProvider` → Anthropic key or a local `/v1`
+endpoint, the same resolver `outcome_eval`/`acceptance_eval` use) rather than a bespoke
+judge.
+
+The axis is **advisory and degrades honestly**: with no judge provider configured it
+reports `answerQuality.status: "inconclusive"` instead of fabricating a score, and it
+never fails the benchmark — the token/tool-call axes stand regardless. Off by default
+(`status: "skipped"`), so the deterministic headline and CI runs are unchanged. The JSON
+result gains an `answerQuality` block (per-strategy sufficiency counts) and each scenario
+gains a `quality` grade plus the exact `query` the judge was asked; `harness graph bench
+--judge --json` lets a reviewer trace bench → judge → score. Also fixes a pre-existing bug
+where the program-global `--json` option shadowed `graph bench --json`. `Refs #1271`.

--- a/docs/benchmarks/graph-token-savings/REPRODUCING.md
+++ b/docs/benchmarks/graph-token-savings/REPRODUCING.md
@@ -18,9 +18,23 @@ Two **objective, deterministic** axes are measured:
   strategy puts into the model's context to answer a question.
 - **Tool calls** — how many discrete retrieval calls each strategy makes.
 
-Answer quality — the comparator's third axis ("83%") — is **not** measured here. Grading whether
-each strategy's payload actually answers the question requires an LLM judge and is non-deterministic;
-it is a deferred slice (see [Deferred slices](#deferred-slices)).
+Answer quality — the comparator's third axis ("83%") — is an **opt-in, advisory** third axis. It is
+not part of the headline (which stays deterministic) and is off by default. Pass `--judge` and an LLM
+judge grades whether each strategy's retrieved payload is _sufficient_ to answer the query:
+
+```bash
+# needs a judge provider: ANTHROPIC_API_KEY, or a local /v1 via HARNESS_ANALYSIS_BASE_URL
+harness graph bench --judge --json
+```
+
+The result gains an `answerQuality` block (`status: skipped | inconclusive | measured`, plus per-
+strategy sufficiency counts) and each scenario gains a `quality` grade + the exact `query` the judge
+was asked. It **reuses the shared harness eval/judge plumbing** (`resolveAnalysisProvider`, the same
+resolver `outcome_eval` / `acceptance_eval` use) and **degrades honestly**: with no judge configured
+it reports `status: "inconclusive"` rather than fabricating a score, and it never fails the benchmark
+— the token/tool-call axes stand regardless. Because it is opt-in and non-deterministic it is
+excluded from CI runs (the default no-`--judge` path is byte-stable). A published multi-repo answer-
+quality number is still deferred (see [Deferred slices](#deferred-slices)).
 
 ## The honest target
 
@@ -80,8 +94,9 @@ that is the surface an agent actually surfaces into context (counts + top-risk i
 subgraph. Detailed mode on hub nodes is unbounded (see the detailed-mode finding in
 [`RESULTS.md`](./RESULTS.md)); it is deliberately excluded from the headline and documented as a
 finding rather than silently measured. The consequence — the graph returns a scoped summary while
-the naive side returns full content — is exactly why the **answer-quality axis is deferred**: the
-token ratio is "cost to retrieve a scoped answer", and whether that answer suffices is unmeasured.
+the naive side returns full content — is exactly what the **answer-quality axis** exists to check:
+the token ratio is "cost to retrieve a scoped answer", and whether that scoped answer actually
+suffices is what the opt-in `--judge` axis grades (advisory; see above).
 
 ### Fairness rules
 
@@ -102,9 +117,26 @@ token ratio is "cost to retrieve a scoped answer", and whether that answer suffi
 
 Reported per-family and overall.
 
+### Answer-quality fields (`--judge` only)
+
+When `--judge` is passed the machine-readable result carries:
+
+- `answerQuality.status` — `skipped` (no `--judge`), `inconclusive` (requested but no judge
+  provider reachable), or `measured`.
+- `answerQuality.graph` / `.naive` — per-strategy `{ sufficient, insufficient, inconclusive, total,
+sufficientRate }`. `sufficientRate = sufficient / (sufficient + insufficient)`, or `null` when
+  nothing was decidable (never a fabricated score).
+- each `scenarios[].quality.graph` / `.naive` — `{ sufficient: boolean | null, confidence,
+rationale }`, and `scenarios[].query` — the exact question the judge was asked.
+
+The axis is **advisory**: it never changes `ok` and never fails the benchmark.
+
 ## Deferred slices (`Refs #1271`)
 
-- **Answer-quality axis (the "83%").** Needs an LLM judge grading each payload against the question.
+- **Answer-quality axis (the "83%").** The mechanism now ships as an opt-in, advisory `--judge`
+  flag (an LLM judge grades retrieval sufficiency per payload; see [What this measures](#what-this-measures)).
+  Still deferred: a _published_ multi-repo answer-quality number (this runs on one repo at a time and
+  requires a judge provider, so the axis is not folded into the deterministic headline).
 - **Multi-repo corpus.** The comparator spans 31 repos; this harness runs on one repo at a time.
   Broadening to a corpus (loop the two steps over N cloned repos, aggregate) is additive.
 - **Head-to-head against the competitors' own harnesses.** This measures harness vs a naive

--- a/docs/benchmarks/graph-token-savings/RESULTS.md
+++ b/docs/benchmarks/graph-token-savings/RESULTS.md
@@ -40,9 +40,15 @@ number is trustworthy rather than flattering:
    counts, top-risk items, node/edge summaries. The naive side reads whole files. So part of the
    gap is that the graph returns a _scoped answer_ while naive returns _raw content_. Whether the
    scoped summary actually suffices to answer the question is the **answer-quality axis (the
-   comparator's "83%")**, which is **not measured here** — it needs an LLM judge and is a deferred
-   slice (`Refs #1271`). Treat the token ratio as "cost to retrieve a scoped answer", not "cost to
-   retrieve an equally-complete answer".
+   comparator's "83%")**. That axis is now **measurable, opt-in and advisory**: pass `--judge`
+   and an LLM judge grades whether each strategy's retrieved payload is _sufficient_ to answer the
+   query (`answerQuality` in the JSON result; per-scenario `quality` grades). It reuses the shared
+   harness eval/judge plumbing (`resolveAnalysisProvider` → Anthropic key or `HARNESS_ANALYSIS_BASE_URL`),
+   and **degrades honestly**: with no judge configured it reports `status: "inconclusive"` rather
+   than fabricating a score, and it _never_ fails the benchmark — the token/tool-call axes stand
+   regardless. The headline numbers above are token/tool-call only (run without `--judge`); treat
+   the token ratio as "cost to retrieve a scoped answer", not "cost to retrieve an equally-complete
+   answer". A published multi-repo answer-quality number remains a deferred slice (`Refs #1271`).
 
 2. **`find-context` is a loss (0.72×) — reported, not hidden.** `find_context_for` expands a 2-hop
    subgraph (nodes + edges as JSON) around each search hit, which is more verbose than reading the
@@ -71,6 +77,7 @@ number is trustworthy rather than flattering:
 On the two objective axes this benchmark measures — retrieval tokens and tool calls — graph-scoped
 retrieval on this repo comfortably beats the honest comparator target, driven by the structural
 families (`impact`, `dependencies`, `blast-radius`). The result is bounded by two honest facts: the
-answer-quality axis is unmeasured, and `find-context` loses. The detailed-mode blowup is filed as a
+headline is token/tool-call only (the answer-quality axis is opt-in via `--judge` and advisory, not
+folded into the headline number), and `find-context` loses. The detailed-mode blowup is filed as a
 roadmap input. This is the first published token number for the harness code graph; the methodology
 is re-runnable so the number can be kept current and extended to the deferred axes.

--- a/docs/benchmarks/graph-token-savings/results/latest.json
+++ b/docs/benchmarks/graph-token-savings/results/latest.json
@@ -513,5 +513,10 @@
     },
     "tokenSavings": 26.48,
     "toolCallSavings": 44.46
+  },
+  "answerQuality": {
+    "status": "skipped",
+    "advisory": true,
+    "note": "Answer-quality axis not run (pass --judge to grade retrieval sufficiency with an LLM judge). The comparator reports 83% on this axis; the objective axes here stand alone."
   }
 }

--- a/docs/changes/graph-bench-answer-quality/plans/plan.md
+++ b/docs/changes/graph-bench-answer-quality/plans/plan.md
@@ -1,0 +1,73 @@
+# Plan: Answer-quality axis for `harness graph bench`
+
+> Spec: [`../proposal.md`](../proposal.md). Issue #1271 (deferred slice). `Refs #1271`.
+
+## Task breakdown
+
+### T1 — Judge module (`packages/cli/src/commands/graph/bench-judge.ts`)
+
+- Define `QualityGrade` (`sufficient: boolean | null`, `confidence`, `rationale`),
+  `BenchJudge` interface (`grade(query, strategy, payloadText) => Promise<QualityGrade>`).
+- `qualityVerdictSchema` (zod `.strict()`: `{ sufficient, confidence, rationale }`) — the
+  LLM never returns authority/score; sufficiency is derived by us.
+- `buildBenchJudge(provider, model?)`: wraps `AnalysisProvider.analyze<T>()`, truncates
+  payload to `JUDGE_PAYLOAD_CHAR_BUDGET`, strict re-parses, and degrades any failure to an
+  inconclusive grade (`sufficient: null`). Mirrors `OutcomeEvaluator.judge()`.
+- `resolveBenchJudge(model?)`: `resolveAnalysisProvider(model)` → `buildBenchJudge` or
+  `null` when no provider. Reuses the shared eval resolver (decision #1).
+
+### T2 — Wire the judge into `runGraphBench` (`bench.ts`)
+
+- Add `query: string` to `ScenarioResult`; compute a deterministic query per family
+  (`benchQueryFor(family, anchor)`).
+- Capture `graphText` / `naiveText` payloads alongside metrics (naive text = concatenated
+  file contents) so the judge can grade them.
+- Add `GraphBenchOptions.judge?: BenchJudge`. After scenarios are built, if a judge is
+  present, grade each scenario × strategy and attach `quality`.
+- Add `answerQuality` to `GraphBenchResult`: `{ status: 'skipped'|'inconclusive'|'measured',
+advisory: true, note, graph?/naive?: { sufficient, inconclusive, total, sufficientRate } }`.
+  Status rules per proposal. Never touches `result.ok`.
+
+### T3 — Output + CLI flag
+
+- `formatBenchReport`: add an answer-quality section (status; when measured, graph vs
+  naive sufficiency rate). Keep the existing deferred-slice line accurate by status.
+- `createBenchCommand`: add `--judge` and `--judge-model <model>`. When `--judge`, call
+  `resolveBenchJudge(model)`; a null resolver yields `status: 'inconclusive'`.
+
+### T4 — Tests (`bench.test.ts`, `bench-judge.test.ts`)
+
+- Mock-judge test: inject a `BenchJudge` stub → assert every scenario has a `quality`
+  grade for both strategies, aggregate `answerQuality.status === 'measured'`, and
+  sufficiency counts fold correctly.
+- Degrade test: run with no judge → `status: 'skipped'`; run with a judge whose
+  `analyze` rejects (via `buildBenchJudge` over a rejecting provider) → grade
+  `sufficient: null` / aggregate `inconclusive`, `result.ok` still true.
+- Query-derivation unit test for `benchQueryFor`.
+
+### T5 — Docs + reference regen
+
+- RESULTS.md caveat #1 + REPRODUCING.md deferred-slice bullet: describe the measurable
+  axis and honest degradation.
+- Document the new `answerQuality` / `quality` / `query` fields (results/latest.json
+  schema note).
+- `pnpm run generate-docs` to refresh `docs/reference/*` for the new flags.
+
+### T6 — Provenance + gates
+
+- `provenance.json` (issue 1271, stages, plan_path, `Refs #1271`, assumptions[]).
+- Build CLI, run bench.test + bench-judge.test, typecheck, lint, format. Ship through
+  pre-push gates (changeset, format:check, reference-docs freshness). No `--no-verify`.
+
+## Ordering / dependencies
+
+T1 → T2 → T3 (T3 depends on both). T4 after T2/T3. T5 after code stabilises. T6 last.
+
+## Risk / mitigations
+
+- **Payload size to judge**: bounded by a documented char budget constant; surfaced in the
+  result note so the judgment is honest about what it saw.
+- **Non-determinism in CI**: axis is opt-in and mock-injected in tests; no live judge call
+  in CI. Default (`skipped`) path keeps objective axes byte-identical.
+- **Reviewer WIRED-trace**: the query string + per-scenario grade in `--json` output let a
+  reviewer trace bench → judge → score end to end from a live run.

--- a/docs/changes/graph-bench-answer-quality/proposal.md
+++ b/docs/changes/graph-bench-answer-quality/proposal.md
@@ -1,0 +1,116 @@
+# Proposal: Answer-quality axis for the graph token-savings benchmark
+
+> Deferred slice of issue #1271. `Refs #1271`.
+
+## Problem
+
+`harness graph bench` (`packages/cli/src/commands/graph/bench.ts`, shipped in PR #1588)
+measures **two** objective, deterministic axes for graph-scoped retrieval vs naive
+file-by-file exploration:
+
+1. **Tokens** — chars ÷ 4 of the text each strategy puts into context.
+2. **Tool calls** — discrete retrieval calls each strategy makes.
+
+The comparator (arXiv 2603.27277) reports a **third** axis — **answer quality (83%)**:
+whether the retrieved context actually _suffices to answer_ the query. That axis was
+deferred because it needs an LLM judge and is non-deterministic. Without it, the token
+ratio is honestly labelled "cost to retrieve a scoped answer", not "cost to retrieve an
+equally-complete answer" — a caveat RESULTS.md calls out explicitly. The number is
+therefore incomplete: a reviewer cannot see whether the cheap graph payload actually
+answers the question or just returns less.
+
+## Goal
+
+Add the answer-quality axis to `harness graph bench`: for each benchmark query, an LLM
+**judge** grades whether each strategy's retrieved payload is _sufficient_ to answer the
+query. Reuse the existing harness eval/judge plumbing rather than building a bespoke
+judge. Degrade honestly when no judge is reachable. Wire it into the command output and
+the published benchmark docs.
+
+## Non-goals
+
+- **Multi-repo corpus** (still deferred, `Refs #1271`).
+- Making the quality axis a **blocking** gate — it is advisory, like `outcome_eval`'s
+  low-confidence verdicts. The bench never fails because of it.
+- Grading _correctness_ of an answer the agent would write. We grade whether the
+  **retrieved payload contains enough** to answer — a retrieval-sufficiency judgment.
+
+## Approach
+
+### Reuse the eval/judge infrastructure
+
+The harness already has a provider-neutral judge seam:
+
+- `resolveAnalysisProvider(model?)` (`packages/cli/src/mcp/utils/analysis-provider.ts`)
+  resolves a real `AnalysisProvider` with precedence **Anthropic key → local `/v1`
+  endpoint (`HARNESS_ANALYSIS_BASE_URL`) → null**. This is the identical resolver
+  `outcome_eval` / `acceptance_eval` use.
+- `AnalysisProvider.analyze<T>({ prompt, systemPrompt, responseSchema, model })`
+  (`@harness-engineering/intelligence`) returns a schema-validated structured verdict.
+
+The new judge is a thin wrapper over that seam — no new provider, no new key plumbing.
+It mirrors `OutcomeEvaluator.judge()`: strict-schema re-parse, and any provider
+rejection / parse failure degrades to an **inconclusive** grade rather than throwing.
+
+### The query per scenario
+
+Each scenario already has an `anchor`. `find-context` and `ask` anchors are already
+natural-language queries; the structural families (`impact`, `blast-radius`,
+`dependencies`, `outline`) get a deterministic query phrasing derived from the family +
+anchor (e.g. `"What is the blast radius of <file> — which files/symbols are affected?"`).
+The query is stored on each `ScenarioResult` (new `query` field) so a reviewer can read
+exactly what the judge was asked and the run is reproducible.
+
+### The grade
+
+For each scenario × strategy the judge answers: **is this retrieved payload sufficient to
+answer the query?** → `{ sufficient: boolean, confidence, rationale }`. Payloads are
+truncated to a bounded, documented character budget before judging (the naive payload is
+whole files and can be ~900k tokens); the budget is a source constant and surfaced in the
+result note so the judgment is honest about what it saw.
+
+### Honest degradation (deterministic-friendly for CI)
+
+The axis is **opt-in** via `--judge`. Its status in the result:
+
+- `--judge` **absent** → `status: 'skipped'` (default; the two objective axes stand
+  alone, exactly as today — byte-compatible for existing consumers except the additive
+  `answerQuality` block).
+- `--judge` present but **no provider** reachable/configured → `status: 'inconclusive'`,
+  advisory, note explains no judge — **the benchmark still succeeds** with its token/
+  tool-call axes.
+- `--judge` present **with** a provider → `status: 'measured'`; individual scenarios whose
+  grade call fails degrade to an inconclusive grade and are counted separately, never
+  faking a score.
+
+The axis is **always advisory**: it never changes `result.ok` and never fails the bench.
+Tests inject a mock judge so the wiring (bench → judge → per-scenario grade → aggregate)
+is exercised deterministically, and a no-judge path proves the INCONCLUSIVE degrade.
+
+### Output + docs wiring
+
+- `formatBenchReport` gains an answer-quality line/section (status + graph vs naive
+  sufficiency rates when measured).
+- `GraphBenchResult` gains `answerQuality` (aggregate) and each `ScenarioResult` gains an
+  optional `quality` grade + the `query` string.
+- `docs/benchmarks/graph-token-savings/` — RESULTS.md caveat #1 updated to describe the
+  now-measurable axis, REPRODUCING.md deferred-slice bullet updated, and
+  `results/latest.json` schema documented to carry the new fields.
+
+## Acceptance criteria
+
+1. Running `harness graph bench --judge` with a configured provider produces, in the live
+   command output and the `--json` / `--out` result, a per-scenario `quality` grade for
+   both strategies and an aggregate `answerQuality` block with `status: 'measured'` — a
+   reviewer can trace **bench → judge → quality score** in the output.
+2. Running `harness graph bench --judge` with **no** provider configured reports
+   `answerQuality.status: 'inconclusive'` (advisory), does **not** fabricate a score, and
+   the benchmark still exits 0 with its token/tool-call axes intact.
+3. Running `harness graph bench` **without** `--judge` is behaviourally unchanged except
+   for the additive `answerQuality: { status: 'skipped' }` block — the objective axes are
+   byte-identical.
+4. A test injects a mock judge and asserts the axis is computed per scenario and folds
+   into the aggregate; a second test asserts the no-judge / unreachable path degrades to
+   INCONCLUSIVE without throwing and without failing the bench.
+5. The published benchmark docs (RESULTS.md, REPRODUCING.md, results/latest.json schema)
+   reflect the new axis. `docs/reference/*` regenerated for the new CLI flags.

--- a/docs/changes/graph-bench-answer-quality/provenance.json
+++ b/docs/changes/graph-bench-answer-quality/provenance.json
@@ -1,0 +1,53 @@
+{
+  "issue": 1271,
+  "title": "Answer-quality axis for the graph token-savings benchmark",
+  "item": "#1271-judge",
+  "fleet": "roadmap-fleet",
+  "closing_keyword": "Refs #1271",
+  "plan_path": "docs/changes/graph-bench-answer-quality/plans/plan.md",
+  "proposal_path": "docs/changes/graph-bench-answer-quality/proposal.md",
+  "stages": [
+    {
+      "stage": "brainstorming",
+      "output": "docs/changes/graph-bench-answer-quality/proposal.md",
+      "summary": "Framed the deferred answer-quality axis: an LLM judge grades retrieval sufficiency per strategy, reusing the shared eval/judge plumbing, advisory + honest-degrade."
+    },
+    {
+      "stage": "planning",
+      "output": "docs/changes/graph-bench-answer-quality/plans/plan.md",
+      "summary": "Task breakdown T1 judge module, T2 wire into runGraphBench, T3 output+CLI flag, T4 tests, T5 docs+reference regen, T6 provenance+gates."
+    },
+    {
+      "stage": "execution",
+      "summary": "Added packages/cli/src/commands/graph/bench-judge.ts (BenchJudge over AnalysisProvider via resolveBenchJudge); wired answerQuality axis + per-scenario quality + query into runGraphBench/formatBenchReport; added --judge/--judge-model flags; fixed pre-existing global --json shadowing.",
+      "files": [
+        "packages/cli/src/commands/graph/bench-judge.ts",
+        "packages/cli/src/commands/graph/bench.ts",
+        "packages/cli/src/commands/graph/bench.test.ts",
+        "packages/cli/src/commands/graph/bench-judge.test.ts",
+        "docs/benchmarks/graph-token-savings/RESULTS.md",
+        "docs/benchmarks/graph-token-savings/REPRODUCING.md",
+        "docs/benchmarks/graph-token-savings/results/latest.json",
+        "docs/reference/cli-commands.md"
+      ]
+    },
+    {
+      "stage": "verification",
+      "summary": "16 bench/bench-judge tests pass; cli typecheck clean; live WIRED trace: `harness graph bench --judge` with a local /v1 judge produced status=measured with per-scenario quality (graph 100% / naive 0% sufficient); with no provider produced status=inconclusive and ok=true (benchmark still succeeded).",
+      "evidence": [
+        "vitest: 16 passed (bench.test.ts + bench-judge.test.ts)",
+        "live measured: answerQuality.status=measured, graph.sufficientRate=1, naive.sufficientRate=0",
+        "live degrade: answerQuality.status=inconclusive, ok=true"
+      ]
+    }
+  ],
+  "assumptions": [
+    "Reused the existing shared eval judge seam (resolveAnalysisProvider + AnalysisProvider.analyze) rather than adding a bespoke judge or new provider/key plumbing, per confirmed decision #1.",
+    "The answer-quality axis is opt-in via --judge (off by default) so the default run stays deterministic for CI; a live judge is never invoked in CI. Tests inject a mock judge to exercise the measured path.",
+    "Judged payloads are truncated to a documented 12000-char budget (naive payloads can be ~900k tokens); the budget is surfaced in the result note so the judgment is honest about what it saw.",
+    "Structural families (impact/blast-radius/dependencies/outline) get a deterministic synthesized query string (stored on each scenario) since their anchor is a file path, not a natural-language question; find-context/ask anchors are used verbatim.",
+    "results/latest.json was patched additively with the answerQuality block a default (no --judge) run emits, to keep the published schema consistent without re-running the full ~51k-node repo benchmark.",
+    "Fixed a pre-existing bug where the program-global --json option shadowed `graph bench --json` (verified present on origin/main); the --out path was already unaffected.",
+    "Multi-repo answer-quality corpus remains deferred (Refs #1271)."
+  ]
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1035,6 +1035,8 @@ Measure token + tool-call savings of graph-scoped retrieval vs naive file reads
 - `--json` — Emit the full machine-readable result as JSON
 - `--out` — Write the machine-readable result JSON to a file
 - `--top` — Anchors per structural family (default: "5")
+- `--judge` — Grade the answer-quality axis with an LLM judge (retrieval sufficiency; advisory). Requires ANTHROPIC_API_KEY or HARNESS_ANALYSIS_BASE_URL; degrades to INCONCLUSIVE if neither is set.
+- `--judge-model` — Model override for the answer-quality judge
 
 ### `harness graph export`
 

--- a/packages/cli/src/commands/graph/bench-judge.test.ts
+++ b/packages/cli/src/commands/graph/bench-judge.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import type { AnalysisProvider } from '@harness-engineering/intelligence';
+import { buildBenchJudge, JUDGE_PAYLOAD_CHAR_BUDGET } from './bench-judge.js';
+
+/** A provider whose analyze() returns a fixed result, capturing the request. */
+function fakeProvider(
+  result: unknown,
+  capture?: (req: { prompt: string }) => void
+): AnalysisProvider {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async analyze(req: any) {
+      capture?.(req);
+      return {
+        result,
+        tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        model: 'fake',
+        latencyMs: 0,
+      };
+    },
+  } as AnalysisProvider;
+}
+
+describe('buildBenchJudge', () => {
+  it('returns the provider verdict for a well-formed response', async () => {
+    const judge = buildBenchJudge(
+      fakeProvider({ sufficient: true, confidence: 'high', rationale: 'names the right files' })
+    );
+    const grade = await judge.grade('What is the impact of X?', 'graph', 'impacted: a.ts, b.ts');
+    expect(grade.sufficient).toBe(true);
+    expect(grade.confidence).toBe('high');
+  });
+
+  it('degrades to INCONCLUSIVE (sufficient=null) when the provider rejects', async () => {
+    const rejecting: AnalysisProvider = {
+      analyze: () => Promise.reject(new Error('rate limited')),
+    } as AnalysisProvider;
+    const grade = await buildBenchJudge(rejecting).grade('q', 'naive', 'payload');
+    expect(grade.sufficient).toBeNull();
+    expect(grade.confidence).toBe('low');
+  });
+
+  it('degrades to INCONCLUSIVE when the response is malformed or injects extra keys', async () => {
+    // Strict re-parse rejects an injected `authority` key — the judge cannot smuggle authority.
+    const judge = buildBenchJudge(
+      fakeProvider({ sufficient: true, confidence: 'high', rationale: 'x', authority: 'blocking' })
+    );
+    const grade = await judge.grade('q', 'graph', 'payload');
+    expect(grade.sufficient).toBeNull();
+  });
+
+  it('truncates an oversized payload before sending it to the judge', async () => {
+    let seenPrompt = '';
+    const judge = buildBenchJudge(
+      fakeProvider({ sufficient: false, confidence: 'low', rationale: 'too little' }, (r) => {
+        seenPrompt = r.prompt;
+      })
+    );
+    const huge = 'x'.repeat(JUDGE_PAYLOAD_CHAR_BUDGET * 3);
+    await judge.grade('q', 'naive', huge);
+    expect(seenPrompt).toMatch(/truncated for judging/);
+    // The prompt is bounded — it does not carry the full 3× payload verbatim.
+    expect(seenPrompt.length).toBeLessThan(JUDGE_PAYLOAD_CHAR_BUDGET + 500);
+  });
+});

--- a/packages/cli/src/commands/graph/bench-judge.ts
+++ b/packages/cli/src/commands/graph/bench-judge.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+import type { AnalysisProvider } from '@harness-engineering/intelligence';
+import { resolveAnalysisProvider } from '../../mcp/utils/analysis-provider.js';
+
+/**
+ * Answer-quality judge for `harness graph bench` (deferred slice of issue #1271).
+ *
+ * The two objective bench axes (tokens, tool calls) measure retrieval *cost*. This
+ * third axis measures whether the retrieved payload actually *suffices to answer* the
+ * query — the comparator's "83%" axis. It reuses the shared harness eval/judge seam
+ * (`resolveAnalysisProvider` + `AnalysisProvider.analyze<T>()`, the exact plumbing
+ * `outcome_eval` / `acceptance_eval` use) rather than a bespoke judge.
+ *
+ * It degrades honestly: any provider rejection or malformed response yields an
+ * INCONCLUSIVE grade (`sufficient: null`) rather than a fabricated score, and no judge
+ * ever fails the benchmark — the axis is advisory, exactly like a low-confidence
+ * `outcome_eval` verdict.
+ */
+
+/** Which retrieval strategy produced the payload being graded. */
+export type BenchStrategy = 'graph' | 'naive';
+
+/**
+ * A single answer-quality grade. `sufficient: null` is the honest INCONCLUSIVE state —
+ * the judge was unreachable or returned an unusable response. A grade is NEVER fabricated.
+ */
+export interface QualityGrade {
+  /** true = payload suffices to answer the query; false = it does not; null = inconclusive. */
+  sufficient: boolean | null;
+  confidence: 'low' | 'medium' | 'high';
+  rationale: string;
+}
+
+export interface BenchJudge {
+  /** Grade whether `payloadText` is sufficient to answer `query`. Total: never throws. */
+  grade(query: string, strategy: BenchStrategy, payloadText: string): Promise<QualityGrade>;
+}
+
+/**
+ * Character budget for the payload handed to the judge. The naive payload is whole files
+ * (can be ~900k tokens); the graph payload is a scoped summary. Both are truncated to the
+ * same budget so the judgment is comparable and the call is bounded. Surfaced in the
+ * result note so the axis is honest about what the judge actually saw.
+ */
+export const JUDGE_PAYLOAD_CHAR_BUDGET = 12_000;
+
+const INCONCLUSIVE: QualityGrade = {
+  sufficient: null,
+  confidence: 'low',
+  rationale:
+    'Answer-quality judge unreachable or returned an unusable response; axis is inconclusive.',
+};
+
+/** Strict schema — the LLM returns only sufficiency/confidence/rationale, never authority. */
+const qualityVerdictSchema = z
+  .object({
+    sufficient: z.boolean(),
+    confidence: z.enum(['low', 'medium', 'high']),
+    rationale: z.string(),
+  })
+  .strict();
+
+type LlmQualityVerdict = z.infer<typeof qualityVerdictSchema>;
+
+const JUDGE_SYSTEM_PROMPT =
+  'You are a retrieval-sufficiency judge for a code-navigation benchmark. Given a developer ' +
+  'query and the text a retrieval strategy surfaced into context, decide whether that text ' +
+  'contains ENOUGH information to answer the query. Judge sufficiency of the retrieved payload, ' +
+  'not whether a final prose answer is perfectly worded. A scoped summary that names the right ' +
+  'files/symbols/relationships can be sufficient even if terse. Reply strictly as JSON matching ' +
+  'the schema: {"sufficient": boolean, "confidence": "low"|"medium"|"high", "rationale": string}.';
+
+function truncate(text: string): string {
+  if (text.length <= JUDGE_PAYLOAD_CHAR_BUDGET) return text;
+  return text.slice(0, JUDGE_PAYLOAD_CHAR_BUDGET) + '\n…[truncated for judging]';
+}
+
+function buildJudgePrompt(query: string, strategy: BenchStrategy, payloadText: string): string {
+  return [
+    `Query: ${query}`,
+    `Retrieval strategy: ${strategy}`,
+    'Retrieved payload (may be truncated):',
+    '---',
+    truncate(payloadText),
+    '---',
+    'Is this payload sufficient to answer the query?',
+  ].join('\n');
+}
+
+/**
+ * One provider call + strict re-parse. Mirrors `OutcomeEvaluator.judge()`: ANY failure
+ * (provider rejection, malformed or authority-injected payload) degrades to INCONCLUSIVE
+ * rather than throwing. The strict re-parse rejects any extra key even if the provider
+ * did not enforce strict mode — the judge cannot smuggle an `authority` field.
+ */
+async function gradeOnce(
+  provider: AnalysisProvider,
+  model: string | undefined,
+  query: string,
+  strategy: BenchStrategy,
+  payloadText: string
+): Promise<QualityGrade> {
+  try {
+    const response = await provider.analyze<LlmQualityVerdict>({
+      prompt: buildJudgePrompt(query, strategy, payloadText),
+      systemPrompt: JUDGE_SYSTEM_PROMPT,
+      responseSchema: qualityVerdictSchema,
+      ...(model !== undefined && { model }),
+    });
+    const llm = qualityVerdictSchema.parse(response.result);
+    return { sufficient: llm.sufficient, confidence: llm.confidence, rationale: llm.rationale };
+  } catch {
+    return { ...INCONCLUSIVE };
+  }
+}
+
+/** Build a real judge over an `AnalysisProvider`. Total: each grade never throws. */
+export function buildBenchJudge(provider: AnalysisProvider, model?: string): BenchJudge {
+  return {
+    grade: (query, strategy, payloadText) =>
+      gradeOnce(provider, model, query, strategy, payloadText),
+  };
+}
+
+/**
+ * Resolve the real judge from the shared eval provider chain (Anthropic key → local
+ * `/v1` endpoint → null). Returns `null` when no provider is configured, so the caller
+ * reports the axis as INCONCLUSIVE/advisory without fabricating a score.
+ */
+export async function resolveBenchJudge(model?: string): Promise<BenchJudge | null> {
+  const provider = await resolveAnalysisProvider(model);
+  if (!provider) return null;
+  return buildBenchJudge(provider as AnalysisProvider, model);
+}

--- a/packages/cli/src/commands/graph/bench.test.ts
+++ b/packages/cli/src/commands/graph/bench.test.ts
@@ -7,8 +7,10 @@ import {
   runGraphBench,
   estimateBenchTokens,
   formatBenchReport,
+  benchQueryFor,
   type GraphBenchResult,
 } from './bench.js';
+import type { BenchJudge, QualityGrade } from './bench-judge.js';
 
 describe('estimateBenchTokens', () => {
   it('mirrors the chars/4 estimator', () => {
@@ -94,4 +96,109 @@ describe('runGraphBench on a fixture graph', () => {
     expect(report).toMatch(/issue #1271/);
     expect(report).toMatch(/OVERALL/);
   });
+
+  it('reports the answer-quality axis as skipped when no judge is supplied', () => {
+    expect(result.answerQuality.status).toBe('skipped');
+    expect(result.answerQuality.advisory).toBe(true);
+    // Every scenario carries a stable, reviewer-readable query; none is graded.
+    for (const s of result.scenarios) {
+      expect(typeof s.query).toBe('string');
+      expect(s.query.length).toBeGreaterThan(0);
+      expect(s.quality).toBeUndefined();
+    }
+    expect(formatBenchReport(result)).toMatch(/Answer quality.*not run/);
+  });
+});
+
+describe('benchQueryFor', () => {
+  it('phrases structural families and passes NL anchors through', () => {
+    expect(benchQueryFor('impact', 'src/a.ts')).toMatch(/impact of changing src\/a\.ts/);
+    expect(benchQueryFor('blast-radius', 'src/a.ts')).toMatch(/blast radius of src\/a\.ts/);
+    expect(benchQueryFor('dependencies', 'src/a.ts')).toMatch(/depend on/);
+    expect(benchQueryFor('outline', 'src/a.ts')).toMatch(/functions, classes, and exports/);
+    // find-context / ask anchors are already natural-language queries.
+    expect(benchQueryFor('ask', 'What loads the store?')).toBe('What loads the store?');
+    expect(benchQueryFor('find-context', 'add a subcommand')).toBe('add a subcommand');
+  });
+});
+
+describe('runGraphBench answer-quality axis', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'graph-bench-judge-'));
+    const src = path.join(dir, 'src');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(
+      path.join(src, 'b.ts'),
+      `export const BAR = 42;\nexport function bar() { return BAR; }\n`
+    );
+    fs.writeFileSync(
+      path.join(src, 'a.ts'),
+      `import { bar, BAR } from './b.js';\nexport function foo() { return bar() + BAR; }\n`
+    );
+    await runScan(dir);
+  }, 60_000);
+
+  afterAll(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('grades every scenario on both strategies and aggregates when a judge is injected', async () => {
+    const calls: Array<{ query: string; strategy: string }> = [];
+    // Deterministic mock judge: graph payloads sufficient, naive insufficient.
+    const judge: BenchJudge = {
+      async grade(query, strategy): Promise<QualityGrade> {
+        calls.push({ query, strategy });
+        return {
+          sufficient: strategy === 'graph',
+          confidence: 'high',
+          rationale: `mock grade for ${strategy}`,
+        };
+      },
+    };
+
+    const result = await runGraphBench(dir, { top: 1, judge });
+    expect(result.ok).toBe(true);
+    expect(result.answerQuality.status).toBe('measured');
+    // Judge was called twice per scenario (graph + naive) — bench → judge is wired.
+    expect(calls.length).toBe(result.scenarios.length * 2);
+    // Every scenario carries a per-strategy grade a reviewer can trace.
+    for (const s of result.scenarios) {
+      expect(s.quality?.graph.sufficient).toBe(true);
+      expect(s.quality?.naive.sufficient).toBe(false);
+    }
+    // Aggregate folds the grades: graph fully sufficient, naive fully insufficient.
+    expect(result.answerQuality.graph?.sufficient).toBe(result.scenarios.length);
+    expect(result.answerQuality.graph?.sufficientRate).toBe(1);
+    expect(result.answerQuality.naive?.insufficient).toBe(result.scenarios.length);
+    expect(result.answerQuality.naive?.sufficientRate).toBe(0);
+    expect(formatBenchReport(result)).toMatch(/Answer quality.*advisory/s);
+  }, 60_000);
+
+  it('folds an inconclusive judge into the axis without faking a score or failing the bench', async () => {
+    // A judge that cannot decide (mirrors a provider that rejected every call).
+    const inconclusiveJudge: BenchJudge = {
+      async grade(): Promise<QualityGrade> {
+        return { sufficient: null, confidence: 'low', rationale: 'unreachable' };
+      },
+    };
+    const result = await runGraphBench(dir, { top: 1, judge: inconclusiveJudge });
+    // The bench still succeeds — the axis is advisory.
+    expect(result.ok).toBe(true);
+    expect(result.answerQuality.status).toBe('measured');
+    // No fabricated score: every grade is inconclusive, sufficientRate is null.
+    expect(result.answerQuality.graph?.inconclusive).toBe(result.scenarios.length);
+    expect(result.answerQuality.graph?.sufficientRate).toBeNull();
+    expect(result.answerQuality.naive?.sufficientRate).toBeNull();
+  }, 60_000);
+
+  it('reports INCONCLUSIVE when a judge was requested but none was reachable', async () => {
+    const result = await runGraphBench(dir, { top: 1, judgeRequestedButUnavailable: true });
+    expect(result.ok).toBe(true);
+    expect(result.answerQuality.status).toBe('inconclusive');
+    expect(result.answerQuality.advisory).toBe(true);
+    for (const s of result.scenarios) expect(s.quality).toBeUndefined();
+    expect(formatBenchReport(result)).toMatch(/INCONCLUSIVE/);
+  }, 60_000);
 });

--- a/packages/cli/src/commands/graph/bench.ts
+++ b/packages/cli/src/commands/graph/bench.ts
@@ -10,15 +10,21 @@ import {
 } from '../../mcp/tools/graph/index.js';
 import { handleCodeOutline } from '../../mcp/tools/code-nav.js';
 import { ExitCode } from '../../utils/errors.js';
+import type { BenchJudge, QualityGrade } from './bench-judge.js';
+import { resolveBenchJudge, JUDGE_PAYLOAD_CHAR_BUDGET } from './bench-judge.js';
 
 /**
  * Reproducible graph token-savings benchmark (issue #1271).
  *
  * Measures two objective, deterministic axes — tokens and tool calls — for
  * graph-scoped retrieval (the real shipped MCP tool handlers) versus the naive
- * file-by-file exploration a graph-less agent is forced into. Answer quality
- * (the comparator's "83%" axis) needs an LLM judge and is a deferred slice
- * (Refs #1271); it is intentionally not measured here.
+ * file-by-file exploration a graph-less agent is forced into. A third axis —
+ * answer quality (the comparator's "83%") — is opt-in and advisory: pass a judge
+ * (`--judge`; see bench-judge.ts) and an LLM grades whether each strategy's
+ * retrieved payload suffices to answer the query. It degrades honestly to
+ * INCONCLUSIVE when no judge is reachable and never fails the benchmark, so the
+ * default (no-judge) run stays deterministic. A published multi-repo
+ * answer-quality number remains deferred (Refs #1271).
  *
  * The honest target is the arXiv comparator figure (preprint 2603.27277: ~10x
  * fewer tokens, ~2.1x fewer tool calls), NOT the flattering 99.2% README figure.
@@ -51,12 +57,52 @@ export interface StrategyMetrics {
   bytes: number;
 }
 
+/** Per-scenario answer-quality grade for each strategy (populated only when a judge runs). */
+export interface ScenarioQuality {
+  graph: QualityGrade;
+  naive: QualityGrade;
+}
+
 export interface ScenarioResult {
   id: string;
   family: string;
   anchor: string;
+  /** The exact natural-language query the answer-quality judge is (or would be) asked. */
+  query: string;
   graph: StrategyMetrics;
   naive: StrategyMetrics;
+  /** Answer-quality grades; present only when the bench ran with a judge. */
+  quality?: ScenarioQuality;
+}
+
+/** Aggregate sufficiency counts for one strategy across all judged scenarios. */
+export interface QualityAggregate {
+  /** Scenarios graded sufficient (payload answers the query). */
+  sufficient: number;
+  /** Scenarios graded insufficient. */
+  insufficient: number;
+  /** Scenarios the judge could not decide (unreachable / unusable response). */
+  inconclusive: number;
+  /** Total scenarios considered. */
+  total: number;
+  /** sufficient / (sufficient + insufficient); null when nothing was decidable. */
+  sufficientRate: number | null;
+}
+
+/**
+ * The answer-quality axis (the comparator's "83%"), advisory by construction — it never
+ * changes `result.ok`. `status`:
+ * - `skipped`      — no judge requested (`--judge` absent); objective axes stand alone.
+ * - `inconclusive` — a judge was requested but no provider was reachable/configured.
+ * - `measured`     — a judge graded the scenarios (individual grades may still be inconclusive).
+ */
+export interface AnswerQualityAxis {
+  status: 'skipped' | 'inconclusive' | 'measured';
+  /** Always true: the axis is advisory and never fails the benchmark. */
+  advisory: true;
+  note: string;
+  graph?: QualityAggregate;
+  naive?: QualityAggregate;
 }
 
 export interface FamilyAggregate {
@@ -89,10 +135,22 @@ export interface GraphBenchResult {
     tokenSavings: number;
     toolCallSavings: number;
   };
+  answerQuality: AnswerQualityAxis;
 }
 
 export interface GraphBenchOptions {
   top?: number;
+  /**
+   * Answer-quality judge. When supplied, each scenario × strategy is graded for
+   * retrieval sufficiency. Absent → the axis is reported as `skipped`. Injected in
+   * tests; the CLI resolves the real judge via `resolveBenchJudge`.
+   */
+  judge?: BenchJudge;
+  /**
+   * The judge was requested (`--judge`) but no provider was reachable. Distinguishes the
+   * honest `inconclusive` axis from a plain `skipped` (no `--judge`) run.
+   */
+  judgeRequestedButUnavailable?: boolean;
 }
 
 // Fixed task-context inputs live in source so a reviewer can read exactly what was asked.
@@ -135,6 +193,52 @@ function handlerText(result: { content?: Array<{ type: string; text?: string }> 
 function metricsFromText(text: string, toolCalls: number): StrategyMetrics {
   const bytes = Buffer.byteLength(text, 'utf8');
   return { tokens: estimateBenchTokens(text), toolCalls, bytes };
+}
+
+/**
+ * Deterministic query phrasings for the structural families (anchor is a file path).
+ * `find-context` / `ask` are absent here — their anchor is already a natural-language query.
+ */
+const STRUCTURAL_QUERY: Record<string, (anchor: string) => string> = {
+  impact: (a) => `What is the impact of changing ${a}? Which files and symbols are affected?`,
+  'blast-radius': (a) =>
+    `What is the blast radius of ${a}? Which files depend on it and would be affected by a change?`,
+  dependencies: (a) => `What does ${a} depend on — its direct and transitive local dependencies?`,
+  outline: (a) => `What functions, classes, and exports are defined in ${a}?`,
+};
+
+/**
+ * The natural-language query the answer-quality judge is asked for a scenario. For
+ * `find-context` / `ask` the anchor is already a query; the structural families get a
+ * deterministic phrasing so a reviewer can read exactly what was asked.
+ */
+export function benchQueryFor(family: string, anchor: string): string {
+  return STRUCTURAL_QUERY[family]?.(anchor) ?? anchor;
+}
+
+/** Concatenated text of the files a naive strategy reads — the payload handed to the judge. */
+function naiveTextOf(files: SourceFile[]): string {
+  return files.map((f) => `// ${f.rel}\n${f.content}`).join('\n\n');
+}
+
+/** Fold a list of grades into an aggregate sufficiency count for one strategy. */
+function aggregateQuality(grades: QualityGrade[]): QualityAggregate {
+  let sufficient = 0;
+  let insufficient = 0;
+  let inconclusive = 0;
+  for (const g of grades) {
+    if (g.sufficient === true) sufficient += 1;
+    else if (g.sufficient === false) insufficient += 1;
+    else inconclusive += 1;
+  }
+  const decided = sufficient + insufficient;
+  return {
+    sufficient,
+    insufficient,
+    inconclusive,
+    total: grades.length,
+    sufficientRate: decided > 0 ? Math.round((sufficient / decided) * 100) / 100 : null,
+  };
 }
 
 interface SourceFile {
@@ -329,6 +433,11 @@ export async function runGraphBench(
       tokenSavings: 0,
       toolCallSavings: 0,
     },
+    answerQuality: {
+      status: 'skipped',
+      advisory: true,
+      note: 'Answer-quality axis not run (no graph to benchmark).',
+    },
   };
 
   if (!store) {
@@ -363,6 +472,22 @@ export async function runGraphBench(
   const byLargest = [...sources.values()].sort((a, b) => b.bytes - a.bytes).slice(0, top);
 
   const scenarios: ScenarioResult[] = [];
+  // Retrieved payload text per scenario, kept so the (optional) answer-quality judge can
+  // grade what each strategy actually surfaced. Keyed by scenario id.
+  const payloads = new Map<string, { graphText: string; naiveText: string }>();
+
+  const record = (
+    fields: Omit<ScenarioResult, 'query' | 'quality'>,
+    graphText: string,
+    naiveText: string
+  ): void => {
+    const scenario: ScenarioResult = {
+      ...fields,
+      query: benchQueryFor(fields.family, fields.anchor),
+    };
+    scenarios.push(scenario);
+    payloads.set(scenario.id, { graphText, naiveText });
+  };
 
   // --- impact ---
   // `summary` mode is the context-scoping surface an agent surfaces into context
@@ -372,26 +497,30 @@ export async function runGraphBench(
   for (const r of byInbound) {
     const rel = r.node.path;
     const res = await handleGetImpact({ path: projectPath, filePath: rel, mode: 'summary' });
-    const graph = metricsFromText(handlerText(res), 1);
+    const graphText = handlerText(res);
+    const graph = metricsFromText(graphText, 1);
     const hits = grepFiles(sources, symbolFor(rel), rel);
     const naive = naiveReadFiles(hits, 1); // 1 grep + N reads
-    scenarios.push({ id: `impact:${rel}`, family: 'impact', anchor: rel, graph, naive });
+    record(
+      { id: `impact:${rel}`, family: 'impact', anchor: rel, graph, naive },
+      graphText,
+      naiveTextOf(hits)
+    );
   }
 
   // --- blast-radius ---
   for (const r of byInbound) {
     const rel = r.node.path;
     const res = await handleComputeBlastRadius({ path: projectPath, file: rel });
-    const graph = metricsFromText(handlerText(res), 1);
+    const graphText = handlerText(res);
+    const graph = metricsFromText(graphText, 1);
     const hits = grepFiles(sources, symbolFor(rel), rel);
     const naive = naiveReadFiles(hits, 1);
-    scenarios.push({
-      id: `blast-radius:${rel}`,
-      family: 'blast-radius',
-      anchor: rel,
-      graph,
-      naive,
-    });
+    record(
+      { id: `blast-radius:${rel}`, family: 'blast-radius', anchor: rel, graph, naive },
+      graphText,
+      naiveTextOf(hits)
+    );
   }
 
   // --- dependencies (query_graph depth 2) ---
@@ -405,50 +534,61 @@ export async function runGraphBench(
       maxDepth: 2,
       mode: 'summary',
     });
-    const graph = metricsFromText(handlerText(res), 1);
+    const graphText = handlerText(res);
+    const graph = metricsFromText(graphText, 1);
     const anchorFile = sources.get(rel)!;
     const imports = localImportsOf(sources, anchorFile);
     const naive = naiveReadFiles([anchorFile, ...imports], 0); // reads only: 1 anchor + M imports
-    scenarios.push({
-      id: `dependencies:${rel}`,
-      family: 'dependencies',
-      anchor: rel,
-      graph,
-      naive,
-    });
+    record(
+      { id: `dependencies:${rel}`, family: 'dependencies', anchor: rel, graph, naive },
+      graphText,
+      naiveTextOf([anchorFile, ...imports])
+    );
   }
 
   // --- outline ---
   for (const f of byLargest) {
     const res = await handleCodeOutline({ path: f.abs });
-    const graph = metricsFromText(handlerText(res), 1);
+    const graphText = handlerText(res);
+    const graph = metricsFromText(graphText, 1);
     const naive = naiveReadFiles([f], 1); // 1 read of the whole file
-    scenarios.push({ id: `outline:${f.rel}`, family: 'outline', anchor: f.rel, graph, naive });
+    record(
+      { id: `outline:${f.rel}`, family: 'outline', anchor: f.rel, graph, naive },
+      graphText,
+      naiveTextOf([f])
+    );
   }
 
   // --- find-context ---
   for (const intent of FIND_CONTEXT_INTENTS) {
     const res = await handleFindContextFor({ path: projectPath, intent });
-    const graph = metricsFromText(handlerText(res), 1);
+    const graphText = handlerText(res);
+    const graph = metricsFromText(graphText, 1);
     const hits = keywordSearch(sources, intent, top);
     const naive = naiveReadFiles(hits, 1);
-    scenarios.push({
-      id: `find-context:${intent}`,
-      family: 'find-context',
-      anchor: intent,
-      graph,
-      naive,
-    });
+    record(
+      { id: `find-context:${intent}`, family: 'find-context', anchor: intent, graph, naive },
+      graphText,
+      naiveTextOf(hits)
+    );
   }
 
   // --- ask ---
   for (const question of ASK_QUESTIONS) {
     const res = await handleAskGraph({ path: projectPath, question });
-    const graph = metricsFromText(handlerText(res), 1);
+    const graphText = handlerText(res);
+    const graph = metricsFromText(graphText, 1);
     const hits = keywordSearch(sources, question, top);
     const naive = naiveReadFiles(hits, 1);
-    scenarios.push({ id: `ask:${question}`, family: 'ask', anchor: question, graph, naive });
+    record(
+      { id: `ask:${question}`, family: 'ask', anchor: question, graph, naive },
+      graphText,
+      naiveTextOf(hits)
+    );
   }
+
+  // --- answer-quality axis (advisory; the comparator's "83%") ---
+  const answerQuality = await judgeAnswerQuality(scenarios, payloads, opts);
 
   // Aggregate per family + overall.
   const familyMap = new Map<string, ScenarioResult[]>();
@@ -492,6 +632,56 @@ export async function runGraphBench(
       tokenSavings: ratio(overallNaive.tokens, overallGraph.tokens),
       toolCallSavings: ratio(overallNaive.toolCalls, overallGraph.toolCalls),
     },
+    answerQuality,
+  };
+}
+
+/**
+ * Run the answer-quality axis over the built scenarios. Advisory by construction — it
+ * never fails the benchmark. Degrades honestly:
+ * - no judge requested        → `skipped`.
+ * - requested, none reachable → `inconclusive` (no fabricated score).
+ * - judge present             → `measured`; a per-scenario grade that the judge could not
+ *   decide is counted as inconclusive, never faked. Grades are attached to each scenario
+ *   in place so a reviewer can trace bench → judge → score.
+ */
+async function judgeAnswerQuality(
+  scenarios: ScenarioResult[],
+  payloads: Map<string, { graphText: string; naiveText: string }>,
+  opts: GraphBenchOptions
+): Promise<AnswerQualityAxis> {
+  if (!opts.judge) {
+    return opts.judgeRequestedButUnavailable
+      ? {
+          status: 'inconclusive',
+          advisory: true,
+          note: 'Answer-quality axis requested (--judge) but no judge provider was reachable/configured (set ANTHROPIC_API_KEY or HARNESS_ANALYSIS_BASE_URL). The token and tool-call axes still stand.',
+        }
+      : {
+          status: 'skipped',
+          advisory: true,
+          note: 'Answer-quality axis not run (pass --judge to grade retrieval sufficiency with an LLM judge). The comparator reports 83% on this axis; the objective axes here stand alone.',
+        };
+  }
+
+  const judge = opts.judge;
+  const graphGrades: QualityGrade[] = [];
+  const naiveGrades: QualityGrade[] = [];
+  for (const scenario of scenarios) {
+    const payload = payloads.get(scenario.id) ?? { graphText: '', naiveText: '' };
+    const graph = await judge.grade(scenario.query, 'graph', payload.graphText);
+    const naive = await judge.grade(scenario.query, 'naive', payload.naiveText);
+    scenario.quality = { graph, naive };
+    graphGrades.push(graph);
+    naiveGrades.push(naive);
+  }
+
+  return {
+    status: 'measured',
+    advisory: true,
+    note: `Retrieval-sufficiency graded by an LLM judge over each strategy's payload (truncated to ${JUDGE_PAYLOAD_CHAR_BUDGET} chars before judging). Advisory: never fails the benchmark. Individual scenarios the judge could not decide are counted as inconclusive, never faked.`,
+    graph: aggregateQuality(graphGrades),
+    naive: aggregateQuality(naiveGrades),
   };
 }
 
@@ -526,8 +716,69 @@ export function formatBenchReport(result: GraphBenchResult): string {
   lines.push(
     `Tool calls: graph ${o.graph.toolCalls} vs naive ${o.naive.toolCalls} (${o.toolCallSavings}x fewer).`
   );
-  lines.push('Answer quality (comparator 83%) is not measured here — deferred slice (Refs #1271).');
+  lines.push('');
+  lines.push(formatAnswerQuality(result.answerQuality));
   return lines.join('\n');
+}
+
+/** Human-readable answer-quality axis (advisory; the comparator's "83%"). */
+export function formatAnswerQuality(axis: AnswerQualityAxis): string {
+  const pct = (agg: QualityAggregate): string =>
+    agg.sufficientRate === null
+      ? 'n/a (no decidable grades)'
+      : `${Math.round(agg.sufficientRate * 100)}% sufficient (${agg.sufficient}/${agg.sufficient + agg.insufficient} decided, ${agg.inconclusive} inconclusive)`;
+  switch (axis.status) {
+    case 'skipped':
+      return 'Answer quality (comparator 83%): not run — pass --judge to grade retrieval sufficiency (advisory).';
+    case 'inconclusive':
+      return 'Answer quality (comparator 83%): INCONCLUSIVE — --judge requested but no judge provider reachable; token/tool-call axes still stand (advisory).';
+    case 'measured':
+      return [
+        'Answer quality (comparator 83%) — advisory, retrieval-sufficiency judged by an LLM:',
+        `  graph: ${axis.graph ? pct(axis.graph) : 'n/a'}`,
+        `  naive: ${axis.naive ? pct(axis.naive) : 'n/a'}`,
+      ].join('\n');
+  }
+}
+
+interface BenchCliOptions {
+  json?: boolean;
+  out?: string;
+  top: string;
+  judge?: boolean;
+  judgeModel?: string;
+}
+
+/** Parse `--top` into a positive anchor count, defaulting to 5. */
+function parseTop(raw: string): number {
+  const top = Number.parseInt(raw, 10);
+  return Number.isFinite(top) && top > 0 ? top : 5;
+}
+
+/**
+ * Resolve the answer-quality judge options from `--judge` / `--judge-model`. When `--judge`
+ * is passed but no provider is reachable, returns the honest "requested but unavailable"
+ * flag so the axis reports INCONCLUSIVE rather than a fabricated score.
+ */
+async function resolveJudgeOptions(
+  opts: BenchCliOptions
+): Promise<Pick<GraphBenchOptions, 'judge' | 'judgeRequestedButUnavailable'>> {
+  if (!opts.judge) return {};
+  const judge = await resolveBenchJudge(opts.judgeModel);
+  return judge ? { judge } : { judgeRequestedButUnavailable: true };
+}
+
+/** Write (when `--out`) and print the bench result; exits non-zero on abstention. */
+function emitBenchResult(result: GraphBenchResult, out: string | undefined, asJson: boolean): void {
+  if (out) {
+    fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+    fs.writeFileSync(path.resolve(out), JSON.stringify(result, null, 2) + '\n');
+  }
+  if (!result.ok) {
+    console.error(result.message);
+    process.exit(ExitCode.ZERO_DENOMINATOR);
+  }
+  console.log(asJson ? JSON.stringify(result, null, 2) : formatBenchReport(result));
 }
 
 export function createBenchCommand(): Command {
@@ -536,28 +787,19 @@ export function createBenchCommand(): Command {
     .option('--json', 'Emit the full machine-readable result as JSON')
     .option('--out <path>', 'Write the machine-readable result JSON to a file')
     .option('--top <n>', 'Anchors per structural family', '5')
-    .action(async (opts: { json?: boolean; out?: string; top: string }, cmd: Command) => {
-      const globalOpts = cmd.optsWithGlobals() as { config?: string };
+    .option(
+      '--judge',
+      'Grade the answer-quality axis with an LLM judge (retrieval sufficiency; advisory). Requires ANTHROPIC_API_KEY or HARNESS_ANALYSIS_BASE_URL; degrades to INCONCLUSIVE if neither is set.'
+    )
+    .option('--judge-model <model>', 'Model override for the answer-quality judge')
+    .action(async (opts: BenchCliOptions, cmd: Command) => {
+      const globalOpts = cmd.optsWithGlobals() as { config?: string; json?: boolean };
       const projectPath = path.resolve(globalOpts.config ? path.dirname(globalOpts.config) : '.');
-      const top = Number.parseInt(opts.top, 10);
-      const result = await runGraphBench(projectPath, {
-        top: Number.isFinite(top) && top > 0 ? top : 5,
-      });
-
-      if (opts.out) {
-        fs.mkdirSync(path.dirname(path.resolve(opts.out)), { recursive: true });
-        fs.writeFileSync(path.resolve(opts.out), JSON.stringify(result, null, 2) + '\n');
-      }
-
-      if (!result.ok) {
-        console.error(result.message);
-        process.exit(ExitCode.ZERO_DENOMINATOR);
-      }
-
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(formatBenchReport(result));
-      }
+      // `--json` is also declared as a program-global option, which shadows the
+      // subcommand flag; honor either so `graph bench --json` emits JSON.
+      const asJson = opts.json === true || globalOpts.json === true;
+      const judgeOpts = await resolveJudgeOptions(opts);
+      const result = await runGraphBench(projectPath, { top: parseTop(opts.top), ...judgeOpts });
+      emitBenchResult(result, opts.out, asJson);
     });
 }


### PR DESCRIPTION
## What

Adds the **answer-quality axis** (the comparator's "83%") to `harness graph bench` — the deferred third axis of #1271. The benchmark measured two objective axes (retrieval tokens, tool calls); it now optionally grades whether each strategy's retrieved payload actually *suffices to answer* the query.

`Refs #1271` (multi-repo corpus remains deferred).

## How it's wired (WIRED trace: bench → judge → score)

- New `packages/cli/src/commands/graph/bench-judge.ts`: a `BenchJudge` over the shared `AnalysisProvider` seam, resolved via `resolveBenchJudge` → **`resolveAnalysisProvider`** — the *identical* resolver `outcome_eval` / `acceptance_eval` use (Anthropic key → local `/v1` via `HARNESS_ANALYSIS_BASE_URL` → null). No bespoke judge, no new key plumbing.
- `runGraphBench` captures each strategy's payload, and when a judge is present grades every scenario × strategy, attaching a per-scenario `quality` grade + the exact `query` asked, and folds them into an aggregate `answerQuality` block.
- CLI: `--judge` / `--judge-model`. `harness graph bench --judge --json` lets a reviewer trace bench → judge → per-scenario score in the output.

Verified live on a fixture graph: with a local `/v1` judge, `answerQuality.status: "measured"` (graph 100% / naive 0% sufficient, per-scenario grades present); with no provider, `answerQuality.status: "inconclusive"` and the benchmark still exits 0.

## Honest degradation

- No `--judge` → `status: "skipped"` (default; objective axes byte-identical, deterministic for CI).
- `--judge` but no provider reachable → `status: "inconclusive"` (advisory) — **never fabricates a score**, benchmark still succeeds.
- `--judge` with a provider → `status: "measured"`; a scenario the judge can't decide is counted `inconclusive`, never faked.

The axis is **always advisory** — it never changes `result.ok` and never fails the benchmark.

## Also

Fixes a pre-existing bug where the program-global `--json` option shadowed `graph bench --json` (verified present on `origin/main`; the `--out` path was already unaffected).

## Tests

- `bench.test.ts`: mock-judge injection asserts every scenario is graded on both strategies and folds into the aggregate; a no-judge run reports `skipped`; an inconclusive judge folds to `inconclusive` without failing the bench; a requested-but-unavailable run reports `inconclusive`; `benchQueryFor` phrasing.
- `bench-judge.test.ts`: well-formed verdict passthrough, provider-rejection → INCONCLUSIVE, injected-`authority` strict-parse rejection → INCONCLUSIVE, oversized-payload truncation.
- 16 passing. `docs/reference/*` regenerated for the new flags; RESULTS.md / REPRODUCING.md / results/latest.json updated.

## Assumptions made

- Reused the existing shared eval judge seam rather than a bespoke judge/provider (confirmed decision #1).
- Axis is opt-in (off by default) so default/CI runs stay deterministic; tests inject a mock judge — no live judge in CI.
- Judged payloads truncated to a documented 12,000-char budget (naive payloads can be ~900k tokens); the budget is surfaced in the result note.
- Structural families get a deterministic synthesized query (stored per scenario); `find-context` / `ask` anchors used verbatim.
- `results/latest.json` patched additively with the `answerQuality` block a default (no-`--judge`) run emits, rather than re-running the full ~51k-node repo benchmark.
- Multi-repo answer-quality corpus remains deferred (`Refs #1271`).
