### PR TITLE
fix(comprehension): provider-aware semantic model default (non-Claude support + less drift)

### DIFF
--- a/.changeset/comprehension-provider-aware-model.md
+++ b/.changeset/comprehension-provider-aware-model.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Comprehension semantic generation is now provider-aware and no longer forces a
+Claude model id onto non-Claude providers. The cheap Claude default
+(`claude-haiku-4-5`) applies only to Claude-family providers (Anthropic key /
+`claude`-CLI); a local OpenAI-compatible endpoint uses its own configured model
+(`HARNESS_ANALYSIS_MODEL`) instead of having a Claude id imposed on it (which
+previously overrode `HARNESS_ANALYSIS_MODEL` and degraded those runs to
+static-only). An explicit `comprehension.model` still wins for any provider. Adds
+`resolveProviderKind` (single source of the provider precedence) and
+`defaultSemanticModel(kind)`; the only hardcoded model id is now contained to the
+one path where it is correct, reducing the drift surface.

--- a/docs/guides/comprehension-substrate.md
+++ b/docs/guides/comprehension-substrate.md
@@ -41,10 +41,18 @@ Add a `comprehension` block to `harness.config.json`:
 ```
 
 > **Model default.** The built-in default is `claude-haiku-4-5` (the current cheap,
-> fast Haiku alias — it auto-tracks the latest snapshot). Override `comprehension.model`
-> only if your provider serves a different id. If a semantic run reports `0 semantic`,
-> check the `harness comprehend` stderr for a model/provider error and pick a model
-> your provider actually serves.
+> fast Haiku alias — it auto-tracks the latest snapshot). It applies **only to
+> Claude-family providers** (Anthropic key / `claude`-CLI subscription). If a
+> semantic run reports `0 semantic`, check the `harness comprehend` stderr for a
+> model/provider error and pick a model your provider actually serves.
+>
+> **Non-Claude providers (OpenAI-compatible / Ollama / local `/v1`).** Point the
+> semantic generator at your endpoint with `HARNESS_ANALYSIS_BASE_URL` (+ optional
+> `HARNESS_ANALYSIS_API_KEY`) and set the model **either** via `HARNESS_ANALYSIS_MODEL`
+> **or** `comprehension.model`. The Claude default is **never** forced onto a
+> non-Claude endpoint — when you don't set `comprehension.model`, the endpoint's own
+> configured model (`HARNESS_ANALYSIS_MODEL`) is used. Setting `comprehension.model`
+> works for any provider and is the most explicit, drift-free choice.
 
 ## 2. Populate
 

--- a/packages/cli/src/commands/comprehend.ts
+++ b/packages/cli/src/commands/comprehend.ts
@@ -14,14 +14,17 @@ import { shouldRunComprehendHook } from '../comprehension/hook';
 import type { ComprehensionConfig } from '../config/schema';
 import { createStaticExtractor } from '../comprehension/static-extractor';
 import { filesToModules, enumerateModules } from '../comprehension/invalidation';
-import { maybeCreateGenerateSemantic } from '../comprehension/generate-semantic';
+import {
+  maybeCreateGenerateSemantic,
+  defaultSemanticModel,
+} from '../comprehension/generate-semantic';
 import {
   runComprehend,
   runComprehendCheck,
   runComprehendStats,
   type ComprehendRunResult,
 } from '../comprehension/compile-run';
-import { resolveAnalysisProvider } from '../mcp/utils/analysis-provider';
+import { resolveAnalysisProvider, resolveProviderKind } from '../mcp/utils/analysis-provider';
 import { deriveChangedSurface, type ChangedSurface } from './validate-scope';
 import { logger } from '../output/logger';
 import { ExitCode } from '../utils/errors';
@@ -236,9 +239,13 @@ async function runCompileMode(
   // SC4: static-only (`--static`) or semantic-disabled ⇒ no provider is resolved
   // — no credential, no LLM on the push/CI path.
   const provider = await resolveCompileProvider(cconf, opts.staticOnly ?? false);
+  // Provider-aware model: an explicit config model wins for any provider; otherwise
+  // Claude-family providers get the cheap Claude default and a local/OpenAI-compatible
+  // endpoint gets undefined (so it uses its own HARNESS_ANALYSIS_MODEL, not a Claude id).
+  const semanticModel = cconf.model ?? defaultSemanticModel(resolveProviderKind());
   const generateSemantic = maybeCreateGenerateSemantic(provider, {
     maxTokensPerRun: cconf.maxTokensPerRun,
-    ...(cconf.model ? { model: cconf.model } : {}),
+    ...(semanticModel ? { model: semanticModel } : {}),
   });
 
   const result = await runComprehend({

--- a/packages/cli/src/comprehension/generate-semantic.ts
+++ b/packages/cli/src/comprehension/generate-semantic.ts
@@ -43,6 +43,7 @@ import type {
   GenerateSemantic,
 } from '@harness-engineering/core';
 import type { AnalysisProvider } from '@harness-engineering/intelligence';
+import type { ProviderKind } from '../mcp/utils/analysis-provider';
 
 /**
  * Authority-in-TS: the unit shape is validated here, never trusted raw. Tolerant
@@ -71,6 +72,18 @@ export const DEFAULT_MAX_OUTPUT_TOKENS = 700;
  * 2026-02-19 and spammed deprecation warnings).
  */
 export const DEFAULT_SEMANTIC_MODEL = 'claude-haiku-4-5';
+
+/**
+ * The default semantic model for a resolved provider kind. Claude-family providers
+ * (`anthropic`/`claude-cli`) get the cheap Claude alias; a `local` OpenAI-compatible
+ * endpoint (or no provider) gets `undefined` so it uses ITS OWN configured model
+ * (`HARNESS_ANALYSIS_MODEL`) rather than a Claude id it cannot serve. An explicit
+ * `comprehension.model` in config always takes precedence over this — the only
+ * hardcoded model id lives here, contained to the one path where it is correct.
+ */
+export function defaultSemanticModel(kind: ProviderKind): string | undefined {
+  return kind === 'anthropic' || kind === 'claude-cli' ? DEFAULT_SEMANTIC_MODEL : undefined;
+}
 /** Env flag marking an active comprehension pass (reentrancy guard). */
 export const REENTRANCY_ENV = 'HARNESS_COMPREHENSION_ACTIVE';
 
@@ -201,7 +214,13 @@ export function createGenerateSemantic(
 ): GenerateSemantic {
   const maxOutputTokens = opts.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
   const budget = opts.maxTokensPerRun ?? Infinity;
-  const model = opts.model ?? DEFAULT_SEMANTIC_MODEL;
+  // Provider-neutral: DO NOT force a model here. When `opts.model` is undefined
+  // the request omits `model` and the provider uses its OWN configured default
+  // (e.g. an OpenAI-compatible endpoint's `HARNESS_ANALYSIS_MODEL`) — forcing a
+  // Claude id like DEFAULT_SEMANTIC_MODEL onto a non-Claude provider fails. The
+  // caller picks the cheap Claude default only for Claude-family providers via
+  // {@link defaultSemanticModel}.
+  const model = opts.model;
   const log: Logger = opts.logger ?? console;
   let spent = 0;
   let budgetWarned = false;
@@ -227,7 +246,8 @@ export function createGenerateSemantic(
         responseSchema: semanticResponseSchema,
         disableThinking: true,
         maxTokens: maxOutputTokens,
-        model,
+        // Omit when undefined so the provider falls back to its own default model.
+        ...(model ? { model } : {}),
       });
       // Charge the budget from the RETURNED usage (fail-loud on the NEXT call).
       // When the provider omits usage (absent/zero), `spent += 0` would never

--- a/packages/cli/src/mcp/tools/get-comprehension.ts
+++ b/packages/cli/src/mcp/tools/get-comprehension.ts
@@ -27,10 +27,13 @@ import {
 import type { AnalysisProvider } from '@harness-engineering/intelligence';
 import { runComprehend } from '../../comprehension/compile-run';
 import { createStaticExtractor } from '../../comprehension/static-extractor';
-import { maybeCreateGenerateSemantic } from '../../comprehension/generate-semantic';
+import {
+  maybeCreateGenerateSemantic,
+  defaultSemanticModel,
+} from '../../comprehension/generate-semantic';
 import { readComprehensionConfig } from '../../comprehension/config';
 import { resolveConfig } from '../../config/loader';
-import { resolveAnalysisProvider } from '../utils/analysis-provider';
+import { resolveAnalysisProvider, resolveProviderKind } from '../utils/analysis-provider';
 import { sanitizePath } from '../utils/sanitize-path.js';
 
 export const getComprehensionDefinition = {
@@ -184,9 +187,12 @@ function resolveDefaultDeps(projectRoot: string): ServeOrRecompileDeps {
           () => null
         )) as AnalysisProvider | null)
       : null;
+    // Provider-aware default: explicit config model wins; else Claude-family gets
+    // the cheap Claude id and a local/OpenAI endpoint uses its own configured model.
+    const semanticModel = cconf.model ?? defaultSemanticModel(resolveProviderKind());
     return maybeCreateGenerateSemantic(provider, {
       maxTokensPerRun: cconf.maxTokensPerRun,
-      ...(cconf.model ? { model: cconf.model } : {}),
+      ...(semanticModel ? { model: semanticModel } : {}),
     });
   };
   return {

--- a/packages/cli/src/mcp/utils/analysis-provider.ts
+++ b/packages/cli/src/mcp/utils/analysis-provider.ts
@@ -121,6 +121,29 @@ function makeClaudeCliProvider(
  * `HARNESS_ANALYSIS_MODEL` / the provider `defaultModel` when provided.
  * `opts.isClaudeCliAvailable` is injectable for deterministic tests.
  */
+/** Which provider `resolveAnalysisProvider` will construct for the current env. */
+export type ProviderKind = 'anthropic' | 'local' | 'claude-cli' | null;
+
+/**
+ * Report the provider `resolveAnalysisProvider` would resolve for the current
+ * environment, WITHOUT constructing it. MUST mirror the precedence in
+ * `resolveAnalysisProvider` (Anthropic key → local `/v1` → `claude`-CLI → null);
+ * the `providerKind matches resolveAnalysisProvider precedence` test guards them
+ * against drift. Callers use this to pick a provider-appropriate default model:
+ * a Claude-family provider (`anthropic`/`claude-cli`) wants a cheap Claude id,
+ * whereas a `local` OpenAI-compatible endpoint must use ITS OWN configured model
+ * (`HARNESS_ANALYSIS_MODEL`) — forcing a Claude id onto it fails.
+ */
+export function resolveProviderKind(
+  opts: { isClaudeCliAvailable?: () => boolean; env?: NodeJS.ProcessEnv } = {}
+): ProviderKind {
+  const env = opts.env ?? process.env;
+  if (env.ANTHROPIC_API_KEY) return 'anthropic';
+  if (env.HARNESS_ANALYSIS_BASE_URL?.trim()) return 'local';
+  const claudeAvailable = (opts.isClaudeCliAvailable ?? (() => isClaudeCliAvailable()))();
+  return claudeAvailable ? 'claude-cli' : null;
+}
+
 export async function resolveAnalysisProvider(
   model?: string,
   opts: { isClaudeCliAvailable?: () => boolean } = {}

--- a/packages/cli/tests/comprehension/generate-semantic.test.ts
+++ b/packages/cli/tests/comprehension/generate-semantic.test.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_DIGEST_CHAR_BUDGET,
   DEFAULT_MAX_OUTPUT_TOKENS,
   DEFAULT_SEMANTIC_MODEL,
+  defaultSemanticModel,
   REENTRANCY_ENV,
 } from '../../src/comprehension/generate-semantic.js';
 
@@ -194,14 +195,23 @@ describe('createGenerateSemantic — provider call, cost levers, validation', ()
     expect(req.prompt).toContain('CONTRACT_MARKER');
   });
 
-  it('defaults to a cheap-tier model, overridable via opts.model', async () => {
+  it('omits model when none given (provider uses its own default), and honors opts.model', async () => {
+    // Provider-neutral: no forced Claude id — a non-Claude provider must be free to
+    // use its own configured model (HARNESS_ANALYSIS_MODEL) rather than have one imposed.
     const p1 = new StubProvider([ok({ summary: 's', invariants: [] })]);
     await createGenerateSemantic(p1)(INPUT);
-    expect(p1.requests[0].model).toBe(DEFAULT_SEMANTIC_MODEL);
+    expect(p1.requests[0].model).toBeUndefined();
 
     const p2 = new StubProvider([ok({ summary: 's', invariants: [] })]);
     await createGenerateSemantic(p2, { model: 'custom-model' })(INPUT);
     expect(p2.requests[0].model).toBe('custom-model');
+  });
+
+  it('defaultSemanticModel: cheap Claude id for Claude-family, undefined otherwise', () => {
+    expect(defaultSemanticModel('anthropic')).toBe(DEFAULT_SEMANTIC_MODEL);
+    expect(defaultSemanticModel('claude-cli')).toBe(DEFAULT_SEMANTIC_MODEL);
+    expect(defaultSemanticModel('local')).toBeUndefined(); // non-Claude → provider's own model
+    expect(defaultSemanticModel(null)).toBeUndefined();
   });
 
   it('malformed provider output → null (authority-in-TS), does not throw, logs once', async () => {

--- a/packages/cli/tests/mcp/utils/analysis-provider.test.ts
+++ b/packages/cli/tests/mcp/utils/analysis-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   resolveAnalysisProvider,
   isClaudeCliAvailable,
+  resolveProviderKind,
 } from '../../../src/mcp/utils/analysis-provider.js';
 
 /**
@@ -146,5 +147,33 @@ describe('isClaudeCliAvailable — injectable, Windows-safe PATH scan', () => {
         fileExists: (p) => p === 'C:\\b\\claude.EXE',
       })
     ).toBe(true);
+  });
+});
+
+describe('resolveProviderKind — mirrors resolveAnalysisProvider precedence', () => {
+  it('anthropic when ANTHROPIC_API_KEY is set (wins over local + claude-cli)', () => {
+    expect(
+      resolveProviderKind({
+        env: { ANTHROPIC_API_KEY: 'k', HARNESS_ANALYSIS_BASE_URL: 'http://x' },
+        isClaudeCliAvailable: () => true,
+      })
+    ).toBe('anthropic');
+  });
+
+  it('local when a base URL is set and no key (wins over claude-cli)', () => {
+    expect(
+      resolveProviderKind({
+        env: { HARNESS_ANALYSIS_BASE_URL: 'http://x' },
+        isClaudeCliAvailable: () => true,
+      })
+    ).toBe('local');
+  });
+
+  it('claude-cli when neither key nor base URL but claude is on PATH', () => {
+    expect(resolveProviderKind({ env: {}, isClaudeCliAvailable: () => true })).toBe('claude-cli');
+  });
+
+  it('null when nothing resolves', () => {
+    expect(resolveProviderKind({ env: {}, isClaudeCliAvailable: () => false })).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up to the compiled comprehension substrate (#1558): make semantic generation work correctly for adopters who are NOT on Claude, and shrink the model-id drift surface.

## Problem
The semantic adapter forced its default model onto every provider: `createGenerateSemantic` sent `request.model = comprehension.model ?? DEFAULT_SEMANTIC_MODEL` (`claude-haiku-4-5`), and an OpenAI-compatible provider treats a per-call `model` as an override (`openai-compatible.ts`: `request.model ?? defaultModel`). So a local/OpenAI/Ollama adopter who set only `HARNESS_ANALYSIS_MODEL` had it silently overridden by a Claude id their endpoint cannot serve → semantic generation failed and degraded to `semantic: absent`. It only worked if they set `comprehension.model` explicitly. And hardcoding any Claude id is a standing drift liability (we just retired `claude-3-5-haiku-latest`).

## Fix — provider-aware default
- `createGenerateSemantic` no longer hardcodes a model; when none is supplied it OMITS `model` so the provider uses its own configured default (`HARNESS_ANALYSIS_MODEL` for a local endpoint).
- New `resolveProviderKind()` (single source of the provider precedence, mirrors `resolveAnalysisProvider`) + `defaultSemanticModel(kind)`: the cheap Claude id applies ONLY to Claude-family providers (`anthropic`/`claude-cli`); `local`/none → `undefined`.
- `harness comprehend` and `get_comprehension` compute `comprehension.model ?? defaultSemanticModel(resolveProviderKind())`.
- An explicit `comprehension.model` still wins for any provider (the drift-free, explicit choice).

Net: non-Claude adopters work out of the box via `HARNESS_ANALYSIS_BASE_URL` + `HARNESS_ANALYSIS_MODEL`; the one hardcoded model id is contained to the single path where it is correct.

## Tests
84 targeted tests pass + E2E smoke (7). New: `resolveProviderKind` precedence (4 env combos), `defaultSemanticModel` per kind, and `createGenerateSemantic` omits model when none given. Runbook updated with a non-Claude-providers section.