### PR TITLE
docs(roadmap): 6 remnants-round roadmap items (#1676–#1681)

### DIFF
--- a/docs/plans/cross-domain-build-order-2026-08-27.md
+++ b/docs/plans/cross-domain-build-order-2026-08-27.md
@@ -1,0 +1,169 @@
+# Cross-Domain Roadmap — Build Order
+
+**Date:** 2026-08-27 · **Scope:** the 117 roadmap items filed by the cross-domain ideation program
+(issues #1522–#1569, #1604–#1624, #1628–#1635, #1638–#1650, #1653–#1664, #1666–#1674, #1676–#1681)
+· **Purpose:** turn the backlog from a library into a program — a dependency-ordered wave plan.
+
+## How to read this
+
+Waves are dependency layers, not sprints: everything in a wave can start once the prior wave's
+items it cites are usable. Waves 1–2 run in parallel after Wave 0. Waves 3 and 4 are parallel
+tracks. Item detail (wiring, adopter usage, dogfooding, acceptance) lives in each linked issue.
+
+## The unlock list
+
+Ten items carry the most downstream dependency weight. Building these first unblocks the most:
+
+| Unlock                               | Issue        | Unblocks                                                                    |
+| ------------------------------------ | ------------ | --------------------------------------------------------------------------- |
+| Denominator declaration              | #1530        | every metric item                                                           |
+| Provenance trailer                   | #1531        | cost attribution, autonomy ratio, idiom tracing, realization, double-entry  |
+| Intent as unit of record             | #1538        | briefback, realization, forecasting, Kelly, derivation loops                |
+| Rework-rate instrumentation          | #1528        | intent coding, moral hazard, MDL, compaction validation, briefback evidence |
+| Metrology calibration chains         | #1645        | Goodhart sentinel, Kalman fusion, judge trust, spaced repetition            |
+| Causal-inference toolkit             | #1566        | skill P&L, MDL pruning, moral hazard, realization, economic thresholds      |
+| Unified admission control            | #1548        | every governor, DBR, shadow pricing, crisis modes, fuzzing budget           |
+| Mutation testing + capture-recapture | #1554, #1553 | NNR, Goodhart truth pairs, drills corpus, portfolio verification            |
+| Transparency log                     | #1556        | passports, threshold auth, safety-case evidence, audit sampling statements  |
+| Queueing model                       | #1555        | DBR, newsvendor, bullwhip, cavitation context, capacity governor            |
+
+## Wave 0 — Measurement floor (7)
+
+Nothing downstream is trustworthy without these. All are schema/instrumentation work, small to medium.
+
+| Item                                                        | Issue |
+| ----------------------------------------------------------- | ----- |
+| Denominator declaration in metric outputs                   | #1530 |
+| Provenance trailer on agent commits                         | #1531 |
+| Stability gate on ranked outputs                            | #1529 |
+| Rework-rate instrumentation                                 | #1528 |
+| Metrology calibration chains                                | #1645 |
+| Harness SLOs + alarm rationalization (alarm registry first) | #1643 |
+| Intent as the unit of record                                | #1538 |
+
+## Wave 1 — Quick wins (8)
+
+Small, mostly independent, immediate ROI; they pay for the rest of the program and build trust.
+
+| Item                                 | Issue | Why here                                            |
+| ------------------------------------ | ----- | --------------------------------------------------- |
+| Stability-ordered context layout     | #1634 | P1; token savings on every request, content-neutral |
+| Content-addressed gate memoization   | #1639 | P1; compute/token savings, proven pattern           |
+| Model-update regression sentinel     | #1617 | P1; standalone; trust event every firing            |
+| Mission-command briefback            | #1658 | P1; one round-trip kills the largest rework source  |
+| Taguchi loss (distance emission)     | #1673 | one schema field; recovers the leading indicator    |
+| Autonomy-ratio benchmark             | #1638 | nearly free; the credibility artifact               |
+| Cost-per-merged-PR attribution       | #1522 | needs #1531; the unit-cost number                   |
+| Scoped validation to changed surface | #1523 | CI time drop, immediate                             |
+
+## Wave 2 — Ground truth (9)
+
+The instruments that keep every later proxy honest. Protect the metric estate before scaling it.
+
+| Item                                              | Issue |
+| ------------------------------------------------- | ----- |
+| Mutation testing the gate stack                   | #1554 |
+| Capture-recapture defect estimation               | #1553 |
+| Judge calibration against outcomes                | #1560 |
+| Observational causal-inference toolkit            | #1566 |
+| Goodhart sentinel (activates as truth pairs land) | #1642 |
+| Number-needed-to-run gate accounting              | #1659 |
+| Known-answer pipeline drills                      | #1616 |
+| Near-miss ledger + leading indicators             | #1565 |
+| Basal token metabolism                            | #1628 |
+
+## Wave 3 — Control plane (18)
+
+Governors, admission, and flow control. Parallel track with Wave 4.
+
+Admission & budgets: unified admission control #1548 · budget governor #1525 · team capacity
+governor #1537 · rate-limit fan-out governor #1532 · context-replay budget #1524.
+Flow models & controllers: queueing model #1555 · scalability-law fit #1552 · AIMD concurrency
+#1606 · feedback control for governors #1567 · Nyquist oversight bound #1618 · bullwhip dampening
+#1666 · drum-buffer-rope #1676 · cavitation detection #1611 · crisis standards / degraded modes #1654.
+Economics: value-per-spend routing #1542 · capacity shadow pricing #1569 · Kelly staking #1668 ·
+newsvendor provisioning #1679.
+
+## Wave 4 — Safe autonomy (13)
+
+The authorization stack for unattended operation; the safety case is the capstone that cites the rest.
+
+Contracts & authority: unattended-safe contract #1533 · policy-level human control #1534 ·
+separation of duties #1661 · threshold m-of-n authorization #1650.
+Runtime integrity: agent apoptosis + lineage hygiene #1605 · adversarial input hardening #1559 ·
+unattended work decomposition #1536.
+Evidence & audit: transparency log #1556 · model-check the orchestration protocol #1562 ·
+normal-accidents coupling audit #1669.
+Operations: sterile cockpit #1672 · incident command structure #1667.
+Capstone: **unattended-operation safety case #1674**.
+
+## Wave 5 — Throughput & review economics (19)
+
+Landing at scale, and spending review attention where it matters. Needs Waves 3–4 partially.
+
+Landing: speculative merge queue #1647 · concurrent-change coordination #1539 · stigmergic
+coordination #1623 · interface futures #1615 · speculative execution #1622 · SMED changeover #1671.
+Review attention: typicality triage #1561 · **risk-tiered review gate #1527** · standards of review
+#1663 · precedent / stare decisis #1660 · design intent as executable constraint #1543.
+Verification composition: redundancy dial #1563 · portfolio-diverse verification #1631 ·
+outcrossing #1619 · verification by construction #1535 · spec back-translation #1662 ·
+Toulmin justifications #1681 · double-entry work ledger #1655 · statistical audit sampling #1664.
+
+> **Pull-forward note:** the review-attention cluster (#1527, #1561) answers "how much attention
+> does this PR deserve" and depends only on blast-radius tooling that already exists plus Wave-2
+> outcome data. It is deliberately pullable into Wave 2 if human review attention is the current
+> binding constraint — see the pre-existing `risk-forecasting-not-estimation` shard and the
+> pre-merge-brief "Worth your eyes" section, which these items upgrade from heuristic to calibrated.
+
+## Wave 6 — Knowledge & compression (15)
+
+Compounding layers: what the system knows, and what it costs to say.
+
+Knowledge: compiled comprehension substrate #1558 · MDL pruning #1630 · rejection ledger #1620 ·
+spaced-repetition re-verification #1680 · IRT difficulty/ability model #1657 · intent coding theory
+#1614 · reference-class forecasting #1670 · Kalman signal fusion #1677.
+Compression: rate-distortion compaction #1633 · trained dictionaries #1635 · progressive encoding
+#1632 · semantic canonicalization #1646.
+Codebase dynamics: idiom contagion epidemiology #1612 · dependency percolation margin #1608 ·
+immune detector population #1613.
+
+## Wave 7 — Production loop & program economics (15)
+
+Closing the loop with production, and auditing the program itself.
+
+Production: intent derivation from signal #1540 · closed-loop remediation #1541 · metric-gated
+progressive delivery #1644 · continuous fuzzing fleet #1640.
+Risk & learning: Gutenberg–Richter failure scaling #1629 · desire-path mining #1641 · situational
+digests #1564 · operator proficiency #1568 · moral-hazard instrumentation #1678.
+Program audit: controlled experiments on its own effect #1551 · strategy realization accounting
+#1649 · skill value ledger #1621 · economic injury thresholds #1656 · flow Reynolds number #1610 ·
+merged-but-unreleased inventory #1526.
+
+## Wave 8 — Ecosystem & adoption (13)
+
+Network effects last: they need the base to win on standalone merit first.
+
+Inbound: contribution triage at scale #1544 · contributor trust tiering #1545 · machine pre-review
+#1546 · semantic duplicate detection #1547 · provenance/authorship detection #1550 ·
+cross-boundary collision detection #1549.
+Federation: verification passports #1624 · federated gate calibration #1609 · standards interop
+#1648 · commons governance #1653.
+Adoption: counterfactual shadow trial #1607 · adoption-funnel telemetry #1604.
+
+(Autonomy ratio, though adoption-facing, ships in Wave 1 because it is measurement-only.)
+
+## Staging against capacity
+
+- **First ten to build** (Wave 0 + the four P1 quick wins): #1530, #1531, #1538, #1528, #1645,
+  #1643, #1529, then #1634, #1639, #1617. Everything else cites at least one of these.
+- One build wave ≈ one fleet batch at current throughput; Waves 0–2 are dominated by
+  schema/telemetry work and parallelize well; Waves 3–5 are the heavy engineering.
+- Re-derive this ordering when the constraint moves: it assumes review attention is the binding
+  resource. If token budget becomes binding first, Wave 1's compression items and Wave 6's
+  compression cluster move up a wave.
+
+## Provenance
+
+Sequenced from the dependency declarations in each item's issue (Dependencies / Wiring sections),
+2026-08-27. When items ship or dependencies change, regenerate the wave placement rather than
+patching it by hand.

--- a/docs/roadmap.d/drum-buffer-rope-scheduling.md
+++ b/docs/roadmap.d/drum-buffer-rope-scheduling.md
@@ -1,0 +1,16 @@
+---
+slug: "drum-buffer-rope-scheduling"
+milestone: "Fleet Family — Batch Orchestration"
+order: 148
+---
+
+### Drum-buffer-rope — subordinating work release to the constraint
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Theory of Constraints scheduling rests on one observation with teeth: a system produces at the pace of its constraint, so releasing work faster than the constraint's pace creates only queues, and an hour lost at the constraint is an hour lost forever while an hour lost elsewhere is a mirage. Drum-buffer-rope operationalizes it — the drum is the constraint's schedule, the buffer is protective work-in-progress placed only in front of the constraint, and the rope ties upstream release to the drum's pace so nothing enters faster than the bottleneck can consume. The pipeline's constraint is usually known (review attention or verification compute) yet release is governed by demand at the front door: intents decompose and dispatch at arrival rate, queueing at the constraint as aging inventory. Implement the mechanism over instruments already filed: the queueing model and capacity governor identify the constraint and its pace (the drum); admission control's release rate ties to it (the rope); buffers concentrate before the constraint only, sized by buffer-management (penetration alarms — how deep into the protective buffer has consumption reached — as the operational signal); and everything non-constraint deliberately idles rather than producing queue. The cultural import is the hard part encoded as policy: utilization of non-constraints is explicitly not a goal, and the telemetry stops rewarding it.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1676

--- a/docs/roadmap.d/kalman-signal-fusion.md
+++ b/docs/roadmap.d/kalman-signal-fusion.md
@@ -1,0 +1,16 @@
+---
+slug: "kalman-signal-fusion"
+milestone: "v5.0 — Telemetry & Effectiveness"
+order: 155
+---
+
+### Kalman fusion — one state estimate from many noisy quality signals
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** The roadmap now ships dozens of noisy, partial, differently-lagged signals about the same underlying states — pipeline health, codebase quality, fleet capacity — and every consumer (governors, dashboards, alarms) reads raw individual signals, each too noisy to act on alone and jointly inconsistent. Estimation theory solved this: the Kalman filter fuses noisy measurements with a process model into the optimal state estimate with an explicit uncertainty band, via the predict-update cycle — predict how the state should have evolved, correct by each measurement weighted by its measured reliability. Build the fusion layer: declared state variables (per-surface quality, per-stage capacity, per-gate effectiveness), process models (how each drifts between measurements), measurement models per signal (what each instrument observes, with noise estimated from the metrology calibration data), and the filter producing fused estimates with covariance. Consumers then act on one coherent estimate with an honest error bar instead of whipsawing between contradictory raw signals. Distinct from SPC (detects shifts in one series) and the Goodhart sentinel (cross-checks proxies against truth): this is the state estimator that turns the instrument estate into a single legible picture — and its innovation sequence (measurement-vs-prediction surprise) is itself a cheap anomaly signal.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1677

--- a/docs/roadmap.d/moral-hazard-instrumentation.md
+++ b/docs/roadmap.d/moral-hazard-instrumentation.md
@@ -1,0 +1,16 @@
+---
+slug: "moral-hazard-instrumentation"
+milestone: "v5.0 — Telemetry & Effectiveness"
+order: 156
+---
+
+### Moral hazard — measuring whether safety nets erode upstream care
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Insurance economics names the effect every layered-defense system suffers and none measures: protection changes behavior — the insured take more risk because the net exists. Applied here: as review gates strengthen, do authors (human and agent) test less? As auto-remediation expands, does deploy care decline? As the merge queue catches semantic conflicts, does pre-merge diligence atrophy? The defense-in-depth roadmap assumes layers add; moral hazard says layers partially cannibalize, and the difference between gross and net protection is currently invisible. Instrument it: natural experiments already exist in the telemetry (gates strengthen at known dates, protections roll out per-repo — difference-in-differences on upstream care metrics: author-run test rates, pre-submit fix rates, spec thoroughness, time-in-verification before submission), with the causal toolkit supplying the estimators. Where hazard is measured real, the insurance industry's mechanisms transfer: deductibles (the author bears a first-loss cost when the net catches their preventable failure — e.g., authoring the regression test), experience rating (already filed as trust tiering — its premiums should reflect caught-preventable rates), and coverage exclusions (classes the net deliberately does not catch, published, so upstream care remains rational). The honest possibility this item must allow: measured hazard may be near zero for agents — that finding is equally valuable, because it licenses aggressive netting.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1678

--- a/docs/roadmap.d/newsvendor-capacity-provisioning.md
+++ b/docs/roadmap.d/newsvendor-capacity-provisioning.md
@@ -1,0 +1,16 @@
+---
+slug: "newsvendor-capacity-provisioning"
+milestone: "Fleet Family — Batch Orchestration"
+order: 149
+---
+
+### Newsvendor provisioning — critical-fractile sizing for advance capacity commitments
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Inventory theory's newsvendor model solves one-shot provisioning under demand uncertainty exactly: given a demand distribution, an overage cost (provisioned but unused) and an underage cost (demand unmet), the optimal commitment is the critical fractile — provision to the demand quantile equal to underage/(underage+overage) — not the mean, not the max, and never a round number chosen in a meeting. The pipeline makes newsvendor decisions constantly without the arithmetic: reserving compute/quota windows for overnight fleets, pre-warming worktrees and caches, sizing standing verifier pools, pre-purchasing rate-limit headroom — each committed before demand is known, each with asymmetric regret (an idle reservation costs its price; an exhausted one stalls the constraint and, per drum-buffer-rope, that hour is lost forever). Implement the calculator where these commitments are made: demand distributions from the same telemetry reference-class forecasting builds on, explicit overage/underage cost declarations per commitment class (underage at the constraint priced by lost drum-hours), the critical-fractile computation replacing convention, and realized-demand feedback sharpening the distributions. The signature output is legible asymmetry: when stockout at the bottleneck is 10× the cost of idle reserve, the right answer is provisioning at the 91st percentile, and the calculator says so with the arithmetic shown.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1679

--- a/docs/roadmap.d/spaced-repetition-reverification.md
+++ b/docs/roadmap.d/spaced-repetition-reverification.md
@@ -1,0 +1,16 @@
+---
+slug: "spaced-repetition-reverification"
+milestone: "v2.0 Knowledge Graph & Personas"
+order: 2
+---
+
+### Spaced repetition — expanding-interval re-verification for standing knowledge
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Learning science's most robust result is the spacing effect, and its scheduling algorithms (Leitner boxes through SM-2) share one shape: re-test at expanding intervals while an item keeps passing, contract sharply on failure — maximum assurance per test administered. Standing knowledge here — compiled facts, calibration baselines, safety-case evidence, precedents, canonical assumptions — is re-verified on either fixed cadences (wasteful for stable items, too slow for volatile ones) or never. Import the scheduler: every re-verifiable item carries a verification interval that expands on each pass (stable knowledge earns infrequent checks) and collapses on failure or on premise-change signals (an item that failed re-verification, or whose linked premises shifted, returns to the short-interval box), with per-class interval policies and a global re-verification budget the scheduler optimizes within. This is the missing scheduling discipline behind several shipped items — metrology recalibration cadences, safety-case evidence currency, rejection-ledger premise checks, knowledge-store staleness — replacing their per-item fixed cadences with one budget-aware scheduler that spends verification where instability has been demonstrated. The measurable claim: at equal verification spend, spaced scheduling holds a lower stale-knowledge rate than fixed cadence.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1680

--- a/docs/roadmap.d/toulmin-structured-justifications.md
+++ b/docs/roadmap.d/toulmin-structured-justifications.md
@@ -1,0 +1,16 @@
+---
+slug: "toulmin-structured-justifications"
+milestone: "v5.0 — Enforcement Hardening"
+order: 142
+---
+
+### Toulmin justifications — machine-checkable argument structure for verdicts
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Argumentation theory's Toulmin model decomposes any practical argument into checkable parts: the claim, the grounds (evidence it rests on), the warrant (why these grounds license this claim), the qualifier (strength and conditions), and the rebuttal (what would defeat it). Agent verdicts today are prose justifications — plausible-sounding, structurally unexaminable, and uniform in confidence regardless of evidence. Require verdict-bearing outputs (review findings, gate judgments, co-sign decisions, escalations) to carry Toulmin structure: grounds must reference real artifacts (the double-entry ledger's credit discipline applied to arguments — a ground with no artifact link is an unbalanced claim), warrants must cite a rule, precedent, or calibrated judgment class, qualifiers must be explicit ('holds unless the config overrides X'), and the rebuttal field states what evidence would flip the verdict. The structure is what downstream machinery needs and prose denies: co-signers check arguments part-by-part instead of re-deriving; standards-of-review deference attaches to specific parts (facts get clear-error, warrants get de novo); the stated rebuttal is a test specification — often mechanically checkable now; and judge calibration localizes failures to bad grounds versus bad warrants, which have different fixes.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1681

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -945,6 +945,28 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** P3
 - **External-ID:** github:Intense-Visions/harness-engineering#1667
 
+### Drum-buffer-rope — subordinating work release to the constraint
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Theory of Constraints scheduling rests on one observation with teeth: a system produces at the pace of its constraint, so releasing work faster than the constraint's pace creates only queues, and an hour lost at the constraint is an hour lost forever while an hour lost elsewhere is a mirage. Drum-buffer-rope operationalizes it — the drum is the constraint's schedule, the buffer is protective work-in-progress placed only in front of the constraint, and the rope ties upstream release to the drum's pace so nothing enters faster than the bottleneck can consume. The pipeline's constraint is usually known (review attention or verification compute) yet release is governed by demand at the front door: intents decompose and dispatch at arrival rate, queueing at the constraint as aging inventory. Implement the mechanism over instruments already filed: the queueing model and capacity governor identify the constraint and its pace (the drum); admission control's release rate ties to it (the rope); buffers concentrate before the constraint only, sized by buffer-management (penetration alarms — how deep into the protective buffer has consumption reached — as the operational signal); and everything non-constraint deliberately idles rather than producing queue. The cultural import is the hard part encoded as policy: utilization of non-constraints is explicitly not a goal, and the telemetry stops rewarding it.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1676
+
+### Newsvendor provisioning — critical-fractile sizing for advance capacity commitments
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Inventory theory's newsvendor model solves one-shot provisioning under demand uncertainty exactly: given a demand distribution, an overage cost (provisioned but unused) and an underage cost (demand unmet), the optimal commitment is the critical fractile — provision to the demand quantile equal to underage/(underage+overage) — not the mean, not the max, and never a round number chosen in a meeting. The pipeline makes newsvendor decisions constantly without the arithmetic: reserving compute/quota windows for overnight fleets, pre-warming worktrees and caches, sizing standing verifier pools, pre-purchasing rate-limit headroom — each committed before demand is known, each with asymmetric regret (an idle reservation costs its price; an exhausted one stalls the constraint and, per drum-buffer-rope, that hour is lost forever). Implement the calculator where these commitments are made: demand distributions from the same telemetry reference-class forecasting builds on, explicit overage/underage cost declarations per commitment class (underage at the constraint priced by lost drum-hours), the critical-fractile computation replacing convention, and realized-demand feedback sharpening the distributions. The signature output is legible asymmetry: when stockout at the bottleneck is 10× the cost of idle reserve, the right answer is provisioning at the 91st percentile, and the calculator says so with the arithmetic shown.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1679
+
 ## v5.0 — Enforcement Hardening
 
 ### Audit and cap the pre-commit --skip list
@@ -1298,6 +1320,17 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** P3
 - **External-ID:** github:Intense-Visions/harness-engineering#1673
+
+### Toulmin justifications — machine-checkable argument structure for verdicts
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Argumentation theory's Toulmin model decomposes any practical argument into checkable parts: the claim, the grounds (evidence it rests on), the warrant (why these grounds license this claim), the qualifier (strength and conditions), and the rebuttal (what would defeat it). Agent verdicts today are prose justifications — plausible-sounding, structurally unexaminable, and uniform in confidence regardless of evidence. Require verdict-bearing outputs (review findings, gate judgments, co-sign decisions, escalations) to carry Toulmin structure: grounds must reference real artifacts (the double-entry ledger's credit discipline applied to arguments — a ground with no artifact link is an unbalanced claim), warrants must cite a rule, precedent, or calibrated judgment class, qualifiers must be explicit ('holds unless the config overrides X'), and the rebuttal field states what evidence would flip the verdict. The structure is what downstream machinery needs and prose denies: co-signers check arguments part-by-part instead of re-deriving; standards-of-review deference attaches to specific parts (facts get clear-error, warrants get de novo); the stated rebuttal is a test specification — often mechanically checkable now; and judge calibration localizes failures to bad grounds versus bad warrants, which have different fixes.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1681
 
 ## v5.0 — Catalog Rationalization
 
@@ -1808,6 +1841,28 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** P3
 - **External-ID:** github:Intense-Visions/harness-engineering#1669
+
+### Kalman fusion — one state estimate from many noisy quality signals
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** The roadmap now ships dozens of noisy, partial, differently-lagged signals about the same underlying states — pipeline health, codebase quality, fleet capacity — and every consumer (governors, dashboards, alarms) reads raw individual signals, each too noisy to act on alone and jointly inconsistent. Estimation theory solved this: the Kalman filter fuses noisy measurements with a process model into the optimal state estimate with an explicit uncertainty band, via the predict-update cycle — predict how the state should have evolved, correct by each measurement weighted by its measured reliability. Build the fusion layer: declared state variables (per-surface quality, per-stage capacity, per-gate effectiveness), process models (how each drifts between measurements), measurement models per signal (what each instrument observes, with noise estimated from the metrology calibration data), and the filter producing fused estimates with covariance. Consumers then act on one coherent estimate with an honest error bar instead of whipsawing between contradictory raw signals. Distinct from SPC (detects shifts in one series) and the Goodhart sentinel (cross-checks proxies against truth): this is the state estimator that turns the instrument estate into a single legible picture — and its innovation sequence (measurement-vs-prediction surprise) is itself a cheap anomaly signal.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1677
+
+### Moral hazard — measuring whether safety nets erode upstream care
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Insurance economics names the effect every layered-defense system suffers and none measures: protection changes behavior — the insured take more risk because the net exists. Applied here: as review gates strengthen, do authors (human and agent) test less? As auto-remediation expands, does deploy care decline? As the merge queue catches semantic conflicts, does pre-merge diligence atrophy? The defense-in-depth roadmap assumes layers add; moral hazard says layers partially cannibalize, and the difference between gross and net protection is currently invisible. Instrument it: natural experiments already exist in the telemetry (gates strengthen at known dates, protections roll out per-repo — difference-in-differences on upstream care metrics: author-run test rates, pre-submit fix rates, spec thoroughness, time-in-verification before submission), with the causal toolkit supplying the estimators. Where hazard is measured real, the insurance industry's mechanisms transfer: deductibles (the author bears a first-loss cost when the net catches their preventable failure — e.g., authoring the regression test), experience rating (already filed as trust tiering — its premiums should reflect caught-preventable rates), and coverage exclusions (classes the net deliberately does not catch, published, so upstream care remains rational). The honest possibility this item must allow: measured hazard may be near zero for agents — that finding is equally valuable, because it licenses aggressive netting.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1678
 
 ## v5.0 — Trust & Security Model
 
@@ -3009,6 +3064,17 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** P2
 - **External-ID:** github:Intense-Visions/harness-engineering#1630
+
+### Spaced repetition — expanding-interval re-verification for standing knowledge
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Learning science's most robust result is the spacing effect, and its scheduling algorithms (Leitner boxes through SM-2) share one shape: re-test at expanding intervals while an item keeps passing, contract sharply on failure — maximum assurance per test administered. Standing knowledge here — compiled facts, calibration baselines, safety-case evidence, precedents, canonical assumptions — is re-verified on either fixed cadences (wasteful for stable items, too slow for volatile ones) or never. Import the scheduler: every re-verifiable item carries a verification interval that expands on each pass (stable knowledge earns infrequent checks) and collapses on failure or on premise-change signals (an item that failed re-verification, or whose linked premises shifted, returns to the short-interval box), with per-class interval policies and a global re-verification budget the scheduler optimizes within. This is the missing scheduling discipline behind several shipped items — metrology recalibration cadences, safety-case evidence currency, rejection-ledger premise checks, knowledge-store staleness — replacing their per-item fixed cadences with one budget-aware scheduler that spends verification where instability has been demonstrated. The measurable claim: at equal verification spend, spaced scheduling holds a lower stale-knowledge rate than fixed cadence.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** github:Intense-Visions/harness-engineering#1680
 
 ## v2.0 Advanced Features
 


### PR DESCRIPTION
## What

The final ideation round of the cross-domain roadmap program: 6 shards, aggregate regenerated (282/282 headings), cross-linked to issues #1676–#1681, each carrying the full working format (Why / Deliverables / Acceptance / Wiring / Adopter usage / Dogfooding).

- **Kalman signal fusion** (estimation theory) — one fused state estimate with uncertainty bands from the instrument estate
- **Toulmin-structured justifications** (argumentation theory) — machine-checkable claim/grounds/warrant/rebuttal structure on verdicts
- **Moral-hazard instrumentation** (insurance economics) — net vs. gross protection: does each safety layer erode upstream care
- **Spaced-repetition re-verification** (learning science) — the budget-aware scheduler behind metrology, safety-case evidence, and knowledge staleness
- **Drum-buffer-rope scheduling** (theory of constraints) — work release tied to the constraint's pace
- **Newsvendor capacity provisioning** (inventory theory) — critical-fractile sizing for advance commitments

All deliberately P3: this is the remnants pass, closing the ideation program. The next pass over this roadmap should be sequencing, not generation.

## Stacking

Based on `docs/institutional-roadmap-2026-08-27` (PR #1675); auto-retargets to `main` when it merges. Merge order: #1675 → this.

## Verification

- `harness roadmap regen` clean: 282 headings for 282 shards
- All 6 External-IDs resolve to issues #1676–#1681
- Full pre-push gate passed
