### PR TITLE
docs(ideation): commit 2026-08-13 ideate-fleet strategy-track snapshot

### DIFF
--- a/docs/ideation/ceiling-raising-via-llm-judgme-2026-08-13.md
+++ b/docs/ideation/ceiling-raising-via-llm-judgme-2026-08-13.md
@@ -1,0 +1,114 @@
+---
+topic: 'Ceiling-raising via LLM judgment: complete and extend the craft-pipeline family that critiques quality beyond rule-based linters — the remaining docs-craft, code-craft, api-craft, cli-ergonomics skills and the craft fleet that composes them'
+generated_at: '2026-08-13T12:00:00Z'
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Ceiling-raising via LLM judgment — complete and extend the craft-pipeline family
+
+## Inputs
+
+- Topic: Ceiling-raising via LLM judgment — complete and extend the craft-pipeline family that critiques quality beyond rule-based linters (the docs-craft, code-craft, api-craft, cli-ergonomics skills and the craft fleet that composes them).
+- Generated: 2026-08-13T12:00:00Z
+- Strategy grounding: enabled — STRATEGY.md present and valid; track match "Ceiling-raising via LLM judgment".
+- Objection policy: none — each candidate carries its single strongest objection as a standing, accepted downside; none are rebutted.
+
+## Grounding note
+
+Reconnaissance of the repo shows the four skills named in the theme (docs-craft, code-craft, api-craft, cli-ergonomics-craft) plus the six earlier ones (naming, spec, test, copy, knowledge, security) and harness-design-craft — eleven craft skills total — and the `craft-fleet` that composes them have all shipped. The theme's "complete" is therefore effectively done at the skill-inventory level; the live leverage is now in **extending, hardening, and compounding** the family. Candidates below are grounded in observed asymmetries: only 4 of 11 craft skills expose a `_finalize` tool; `code-craft` explicitly foreshadows a future `align-code` autofix sibling; the family shares a 3-axis (tier × impact × confidence) output model (ADR 0019) and a formal verifier interface; rubric catalogs are hardcoded (seeded from Martin/Beck/Karlton); and craft findings are advisory-by-design with no calibration loop back into their own confidence.
+
+## Ranked candidates
+
+### 1. Cross-craft finding dedup and composition in craft-fleet — score: 6.00
+
+- Premise: Add a location-keyed dedup/composition pass to `craft-fleet`'s SELECT phase so a single code site flagged by multiple craft skills (e.g. naming + code + copy) collapses into one composed finding instead of three parallel `(scope, domain)` targets.
+- Persona: The tech lead running a batch craft sweep whose scarce resource is review attention, and who abandons the fleet's output when the same twenty lines arrive as three separate elevation items.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.75 (advances the Ceiling-raising track; persona references the Target problem's PR-review-backlog cost) — final score 6.00 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection (accepted downside): Composing findings across independent rubric catalogs risks producing a muddled meta-finding that serves no single craft skill's rewrite contract — the fleet's `harness-refactoring` subagents need a cited `runId`+`rubricId`+location per finding, and a composed item either loses that provenance or has to carry three, which complicates the cited-and-net-better verification the fleet's Iron Law depends on. The most likely failure mode is that the dedup silently drops the lower-confidence contributor and the human never learns a second craft skill also objected to that site.
+
+### 2. Golden-set rubric regression harness for judgment drift — score: 4.50
+
+- Premise: Build a curated corpus of exemplar/anti-exemplar snippets per rubric with pinned expected verdicts, run in CI, so a model upgrade or prompt change that shifts any craft skill's judgment is caught as a regression before it ships.
+- Persona: The harness maintainer who upgrades the backend model and currently has no way to know whether spec-craft or code-craft quietly got harsher, softer, or inconsistent overnight.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.75 (advances the Compounding-feedback-loops track; premise references Our approach — machine-checkable, compounding constraints) — final score 4.50 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection (accepted downside): LLM judgment is inherently non-deterministic, so a golden-set harness must tolerate variance without becoming a flaky CI gate that maintainers learn to rerun-until-green — and the moment it tolerates variance it can no longer distinguish real drift from noise. The most likely failure mode is a harness that is either too strict (constant false-positive reds that get muted) or too loose (passes through the exact judgment regressions it was built to catch), with no stable middle band.
+
+### 3. Self-tuning taste-calibration noise floor in craft-fleet — score: 4.00
+
+- Premise: Record the human's accept/reject decision on `craft-fleet`'s CONFIRM-phase verbatim taste-calibration sample and feed it back into the fleet's per-domain noise-floor threshold, so the floor that decides which findings are "above the noise" self-tunes toward that reviewer's demonstrated taste.
+- Persona: The senior engineer who repeatedly rejects the same class of low-value naming nits from the sweep and wants the floor to stop surfacing them without editing a config file.
+- Complexity: low
+- Impact / Confidence / Effort: M/M/L — base score 4.00
+- Strategy alignment: +0.75 (advances the Compounding-feedback-loops track; premise references Our approach — skills that measurably improve over time) — final score 4.00 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection (accepted downside): A floor that tunes itself to one reviewer's accept/reject history overfits to a single person's taste and can silently suppress a whole category of legitimate findings the team would have wanted, converting an advisory floor into an opaque filter no one audits. The most likely failure mode is that the calibration ratchets the floor upward over a few sessions until the fleet reports "quiet" everywhere, and the human mistakes a mis-tuned filter for a codebase that has reached its ceiling.
+
+### 4. Unified craft finalize/persistence contract across all eleven skills — score: 3.75
+
+- Premise: Extract a shared `*_craft_finalize` contract and apply it to all eleven craft skills (only four expose one today) so every craft run persists its findings uniformly as graph nodes with the 3-axis metadata, giving the family one queryable finding store.
+- Persona: The tech lead who wants `harness insights` to answer "where is our craft debt concentrated?" but today gets that signal from only the four skills that happen to persist.
+- Complexity: medium
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.75 (advances the Ceiling-raising track and feeds the Context-Density KPI via the knowledge graph — Our approach) — final score 3.75 (bonus applied — base-score tie with candidate 5)
+- Strongest objection (accepted downside): Forcing eleven skills with genuinely different finding shapes (a prose docs finding vs a per-unit code finding vs a per-endpoint api finding) through one persistence contract risks a lowest-common-denominator schema that loses each domain's specifics, or a bloated union type that is awkward for every consumer. The most likely failure mode is that the "shared" contract needs a per-skill escape hatch within two releases, at which point the unification is nominal and the maintenance cost of the abstraction outweighs the query convenience it promised.
+
+### 5. Wire craft critique into the per-PR code-review pipeline — score: 3.75
+
+- Premise: Integrate the relevant craft skill(s) into the existing multi-agent `code-review` pipeline so that ceiling critique fires automatically on the units changed in a PR, instead of only when a human already suspected something was mediocre and invoked a craft skill by hand on one file.
+- Persona: The tech lead 3–6 months into agent adoption whose review backlog is the bottleneck, and whose agents never get ceiling feedback because no one remembers to run the craft skills.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.75 (advances the Ceiling-raising track; persona references the Target problem — ballooning PR-review backlogs — and the Agent-Autonomy KPI) — final score 3.75 (bonus applied — base-score tie with candidate 4)
+- Strongest objection (accepted downside): Craft findings are advisory and noisy by design, so firing them automatically on every PR risks flooding review with subjective "could be better" comments that reviewers learn to ignore — the same alert-fatigue that killed inline-lint-comment bots — and worse, an agent may thrash trying to satisfy contradictory taste feedback with no human to arbitrate. The most likely failure mode is that teams disable the integration within a sprint because the signal-to-noise ratio on a per-PR cadence is worse than the deliberate, human-initiated one-file cadence the craft skills were designed for.
+
+### 6. Per-rubric confidence calibration loop from outcome telemetry — score: 2.75
+
+- Premise: Close a feedback loop that records whether each craft finding was accepted or rejected downstream (by the human, by craft-fleet's re-critique, by a merged fix) and calibrates each rubric's confidence prior over time, so persistently-rejected rubrics down-weight and persistently-actioned rubrics gain authority.
+- Persona: The harness maintainer tracking skill-effectiveness baselines who wants the craft family to demonstrably get sharper release-over-release rather than emit the same fixed-confidence judgments forever.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.75 (advances the Compounding-feedback-loops track; premise references Our approach — skills that measurably improve and compound) — final score 2.75 (bonus applied — base-score tie with candidates 7 and 8)
+- Strongest objection (accepted downside): Calibrating rubric confidence from accept/reject outcomes conflates "the reviewer disagreed with this rubric" with "this rubric was wrong here," and taste rejections are sparse, personal, and context-dependent — a rubric that is right but unpopular will be down-weighted into silence, permanently lowering the family's ceiling to match the median reviewer's tolerance. The most likely failure mode is a feedback loop that optimizes for agreement rather than quality, quietly amputating the family's most demanding (and most valuable) rubrics.
+
+### 7. New infra/config-craft domain skill — score: 2.75
+
+- Premise: Extend the craft family with a new domain skill that critiques the quality of infrastructure-as-code and configuration (Dockerfiles, CI YAML, `harness.config.json`, compose files) — the readability, honesty, and maintainability questions a YAML/schema linter cannot ask.
+- Persona: The senior engineer whose CI and container config has quietly rotted into copy-pasted, unexplained, drift-prone stanzas that no rule-based linter flags but every new hire misreads.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.75 (advances the Ceiling-raising track by adding a domain; premise references Our approach — constraints-as-code extended to config surfaces) — final score 2.75 (bonus applied — base-score tie with candidates 6 and 8)
+- Strongest objection (accepted downside): Infra/config quality is far more environment- and org-specific than code or prose quality — what reads as a smell in one team's CI is a deliberate, load-bearing choice in another's — so a generic rubric catalog will produce a high false-positive rate and little of the near-universal signal that made error-message and naming critique land. The most likely failure mode is a twelfth craft skill whose findings are so context-dependent that the honest confidence axis pins everything to "low," and the skill is never trusted enough to act on.
+
+### 8. Adopter-extensible / override-able rubric catalogs — score: 2.75
+
+- Premise: Let adopters add, disable, or override craft rubrics through project config rather than the hardcoded seed catalogs, so a team can encode its own house taste (or mute a rubric that fights its conventions) without forking the substrate.
+- Persona: The tech lead at an adopting org whose team standards diverge from the Martin/Beck/Karlton defaults and who currently has no lever short of ignoring the whole skill.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.75 (advances the External-adoption track; premise references Our approach — constraints-as-code that adopters own) — final score 2.75 (bonus applied — base-score tie with candidates 6 and 7)
+- Strongest objection (accepted downside): A curated rubric catalog is the product — its value is precisely that it encodes expert taste the adopter does not have — so handing adopters an override knob invites them to mute the rubrics they find annoying (which are often the ones they most need), hollowing the ceiling down to what they already believed. The most likely failure mode is that override configs become the mechanism by which teams disable exactly the demanding judgment the family exists to supply, and the feature ships a foot-gun dressed as flexibility.
+
+### 9. align-code safe-autofix sibling for code-craft — score: 1.00
+
+- Premise: Ship the `align-code` sibling that `code-craft`'s SKILL.md already foreshadows — a bounded, behavior-preserving autofix path that applies only the highest-confidence, mechanically-safe code-craft findings, mirroring how `align-design-system` applies safe drift codemods.
+- Persona: The individual developer running 10+ agent sessions a week who wants the obvious readability wins applied automatically rather than read as a critique they must action by hand.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score 1.00
+- Strategy alignment: +0.75 (advances the Ceiling-raising track; premise references Our approach — turning judgment into mechanically-applied change) — final score 1.00 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection (accepted downside): Safe behavior-preserving rewriting of subjective code quality is exactly the thing `craft-fleet` deliberately refuses to do at scale ("file-don't-rewrite") because taste-driven autofix produces churn, style-thrash, and un-reviewable bulk diffs — the confidence axis on code-craft findings is low precisely because "this reads better" is contestable. The most likely failure mode is that the set of findings genuinely safe to auto-apply is so small it does not justify a whole sibling skill, while any wider net reintroduces the churn the family was architected to avoid.
+
+### 10. Provider-neutral craft judgment routing — score: 0.67
+
+- Premise: Add per-rubric backend routing so craft critique can run off the Claude-only path (local models, other providers) with each rubric declaring the judgment strength it needs, extending the family across the multi-client substrate.
+- Persona: The Cursor/Codex/Gemini-CLI or local-model adopter who wants ceiling critique without being locked to a single provider's judgment.
+- Complexity: high
+- Impact / Confidence / Effort: M/L/H — base score 0.67
+- Strategy alignment: +0.75 (advances the Multi-client-portability track; premise references Our approach — a substrate usable across clients) — final score 0.67 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection (accepted downside): Taste judgment is the single capability where weaker/local models are furthest behind — prior local-pipeline work here found local models can execute mechanical fixes but hit a hard ceiling on the structured, subjective judgment craft skills demand — so routing craft critique to them produces confident-but-hollow verdicts that are worse than no critique because they carry the family's authority without its discernment. The most likely failure mode is that provider-neutral routing technically works while silently degrading the one thing the craft family exists to provide, and the degradation is invisible precisely because bad taste reads exactly like good taste in prose.

--- a/docs/ideation/compounding-feedback-loops-mec-2026-08-13.md
+++ b/docs/ideation/compounding-feedback-loops-mec-2026-08-13.md
@@ -1,0 +1,128 @@
+---
+topic: 'Compounding feedback loops: mechanisms that make agents and skills measurably improve over time — the skill-proposal loop, skill-effectiveness baselines, trust scoring, and prompt injection from historical outcomes'
+generated_at: 2026-08-13T16:00:00Z
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Compounding feedback loops (skill-proposal loop, effectiveness baselines, trust scoring, historical-outcome prompt injection)
+
+## Inputs
+
+- Topic: "Compounding feedback loops: mechanisms that make agents and skills measurably improve over time — the skill-proposal loop, skill-effectiveness baselines, trust scoring, and prompt injection from historical outcomes"
+- Generated: 2026-08-13T16:00:00Z
+- Strategy grounding: enabled — STRATEGY.md present and valid; matching track "Compounding feedback loops" (skill proposal loop, skill effectiveness baselines, trust scoring, prompt injection from historical outcomes)
+- Objection policy: none — each candidate's single strongest objection stands as an accepted downside (not rebutted)
+
+Grounding note: candidates were checked against the current codebase. The skill-proposal loop is largely complete (emit → auto-retrospect → mechanical gate → human approve → promote); skill-effectiveness and trust scorers exist and are wired together (persona effectiveness → review-finding trust), but effectiveness is computed on demand rather than snapshotted, trust never gates autonomy, and historical outcomes reach scoring/gates/humans but are never push-injected into new agent run prompts. Premises target those confirmed gaps rather than restating shipped machinery.
+
+## Ranked candidates
+
+### 1. Weight skill recommendation by measured effectiveness — score: 6.50
+
+- Premise: Feed the existing Laplace-smoothed skill success rates (`packages/intelligence/.../skill-scorer.ts`) into `recommend_skills`/`advise_skills` so proven skills rank higher and `detectFailingSkills`/`detectAbandonedSkills` outputs are demoted at selection time.
+- Persona: A tech lead 3–6 months into agent adoption who watches the agent keep reaching for a skill that quietly underperforms, because selection is blind to outcomes.
+- Complexity: low
+- Impact / Confidence / Effort: M / H / L — base score 6.00
+- Strategy alignment: +0.5 track:Compounding feedback loops — final score 6.50
+- Strongest objection: The scorer already exists, so this is "just wiring," which usually means the value is capped by the quality of the signal underneath it — adoption telemetry is sparse per skill, and Laplace smoothing over a handful of invocations produces rankings that swing on one or two runs. Most likely failure mode: low-volume skills get ranked by noise, the recommender starts steering agents away from a rarely-used-but-correct skill, and a human notices the recommendation got _worse_, eroding trust in the whole feedback loop. For the objection not to hold, per-skill invocation counts would need to clear a confidence floor before effectiveness is allowed to move the ranking at all.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 2. Cluster skill proposals into a ranked recurring-gap backlog — score: 6.50
+
+- Premise: Add semantic clustering over the open proposals in `.harness/proposals/` so recurring gaps (today deduped only per-target-skill by the store) surface as a single ranked "most-requested capability" backlog instead of scattered one-off records.
+- Persona: A tech lead triaging the proposal queue who cannot tell that six differently-worded proposals are really one missing skill everyone keeps hitting.
+- Complexity: low
+- Impact / Confidence / Effort: M / H / L — base score 6.00
+- Strategy alignment: +0.5 track:Compounding feedback loops — final score 6.50
+- Strongest objection: Clustering is only worth building once proposal volume is high enough to hide signal, and right now the queue is small enough that a human scanning `harness proposals list` sees the duplication unaided — so this optimizes a problem that does not yet bite. Most likely failure mode: embedding-based clustering mis-groups near-synonym gaps that are actually distinct, or splits one gap across two clusters, and the "ranked backlog" is less trustworthy than the raw list it replaced. For the objection not to hold, the proposal inflow (including the auto-retrospection emitter) would need to be producing enough volume that manual dedup has already become the bottleneck.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 3. Snapshot skill-effectiveness baselines with drift thresholds — score: 3.75
+
+- Premise: Periodically snapshot per-skill effectiveness (from `adoption.jsonl` + `execution_outcome` nodes) into a persisted baseline artifact with per-skill drift thresholds, replacing today's compute-on-demand scores that have no historical anchor.
+- Persona: A tech lead who wants a defensible "is our skill catalog getting better or worse this month" number, not a figure recomputed fresh every time it is asked.
+- Complexity: medium
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach (machine-checkable baselines mirror the Harness-Coverage / architecture-timeline pattern) — final score 3.75
+- Strongest objection: Baselines are only meaningful if the underlying outcome labels are trustworthy, and effectiveness here is a blend of outcome-eval verdicts and self-reported invocation outcomes that carry known noise (abandoned-mid-workflow is ambiguous, `failureCategory` is coarse). Most likely failure mode: a snapshot bakes in a bad month as "the baseline," every subsequent skill edit trips a drift threshold against a distorted anchor, and the team learns to ignore the drift alerts — the exact fate of a ratchet nobody trusts. For the objection not to hold, the outcome-labeling pipeline would need calibration (and probably a minimum sample size per skill) _before_ any threshold is allowed to fire.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 4. Push-inject top-K similar historical outcomes into new-run prompts — score: 3.75
+
+- Premise: Have the orchestrator retrieve the top-K most-similar prior `execution_outcome` nodes and `docs/solutions` post-mortems for the task at hand and inject their lessons into the dispatch prompt, extending `priorGateFailure` (today same-issue-retry only) to cross-run "last time a similar task failed because X."
+- Persona: A solo developer running 10+ agent sessions a week who keeps re-hitting failures the harness already recorded, because every new invocation starts cold and never sees the prior lesson unless it thinks to call `search_similar`.
+- Complexity: medium
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:Compounding feedback loops (the marquee "prompt injection from historical outcomes" bullet), +0.25 Target problem ("each agent invocation starts cold, re-litigates settled decisions") — final score 3.75
+- Strongest objection: Retrieval precision is the whole ballgame, and injecting the _wrong_ K prior outcomes is strictly worse than injecting none — it spends scarce context budget priming the executor toward a lesson from a superficially-similar-but-actually-different task, and negative transfer degrades runs that would otherwise have succeeded. Most likely failure mode: similarity is computed over task descriptions (a length/keyword proxy, as the AMR pre-diff classifier already is), the top-K are topically adjacent but causally irrelevant, and the agent over-indexes on a red herring. For the objection not to hold, retrieval would need a relevance gate strong enough that low-confidence matches inject nothing rather than something.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 5. Skill-effectiveness ratchet as a CI gate — score: 2.75
+
+- Premise: Promote `detectFailingSkills` from a report into a CI gate that flags (non-blocking floor first) when a skill's smoothed success rate regresses beyond its baseline tolerance, mirroring the coverage/architecture ratchets already in the pre-push gauntlet.
+- Persona: A tech lead who wants a silently-degrading skill to trip a gate in CI the same way a layer violation does, rather than being discovered in a monthly retrospective.
+- Complexity: medium
+- Impact / Confidence / Effort: M / M / M — base score 2.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach (constraints-as-code: another machine-checkable ratchet) — final score 2.75
+- Strongest objection: A ratchet keyed to a noisy, low-volume metric is a false-positive machine, and the harness already carries several non-blocking floors (required-review, security baseline) that teams have learned to merge through — adding another one that cries wolf trains the team to ignore gate output generally, which is a net negative for the whole enforcement thesis. Most likely failure mode: an unrelated PR merges during a bad-luck window of skill outcomes, the ratchet reds, the author has no lever to green it (skill quality is not what their PR changed), and the gate becomes noise. For the objection not to hold, this depends entirely on candidate #3's calibrated baseline plus a sample-size floor — without those it should not be built.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 6. Curated anti-pattern corpus injected as executor guardrails — score: 2.75
+
+- Premise: Mine recurring failures from `execution_outcome` NOT_SATISFIED verdicts and black-box `gate-blocked` records into a small human-curated "known failure modes" set that is injected as explicit prohibitions into executor prompts.
+- Persona: A solo heavy user whose agent keeps re-committing the same class of mistake (e.g. barrel-integration thrash, empty-diff halts) that the harness has already seen dozens of times.
+- Complexity: medium
+- Impact / Confidence / Effort: M / M / M — base score 2.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Target problem ("agents drift back to bad patterns the moment a session forgets the prompt") — final score 2.75
+- Strongest objection: Curation does not scale and staleness rots the corpus — a "known failure modes" list is only as good as its last human curation pass, and an out-of-date prohibition ("never do X") actively fights a change that has since made X correct, so the guardrail becomes a source of drift rather than a cure. Most likely failure mode: the corpus is seeded once with real failures, never revisited, and six months later it is prohibiting patterns that the codebase now mandates. For the objection not to hold, the corpus would need an expiry/review cadence tied to the same retrospection loop that produces skill proposals, so entries decay unless re-affirmed.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 7. Per-backend/per-agent trust score feeding routing — score: 2.75
+
+- Premise: Compute a rolling trust score per (backend, task-class) from historical gate pass rates and feed it into the `BackendRouter` so demonstrably-unreliable backends are downgraded or escorted (paired with a reviewer) rather than dispatched blind.
+- Persona: A tech lead running a mixed local/cloud fleet who currently has no signal for "this backend keeps failing this class of task" beyond reading black-box records by hand.
+- Complexity: high
+- Impact / Confidence / Effort: H / M / H — base score 2.00
+- Strategy alignment: +0.5 track:Compounding feedback loops (trust scoring), +0.25 Our approach ("the substrate the agent runs on, not the agent itself, determines reliability") — final score 2.75
+- Strongest objection: A trust score that reroutes work creates a self-reinforcing feedback trap: a backend that scores low gets fewer (and only harder, escorted) tasks, which prevents it from ever recovering its score, so the loop ossifies an early bad streak into a permanent demotion regardless of later capability or a model upgrade. Most likely failure mode: a transient bad window (a flaky CI period, one gnarly task-class) tanks a backend's trust, routing starves it, and the score never rebuilds because the evidence stream dried up. For the objection not to hold, the router would need an exploration policy (periodic trust-blind dispatch) so scores can recover — which is real ML-systems complexity, not a weekend wiring job.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 8. Build the stubbed skill-mode soundness-review gate — score: 1.33
+
+- Premise: Replace the proposal-promotion gate's explicit "degraded mode" (mechanical YAML/markdown/diff checks only) with the named-but-unbuilt semantic gate `harness skill run harness-soundness-review --mode skill`, so agent-proposed skills are judged on soundness before human approval, not just well-formedness.
+- Persona: A tech lead reviewing agent-proposed skills who currently gets a "the YAML is valid" green light that says nothing about whether the proposed skill is actually a good idea.
+- Complexity: high
+- Impact / Confidence / Effort: M / M / H — base score 1.33
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach (a machine-checkable constraint on the promotion path) — final score 1.33 (bonus recorded but NOT applied — no adjacent base-score tie within 0.05)
+- Strongest objection: The gate is stubbed precisely because "the skill-mode check vocabulary is not yet designed" — the hard part is not running soundness-review, it is defining what soundness _means_ for a skill (as opposed to a spec), and shipping a gate on top of an under-specified rubric produces confident-but-arbitrary verdicts that a human reviewer must then second-guess, adding a step without adding trust. Most likely failure mode: the LLM judge blocks a perfectly good proposed skill on a rubric criterion nobody agreed to, the reviewer overrides it, and the gate becomes advisory theater. For the objection not to hold, the skill-soundness rubric would need to be designed and validated against real proposals _before_ the gate is wired — that design work, not the wiring, is the actual project.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 9. Trust-gated autonomy escalation — score: 1.75
+
+- Premise: Make a run's unattended/auto-merge eligibility rise and fall with the acting agent's accumulated trust score and the live holiday-confidence gates, replacing today's fixed pass/fail gates with an earned-autonomy ladder.
+- Persona: A tech lead deciding whether to leave the fleet running unattended over a weekend, who today has only a repo-wide holiday-confidence number and no per-agent "has this one earned the leash" signal.
+- Complexity: high
+- Impact / Confidence / Effort: H / L / H — base score 1.00
+- Strategy alignment: +0.5 track:Compounding feedback loops (trust scoring), +0.25 Target problem (the "if the senior disappears for two weeks, what holds?" thesis) — final score 1.75
+- Strongest objection: Autonomy is the single highest-blast-radius decision the harness makes, and letting an _accumulated_ score raise the auto-merge bar means one over-trusted agent on a streak can ship something catastrophic unattended precisely when oversight has been dialed down — the failure is rare but unbounded, which is the worst risk profile. Most likely failure mode: trust accrued on easy task-classes transfers to a hard one, the agent ships a subtly wrong change during the unattended window, and no human is watching because the ladder said it was safe. For the objection not to hold, escalation would need to be strictly bounded (trust can widen review, never remove the human merge gate) — at which point much of the headline value evaporates.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 10. Feed black-box forensic records back into routing and planning — score: 1.75
+
+- Premise: Read the today-write-only `.harness/black-box/run-*/run.json` records (routing choices, provenance, per-unit `gateReason`) back into routing decisions and pre-run planning, closing the loop on a forensic sink that currently informs nothing.
+- Persona: A tech lead who has 60+ richly-detailed run records that explain exactly why past runs failed, none of which the harness ever consults when planning the next run.
+- Complexity: medium
+- Impact / Confidence / Effort: M / L / M — base score 1.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach (durable grounding fed back into the substrate) — final score 1.75
+- Strongest objection: Black-box records were designed as a forensic sink for humans, and their schema is optimized for post-hoc debugging, not for machine consumption — repurposing them as a planning input means treating an audit log as a decision oracle, and the two goals conflict (a forensic record wants completeness and stability; a routing input wants a curated, low-latency, schema-stable signal). Most likely failure mode: the record format shifts to serve routing, its forensic value degrades, and the routing signal it feeds substantially overlaps what `execution_outcome` nodes already provide via candidate #4 — so this either duplicates #4 or corrupts the forensic trail. For the objection not to hold, there would need to be a routing-relevant signal in black-box records that is genuinely absent from the graph's outcome nodes.
+- Objection answered: no (accepted downside per objection policy: none)
+
+## Handoff
+
+- Ideation artifact written: docs/ideation/compounding-feedback-loops-mec-2026-08-13.md
+- Top pick: "Weight skill recommendation by measured effectiveness" — score 6.50
+- Next: invoke /harness:brainstorming "Effectiveness-weighted skill recommendation" to take a candidate into a spec, OR /harness:roadmap to enqueue picks for later.

--- a/docs/ideation/external-adoption-flywheel-mak-2026-08-13.md
+++ b/docs/ideation/external-adoption-flywheel-mak-2026-08-13.md
@@ -1,0 +1,149 @@
+---
+topic: 'External adoption flywheel: make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale — skill marketplace, constraint-sharing bundles, harness:blueprint codebase courseware, telemetry-driven adoption insights'
+generated_at: '2026-08-13T12:00:00Z'
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: External adoption flywheel
+
+## Inputs
+
+- Topic: External adoption flywheel: make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale — skill marketplace, constraint-sharing bundles, harness:blueprint codebase courseware, telemetry-driven adoption insights
+- Generated: 2026-08-13T12:00:00Z
+- Strategy grounding: enabled — STRATEGY.md present and valid; matching track "External adoption flywheel"
+- Objection policy: none — each candidate's single strongest objection stands as an accepted downside (not rebutted)
+
+## Scoring notes
+
+- Mapping: `low|medium|high → 1|2|3`. `base_score = (impact × confidence) ÷ effort`, rounded to 2 decimals.
+- Order is by **base score** descending (monotonically non-increasing).
+- Strategy-alignment bonus (`+0.5` track match, `+0.25` Target-problem/Our-approach reference; max `+0.75`) is **recorded for every candidate** but **applied to the final score only within an exact base-score tie** (`|Δbase| ≤ 0.05`). It never reorders candidates across different base scores.
+
+## Ranked candidates
+
+### 1. `harness init --template <stack>` ships a working constraint set on first command — score: 6.00
+
+- Premise: Ship `harness init --template <stack>` starter templates (Next.js, FastAPI, Go) that scaffold a working constraint set — layer ESLint rules, entropy detectors, and a STRATEGY.md seed — on the first command, so an external adopter hits a firing constraint within minutes.
+- Persona: An individual developer running agents heavily (10+ sessions/week) trying harness for the first time on their own stack.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.75 (track "External adoption flywheel" +0.5; references Our approach — constraints-as-code from first run +0.25) — recorded, not applied (no base-score tie) — final score 6.00
+- Strongest objection: The strongest objection is maintenance surface — each stack template is a second copy of the harness's evolving constraint surface, and the moment core rule schemas or detector configs change, every template silently drifts to a broken or misleading starting state, the worst possible first impression for an evaluator. The most likely failure mode is a new adopter running `init --template next` months after the template was authored, getting config the current CLI rejects, and concluding the harness is brittle. For the objection not to hold, templates would need to be generated from the same source of truth the core ships (not hand-maintained) and covered by CI that fails when a template no longer initializes cleanly.
+- Objection answered: no — accepted as a standing downside.
+
+### 2. `harness assess --adopt` — pre-adoption readiness report on an untouched repo — score: 4.50
+
+- Premise: Add `harness assess --adopt` that runs read-only against an untouched external repo and outputs which constraints would fire, an estimated drift-debt figure, and a one-page "what you'd get" summary — before the adopter changes a single file.
+- Persona: A tech lead evaluating harness on a real team repo during a time-boxed trial, needing evidence before asking the team to commit.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.75 (track "External adoption flywheel" +0.5; references Target problem — surfaces the drift the repo already carries +0.25) — recorded, not applied (no base-score tie) — final score 4.50
+- Strongest objection: The strongest objection is that a pre-adoption scan is exactly where false positives are most expensive: the evaluator has no baseline, no context for which findings matter, and one noisy report ("1,400 violations") reads as either alarmist or unactionable, killing the trial at first contact. The likely failure mode is the report surfacing raw absolute counts against an un-baselined repo — which the harness itself normally treats as baseline-relative — so the number is both large and meaningless. For it not to hold, the report would need to lead with a small, curated, high-confidence subset and frame counts as "new drift per PR going forward," not a total indictment of existing code.
+- Objection answered: no — accepted as a standing downside.
+
+### 3. Portable constraint-pack export/import (`harness pack export|import`) — score: 3.75
+
+- Premise: Define a versioned, portable "constraint pack" artifact (layer ESLint rules + entropy detector config + STRATEGY.md section seeds) with `harness pack export`/`import`, so a team can lift a proven constraint set from one repo into another.
+- Persona: A senior engineer standardizing architecture rules across several repos in the same org.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.75 (track "External adoption flywheel" — constraint-sharing bundles, verbatim +0.5; references Our approach — encoding constraints as portable code +0.25) — applied (base-score tie with #4, |Δbase| = 0.00) — final score 3.75
+- Strongest objection: The strongest objection is portability-in-name-only: architectural constraints encode a repo's specific layer topology, path aliases, and package layout, so a pack lifted wholesale into a differently-shaped repo either fails to load or, worse, enforces the wrong boundaries silently. The likely failure mode is an import that "succeeds" but pins layer rules to directories that don't exist in the target, producing zero enforcement while displaying green. For it not to hold, packs would need an explicit parameterization/mapping step at import and a validation pass that proves each imported rule actually binds to real code in the target.
+- Objection answered: no — accepted as a standing downside.
+
+### 4. Opt-in telemetry-driven adoption insights view — score: 3.75
+
+- Premise: Build an opt-in, DO_NOT_TRACK-respecting telemetry pipeline that reports anonymized skill- and constraint-usage from external projects into an "External Adoption" insights view, so the team can see which parts of the thesis actually get exercised off-repo.
+- Persona: The harness maintainer team deciding where to invest, plus a prospective adopter reading a public "what's working" signal.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.75 (track "External adoption flywheel" — telemetry-driven adoption insights, verbatim +0.5; references Our approach — operationalizes whether the thesis generalizes +0.25) — applied (base-score tie with #3, |Δbase| = 0.00) — final score 3.75
+- Strongest objection: The strongest objection is sample bias plus consent friction: privacy-conscious senior engineers (the exact primary persona) are the most likely to leave DO_NOT_TRACK on, so the telemetry over-represents casual users and under-represents the teams whose behavior the thesis most needs to validate. The likely failure mode is confidently steering roadmap toward features the loud, opted-in minority uses while the target segment's needs stay invisible. For it not to hold, the sample would need either a demonstrably representative opt-in rate or a parallel qualitative channel that corrects for the self-selection.
+- Objection answered: no — accepted as a standing downside.
+
+### 5. Skill marketplace with `harness skill publish|install` — score: 2.75
+
+- Premise: Stand up a skill marketplace with `harness skill publish` / `harness skill install <name>` so external authors can share and consume harness skills the way plugins are shared today.
+- Persona: A tech lead maintaining an internal team skill library who wants to both consume community skills and publish their own.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.75 (track "External adoption flywheel" — skill marketplace, verbatim +0.5; references Our approach — distributing workflow-rigidity skills +0.25) — applied (base-score tie with #6 and #7, |Δbase| = 0.00) — final score 2.75
+- Strongest objection: The strongest objection is that a marketplace for executable skills is a supply-chain risk masquerading as a distribution feature: skills run with real tool access, so an install-by-name flow without provenance, sandboxing, and review is a credential-and-filesystem exposure vector, and adopters burned by npm-style attacks will (correctly) refuse to install unvetted skills. The likely failure mode is either a malicious/low-quality skill damaging an early adopter's repo, or the trust bar being set so high that nobody publishes and the shelves stay empty. For it not to hold, the marketplace needs signed provenance, a review/trust tier, and capability scoping before it opens.
+- Objection answered: no — accepted as a standing downside.
+
+### 6. One-command cross-client setup installer (`harness setup`) — score: 2.75
+
+- Premise: Ship a single `harness setup` installer that configures the harness plugin and MCP wiring correctly across all four clients (Claude Code, Cursor, Codex, Gemini CLI) from one command, removing per-client setup as an adoption barrier.
+- Persona: An individual developer on a non-Claude client (Cursor/Gemini) who bounces off multi-step manual setup.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.75 (tracks "External adoption flywheel" and "Multi-client portability" +0.5; references Our approach — one portable substrate across clients +0.25) — applied (base-score tie with #5 and #7, |Δbase| = 0.00) — final score 2.75
+- Strongest objection: The strongest objection is that a one-command cross-client installer concentrates four independently-drifting config surfaces behind a single "it just works" promise, so the weakest-maintained client path becomes the face of the product — and when Gemini or Codex changes its plugin/MCP format, the installer confidently writes a now-invalid config and the adopter's first experience is a broken tool. The likely failure mode is silent misconfiguration on the least-exercised client. For it not to hold, each client path would need its own post-install verification that proves the wiring actually works, not just that files were written.
+- Objection answered: no — accepted as a standing downside.
+
+### 7. Shareable Harness-Coverage / Drift-Floor badge and report link — score: 2.75
+
+- Premise: Generate a hosted, shareable summary link (and README badge) of a repo's Harness Coverage and Drift Floor, giving adopters social-proof artifacts to advocate internally.
+- Persona: A tech lead who has adopted harness and needs a shareable artifact to make the internal case for team-wide rollout.
+- Complexity: low
+- Impact / Confidence / Effort: L/M/L — base score 2.00
+- Strategy alignment: +0.75 (track "External adoption flywheel" — social proof drives adoption +0.5; references Our approach — surfaces Harness Coverage / Drift Floor metrics +0.25) — applied (base-score tie with #5 and #6, |Δbase| = 0.00) — final score 2.75
+- Strongest objection: The strongest objection is that a public badge optimizes for the wrong thing: Harness Coverage as a headline number invites gaming (documenting trivial rules to inflate the ratio) and, as a shareable artifact, does little to convert a skeptical VP who cares about shipped outcomes, not a coverage percentage — while committing the team to operating a hosted report service. The likely failure mode is low advocacy value for real hosting/operations cost. For it not to hold, the badge would need to surface an outcome metric an executive already trusts (agent-autonomy or drift-per-PR trend) rather than an internal coverage ratio.
+- Objection answered: no — accepted as a standing downside.
+
+### 8. Telemetry-seeded "projects like yours also enforce X" recommendations — score: 1.50
+
+- Premise: Use anonymized adoption telemetry to power "projects like yours also enforce X" recommendations that nudge mid-adoption teams toward constraints their peers found valuable.
+- Persona: A team a few months into harness adoption, unsure which additional constraints are worth enabling next.
+- Complexity: medium
+- Impact / Confidence / Effort: H/L/M — base score 1.50
+- Strategy alignment: +0.75 (track "External adoption flywheel" — telemetry-driven insights +0.5; references Our approach — peer-driven constraint adoption +0.25) — recorded, not applied (no base-score tie) — final score 1.50
+- Strongest objection: The strongest objection is the cold-start dependency: peer-based recommendations require a large, representative telemetry corpus that the External Adoption track has not yet produced, so shipping this before the data exists yields generic or misleading nudges that erode trust exactly when a mid-adoption team is deciding whether to deepen investment. The likely failure mode is a recommender that, on a thin/biased sample, confidently suggests constraints ill-suited to the team's stack. For it not to hold, the telemetry pipeline (#4) would need to be live, opted-into at scale, and demonstrably representative first.
+- Objection answered: no — accepted as a standing downside.
+
+### 9. `harness blueprint` — knowledge-graph-driven codebase courseware — score: 2.08
+
+- Premise: Build `harness blueprint` that turns the knowledge graph of a codebase into an interactive, guided courseware tour (architecture, key paths, conventions) for someone learning an unfamiliar repo.
+- Persona: A new hire or contributor onboarding onto an unfamiliar harness-managed codebase.
+- Complexity: high
+- Impact / Confidence / Effort: M/M/H — base score 1.33
+- Strategy alignment: +0.75 (track "External adoption flywheel" — harness:blueprint codebase courseware, verbatim +0.5; references Our approach — durable grounding in the knowledge graph +0.25) — applied (base-score tie with #10, |Δbase| = 0.00) — final score 2.08
+- Strongest objection: The strongest objection is that auto-generated courseware conflates a map with a lesson: a knowledge-graph-derived tour can enumerate modules, layers, and paths accurately yet fail to teach the "why" a human mentor conveys, so learners get a structurally complete but pedagogically flat artifact they abandon. The likely failure mode is high generation cost producing a tour that reads like generated documentation and drifts stale as the code moves. For it not to hold, the courseware would need a curation layer where a human seeds the narrative/intent and the graph only fills in the structural scaffolding.
+- Objection answered: no — accepted as a standing downside.
+
+### 10. Searchable public registry indexing shared constraint packs — score: 2.08
+
+- Premise: Stand up a searchable public registry indexing shared constraint packs (from #3) so adopters can discover and pull a proven ruleset for their stack or domain.
+- Persona: A tech lead browsing for a battle-tested constraint set rather than authoring one from scratch.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/H — base score 1.33
+- Strategy alignment: +0.75 (track "External adoption flywheel" — extends constraint-sharing/marketplace +0.5; references Our approach — discoverable constraints-as-code +0.25) — applied (base-score tie with #9, |Δbase| = 0.00) — final score 2.08
+- Strongest objection: The strongest objection is compounded dependency and empty-shelf risk: a registry adds nothing until portable packs (#3) both exist and are numerous and trustworthy enough to browse, so building the discovery layer first inverts the dependency order and risks a polished storefront with empty shelves — while inheriting the same provenance/trust burden as the skill marketplace. The likely failure mode is launching a registry that indexes two internal packs and signals abandonment. For it not to hold, #3 adoption would need to have already produced a critical mass of shareable, vetted packs.
+- Objection answered: no — accepted as a standing downside.
+
+## Ranking table (base-score order)
+
+| Rank | Premise (short)                                  | I/C/E | Base | Bonus | Final |
+| ---- | ------------------------------------------------ | ----- | ---- | ----- | ----- |
+| 1    | Stack starter templates (`init --template`)      | M/H/L | 6.00 | +0.75 | 6.00  |
+| 2    | Pre-adoption readiness report (`assess --adopt`) | H/H/M | 4.50 | +0.75 | 4.50  |
+| 3    | Portable constraint-pack export/import           | H/M/M | 3.00 | +0.75 | 3.75  |
+| 4    | Opt-in telemetry adoption insights               | H/M/M | 3.00 | +0.75 | 3.75  |
+| 5    | Skill marketplace (publish/install)              | H/M/H | 2.00 | +0.75 | 2.75  |
+| 6    | Cross-client setup installer (`harness setup`)   | M/M/M | 2.00 | +0.75 | 2.75  |
+| 7    | Shareable Harness-Coverage badge/report          | L/M/L | 2.00 | +0.75 | 2.75  |
+| 8    | Telemetry-seeded skill recommendations           | H/L/M | 1.50 | +0.75 | 1.50  |
+| 9    | `harness blueprint` codebase courseware          | M/M/H | 1.33 | +0.75 | 2.08  |
+| 10   | Public constraint-pack registry                  | M/M/H | 1.33 | +0.75 | 2.08  |
+
+Note: bonus is applied to the final score only within an exact base-score tie (#3/#4, #5/#6/#7, #9/#10). Singletons (#1, #2, #8) record the bonus but do not apply it, so #8's final (1.50) is intentionally below the applied finals of the lower-base #9/#10 tie — order remains by base score, per the ranking contract.
+
+## Handoff
+
+- Ideation artifact written: docs/ideation/external-adoption-flywheel-mak-2026-08-13.md
+- Top pick: `harness init --template <stack>` ships a working constraint set on first command — score 6.00
+- Next: invoke `/harness:brainstorming "Stack starter templates"` to take a candidate into a spec, OR `/harness:roadmap` to enqueue picks for later.

--- a/docs/ideation/full-lifecycle-reach-role-shap-2026-08-13.md
+++ b/docs/ideation/full-lifecycle-reach-role-shap-2026-08-13.md
@@ -1,0 +1,132 @@
+---
+topic: 'Full-lifecycle reach: role-shaped front doors for the two non-engineer edges — authoring intent upstream of the spec, and adjudicating outcomes (UAT, sign-off, production signals feeding the graph) downstream'
+generated_at: '2026-08-13T12:00:00Z'
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Full-lifecycle reach — role-shaped front doors for the two non-engineer edges
+
+## Inputs
+
+- Topic: Full-lifecycle reach: role-shaped front doors for the two non-engineer edges — authoring intent upstream of the spec, and adjudicating outcomes (UAT, sign-off, production signals feeding the graph) downstream
+- Generated: 2026-08-13T12:00:00Z
+- Strategy grounding: enabled — STRATEGY.md present and valid; matching track "Full-lifecycle reach"
+- Objection policy: none — each candidate's single strongest objection is surfaced as a standing, accepted downside and is NOT rebutted
+
+## Scoring method
+
+- `low | medium | high → 1 | 2 | 3`. `base_score = (impact × confidence) ÷ effort`, displayed to 2 decimals.
+- Candidates sorted by base score descending (order is monotonically non-increasing in base score).
+- Strategy-alignment bonus (max +0.75): `+0.5` if the premise plausibly advances the "Full-lifecycle reach" Tracks bullet, `+0.25` if premise/persona references the Target problem or Our approach. The bonus is applied to the final score ONLY within an exact base-score tie (|Δbase| ≤ 0.05); it never reorders across differing base scores. The bonus is recorded for every candidate for transparency.
+
+## Ranked candidates
+
+### 1. Auto-derive a plain-language UAT checklist from the spec's acceptance section — score: 9.00
+
+- Premise: A skill transforms a spec's resolved acceptance criteria into an ordered, plain-language pass/fail checklist a non-engineer can walk without reading the spec or touching the CLI.
+- Persona: The client-side product owner or QA reviewer who signs off on delivered work but has never opened a `proposal.md`.
+- Complexity: low
+- Key risk: Acceptance criteria that are vague or implementation-shaped translate into a checklist the reviewer cannot actually judge.
+- Impact / Confidence / Effort: H/H/L — base score 9.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach (recorded; not applied — no base tie) — final score 9.00
+- Strongest objection (standing, accepted downside): The value of the checklist is entirely inherited from acceptance-criteria quality, which acceptance-eval already flags as frequently NOT_MEASURABLE. When the upstream section is a list of implementation tasks rather than observable behaviors, the generated checklist inherits that defect verbatim and hands the reviewer un-adjudicable items ("verify the reducer is pure"), giving false confidence that a human edge was covered when it was mechanically decorated. The most likely failure mode is a green checklist over a spec whose behaviors were never observably specified — the exact gap this edge was meant to close.
+
+### 2. Post-ship stakeholder outcome digest: delivered-vs-requested in plain language — score: 6.00
+
+- Premise: After a change ships, a skill emits a plain-language digest mapping each originally-requested outcome to what was actually delivered, for the non-engineer who authored the intent.
+- Persona: The requirements author (client sponsor / PM) who described the need upstream and wants to know, without reading a diff, whether they got it.
+- Complexity: low
+- Key risk: Without durable links from delivered work back to original intent, the mapping is reconstructed heuristically and can quietly misattribute.
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach (recorded; not applied — no base tie) — final score 6.00
+- Strongest objection (standing, accepted downside): The digest is only as honest as the intent-to-delivery linkage beneath it, and today that linkage does not durably exist (candidate #5 is the thing that would create it). Absent real traceability edges, the digest is an LLM re-derivation of "what you asked for" from whatever text it can reach, which reads as authoritative to a non-technical sponsor precisely because it is fluent — a confidently-worded mapping that can silently drop a dropped requirement or claim coverage for a partially-met one. The failure mode is a polished report that manufactures closure the pipeline did not actually earn.
+
+### 3. Product-requirements middle skill: BRD → structured, traceable requirements — score: 4.50
+
+- Premise: A skill converts an approved BRD into a set of structured, individually-addressable requirement records that specs downstream link to, filling the "product-requirements middle" gap named in the strategy between product-advisor and brainstorming.
+- Persona: The solution architect translating a signed-off BRD into something the spec author can build against without re-litigating scope.
+- Complexity: medium
+- Key risk: It can become a redundant artifact layer between the BRD and the spec that authors skip, adding ceremony without grounding.
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.5 track:Full-lifecycle reach, +0.25 references Our approach (durable grounding / encoding intent as constraint) = +0.75 (recorded; not applied — no base tie) — final score 4.50
+- Strongest objection (standing, accepted downside): This inserts a mandatory artifact between two artifacts that teams already treat as one hop (BRD → spec), and every intermediate artifact must earn its keep or it becomes drift-generating ceremony. If the requirement records are not mechanically enforced as the only path from BRD to spec, authors route around them and the records rot immediately — an unenforced convention, which the strategy explicitly diagnoses as the failure it exists to fix. The likely failure mode is a well-intentioned middle layer that is authored once, never maintained, and diverges from both the BRD above it and the specs below it.
+
+### 4. Recorded human UAT sign-off wired as a ship gate — score: 3.00
+
+- Premise: A human's recorded UAT adjudication becomes a blocking ship gate in the pipeline (structurally like outcome-eval), so a change cannot ship without a durable, attributable sign-off from the outcome edge.
+- Persona: The accountable non-engineer approver whose sign-off is currently a Slack "lgtm" with no artifact and no gate.
+- Complexity: medium
+- Key risk: A blocking human gate stalls the autonomy the harness is trying to maximize, and can be rubber-stamped to unblock.
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach, +0.25 references Our approach (gate as machine-checkable constraint) = +0.75 (applied within base tie with #5) — final score 3.75
+- Strongest objection (standing, accepted downside): A mandatory human sign-off gate is in direct tension with the Agent-Autonomy and Holiday-Confidence KPIs — the whole thesis is that the senior can disappear for two weeks, and a blocking human edge reintroduces exactly the human-in-the-loop bottleneck the harness sells against. Worse, a gate that blocks is a gate that gets rubber-stamped under delivery pressure, so it degrades into an attestation with the ceremony of a control but none of the assurance. The failure mode is either a pipeline that stalls waiting on a human who has left, or a sign-off click that means nothing.
+
+### 5. Requirement→spec→outcome traceability edges in the knowledge graph — score: 3.00
+
+- Premise: Client requirements are persisted as first-class knowledge-graph nodes with durable edges to the specs that implement them and the execution-outcome nodes that adjudicate them, closing the intent-to-outcome loop as queryable substrate.
+- Persona: The tech lead who needs to answer "which delivered outcome satisfies which original client requirement?" without archaeology across BRDs, specs, and PRs.
+- Complexity: medium
+- Key risk: The edges are only trustworthy if authored/maintained at every hop; a single un-linked hop makes the whole chain unreliable and quietly worse than no chain.
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach, +0.25 references Our approach (durable grounding in the knowledge graph) = +0.75 (applied within base tie with #4) — final score 3.75
+- Strongest objection (standing, accepted downside): Traceability graphs are notorious for being 90% complete and therefore untrustworthy — the value is in completeness, but the maintenance burden falls exactly on the hops (client intent → requirement node) where no engineer has a natural incentive to link. A partially-linked graph is arguably worse than none, because it invites confident queries ("nothing traces to requirement R, so it must be unbuilt") that are false whenever the gap is a missing edge rather than missing work. The failure mode is silent under-linkage that makes the graph an authoritative-looking source of wrong answers.
+
+### 6. Client-intake dashboard lane: guided web interview → BRD draft — score: 2.00
+
+- Premise: A non-CLI dashboard lane runs a guided requirements interview for a client and produces a BRD draft that feeds product-advisor, making the upstream intent edge reachable by someone who will never touch a terminal.
+- Persona: The prospective client or business sponsor describing what they need, who would abandon the pipeline the moment a CLI is required.
+- Complexity: high
+- Key risk: A web front door is a large surface (auth, hosting, session state, UX) whose cost may dwarf the underlying skill it fronts.
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach, +0.25 references Who-it's-for/approach (role-shaped front door for non-engineers) = +0.75 (applied within base tie with #7 and #8) — final score 2.75
+- Strongest objection (standing, accepted downside): Building and operating a hosted, authenticated web lane is a categorically different and larger commitment than shipping a skill — it drags in session persistence, access control, hosting, and an ongoing UX surface — and that cost is incurred before there is any evidence a client will complete a guided interview rather than just booking a call. The likely failure mode is a heavy, perpetually-maintained web property that fronts a thin skill, inverting the harness's own bet that leverage comes from constraints-as-code, not from building yet another CRUD dashboard.
+
+### 7. UAT sign-off dashboard lane: non-engineer web adjudication front door — score: 2.00
+
+- Premise: A dashboard lane presents the plain-language acceptance checklist to a non-engineer reviewer in the browser, captures per-item pass/fail with evidence, and emits the durable sign-off artifact — the downstream twin of the intake lane.
+- Persona: The client-side approver adjudicating whether delivered work meets the agreed outcome, from a browser, without CLI or repo access.
+- Complexity: high
+- Key risk: Same web-surface cost as the intake lane, plus it presumes the checklist (#1) and the sign-off artifact (#4) already exist and are trustworthy.
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach, +0.25 references Who-it's-for/approach (role-shaped front door for non-engineers) = +0.75 (applied within base tie with #6 and #8) — final score 2.75
+- Strongest objection (standing, accepted downside): This lane sits at the top of a dependency stack — it is only meaningful if the plain-language checklist (#1) is trustworthy and the sign-off artifact/gate (#4) exists, so building it first means building a UI over a hollow core. It carries the same hosting/auth/UX operating cost as the intake lane while adding a reviewer-access problem (giving a client scoped visibility into a specific change's outcome without exposing the repo). The failure mode is an expensive web surface that ships ahead of the substrate it needs, producing sign-offs that look rigorous but rest on un-adjudicable checklist items.
+
+### 8. Edge-actor routing: surface "your input is needed" to the right non-engineer — score: 2.00
+
+- Premise: A routing mechanism detects when the pipeline is blocked on a human edge (a requirements gap upstream or a pending sign-off downstream) and surfaces a visible, actionable ask to the specific non-engineer responsible, over a real channel rather than an invisible interaction record.
+- Persona: The busy non-engineer stakeholder who is the bottleneck but never sees the ask because it lives in a log they don't read.
+- Complexity: medium
+- Key risk: Ask-fatigue — a routing layer that notifies too eagerly gets muted, and a muted channel is indistinguishable from no channel.
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach (recorded; +0.25 not credited — premise is plumbing, not intent-encoding) = +0.50 (applied within base tie with #6 and #7) — final score 2.50
+- Strongest objection (standing, accepted downside): Notification routing is deceptively simple to build and genuinely hard to make land — the harness's own history (emit_interaction asks that record but never surface) shows the failure is not delivery mechanics but attention economics, and adding another channel that non-engineers can mute solves nothing. If the ask over-fires it gets filtered to a folder no one opens; if it under-fires the edge stays blocked silently. The failure mode is a routing layer that technically works and behaviorally changes nothing because the human edge was never a delivery problem.
+
+### 9. Intent change-request loop: propagate client requirement changes to affected specs/tasks — score: 1.33
+
+- Premise: When a client revises a requirement mid-flight, a guided flow computes the blast radius over the downstream specs, plans, and open tasks and presents the affected set for re-adjudication, treating intent itself as a change with impact analysis.
+- Persona: The delivery lead absorbing a scope change from the client and needing to know, before committing, what downstream work it invalidates.
+- Complexity: high
+- Key risk: Blast radius over intent requires the traceability edges (#5) to already exist and be complete; without them the propagation is guesswork.
+- Impact / Confidence / Effort: M/M/H — base score 1.33
+- Strategy alignment: +0.5 track:Full-lifecycle reach (recorded; not applied — no base tie) — final score 1.33
+- Strongest objection (standing, accepted downside): This is the most downstream-dependent idea in the set — meaningful blast-radius-over-intent presupposes the requirement→spec→outcome graph (#5) is not just present but complete, and impact analysis over an incomplete graph produces exactly the confident-but-wrong answers that make traceability dangerous. Building it before that substrate is trustworthy yields a change-propagation flow that misses affected work (giving false "safe to change" signals) or floods the lead with spurious impacts. The failure mode is a scope-change tool that erodes trust the first time it says a change is contained when it wasn't.
+
+### 10. Production-signal ingestion: feed post-ship operational signals back into the graph — score: 1.00
+
+- Premise: Post-ship production signals (error rates, usage, incidents) are ingested as feedback nodes attached to the shipped change, extending the outcome edge past sign-off into live operation so the graph learns whether delivered work actually held up in production.
+- Persona: The operator/tech lead who owns the thing after it ships and wants production reality to feed back into the pipeline that produced it, not die in a separate observability tool.
+- Complexity: high
+- Key risk: Production telemetry lives in heterogeneous external systems, and attributing a production signal to a specific shipped change is a hard, noisy correlation problem.
+- Impact / Confidence / Effort: H/L/H — base score 1.00
+- Strategy alignment: +0.5 track:Full-lifecycle reach, +0.25 references Our approach (compounding feedback into the graph) = +0.75 (recorded; not applied — no base tie) — final score 1.00
+- Strongest objection (standing, accepted downside): Attributing production signals to the change that caused them is an unsolved correlation problem even for dedicated observability platforms, and doing it from inside a build-loop harness means either integrating a sprawl of external monitoring systems or ingesting signals too coarse to attribute — both of which land low-confidence. The most likely failure mode is a feedback stream that is either empty (no integrations wired) or noisy (signals that can't be tied to a specific ship), meaning the loop it promises to close stays open while carrying the operational cost of pretending it's closed.
+
+## Handoff
+
+- Ideation artifact written: docs/ideation/full-lifecycle-reach-role-shap-2026-08-13.md
+- Top pick: Auto-derive a plain-language UAT checklist from the spec's acceptance section — score 9.00
+- Next: invoke /harness:brainstorming "UAT Checklist Generator" to take a candidate into a spec, OR /harness:roadmap to enqueue picks for later.

--- a/docs/ideation/multi-client-portability-keep-2026-08-13.md
+++ b/docs/ideation/multi-client-portability-keep-2026-08-13.md
@@ -1,0 +1,99 @@
+---
+topic: 'Multi-client portability: keep the harness usable across Claude Code, Cursor, Codex, Gemini CLI and OpenCode without forking the substrate — marketplace plugins per client, per-skill/per-cognitive-mode backend routing, gateway API for external bridges'
+generated_at: '2026-08-13T12:00:00Z'
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Multi-client portability
+
+## Inputs
+
+- Topic: Multi-client portability — keep the harness usable across Claude Code, Cursor, Codex, Gemini CLI and OpenCode without forking the substrate (marketplace plugins per client, per-skill/per-cognitive-mode backend routing, gateway API for external bridges).
+- Generated: 2026-08-13T12:00:00Z
+- Strategy grounding: enabled — STRATEGY.md present and valid; track match "Multi-client portability". Objection policy: none (every objection recorded as a standing accepted downside; none rebutted).
+
+## Ranked candidates
+
+### 1. A single generative cross-client parity conformance test asserts every client plugin exposes the identical skill, command, agent, and hook set the generator claims — score: 9.00
+
+- Persona: The harness maintainer shipping a new skill or hook who must fan it out across five client plugins and has no signal today when one client silently drifts.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/L — base score 9.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 approach (constraints-as-code that removes a class of drift) — recorded +0.75, not applied (no adjacent base-score tie) — final score 9.00
+- Strongest objection: A conformance test only checks that generated outputs agree with each other, not that each client actually loads and honors them at runtime — so it can pass green while a real Cursor or Gemini install is broken because the client silently ignored a field the generator emitted. The most likely failure mode is a false sense of safety: the test enforces internal generator self-consistency (the exact thing the generator is already deterministic about) while the genuinely lossy step — the client's own parser dropping unsupported hooks/agents fields — happens downstream where this test never looks. For the objection to not hold, the test would need to assert against a captured fixture of what each client genuinely ingests (a golden snapshot per client parser), not merely against the generator's own manifest.
+
+### 2. Extend the strict routing config schema so `routing.policy` and per-backend capabilities are accepted from the config file, not only via the live `PUT /routing/policy` endpoint — score: 6.00
+
+- Persona: The tech lead standardizing a team on a mixed local+cloud backend setup who wants routing declared as reviewable, version-controlled config rather than a runtime API call.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:Multi-client portability (per-skill/per-cognitive-mode backend routing), +0.25 approach (declarative machine-checkable config) — recorded +0.75, applied within base-score tie — final score 6.75
+- Strongest objection: The types already allow it and the code already reads it — only the Zod schema rejects it — so this looks like a trivial one-line schema widening, but that framing hides the real cost: once the config surface is public, its shape becomes a compatibility contract you can never quietly change, and the runtime `PUT` path and the file path will drift in validation semantics unless they share exactly one schema. The most likely failure mode is two subtly different validators (file vs endpoint) accepting different policies, so a config that loads locally is rejected by the gateway or vice versa. For the objection to not hold, both surfaces must be provably routed through a single shared schema with a test pinning their equivalence.
+
+### 3. `harness plugin doctor` — a CLI diagnostic that verifies a client's installed plugin matches the freshly generated marketplace (skill count, version, missing/extra commands) and prints actionable drift — score: 6.00
+
+- Persona: The adopter three months in who reinstalled the harness and cannot figure out why a skill shows up in Claude Code but not in their Cursor install.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 approach (mechanical drift detection surfaced to the human) — recorded +0.75, applied within base-score tie — final score 6.75
+- Strongest objection: A doctor command is only consulted after something already feels broken, so its value is capped by how often adopters think to run it — and the failure it diagnoses (stale installed plugin vs generated marketplace) is one a `harness update` step could prevent outright, making the diagnostic a treatment for a disease better cured upstream. The most likely failure mode is that it becomes a rarely-run command whose own drift-detection logic silently rots because nothing exercises it on the happy path. For the objection to not hold, the doctor check would need to run automatically (as a post-install/pre-run hook) rather than waiting to be invoked by a confused user.
+
+### 4. Client-agnostic skill authoring: `create-skill` emits one canonical skill and mechanically generates all client mirrors and the Gemini TOML, eliminating the current four-hand-copies-plus-symlink authoring ritual — score: 4.50
+
+- Persona: The contributor authoring a new skill who today must produce four byte-identical platform directory copies (or manage symlinks) and regenerate the Gemini `.toml`, and gets no error when one copy is forgotten.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 approach (remove a manual drift source via generation) — recorded +0.75, applied within base-score tie — final score 5.25
+- Strongest objection: Collapsing four copies into one canonical source assumes the four clients are genuinely the same skill with cosmetic differences, but they are not — Gemini needs TOML with no agents field, Cursor runs in commands mode, and the substrate difference is exactly what forced the per-client trees in the first place; a single generator that papers over these will accrete client-specific escape hatches until it is as complex as the thing it replaced. The most likely failure mode is a canonical format expressive enough to be lossless becoming a de-facto fifth dialect nobody wants to learn. For the objection to not hold, the per-client deltas must be provably small and fully data-describable (a capability manifest), not code branches.
+
+### 5. Complete OpenCode as a first-class plugin target, generating its marketplace/plugin artifacts from the same generator the other five clients already use — score: 4.50
+
+- Persona: The senior engineer on a team that has standardized on OpenCode and currently cannot adopt the harness at all because only Claude Code, Cursor, Gemini, Codex, and Antigravity are wired.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.5 track:Multi-client portability (OpenCode named explicitly in the track) — recorded +0.50, applied within base-score tie — final score 5.00
+- Strongest objection: OpenCode is named in the strategy but its actual adoption footprint among the primary persona (tech leads paying the cleanup tax on Claude Code / Cursor / Gemini / Codex) is unknown and plausibly small, so this could be substantial generator and capability-mapping work to reach a client almost nobody on the target team uses — spending portability budget on breadth rather than the depth (parity, conformance) the already-wired clients still lack. The most likely failure mode is a sixth half-supported target that dilutes maintenance attention and degrades because OpenCode lacks native fields for hooks or agents. For the objection to not hold, there must be concrete pull (an actual team blocked on OpenCode) rather than strategy-completeness for its own sake.
+
+### 6. Ship curated per-cognitive-mode backend routing presets (reasoner-vs-coder, thinking-on-vs-off) as an installable bundle, generalizing the proven design-vs-execution split — score: 4.00
+
+- Persona: The adopter running local models who wants sane routing defaults (a strong reasoner for design, a fast coder for execution) without hand-tuning the routing graph themselves.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/L — base score 4.00
+- Strategy alignment: +0.5 track:Multi-client portability (per-cognitive-mode backend routing), +0.25 approach (curated defaults as shareable constraints) — recorded +0.75, not applied (base-score delta > 0.05 to neighbors) — final score 4.00
+- Strongest objection: Routing presets bake a point-in-time judgment about which model is good at what into a shipped artifact, and the local-model landscape churns fast enough that a "reasoner" preset can be obsolete within a quarter — turning a convenience into stale, misleading advice that adopters trust precisely because it shipped with the harness. The most likely failure mode is a preset that silently routes to a weak model for a cognitive mode it is no longer suited to, with the adopter never realizing the default is the problem. For the objection to not hold, presets would need a freshness/versioning story and a way to be corroborated against live benchmarks rather than frozen at author time.
+
+### 7. A single declarative source of truth for hook membership that both `profiles.ts` and `plugin-config.mjs` STANDARD_HOOKS consume, eliminating the dual-source desync that no test catches today — score: 3.00
+
+- Persona: The harness maintainer who changes a hook's profile membership and must remember to edit two unrelated files or silently desync the plugin and Cursor configurations.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 approach (single source of truth = constraints-as-code removing a drift class) — recorded +0.75, applied within base-score tie — final score 3.75
+- Strongest objection: The two files live in different runtimes and package boundaries (a TS source consumed at runtime vs a build-time `.mjs` script), so unifying them means one has to import across a boundary that was deliberately kept separate, or a third generated artifact both derive from — either of which adds a build-order dependency that can fail in ways more confusing than the current "remember to edit both." The most likely failure mode is a generated hook manifest going stale relative to its source and now BOTH consumers being wrong in lockstep, which is harder to notice than one being out of sync with the other. For the objection to not hold, the generation step must be enforced in CI so a stale manifest cannot merge.
+
+### 8. A per-client capability-matrix manifest (hooks / agents / slash-commands / TOML-vs-MD support) declared as data, driving graceful generator degradation and an auto-rendered parity matrix in the docs — score: 3.00
+
+- Persona: The adopter evaluating which client to standardize their team on, who needs to know up front that Gemini has no native agents field and Cursor runs commands-mode before they commit.
+- Complexity: medium
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 approach (capability declared as machine-checkable data) — recorded +0.75, applied within base-score tie — final score 3.75
+- Strongest objection: The capability knowledge already exists — it is encoded implicitly in `plugin-config.mjs`'s per-client branches and comments — so extracting it into a formal manifest is a refactor whose payoff (an auto-rendered docs table, graceful degradation) is real but modest relative to lifting every client's generation path onto a data-driven model without regressing the five that work today. The most likely failure mode is the manifest becoming a second description of capabilities that drifts from the actual code branches it was supposed to replace, leaving two sources of truth instead of one. For the objection to not hold, the generator must be refactored to READ the manifest as its only capability authority, not merely to publish it alongside the existing branches.
+
+### 9. Publish a thin typed gateway client SDK plus one reference external bridge (e.g., a GitHub Action or chatops hook) that drives the harness through the existing gateway API — score: 2.00
+
+- Persona: The platform engineer integrating the harness into an external CI or chatops system who today has only a raw OpenAPI spec and must hand-roll the client and auth flow.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:Multi-client portability (gateway API for external bridges) — recorded +0.50, not applied (base-score delta > 0.05 to neighbors) — final score 2.00
+- Strongest objection: A first-party SDK plus a reference bridge is a large, open-ended surface (auth, versioning, retries, an example integration to maintain) built on the bet that external bridges are a real adoption vector — but the primary persona is a tech lead cleaning up drift inside their own repo, not a platform team wiring the harness into external systems, so this may be depth invested where the demand is thinnest. The most likely failure mode is a shipped SDK and example that go stale because too few external integrators exercise them, becoming a maintenance liability that suggests support the team cannot actually sustain. For the objection to not hold, there must be a concrete external integrator committed to consuming it before the SDK is built.
+
+### 10. A Gemini/Cursor persona shim that synthesizes multi-persona behavior from commands plus context files, since neither client has a native agents/subagents field — score: 0.67
+
+- Persona: The adopter on Gemini CLI or Cursor who wants the harness's multi-persona review to work with the same fidelity it has on Claude Code.
+- Complexity: high
+- Impact / Confidence / Effort: M/L/H — base score 0.67
+- Strategy alignment: +0.5 track:Multi-client portability — recorded +0.50, not applied (base-score delta > 0.05 to neighbors) — final score 0.67
+- Strongest objection: Personas on Claude Code work because the client natively dispatches subagents with isolated context; simulating that on clients with no agents primitive means faking isolation through prompt-stuffing and command chaining, which reproduces the shape of multi-persona review without its actual property (independent contexts that cannot contaminate each other) — so the shim risks looking like parity while delivering a single context wearing several hats. The most likely failure mode is a shim that passes a visual check but produces reviews that are not genuinely independent, quietly undermining the trust the persona system exists to create. For the objection to not hold, the target clients would need some real isolation primitive to build on, which by the premise they lack.

--- a/docs/ideation/shortlists/strategy-track-sweep-2026-08-13.md
+++ b/docs/ideation/shortlists/strategy-track-sweep-2026-08-13.md
@@ -1,0 +1,97 @@
+---
+batch_label: strategy-track sweep (6 confirmed STRATEGY.md tracks)
+batch_slug: strategy-track-sweep
+pinned_date: 2026-08-13
+themes: 6
+themes_verified: 6
+themes_thin: 0
+themes_parked: 0
+themes_rejected: 0
+count_per_theme: 10
+per_theme_cut: 3
+global_cap: 10
+objection_policy: none
+novelty_lookback_days: 90
+concurrency: 2
+strategy_grounded: true
+strategy_path: STRATEGY.md
+all_os_ci: not-applicable (fleet produces no code or PR)
+filed: nothing
+committed: nothing
+---
+
+# Ideate-Fleet Curated Shortlist — strategy-track sweep (2026-08-13)
+
+Wave-1 execute lane of `ideate-fleet`, dispatched by `fleet-command`. Six STRATEGY.md tracks were each run through the **real** `harness-ideate` pipeline in its own git worktree (concurrency 2), producing one ranked artifact per theme (10 candidates each). Every shortlist row traces to a **verified** per-theme artifact collected byte-identical into `docs/ideation/`, and every score below was **independently re-derived** by the orchestrator from the artifact's own impact/confidence/effort values — not taken from any subagent's self-report.
+
+**Nothing was filed. Nothing was committed, staged, or pushed.** This shortlist and the six collected artifacts are ordinary working-tree changes. The pick is the human's act; route a pick to `harness-brainstorming` (to spec one) or to the roadmap (to enqueue several).
+
+## Ranked shortlist (10 of 18 preselected; reserved-slot rule applied)
+
+| #   | Premise                                                                                                                                         | Theme                        | Re-derived score (base → final) | Standing objection (one line)                                                                                                                                                                                        | Novelty                                                                                                 | Artifact                                                                        |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 1   | Auto-derive a plain-language UAT checklist from the spec's acceptance section                                                                   | full-lifecycle-reach         | (3×3)/1 = 9.00 → 9.00           | Value is inherited from acceptance-criteria quality; a spec of implementation tasks yields un-adjudicable items and false "human-edge-covered" confidence.                                                           | novel (adjacent to `uat-user-sign-off-loop`, `acceptance-eval`; neither derives the checklist)          | [full-lifecycle-reach](../full-lifecycle-reach-role-shap-2026-08-13.md)         |
+| 2   | Cross-client parity conformance test: every client plugin exposes the identical skill/command/agent/hook set the generator claims               | multi-client-portability     | (3×3)/1 = 9.00 → 9.00           | Checks generator self-consistency, not that each client actually loads/honors the fields at runtime — can pass green while a real Cursor/Gemini install is broken.                                                   | novel (no covering row; distinct from `add-harness-mcp-list-capabilities-cli`)                          | [multi-client-portability](../multi-client-portability-keep-2026-08-13.md)      |
+| 3   | KG coverage gate fails CI when a package's load-bearing upstream nodes fall below a per-package density threshold                               | upstream-grounding           | (2×3)/1 = 6.00 → 6.75           | A raw node-count rewards volume over load-bearing-ness; a package can clear it with filler ADRs while the number goes green and grounding quality is unchanged.                                                      | novel (operationalizes the Context-Density KPI; no covering row)                                        | [upstream-grounding](../upstream-grounding-make-the-st-2026-08-13.md)           |
+| 4   | Skills assert a minimum valid grounding set as an explicit precondition, degrading gracefully with a recorded warning                           | upstream-grounding           | (2×3)/1 = 6.00 → 6.75           | "Degrade gracefully" normalizes degradation until the warning is background noise; blocking instead interrupts flow mid-edit and users reach for a bypass.                                                           | novel (adjacent to `add-per-skill-capability-declarations`; distinct concern)                           | [upstream-grounding](../upstream-grounding-make-the-st-2026-08-13.md)           |
+| 5   | `harness plugin doctor`: CLI diagnostic that verifies an installed plugin matches the freshly generated marketplace and prints actionable drift | multi-client-portability     | (2×3)/1 = 6.00 → 6.75           | A doctor is consulted only after something feels broken; the drift it diagnoses is better prevented by a `harness update` step, and its own logic rots un-exercised.                                                 | novel (distinct from `add-harness-mcp-list-capabilities-cli`)                                           | [multi-client-portability](../multi-client-portability-keep-2026-08-13.md)      |
+| 6   | Weight skill recommendation by measured effectiveness                                                                                           | compounding-feedback-loops   | (2×3)/1 = 6.00 → 6.50           | Adoption telemetry is sparse per skill; Laplace smoothing over few invocations swings rankings on one or two runs and can steer agents away from a rarely-used-but-correct skill.                                    | novel (adjacent to `extend-skill-effectiveness-scorer`; new recommender wiring)                         | [compounding-feedback-loops](../compounding-feedback-loops-mec-2026-08-13.md)   |
+| 7   | Cluster skill proposals into a ranked recurring-gap backlog                                                                                     | compounding-feedback-loops   | (2×3)/1 = 6.00 → 6.50           | Clustering only pays off at proposal volume the queue does not yet have; embedding-based clustering can mis-group near-synonym gaps and be less trustworthy than the raw list.                                       | novel (aggregation layer atop `activate-the-skill-proposal-pipeline`)                                   | [compounding-feedback-loops](../compounding-feedback-loops-mec-2026-08-13.md)   |
+| 8   | Post-ship stakeholder outcome digest: delivered-vs-requested in plain language                                                                  | full-lifecycle-reach         | (2×3)/2 = 6.00 → 6.00           | Only as honest as the intent-to-delivery linkage beneath it, which does not durably exist yet (entry via candidate #5 in-theme); risks a fluent report that manufactures unearned closure.                           | novel (adjacent to `dashboard-v3-team-stakeholder-views`, `ship-aggregate-telemetry-synthesis-surface`) | [full-lifecycle-reach](../full-lifecycle-reach-role-shap-2026-08-13.md)         |
+| 9   | `harness init --template <stack>` ships a working constraint set on first command                                                               | external-adoption-flywheel   | (2×3)/2 = 6.00 → 6.00           | Each template is a second copy of the evolving constraint surface; core schema changes silently drift templates to a broken first impression unless generated from the shipped source of truth + CI-covered.         | novel (adjacent to `init-scaffold-ecosystem-install-command`, `init-ecosystem-aftercreate`)             | [external-adoption-flywheel](../external-adoption-flywheel-mak-2026-08-13.md)   |
+| 10  | Cross-craft finding dedup and composition in craft-fleet                                                                                        | ceiling-raising-llm-judgment | (2×3)/2 = 6.00 → 6.00           | A composed meta-finding can lose the `runId`+`rubricId`+location provenance the craft-fleet rewrite contract needs, or silently drop the lower-confidence contributor so a second objecting skill is never surfaced. | novel (refinement of shipped `craft-fleet`, PR #1241; not obviously present)                            | [ceiling-raising-llm-judgment](../ceiling-raising-via-llm-judgme-2026-08-13.md) |
+
+Score basis: `base = (impact × confidence) ÷ effort` with `low|medium|high → 1|2|3`; `final = base + strategy-alignment bonus`, bonus applied only inside an exact base-score tie (0 ≤ bonus ≤ 0.75). Cross-batch ranking is by final score descending, ties broken by SELECT order then artifact order.
+
+## Assumptions made
+
+- **Derivation basis / merges.** The six themes are the six `STRATEGY.md` `Tracks` verbatim (present + valid, v2, 2026-07-01), confirmed as-is by the human via fleet-command's CONFIRM round. No disjointness merges were needed — the tracks are already disjoint. SELECT order (= strategic weight order) as confirmed: 1 full-lifecycle-reach, 2 upstream-grounding, 3 compounding-feedback-loops, 4 multi-client-portability, 5 external-adoption-flywheel, 6 ceiling-raising-llm-judgment.
+- **Batch label.** No explicit invocation topic was supplied; per the member convention the batch would take the highest-weighted theme's focus, but this is a whole-strategy sweep, so the batch is labelled `strategy-track-sweep` for a readable, non-misleading filename. Recorded here for transparency.
+- **Pinned batch date.** 2026-08-13 (UTC), used for every artifact filename and this shortlist.
+- **Objection policy.** `none` — every candidate's single strongest objection stands as an accepted downside; none were answered/rebutted by the fleet.
+- **Bounds in force.** count/theme 10 (clamped range [5,25]); per-theme cut 3; global cap 10; novelty lookback 90 days (PRs merged ≥ 2026-05-15); concurrency 2.
+- **Reserved-slot rule.** 1 slot reserved for the highest-scoring survivor of each of the 6 non-thin themes; the remaining 4 slots filled by final score descending. Result: full-lifecycle-reach ×2, upstream-grounding ×2, multi-client-portability ×2, compounding-feedback-loops ×2, external-adoption-flywheel ×1, ceiling-raising-llm-judgment ×1. No cap raise needed (6 reserved ≤ 10).
+- **Novelty sources (all available).** Open GitHub issues (135, via `gh`), roadmap rows (`docs/roadmap.d/`, 149 rows), and PRs merged in the 90-day window (via `gh search prs`). No source was unavailable, so there are **no `novelty-unknown` annotations**. "novel (adjacent to X)" means no tracked row/issue/PR **subsumes** the premise; adjacency is noted for the reader.
+
+## Already-known drops (cited) + backfills
+
+Six preselected candidates were dropped as already-tracked and each backfilled from the next below-cut candidate in-theme:
+
+| Dropped candidate                                                | Theme                      | Covered by                                                                                                  | Backfilled with                                                                                |
+| ---------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Product-requirements middle skill (BRD → traceable requirements) | full-lifecycle-reach       | roadmap `product-requirements-skill-close-the-prd-middle` (+ existing `harness:product-requirements` skill) | → next dropped too, see below                                                                  |
+| Recorded human UAT sign-off wired as a ship gate                 | full-lifecycle-reach       | roadmap `uat-user-sign-off-loop-close-the-outcome-edge` (+ active worktree `feat/uat-signoff-loop`)         | Requirement→spec→outcome traceability edges (in-theme #5)                                      |
+| Portable constraint-pack export/import                           | external-adoption-flywheel | roadmap `opt-in-constraint-packs`                                                                           | → next dropped too, see below                                                                  |
+| Opt-in telemetry-driven adoption insights view                   | external-adoption-flywheel | roadmap `ship-aggregate-telemetry-synthesis-surface` (+ External-Adoption telemetry KPI)                    | Skill marketplace `publish`/`install` (in-theme #5)                                            |
+| `routing.policy`/backend capabilities accepted from config file  | multi-client-portability   | roadmap `adaptive-model-routing` (AMR config surface)                                                       | Client-agnostic skill authoring: one canonical skill → all mirrors + Gemini TOML (in-theme #4) |
+| Snapshot skill-effectiveness baselines with drift thresholds     | compounding-feedback-loops | roadmap `skill-regression-evaluator`                                                                        | Push-inject top-K similar historical outcomes into new-run prompts (in-theme #4)               |
+
+Note: the two full-lifecycle and two external-adoption drops cascaded, so each theme's cut refilled from rank 5.
+
+## Preselected-but-not-shortlisted (survived cut, below the cap)
+
+These are top-3 survivors that did not fit the cap of 10. They remain in their linked artifacts, un-promoted:
+
+- full-lifecycle-reach: Requirement→spec→outcome traceability edges in the knowledge graph (final 3.75)
+- upstream-grounding: Grounding provenance recorded per skill-invocation in the black-box record (final 4.00)
+- compounding-feedback-loops: Push-inject top-K similar historical outcomes into new-run prompts (final 3.75)
+- multi-client-portability: Client-agnostic skill authoring — one canonical skill → all mirrors + Gemini TOML (final 5.25)
+- external-adoption-flywheel: `harness assess --adopt` pre-adoption readiness report (final 4.50); Skill marketplace `publish`/`install` (final 2.75)
+- ceiling-raising-llm-judgment: Golden-set rubric regression harness for judgment drift (final 4.50); Self-tuning taste-calibration noise floor in craft-fleet (final 4.00)
+
+## Per-theme outcome summary
+
+| Theme                        | Ran? | Generated | Verdict  | Shortlisted | Already-known | Below-cut remain in artifact |
+| ---------------------------- | ---- | --------- | -------- | ----------- | ------------- | ---------------------------- |
+| full-lifecycle-reach         | yes  | 10/10     | verified | 2           | 2             | 6                            |
+| upstream-grounding           | yes  | 10/10     | verified | 2           | 0             | 8                            |
+| compounding-feedback-loops   | yes  | 10/10     | verified | 2           | 1             | 7                            |
+| multi-client-portability     | yes  | 10/10     | verified | 2           | 1             | 7                            |
+| external-adoption-flywheel   | yes  | 10/10     | verified | 1           | 2             | 7                            |
+| ceiling-raising-llm-judgment | yes  | 10/10     | verified | 1           | 0             | 9                            |
+
+All-OS CI: **not applicable** for every theme (the fleet produces no code and no PR). Each verdict is backed by an independently-read artifact and an independently-recomputed ranking, never a self-report. Cross-theme dedup backstop: 0 collapses (themes disjoint). Thin: 0. Parked: 0. Rejected: 0.
+
+## What was not done
+
+Nothing was filed — no issue, roadmap row, spec, plan, ADR, or PR. Nothing was committed, staged, or pushed. The six worktrees used for per-theme isolation were removed after their artifacts were collected. This shortlist and the six per-theme artifacts under `docs/ideation/` are working-tree changes the human keeps or discards.

--- a/docs/ideation/upstream-grounding-make-the-st-2026-08-13.md
+++ b/docs/ideation/upstream-grounding-make-the-st-2026-08-13.md
@@ -1,0 +1,109 @@
+---
+topic: 'Upstream grounding: make the strategic and knowledge substrate (STRATEGY.md, the knowledge graph, principles, ADRs) durable enough that downstream skills ground reliably instead of starting cold each invocation'
+generated_at: 2026-08-13T12:00:00Z
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Upstream grounding — make the strategic and knowledge substrate durable enough that downstream skills ground reliably instead of starting cold
+
+## Inputs
+
+- Topic: Upstream grounding: make the strategic and knowledge substrate (STRATEGY.md, the knowledge graph, principles, ADRs) durable enough that downstream skills ground reliably instead of starting cold each invocation
+- Generated: 2026-08-13T12:00:00Z
+- Strategy grounding: enabled — STRATEGY.md present and valid; matching track "Upstream grounding". Objection policy: none (each candidate's strongest objection stands as an accepted downside; none are rebutted).
+
+## Ranked candidates
+
+### 1. A knowledge-graph coverage gate fails CI when a package's load-bearing upstream nodes (ADRs, principles, STRATEGY sections) fall below a per-package density threshold — score: 6.75
+
+- Persona: The tech lead 3–6 months into agent adoption who owns the Context Density KPI and is watching packages accumulate code with no anchoring decisions behind them.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Context Density metric / Our approach (machine-checkable) — final score 6.75
+- Strongest objection: A raw node-count threshold rewards volume over load-bearing-ness — a package can clear the gate with ten shallow, never-read ADRs while a genuinely under-grounded package with two excellent principles fails. The gate measures the proxy (density) the KPI already tracks, not the thing that matters (do downstream skills actually retrieve and use these nodes), so it risks becoming a checkbox that teams satisfy by minting filler nodes, inflating the very substrate it was meant to make trustworthy. Most likely failure mode: the number goes green while grounding quality is unchanged or worse.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 2. Skills assert a minimum valid grounding set as an explicit precondition before running, degrading gracefully (with a recorded warning) when the substrate is missing or stale — score: 6.75
+
+- Persona: The senior engineer who has seen brainstorming and roadmap-pilot produce confident output from an empty or invalid STRATEGY.md and wants a skill to say so out loud rather than silently start cold.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Target problem (starting cold each invocation) — final score 6.75
+- Strongest objection: Preconditions that "degrade gracefully" tend to normalize degradation — once every skill can proceed with a warning, the warning becomes background noise and the assertion changes nothing except adding a line to the log. If the precondition is instead made blocking, it converts a soft cold-start into a hard stop that interrupts flow the moment STRATEGY.md is mid-edit or the graph is rebuilding, and users will reach for a bypass flag that then becomes the default. Most likely failure mode: the guard is either too soft to matter or too hard to tolerate, and no threshold satisfies both.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 3. Each skill invocation records its grounding provenance in the black-box record — exactly which STRATEGY sections, ADRs, principles, and graph nodes it actually consumed — so cold-start vs. genuinely-grounded runs become measurable — score: 4.00
+
+- Persona: The harness maintainer who wants to prove (not assume) that the Upstream-grounding investments change downstream behavior, using the existing per-run flight-recorder.
+- Complexity: low
+- Impact / Confidence / Effort: M/M/L — base score 4.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Target problem (starting cold) — final score 4.00 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection: Recording what a skill _read_ is not the same as recording what it was _influenced by_ — a skill can load a STRATEGY section into context and still ignore it, so provenance produces an optimistic upper bound on grounding that looks like evidence but isn't. Worse, the metric invites gaming: a skill that touches every node scores as maximally grounded regardless of whether the retrieval improved its output. Most likely failure mode: provenance becomes a vanity signal that shows high "grounding" while output quality is unmoved, giving false confidence to the very people trying to validate the thesis.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 4. A precompiled, cached grounding bundle resolves the relevant STRATEGY sections, ADRs, principles, and graph nodes for a given topic into one ready substrate that downstream skills load instead of re-assembling cold each invocation — score: 3.75
+
+- Persona: The tech lead running brainstorming, ideate, and roadmap-pilot back-to-back who watches each skill re-derive the same context from scratch and pay the latency and inconsistency tax every time.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Target problem (starting cold) + Our approach (durable grounding) — final score 3.75
+- Strongest objection: The bundle's value hinges entirely on the topic-relevance selection that decides which nodes belong in it, and that selection is the hard, unsolved part — a bundle that over-includes recreates the cold-start noise it was meant to remove, while one that under-includes silently drops the load-bearing ADR and grounds skills on a confident, incomplete picture. Caching then compounds the error: a stale bundle serves the wrong substrate fast, and invalidation across STRATEGY.md, ADRs, and graph edits is exactly the freshness problem this track is trying to solve, now duplicated in a second place. Most likely failure mode: the bundle is trusted precisely because it's precompiled, so its selection errors propagate unquestioned into every downstream skill.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 5. A staleness detector flags when the upstream substrate has drifted from the code it describes (and from itself) before a downstream skill consumes it, so skills never ground on a substrate that no longer matches reality — score: 3.75
+
+- Persona: The senior engineer whose STRATEGY.md and ADRs lag the codebase by weeks and who currently discovers the drift only when a skill confidently grounds on a decision that was reversed three PRs ago.
+- Complexity: medium
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Our approach (machine-checkable) + Target problem (drift) — final score 3.75
+- Strongest objection: Detecting drift between prose (STRATEGY.md, ADRs, principles) and code is a semantic-alignment problem, and heuristic detectors here are prone to both false positives (flagging a rename as a strategy change) and false negatives (missing a genuine reversal expressed in new code with old vocabulary) — the existing doc-drift detector already had to be made language-aware to tame exactly this. A noisy detector trains users to ignore its warnings, at which point stale grounding sails through anyway. Most likely failure mode: the signal-to-noise ratio never clears the bar where a human trusts the flag, so the substrate keeps drifting while the detector cries wolf.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 6. A grounding-health lane in `harness insights` surfaces per-package upstream coverage, substrate staleness, and grounding provenance in one scannable view — score: 3.75
+
+- Persona: The tech lead who wants a single at-a-glance answer to "is our substrate healthy enough to leave the agent unwatched?" rather than piecing it together from three separate KPI sources.
+- Complexity: low
+- Impact / Confidence / Effort: L/H/L — base score 3.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Context Density / Holiday-Confidence metrics — final score 3.75
+- Strongest objection: A dashboard is a downstream mirror of upstream signals — it can only be as good as the coverage, staleness, and provenance measures feeding it, so building the lane before those measures are trustworthy just renders unreliable numbers more legibly and lends them unearned authority. It also creates maintenance surface that competes for attention with the substrate work itself, and dashboards that don't drive an action tend to be glanced at once and then ignored. Most likely failure mode: the lane ships, looks impressive in a demo, and changes no one's behavior because the metrics behind it aren't yet load-bearing.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 7. ADR lifecycle status is enforced with real transitions (proposed → accepted → superseded) and supersession backlinks, so settled or reversed decisions stop being silently re-litigated by cold agents — score: 2.75
+
+- Persona: The senior engineer who keeps seeing agents re-open architectural questions an ADR already closed because nothing marks the decision as settled or points from the old record to the one that replaced it.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Target problem (re-litigate settled decisions) — final score 2.75
+- Strongest objection: Lifecycle metadata is only durable if it is kept accurate, and ADR status is exactly the kind of field that rots — a decision gets reversed in code while its ADR still reads "accepted," so the enforced status now actively misleads the agent with the authority of a machine-checked field. Enforcing transitions adds process friction (a superseding PR must remember to relink and restatus) that humans skip under deadline, and a half-maintained status graph is worse than none because it looks trustworthy. Most likely failure mode: the status field lies confidently, and agents re-ground on a "settled" decision that no longer holds.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 8. A commit-time hook incrementally re-ingests changed source into the knowledge graph on every merge, so the substrate stays continuously fresh instead of being rebuilt cold on a periodic or manual cadence — score: 2.75
+
+- Persona: The individual developer running 10+ agent sessions a week whose knowledge graph is only as current as the last full rebuild they remembered to run, and who pays for the gap in stale retrievals.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Our approach (durable grounding in a knowledge graph) — final score 2.75
+- Strongest objection: Incremental graph ingestion is genuinely hard to get correct — partial updates must handle deleted symbols, moved files, renamed exports, and cross-package edges without leaving orphaned or duplicated nodes, and an incremental path that silently diverges from a full rebuild produces a substrate that is fresh but wrong, which is more dangerous than one that is stale but consistent. Putting it on a commit/merge hook also loads the hot path everyone feels, so any latency or flake turns into pressure to bypass it (this repo's hooks already draw that complaint). Most likely failure mode: incremental drift accumulates invisibly until a full rebuild reveals the graph had been quietly lying for weeks.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 9. STRATEGY.md and the knowledge graph are kept in bidirectional sync so tracks, metrics, and sections exist as first-class, reachable graph nodes rather than prose the graph can't traverse — score: 2.75
+
+- Persona: The harness maintainer who wants a skill to answer "which shipped work advances the Upstream-grounding track?" by traversing the graph, not by re-parsing STRATEGY.md prose on every invocation.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Our approach (durable grounding in graph and STRATEGY.md) — final score 2.75
+- Strongest objection: Two-way sync between a human-authored prose document and a generated graph is a source-of-truth conflict waiting to happen — the moment both sides can change, you need conflict resolution, and the durable-anchor contract deliberately makes STRATEGY.md human-owned and skills read-only against it, so a bidirectional design risks a skill mutating the very anchor it is supposed to only consume. Even one-way materialization drifts the instant STRATEGY.md is edited without re-seeding. Most likely failure mode: the graph and the document disagree, and downstream skills can no longer tell which one is authoritative — defeating the point of a single durable anchor.
+- Objection answered: no — accepted as a standing downside per objection policy (none).
+
+### 10. A compiler turns documented principles and ADRs into machine-checkable constraints (ESLint rules, validators) semi-automatically, so upstream decisions fire in real time instead of living as prose an agent may never read — score: 1.00
+
+- Persona: The tech lead who has written the architectural principles down but watches agents violate them anyway, because a principle that isn't enforced is a convention the next cold session forgets.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score 1.00
+- Strategy alignment: +0.5 track:Upstream grounding, +0.25 references Our approach (constraints-as-code, machine-checkable) — final score 1.00 (bonus recorded; not applied — no adjacent base-score tie)
+- Strongest objection: The gap between a prose principle ("modules should own one responsibility") and an executable check is precisely where the hard, irreducible engineering judgment lives, and a semi-automatic compiler will either generate constraints so generic they catch nothing or so literal they misfire on the first legitimate exception — and a wrong auto-generated constraint firing in real time is worse than an unenforced principle, because it blocks correct code with machine authority and erodes trust in the whole harness. Most likely failure mode: the compiler produces constraints that are either toothless or tyrannical, and the human ends up hand-writing every rule anyway, which is where the effort actually was.
+- Objection answered: no — accepted as a standing downside per objection policy (none).


### PR DESCRIPTION
These are the six strategy-track ideation artifacts plus the shortlist that indexes them, produced by the 2026-08-13 `ideate-fleet` sweep (one strategy-grounded ideation record per STRATEGY.md track). They are committed here as a dated, point-in-time snapshot, matching the existing `docs/ideation/` convention (`external-source-adoption-tria-2026-08-09.md`, `external-source-feature-matrix-2026-08-10.md`).

Files:
- `docs/ideation/ceiling-raising-via-llm-judgme-2026-08-13.md`
- `docs/ideation/compounding-feedback-loops-mec-2026-08-13.md`
- `docs/ideation/external-adoption-flywheel-mak-2026-08-13.md`
- `docs/ideation/full-lifecycle-reach-role-shap-2026-08-13.md`
- `docs/ideation/multi-client-portability-keep-2026-08-13.md`
- `docs/ideation/upstream-grounding-make-the-st-2026-08-13.md`
- `docs/ideation/shortlists/strategy-track-sweep-2026-08-13.md`

Snapshot only — content is preserved verbatim (only prettier normalization applied to satisfy the format gate). Several top candidates remain live gaps: cross-client parity conformance test, historical-outcome prompt injection, effectiveness-weighted skill recommendation, and auto-derived UAT checklist.

No linked issue.