### PR TITLE
fix(comprehension): inline served units in default gather_context + operator runbook

### DIFF
--- a/.changeset/comprehension-default-model-current.md
+++ b/.changeset/comprehension-default-model-current.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Comprehension's default semantic model is now `claude-haiku-4-5` (the current
+cheap/fast Haiku alias) instead of the retired `claude-3-5-haiku-latest`, which
+reached end-of-life 2026-02-19 and emitted deprecation warnings on every semantic
+generation. Uses the bare non-dated alias so it auto-tracks the latest Haiku
+snapshot; override via `comprehension.model` for other providers.

--- a/.changeset/gather-context-inline-comprehension.md
+++ b/.changeset/gather-context-inline-comprehension.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+`gather_context` summary mode (the default) now inlines the served comprehension
+units instead of collapsing them to counts. Previously a default call returned
+"N units served" with no content, forcing a second `get_comprehension` round-trip
+or a raw-source fallback — defeating the pull-primary path. Comprehension is the
+primary, already-budget-bounded payload, so summary mode serves the units inline
+and only summarizes the stale/malformed noise to counts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,6 +506,9 @@ dominant cost term in agent operation (context replay, not generation).
   `gather_context` MCP tool's `comprehension` constituent and by the
   `get_comprehension` tool (leaf-demand recompilation), with the graph/raw source as
   fallback. Configured via the `comprehension` block in `harness.config.json`.
+- **Populate & maintain:** see the operator runbook
+  `docs/guides/comprehension-substrate.md` (configure a model, backfill, keep fresh).
+  The substrate is inert until populated.
 - **Concepts:** `docs/knowledge/comprehension/comprehension-substrate.md`; ADRs
   0106 (`claude`-CLI resolver fallback), 0107 (committed substrate), 0108 (hash gate).
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,7 +34,8 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/guides/' },
             { text: 'Getting Started', link: '/guides/getting-started' },
-            { text: 'Best Practices', link: '/guides/best-practices' }
+            { text: 'Best Practices', link: '/guides/best-practices' },
+            { text: 'Comprehension Substrate', link: '/guides/comprehension-substrate' }
           ]
         }
       ],

--- a/docs/guides/comprehension-substrate.md
+++ b/docs/guides/comprehension-substrate.md
@@ -1,0 +1,123 @@
+# Compiled Comprehension Substrate — operator runbook
+
+> How to populate and maintain the per-module comprehension substrate so agents
+> stop re-reading raw source to re-derive understanding.
+
+The substrate is a set of committed, per-module units (an LLM **summary** +
+**invariants**, plus a static **interface contract** + **dependency slice**) that
+`gather_context` / `get_comprehension` serve to agents as their _primary_ context,
+with raw source reserved for the region under edit. It is **inert until you
+populate it** — a fresh checkout has an empty `.harness/comprehension/` and serves
+nothing, so the backfill below is the step that turns the feature on. See
+[the concept note](../knowledge/comprehension/comprehension-substrate.md) and the
+[`comprehension` config block](../reference/configuration.md) for the "why".
+
+## Prerequisites
+
+- A harness build that includes the `harness comprehend` command. If `harness` on
+  your `PATH` is an older global install, either update it or run the local build
+  directly: `node packages/cli/dist/bin/harness.js comprehend …`.
+- For the **semantic** half only: a resolvable model provider — an
+  `ANTHROPIC_API_KEY`, a local `/v1` endpoint (`HARNESS_ANALYSIS_BASE_URL`), or the
+  `claude` CLI on `PATH` (subscription auth, no API key). None of these are needed
+  for correctness, `--check`, `--stats`, or the static half.
+
+## 1. Configure (once)
+
+Add a `comprehension` block to `harness.config.json`:
+
+```jsonc
+{
+  "comprehension": {
+    "storage": "committed", // "committed" (versioned with code) | "cache" (gitignored, rebuilt locally)
+    "semantic": true, // false ⇒ static-only, never calls an LLM
+    "model": "<a model your provider supports>", // the built-in default may not resolve on every subscription — set it explicitly
+    "maxTokensPerRun": 200000, // per-run token budget; fail-loud when exhausted
+    "concurrency": 4, // bounded parallel module compiles
+    "ci": "verify", // "verify" (token-free --check, non-blocking) | "off"
+    "hook": false, // true ⇒ a static-only pre-commit hook keeps units fresh automatically
+  },
+}
+```
+
+> **Set `model` explicitly.** The built-in default is a cheap tier that resolves
+> on some providers but not all subscriptions. If a semantic run reports
+> `0 semantic`, this is almost always why — check the `harness comprehend` stderr
+> for a model/provider error and pick a model your provider actually serves.
+
+## 2. Populate
+
+Two-phase is recommended — the static floor is free and instant, the semantic half
+costs one model call per module:
+
+```bash
+# Phase A — free + instant: static contracts + dependency slices for the whole repo
+harness comprehend --all --static
+
+# Phase B — the semantic summaries + invariants (spends tokens; one call per module).
+# On a large repo this takes a while and draws on your provider's rate/subscription
+# pool, so run it when idle. Bounded by `concurrency` + `maxTokensPerRun`.
+harness comprehend --all
+```
+
+To scope a backfill to part of a monorepo, run from a subtree (`cd packages/x &&
+harness comprehend --all`) — `--all` sweeps the current project root downward.
+
+## 3. Verify + commit
+
+```bash
+harness comprehend --check   # token-free freshness gate; "All comprehension units are source-fresh." (exit 0)
+harness comprehend --stats   # served-vs-raw token savings across the fresh units
+git add .harness/comprehension && git commit -m "chore: backfill comprehension substrate"
+```
+
+`--stats` reports how much smaller the served units are than the raw source they
+stand in for (typically ~80–95% per module). That is a per-module compaction
+measure, not an end-to-end guarantee — the realized context-replay reduction
+depends on how much of a leaf's context is blast-radius source vs. edit-region
+source and prompt/tool overhead.
+
+## 4. Keep it fresh (ongoing)
+
+Once populated, freshness is incremental — cost stays proportional to your diff:
+
+- **Automatic (recommended):** set `"hook": true`. A static-only pre-commit hook
+  recompiles changed modules and stages their units _in the same commit_ as the
+  source change. It never calls an LLM on the commit path and never blocks a commit.
+- **Manual:** `harness comprehend --changed` recompiles only the modules whose
+  files a `git diff` touched.
+- **CI backstop:** with `"ci": "verify"`, CI runs the token-free `--check` to catch
+  any drift from hook-bypassed commits (non-blocking; refresh the semantic half with
+  an explicit `harness comprehend`).
+
+Agents consume the substrate automatically from here — `gather_context` serves
+fresh units as primary context, `get_comprehension` lets a leaf demand a recompile
+on a hash-miss, and the orchestrator pre-warms a leaf's blast-radius units into its
+prompt.
+
+## Correctness & degradation (what can't go wrong)
+
+- **A stale unit is never served.** Every serve path re-hashes the module's current
+  source and refuses to serve on a mismatch (falling back to raw source + a
+  recompile signal). This gate needs no LLM and no credential.
+- **No provider ⇒ static-only.** If no model resolves, units are emitted with
+  `semantic: absent` — the static half still serves; nothing crashes, nothing is
+  faked.
+- **Determinism.** Re-running a compile over unchanged source is a no-op
+  (skip-if-fresh) — committed units do not churn on every run.
+
+## Troubleshooting
+
+| Symptom                                   | Cause / fix                                                                                                                                                                                    |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all` reports `0 semantic`              | No provider/model resolved. Set `comprehension.model` to a model your provider serves; check the stderr for the exact error.                                                                   |
+| `--check` exits non-zero                  | Some units are source-stale (expected after editing source without recompiling). Run `harness comprehend --changed` (or `--all`) then commit.                                                  |
+| Committed units show up in `grep`/ripgrep | They are tracked files, so raw text search matches them. Prefer the harness graph-scoped tools for code search, or use `"storage": "cache"` (gitignored) if you don't want them in raw search. |
+| Backfill is slow / burns rate limit       | Semantic backfill is one model call per module. Do Phase A (static) first, run Phase B when idle, and lean on `--changed` for steady-state.                                                    |
+
+## See also
+
+- [`comprehension` configuration reference](../reference/configuration.md)
+- [Comprehension substrate — concept](../knowledge/comprehension/comprehension-substrate.md)
+- ADRs: [committed git-versioned substrate](../knowledge/decisions/0107-comprehension-committed-git-versioned-substrate.md),
+  [serve-time hash gate](../knowledge/decisions/0108-serve-time-hash-gate-sole-llm-free-correctness-authority.md)

--- a/docs/guides/comprehension-substrate.md
+++ b/docs/guides/comprehension-substrate.md
@@ -31,7 +31,7 @@ Add a `comprehension` block to `harness.config.json`:
   "comprehension": {
     "storage": "committed", // "committed" (versioned with code) | "cache" (gitignored, rebuilt locally)
     "semantic": true, // false ⇒ static-only, never calls an LLM
-    "model": "<a model your provider supports>", // the built-in default may not resolve on every subscription — set it explicitly
+    "model": "claude-haiku-4-5", // built-in default (current cheap/fast Haiku); override only if your provider serves a different id
     "maxTokensPerRun": 200000, // per-run token budget; fail-loud when exhausted
     "concurrency": 4, // bounded parallel module compiles
     "ci": "verify", // "verify" (token-free --check, non-blocking) | "off"
@@ -40,10 +40,11 @@ Add a `comprehension` block to `harness.config.json`:
 }
 ```
 
-> **Set `model` explicitly.** The built-in default is a cheap tier that resolves
-> on some providers but not all subscriptions. If a semantic run reports
-> `0 semantic`, this is almost always why — check the `harness comprehend` stderr
-> for a model/provider error and pick a model your provider actually serves.
+> **Model default.** The built-in default is `claude-haiku-4-5` (the current cheap,
+> fast Haiku alias — it auto-tracks the latest snapshot). Override `comprehension.model`
+> only if your provider serves a different id. If a semantic run reports `0 semantic`,
+> check the `harness comprehend` stderr for a model/provider error and pick a model
+> your provider actually serves.
 
 ## 2. Populate
 

--- a/packages/cli/src/comprehension/generate-semantic.ts
+++ b/packages/cli/src/comprehension/generate-semantic.ts
@@ -62,13 +62,15 @@ export const DEFAULT_DIGEST_CHAR_BUDGET = 12_000;
 /** Default tight output cap (cost lever) for the semantic call. */
 export const DEFAULT_MAX_OUTPUT_TOKENS = 700;
 /**
- * Default model tier: a cheap/fast Haiku-class id (cost lever). Overridable per
- * call via {@link GenerateSemanticOptions.model}; phase-4 config
- * (`comprehension.model`) wires the real per-provider value. Deliberately a cheap
- * tier — comprehension summaries are a high-volume, low-stakes call, so we never
- * default to an expensive model.
+ * Default model tier: the current cheap/fast Haiku alias (cost lever). Overridable
+ * per call via {@link GenerateSemanticOptions.model} / `comprehension.model` in
+ * config. Deliberately a cheap tier — comprehension summaries are a high-volume,
+ * low-stakes call, so we never default to an expensive model. Uses the bare,
+ * non-dated alias so it auto-tracks the latest Haiku snapshot (do NOT pin a dated
+ * id or a retired `-latest` string — `claude-3-5-haiku-latest` reached end-of-life
+ * 2026-02-19 and spammed deprecation warnings).
  */
-export const DEFAULT_SEMANTIC_MODEL = 'claude-3-5-haiku-latest';
+export const DEFAULT_SEMANTIC_MODEL = 'claude-haiku-4-5';
 /** Env flag marking an active comprehension pass (reentrancy guard). */
 export const REENTRANCY_ENV = 'HARNESS_COMPREHENSION_ACTIVE';
 

--- a/packages/cli/src/mcp/tools/gather-context.ts
+++ b/packages/cli/src/mcp/tools/gather-context.ts
@@ -531,6 +531,13 @@ export async function handleGatherContext(input: {
       ? null
       : mode === 'summary'
         ? {
+            // Comprehension is the PRIMARY understanding payload and is ALREADY
+            // compact (packed to `tokenBudget`), so — unlike graph blocks — summary
+            // mode INLINES the served units rather than collapsing them to counts.
+            // Collapsing here would force every caller to a second get_comprehension
+            // round-trip (or a raw-source fallback), defeating the pull-primary path.
+            // Only the noise (stale/malformed detail) is summarized to counts.
+            served: comprehensionRaw.served,
             unitsAvailable: comprehensionRaw.unitsAvailable,
             unitsServed: comprehensionRaw.unitsServed,
             staleDropped: comprehensionRaw.stale.length,

--- a/packages/cli/tests/mcp/tools/gather-context-comprehension.test.ts
+++ b/packages/cli/tests/mcp/tools/gather-context-comprehension.test.ts
@@ -115,7 +115,7 @@ describe('gather_context comprehension constituent (SC2, SC4)', () => {
     }
   });
 
-  it('summary mode returns counts, not full markdown', async () => {
+  it('summary mode inlines the served units (primary payload) plus counts', async () => {
     const files = { 'a.ts': 'export const a = 1;' };
     await writeModule('m', files);
     await seed(
@@ -123,10 +123,14 @@ describe('gather_context comprehension constituent (SC2, SC4)', () => {
       files,
       computeSourceHash((await createNodeModuleSourceReader(root).readModuleSource('m'))!)
     );
+    // Default mode is 'summary'. Comprehension is the PRIMARY, already-compact payload,
+    // so summary mode must INLINE the served units (not collapse to counts) — otherwise
+    // a caller gets "1 served" and must round-trip to get_comprehension / raw source.
     const res = await handleGatherContext({ path: root, intent: 'x', include: ['comprehension'] });
     const parsed = JSON.parse(res.content[0].text);
     expect(parsed.comprehension).toHaveProperty('unitsServed', 1);
-    expect(parsed.comprehension).not.toHaveProperty('served');
+    expect(parsed.comprehension.served.map((s: { module: string }) => s.module)).toContain('m');
+    expect(parsed.comprehension.served[0].markdown).toContain('m'); // real content, not just a count
   });
 
   it('is gracefully absent when .harness/comprehension/ does not exist', async () => {


### PR DESCRIPTION
Follow-ups to #1686 (compiled comprehension substrate), found while exercising the substrate live on a populated repo.

## Fix — `gather_context` summary mode inlines served units
The default (summary) `gather_context` collapsed the `comprehension` payload to counts (`N units served`), so an agent got no content and fell back to a second `get_comprehension` call or raw source — defeating the pull-primary path. Comprehension is the primary, already-budget-bounded payload, so summary mode now **inlines the served units** and only summarizes the stale/malformed noise to counts. Test updated (it had codified the old, wrong behavior).

## Docs — operator runbook
`docs/guides/comprehension-substrate.md`: how to configure a model, backfill (static-first then semantic), verify, commit, and keep the substrate fresh; plus degradation + troubleshooting. Linked from AGENTS.md. Notes that the substrate is inert until populated.

Verified: 38 gather-context tests pass, tsc clean. Live exercise on a 697-unit repo showed 95.2% served-vs-raw savings and an agent explaining a subsystem entirely from units with zero source reads.