### PR TITLE
feat(pricing): add cheapest-model-by-cost helper [A/B: comprehension ON]

### DIFF
--- a/.changeset/pricing-cheapest-model.md
+++ b/.changeset/pricing-cheapest-model.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': minor
+---
+
+pricing: add `cheapestModelByCost` helper that returns the model id with the lowest combined input+output cost per 1k tokens from a candidate list.

--- a/.harness/comprehension/packages/core/src/pricing/_module.md
+++ b/.harness/comprehension/packages/core/src/pricing/_module.md
@@ -1,30 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/pricing'
-sourceHash: 'b336bc63c6fa430474a65f6bfe25c2806e3e56b8b3e75b164812b5d281a18d98'
-compiledAt: '2026-08-28T01:22:10.442Z'
+sourceHash: 'c30f32d4cceeeee8f149f597b09a9b886ed502261ed67732bc29bb5e9ea3cda3'
+compiledAt: '2026-08-28T13:24:26.350Z'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['cache.ts', 'calculator.ts', 'index.ts', 'pricing.ts', 'types.ts']
+model: null
+semantic: absent
+members: ['cache.ts', 'calculator.ts', 'index.ts', 'pricing.ts', 'select.ts', 'types.ts']
 ---
-
-## Summary
-
-The `packages/core/src/pricing` module manages LLM pricing data with a resilient multi-tier fallback strategy. It fetches model pricing from LiteLLM's public repo, caches locally for 24 hours, and degrades gracefully to a bundled fallback when offline. The module converts token usage (input, output, cache reads, cache writes) into integer microdollar costs. Main entry point `loadPricingData(projectRoot)` hydrates a `PricingDataset` (model name → pricing map). Cost calculation uses `calculateCost()` and `calculateCacheSavings()` on usage records. Key behaviors: tiered cache strategy (fresh disk cache → network fetch → expired cache → bundled fallback), staleness detection (warns if fallback used >7 days), chat-only filtering, and microdollar precision arithmetic.
-
-## Invariants
-
-- CACHE_TTL_MS = 24 hours — cache age check is hardcoded; changing it shifts all cache invalidation timing
-- TOKENS_PER_MILLION = 1_000_000 — per-token costs normalized to per-million basis in both pricing.ts and calculator.ts; must stay in sync
-- MICRODOLLARS_PER_DOLLAR = 1_000_000 — cost totals multiplied by this; rounding must happen after conversion to avoid precision loss
-- Only chat-mode models included — parseLiteLLMData filters mode !== 'chat'; removing this silently changes dataset
-- Null-checked cache pricing fields — calculateCost guards both record.cacheReadTokens and pricing.cacheReadPer1M separately; if one exists without the other, calculation skips silently
-- Staleness marker cleared on any fresh load — clearStalenessMarker called after cache or network success; breaking this link means 7-day warning never resets
-- Network fetch validates response shape — rejects non-objects/nulls/arrays to prevent caching HTML error pages
-- Bundled fallback.json always present — loadFallbackDataset is synchronous and assumes valid JSON; missing or corrupt fallback breaks entire module
-- Model name lookup is exact-match only — getModelPrice does .get(model) with no normalization; callers must pass exact key from LiteLLM
-- Cache file path is .harness/cache/pricing.json — hard-coded in getCachePath(); changing it breaks cache persistence across runs
 
 ## Interface Contract
 
@@ -39,6 +22,7 @@ export PricingDataset
 export STALENESS_WARNING_DAYS
 export calculateCacheSavings
 export calculateCost
+export cheapestModelByCost
 export getModelPrice
 export loadPricingData
 export parseLiteLLMData

--- a/.harness/comprehension/packages/core/tests/pricing/_module.md
+++ b/.harness/comprehension/packages/core/tests/pricing/_module.md
@@ -1,27 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/pricing'
-sourceHash: '1452e9983200f1e25ac4e164f69481ef37c71bec531419e909c8756e9019cbc2'
-compiledAt: '2026-08-28T01:22:10.888Z'
+sourceHash: 'da908fcb206e8000d7f439a97ffdb7d834f754c73c3eb85539f839424cbc12a4'
+compiledAt: '2026-08-28T13:24:26.345Z'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['cache.test.ts', 'calculator.test.ts', 'pricing.test.ts']
+model: null
+semantic: absent
+members: ['cache.test.ts', 'calculator.test.ts', 'pricing.test.ts', 'select.test.ts']
 ---
-
-## Summary
-
-`packages/core/tests/pricing` is a three-part test suite validating model pricing lookup, parsing, and cost calculation. The cache layer implements a multi-tier fallback (network → disk cache → expired cache → fallback.json) with 24-hour TTL and 7-day staleness warnings. The parser converts LiteLLM's per-token format to internal per-1M rates, filtering to chat-only models. The calculator computes costs and cache savings in microdollars (integers), gracefully returning null for unknown models or missing pricing data rather than throwing.
-
-## Invariants
-
-- Cache TTL is 24 hours—expired caches trigger re-fetch; older caches still serve on network failure
-- Staleness warning fires at 7+ days of fallback.json use; no auto-recovery
-- Cost calculations are microdollars, always integers—never float; critical for billing accuracy
-- Unknown or missing models return null, not error—graceful partial-knowledge consumption
-- Only chat-mode models are indexed—embedding/image_generation/sample_spec filtered at parse time
-- Pricing is optional per field (inputPer1M/outputPer1M required; cache fields optional)—partial models still usable
-- Cache savings computed only when cache pricing is present—models without cache fields return null for savings
 
 ## Interface Contract
 
@@ -35,6 +21,7 @@ members: ['cache.test.ts', 'calculator.test.ts', 'pricing.test.ts']
 import { CACHE_TTL_MS, LITELLM_PRICING_URL, STALENESS_WARNING_DAYS, loadPricingData } from '../../src/pricing/cache'
 import { calculateCacheSavings, calculateCost } from '../../src/pricing/calculator'
 import { getModelPrice, parseLiteLLMData } from '../../src/pricing/pricing'
+import { cheapestModelByCost } from '../../src/pricing/select'
 import { LiteLLMPricingData, PricingDataset } from '../../src/pricing/types'
 import { ModelPricing, UsageRecord } from '@harness-engineering/types'
 import * as fs from 'node:fs/promises'

--- a/packages/core/src/pricing/index.ts
+++ b/packages/core/src/pricing/index.ts
@@ -6,6 +6,7 @@ export {
   STALENESS_WARNING_DAYS,
 } from './cache';
 export { calculateCost, calculateCacheSavings } from './calculator';
+export { cheapestModelByCost } from './select';
 export type {
   PricingDataset,
   PricingCacheFile,

--- a/packages/core/src/pricing/select.ts
+++ b/packages/core/src/pricing/select.ts
@@ -1,0 +1,39 @@
+import type { ModelPricing } from '@harness-engineering/types';
+import type { PricingDataset } from './types';
+
+const TOKENS_PER_MILLION = 1_000_000;
+const TOKENS_PER_THOUSAND = 1_000;
+
+/**
+ * Combined input + output cost per 1k tokens for a model's pricing rates.
+ * Normalizes the per-million rates used throughout the pricing module down to
+ * a per-thousand basis so callers can compare models on a common scale.
+ */
+function costPer1kTokens(pricing: ModelPricing): number {
+  const per1M = pricing.inputPer1M + pricing.outputPer1M;
+  return (per1M / TOKENS_PER_MILLION) * TOKENS_PER_THOUSAND;
+}
+
+/**
+ * Returns the model id with the lowest combined cost per 1k tokens from `models`.
+ * Models absent from the dataset are skipped (exact-match lookup, matching
+ * getModelPrice). Returns null when none of the given models have pricing data.
+ * On a cost tie the earlier model in `models` wins.
+ */
+export function cheapestModelByCost(models: string[], dataset: PricingDataset): string | null {
+  let cheapest: string | null = null;
+  let cheapestCost = Infinity;
+
+  for (const model of models) {
+    const pricing = dataset.get(model);
+    if (!pricing) continue;
+
+    const cost = costPer1kTokens(pricing);
+    if (cost < cheapestCost) {
+      cheapestCost = cost;
+      cheapest = model;
+    }
+  }
+
+  return cheapest;
+}

--- a/packages/core/tests/pricing/select.test.ts
+++ b/packages/core/tests/pricing/select.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { cheapestModelByCost } from '../../src/pricing/select';
+import type { ModelPricing } from '@harness-engineering/types';
+import type { PricingDataset } from '../../src/pricing/types';
+
+const cheap: ModelPricing = { inputPer1M: 0.25, outputPer1M: 1.25 };
+const mid: ModelPricing = { inputPer1M: 3.0, outputPer1M: 15.0 };
+const pricey: ModelPricing = { inputPer1M: 15.0, outputPer1M: 75.0 };
+
+const dataset: PricingDataset = new Map([
+  ['cheap-model', cheap],
+  ['mid-model', mid],
+  ['pricey-model', pricey],
+]);
+
+describe('cheapestModelByCost', () => {
+  it('returns the model with the lowest combined cost per 1k tokens', () => {
+    const result = cheapestModelByCost(['pricey-model', 'mid-model', 'cheap-model'], dataset);
+    expect(result).toBe('cheap-model');
+  });
+
+  it('skips models absent from the dataset', () => {
+    const result = cheapestModelByCost(['unknown-a', 'mid-model', 'unknown-b'], dataset);
+    expect(result).toBe('mid-model');
+  });
+
+  it('returns null when none of the models have pricing data', () => {
+    expect(cheapestModelByCost(['unknown-a', 'unknown-b'], dataset)).toBeNull();
+  });
+
+  it('returns null for an empty model list', () => {
+    expect(cheapestModelByCost([], dataset)).toBeNull();
+  });
+
+  it('breaks cost ties in favor of the earlier model', () => {
+    const tied: PricingDataset = new Map([
+      ['first', { inputPer1M: 1.0, outputPer1M: 2.0 }],
+      ['second', { inputPer1M: 1.0, outputPer1M: 2.0 }],
+    ]);
+    expect(cheapestModelByCost(['first', 'second'], tied)).toBe('first');
+  });
+
+  it('ranks by input + output combined, not input alone', () => {
+    // low-input has cheaper input but far pricier output => not cheapest overall
+    const combo: PricingDataset = new Map([
+      ['low-input', { inputPer1M: 0.1, outputPer1M: 100.0 }],
+      ['balanced', { inputPer1M: 1.0, outputPer1M: 1.0 }],
+    ]);
+    expect(cheapestModelByCost(['low-input', 'balanced'], combo)).toBe('balanced');
+  });
+});


### PR DESCRIPTION
## A/B test — Run A (comprehension ON)

Adds `cheapestModelByCost(models, dataset)` to `packages/core/src/pricing` — returns the model id with the lowest combined input+output cost per 1k tokens from a candidate list. Absent models are skipped; ties favor the earlier model; returns `null` when none are priced.

- New: `packages/core/src/pricing/select.ts` + unit test (6 cases, all green)
- Exported from the pricing barrel
- Matches module conventions (per-million normalization, exact-match lookup like `getModelPrice`)

**This is one arm of a two-arm comprehension A/B measurement — not intended to merge.** Context for the build was gathered via the compiled comprehension unit (`get_comprehension` serve path) for `packages/core/src/pricing`. See the paired baseline PR and the comprehension audit for the token comparison.

Comprehension side effect: editing the module invalidated its committed unit; the pre-commit hook recompiled it **static-only** (no semantic provider in-session), which is why `_module.md` shrinks in the diff.