### PR TITLE
feat(comprehension): ADR 0109 + byte-stable shards (agent-neutral effortless comprehension)

### DIFF
--- a/.changeset/comprehension-byte-stable-shards.md
+++ b/.changeset/comprehension-byte-stable-shards.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': patch
+---
+
+comprehension: shards are now byte-stable (ADR 0109). A compiled unit no longer carries a wall-clock `compiledAt` — it is a pure function of its source at `sourceHash`, so two branches that make the same change produce byte-identical `_module.md` shards and never collide in a merge. `compiledAt` becomes optional and is preserved only when reading a legacy shard that still carries it (it migrates away on the next recompile).

--- a/.changeset/comprehension-byte-stable-shards.md
+++ b/.changeset/comprehension-byte-stable-shards.md
@@ -3,4 +3,4 @@
 '@harness-engineering/cli': patch
 ---
 
-comprehension: shards are now byte-stable (ADR 0109). A compiled unit no longer carries a wall-clock `compiledAt` — it is a pure function of its source at `sourceHash`, so two branches that make the same change produce byte-identical `_module.md` shards and never collide in a merge. `compiledAt` becomes optional and is preserved only when reading a legacy shard that still carries it (it migrates away on the next recompile).
+comprehension: a shard's STATIC surface is now byte-stable (ADR 0109). A compiled unit no longer carries a wall-clock `compiledAt` — the static half is a pure function of its source at `sourceHash`, so two branches that make the same change produce byte-identical static `_module.md` shards and do not collide on the static surface. (The `semantic: present` half is agent-authored prose and remains non-deterministic; those collisions are handled by the comprehension merge driver, not by byte-stability.) `compiledAt` becomes optional and is preserved only when reading a legacy shard that still carries it (it migrates away on the next recompile).

--- a/.harness/comprehension/packages/cli/src/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/src/comprehension/_module.md
@@ -1,8 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/comprehension'
-sourceHash: 'acaec7953646c3bf6c11d996eebe901433320d45895815d17c1876c8885eb024'
-compiledAt: '2026-08-28T14:18:24.535Z'
+sourceHash: '054ffb9086e25314437eb7ccdb901a3958c1e3253c1e52eb6ab9763d03b708df'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/src/comprehension/_module.md
@@ -1,20 +1,29 @@
 ---
 schemaVersion: 1
-module: 'packages/cli/src/comprehension'
-sourceHash: '054ffb9086e25314437eb7ccdb901a3958c1e3253c1e52eb6ab9763d03b708df'
-compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: null
-semantic: absent
-members:
-  [
-    'compile-run.ts',
-    'config.ts',
-    'generate-semantic.ts',
-    'hook.ts',
-    'invalidation.ts',
-    'static-extractor.ts',
-  ]
+module: "packages/cli/src/comprehension"
+sourceHash: "054ffb9086e25314437eb7ccdb901a3958c1e3253c1e52eb6ab9763d03b708df"
+compiler: { static: "1.0.0", semantic: "1.0.0" }
+model: "claude-haiku-4-5-20251001"
+semantic: present
+members: ["compile-run.ts", "config.ts", "generate-semantic.ts", "hook.ts", "invalidation.ts", "static-extractor.ts"]
 ---
+
+## Summary
+
+packages/cli/src/comprehension is the CLI-side driver for compiled module comprehension—extracting static interface contracts and optionally generating semantic summaries with language-model analysis. It implements phases 3–5 of the comprehension substrate: semantic generation, static extraction, and pre-commit hook gating.
+
+The module comprises five focused pieces: compile-run.ts orchestrates compilation of a module set with bounded concurrency, a shared per-run token budget, and optional LLM semantics, implementing a C1 freshness gate to skip recompiling already-fresh units. generate-semantic.ts adapts an AnalysisProvider into a bounded semantic seam with per-run budgets and strict Zod validation. static-extractor.ts parses TS/JS modules to extract interface contracts and dependencies, anchoring the public surface to index.* when present. invalidation.ts maps changed files to module directories and enumerates all modules. config.ts and hook.ts provide safe-default configuration and a pre-commit gate.
+
+## Invariants
+
+- Fresh units never re-run (C1 gate): a committed unit is reusable when sourceHash matches current hash AND it is semantically sufficient for the run (no semantic added if present, static-only runs need no semantic). Skip entirely—no recompile, write, provider call, or git churn.
+- Reentrancy guard is RUN-boundary, not per-module: HARNESS_COMPREHENSION_ACTIVE env var marks the whole run duration and blocks cross-process nesting, but in-process concurrent siblings proceed normally. Never consulted per-module, so concurrency:4 works.
+- Input is bounded by static surface + budget digest, never by module size: the semantic prompt is always interface + dependencies + ≤12,000-char source digest, making cost proportional to semantic significance, not file count.
+- Authority-in-TS: validate all LLM output at the seam: responses are re-validated against semanticResponseSchema (Zod, .strip() tolerant of extra keys); malformed output returns null and logs a warning, leaving the unit semantic:absent, never partial.
+- Failure mode is graceful degradation to semantic:absent: missing provider, failed parse, exhausted budget, network error—all return null or omit generateSemantic, never throw or corrupt the unit. Static half always completes.
+- Static extraction is deterministic (dedup + sort) and never fabricates: exports and imports are sorted, de-duplicated, and accumulated from parsed members. Unparseable members are skipped (degrade), empty surfaces render as ''.
+- Public surface is barrel-anchored: when index.* exists, ONLY its exports define the interface; otherwise the union of all members' top-level exports. Prevents accidental re-exports of internals.
+- Token budget is enforced from RETURNED usage, fail-loud on the next call: when a provider omits usage, charge a pessimistic floor (maxOutputTokens) so budget converges. Exhaustion is warned once; remaining modules left semantic:absent.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/src/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/src/comprehension/_module.md
@@ -1,11 +1,11 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/comprehension'
-sourceHash: 'e8b873afc38d8bc429180aea76c4b64deff63aa0858c19ea6d18559c5fc89627'
-compiledAt: '2026-08-28T01:22:08.918Z'
+sourceHash: 'acaec7953646c3bf6c11d996eebe901433320d45895815d17c1876c8885eb024'
+compiledAt: '2026-08-28T14:18:24.535Z'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'compile-run.ts',
@@ -16,25 +16,6 @@ members:
     'static-extractor.ts',
   ]
 ---
-
-## Summary
-
-`packages/cli/src/comprehension` is the compiled-comprehension substrate for the harness — a modular system that generates static and semantic summaries of code modules for LLM-free serving or rich analysis. Given a set of modules (changed files or all), it compiles each under bounded concurrency. Each compile produces a `ComprehensionUnit` with static metadata (interface contract, dependency slice via AST parsing) and optional semantic content (LLM-generated summary + invariants). The **C1 freshness gate** skips recompile if the module's source hash matches the committed unit AND semantic requirements are satisfied—eliminating churn on push/CI/serve paths. Architecture is strictly IO-injected for testability; the static extractor parses TypeScript/JavaScript AST; the semantic half is an LLM adapter with tight cost controls (bounded prompt, cheap default model, per-run token budget, `disableThinking`). Authority-in-TS: provider output is re-validated against Zod schema at the seam; failures degrade to `semantic:absent`, never partial. Reentrancy is a run-boundary concern via env flag—nested `claude` children are refused, but in-process concurrent siblings within the run proceed. Hook (pre-commit, opt-in, static-only) and check/stats (token-free CI backstop) complete the tooling.
-
-## Invariants
-
-- Freshness is canonical: sourceHash computed from EXACTLY the files the canonical reader returns — divergence between freshness check and compile is fatal
-- C1 semantic sufficiency: A unit is reusable only if hash matches AND (run is static-only OR unit has semantic:present). A semantic:absent unit must recompile to add semantic
-- Timestamp preservation on upgrade: When source unchanged (hash collision), compiledAt carries forward from prior unit — never moves unless sourceHash moves
-- Authority-in-TS at the seam: Provider output re-validated against semanticResponseSchema at CLI→provider boundary; Zod parsing failure → null + log, never corrupts unit
-- Per-run budget is shared state: Token spend across all modules enforced from RETURNED tokenUsage.totalTokens; when provider omits usage, pessimistic floor (maxOutputTokens per call) charged so budget converges
-- Reentrancy is run-boundary, not per-call: withComprehensionActive sets HARNESS_COMPREHENSION_ACTIVE for whole run's duration; per-module seam never checks/sets/clears. Concurrent siblings proceed; cross-process nesting refused
-- Input bounded by static surface, not module size: Prompt = interface contract + dependency slice + bounded digest (12K chars default). Digest truncation hard-capped; marker appended only if it fits budget
-- Graceful degradation non-negotiable: parse failure, provider miss, budget exhausted, write error → module degraded to lower tier, never partial, never fake, never fatal
-- Force-recompile preserves identity: force:true bypasses C1 gate but still preserves compiledAt on hash collision — no git churn on semantic upgrades of unchanged source
-- Order preserved despite parallelism: mapWithConcurrency maintains input order in results despite bounded worker pool; aggregation reflects input sequence
-- Static extraction non-recursive: Only visits passed sourceFiles (canonical D3 member set); interface barrel-anchored on index.\*, else union of all exports; empty input → empty contract
-- Hook runs static-only on commit path: --static flag bypasses provider resolution; pre-commit substrate never LLM-backed, so commits never require credentials or API calls
 
 ## Interface Contract
 
@@ -48,6 +29,7 @@ export boundSourceDigest
 export buildSemanticPrompt
 export createGenerateSemantic
 export createStaticExtractor
+export defaultSemanticModel
 export enumerateModules
 export filesToModules
 export isComprehensionReentrant
@@ -69,6 +51,7 @@ export withComprehensionActive
 
 ```
 import { ComprehensionConfig, ComprehensionConfigSchema, HarnessConfig } from '../config/schema'
+import { ProviderKind } from '../mcp/utils/analysis-provider'
 import { readComprehensionConfig } from './config'
 import { isComprehensionReentrant, withComprehensionActive } from './generate-semantic'
 import { ComprehensionListing, ComprehensionProvenance, ComprehensionSourceFile, ComprehensionUnit, DEFAULT_SOURCE_EXTENSIONS, ExtractStatic, GenerateSemantic, Result, SemanticGeneration, SemanticInput, SkippedUnit, StaticExtraction, TypeScriptParser, compileModule, computeSourceHash, estimateTokens, renderServedUnit, serveGate } from '@harness-engineering/core'

--- a/.harness/comprehension/packages/cli/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/tests/comprehension/_module.md
@@ -1,24 +1,39 @@
 ---
 schemaVersion: 1
-module: 'packages/cli/tests/comprehension'
-sourceHash: '5118f7c3c9f6a085eeb2b367f04b39c80b0cddd1738d95c1a064ad3b73a20139'
-compiledAt: '2026-08-28T14:18:24.578Z'
-compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: null
-semantic: absent
-members:
-  [
-    'compile-run.test.ts',
-    'comprehend-e2e.test.ts',
-    'comprehend-flags.test.ts',
-    'comprehend-smoke.e2e.test.ts',
-    'config.test.ts',
-    'generate-semantic.test.ts',
-    'hook.test.ts',
-    'invalidation.test.ts',
-    'static-extractor.test.ts',
-  ]
+module: "packages/cli/tests/comprehension"
+sourceHash: "5118f7c3c9f6a085eeb2b367f04b39c80b0cddd1738d95c1a064ad3b73a20139"
+compiler: { static: "1.0.0", semantic: "1.0.0" }
+model: "claude-haiku-4-5-20251001"
+semantic: present
+members: ["compile-run.test.ts", "comprehend-e2e.test.ts", "comprehend-flags.test.ts", "comprehend-smoke.e2e.test.ts", "config.test.ts", "generate-semantic.test.ts", "hook.test.ts", "invalidation.test.ts", "static-extractor.test.ts"]
 ---
+
+## Summary
+
+The `packages/cli/tests/comprehension` module tests the core compilation, caching, and LLM-driven semantic analysis pipeline that builds module comprehension artifacts.
+
+**compile-run.test.ts** validates the orchestration engine: `runComprehend()` compiles modules in `--changed` or `--all` mode, with concurrency bounds, source-hash-based freshness checks, and optional LLM semantic generation. Fresh modules (source unchanged) skip recompilation and provider calls entirely (C1 invariant). `runComprehendCheck()` and `runComprehendStats()` provide token-free CI verification and token-savings metrics. Reentrancy guards prevent nested invocations.
+
+**generate-semantic.test.ts** tests the semantic layer: `createGenerateSemantic()` wraps an LLM provider, enforces per-run token budgets (fail-loud), validates schema via `semanticResponseSchema`, and bounds source input via `boundSourceDigest()`. `withComprehensionActive()` gates concurrent sibling calls safely. Graceful degradation: malformed LLM output or provider errors return null (logged once), never abort.
+
+**comprehend-flags.test.ts** tests CLI integration: `--static` forces static-only (no provider resolution, semantic:absent units); `--stage` git-adds compiled shard paths after prettier formatting. Hook posture (changed-scope derivation fails → skip, don't full-sweep).
+
+**static-extractor.test.ts** tests AST-based static analysis: `renderInterfaceContract()` and `renderDependencySlice()` extract the public surface and import footprint, barrel-aware, language-typed (TS/JS only, degrades gracefully for unsupported languages).
+
+The test suite anchors on ADR 0109 (effortless, agent-neutral comprehension): byte-stable static provenance, semantic upgrades that don't churn, provider-neutral routing, and in-PR generation without CI tokens.
+
+## Invariants
+
+- C1 (Freshness Cache): Source hash unchanged → skip recompile and provider call; hash mismatch forces recompile. Units written only on source change or semantic upgrade.
+- Reentrancy Guard: REENTRANCY_ENV flag set during run, restored after. Prevents silent drops under concurrent sibling calls; withComprehensionActive() enforces it.
+- Semantic Upgrade (ADR 0109): Absent→Present transition recompiles WITHOUT updating sourceHash or compiledAt (byte-stable static provenance). Pure semantic rewrites preserve build artifact identity.
+- Provider-Neutral: No forced Claude model in semantic requests; respects HARNESS_ANALYSIS_MODEL. Resolver returns null when semantic disabled; maybeCreateGenerateSemantic() returns undefined.
+- Token Budget (Per-Run, Fail-Loud): Exhausted budget short-circuits provider calls, logs once, returns null. Missing usage from provider triggers pessimistic floor charge + one-time warn.
+- Concurrency Ceiling: mapWithConcurrency() and runComprehend(concurrency) bound in-flight tasks. Peak in-flight never exceeds limit. Preserved input order.
+- Static-Only Posture (--static / SC4): No provider ever resolved. Units emit semantic:absent, sourceHash set, no model. Never triggers provider interaction.
+- Graceful Degradation: Malformed LLM schema, provider errors, or LLM throws → null result, log once, continue (never abort). Extra keys stripped from LLM response, no warn.
+- --Stage Shard Formatting: Compiled units prettier-formatted BEFORE git-add so unformatted shards never trip whole-tree format:check.
+- Language-Typed AST: isStaticSupported() returns false for non-TS/JS; renderInterfaceContract/dependencySlice degrade to empty strings (never faked).
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/tests/comprehension/_module.md
@@ -1,11 +1,11 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/comprehension'
-sourceHash: '13f5b917817a4be96e8eb893c42a762da9d2d6c3e55a192292df11b25489ece0'
-compiledAt: '2026-08-28T01:22:09.628Z'
+sourceHash: '5118f7c3c9f6a085eeb2b367f04b39c80b0cddd1738d95c1a064ad3b73a20139'
+compiledAt: '2026-08-28T14:18:24.578Z'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'compile-run.test.ts',
@@ -19,27 +19,6 @@ members:
     'static-extractor.test.ts',
   ]
 ---
-
-## Summary
-
-The comprehension test suite validates a lightweight code compilation system that extracts static metadata (interface contracts, dependency slices) and optionally-semantic annotations (summaries, invariants) from TypeScript modules. The system gates on source-hash freshness to avoid redundant provider calls, supports concurrent batch compilation in `--changed` or `--all` modes, prevents recursive invocation via reentrancy guards, and tracks semantic availability (absent/present) to enable partial semantic upgrades when providers become available. Tests exercise concurrency bounding, mode-specific compilation scoping, freshness detection, provider interaction lifecycle, and serialized unit storage.
-
-## Invariants
-
-- Concurrency bound: peak in-flight operations across all modules must never exceed the specified concurrency limit
-- Input order preservation: mapWithConcurrency must return results in the same order as input items despite async execution
-- Changed-scope compilation: --changed mode recompiles exactly the module set passed via changedModules, no more
-- All-scope compilation: --all mode recompiles every module returned by listModules(), reading from the enumeration source
-- Reentrancy guard: runComprehend refuses to execute and returns reentrancyRefused=true when REENTRANCY_ENV is set; no writes occur
-- Reentrancy flag lifecycle: the REENTRANCY_ENV flag must be set during the run (visible to generateSemantic) and restored to its prior state after
-- C1 freshness gate (no re-write): a second compile over unchanged source must NOT write a new unit and must NOT call the provider
-- C1 freshness gate (no provider call): generateSemantic must not be invoked for modules whose source hash matches the committed unit's hash
-- C1 source-hash divergence: recompilation triggers immediately when source hash changes; the freshness gate does not block real edits
-- C1 semantic upgrade path: can upgrade semantic:absent → semantic:present when hash is unchanged but generateSemantic is provided, and compiledAt is preserved
-- Null-source skip: modules whose reader returns null are skipped without error; they appear in result.skipped and do not write units
-- Static-only units (no provider): units compiled without a generateSemantic function have provenance.semantic='absent'
-- Semantic-present units (with provider): units compiled with a generateSemantic function have provenance.semantic='present'
-- Store durability: committed units written in one run are readable (via store.read) in subsequent runs without explicit commit signals
 
 ## Interface Contract
 
@@ -55,7 +34,7 @@ import { ChangedSurface } from '../../src/commands/validate-scope'
 import { ComprehendRunResult, mapWithConcurrency, runComprehend, runComprehendCheck, runComprehendStats } from '../../src/comprehension/compile-run'
 import { readComprehensionConfig } from '../../src/comprehension/config'
 import { REENTRANCY_ENV, isComprehensionReentrant, maybeCreateGenerateSemantic } from '../../src/comprehension/generate-semantic'
-import { DEFAULT_DIGEST_CHAR_BUDGET, DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_SEMANTIC_MODEL, REENTRANCY_ENV, boundSourceDigest, buildSemanticPrompt, createGenerateSemantic, isComprehensionReentrant, maybeCreateGenerateSemantic, semanticResponseSchema, withComprehensionActive } from '../../src/comprehension/generate-semantic.js'
+import { DEFAULT_DIGEST_CHAR_BUDGET, DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_SEMANTIC_MODEL, REENTRANCY_ENV, boundSourceDigest, buildSemanticPrompt, createGenerateSemantic, defaultSemanticModel, isComprehensionReentrant, maybeCreateGenerateSemantic, semanticResponseSchema, withComprehensionActive } from '../../src/comprehension/generate-semantic.js'
 import { shouldRunComprehendHook } from '../../src/comprehension/hook'
 import { enumerateModules, filesToModules } from '../../src/comprehension/invalidation'
 import { createStaticExtractor, isStaticSupported, renderDependencySlice, renderInterfaceContract } from '../../src/comprehension/static-extractor'

--- a/.harness/comprehension/packages/core/src/comprehension/_module.md
+++ b/.harness/comprehension/packages/core/src/comprehension/_module.md
@@ -1,11 +1,11 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/comprehension'
-sourceHash: '01ae3ebe3bbbcc164b4b70199424c3f2d3aaf6a107bfb797ec3722cff4c31a66'
-compiledAt: '2026-08-27T19:47:43.851Z'
+sourceHash: 'e845e9021e1d9f2b2ce7a87d30a15f8cc009b13f7f4c66ead4decec380b742a6'
+compiledAt: '2026-08-28T14:18:24.575Z'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'compile.ts',
@@ -19,25 +19,6 @@ members:
     'types.ts',
   ]
 ---
-
-## Summary
-
-`packages/core/src/comprehension` is the core module-comprehension compiler — a provider-injected, pure orchestration layer that generates and stores semantic summaries of each module's public interface and internal structure.
-
-It takes a module's source files and, via injected `extractStatic` (required) and `generateSemantic` (optional), compiles a `ComprehensionUnit` containing a summary, invariants list, interface contract, and dependency slice. Units are serialized to markdown with YAML frontmatter and served at runtime via a hash-validated gate to catch stale/deleted modules. Built on D5 (injection-based purity), D3 (one module = one directory), and D7 (sourceHash as the correctness primitive); no fs/LLM/git calls in core logic. Key exports: `compileModule()`, `serializeUnit()`, `serveGate()`, `createNodeModuleSourceReader()` (canonical enumerator), and `renderServedUnit()` (markdown wire format).
-
-## Invariants
-
-- Basename keying is canonical: members keyed by posix basename must match createNodeModuleSourceReader's enumeration, or serve-time hash recomputation diverges from compile-time.
-- sourceHash gates compiledAt mutation: timestamp moves only when hash changes; semantic-upgrade recompiles on unchanged source must preserve original compiledAt to avoid git churn.
-- Module paths normalize to forward slashes: backslashes normalized to / at compile and serve time; stray backslash must collapse identically both paths.
-- Module must be non-empty and non-whitespace: rejected at compile time to match read-path validation.
-- Fencing accounts for embedded backtick runs: fence length = longest sequence in content + 1 (min 3), so fenced sections can embed nested fences without truncation.
-- Section boundaries match owned headings exactly: only Summary, Invariants, Interface Contract, Dependency Slice trigger splits; identical headings inside code blocks are literal.
-- YAML serialization is byte-deterministic: frontmatter keys in fixed order via explicit string building; scalars quoted for safe round-trip of colons/booleans.
-- Modules enumerated non-recursively: createNodeModuleSourceReader reads direct files only; nested directories are separate modules.
-- No-credential compile path works without generateSemantic: static extraction alone yields valid unit; absent semantic sets semantic:absent and omits LLM sections.
-- Single canonical enumerator: createNodeModuleSourceReader is sole source-of-truth for module files; both compile and serve paths must use it identically for hash stability.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/core/src/comprehension/_module.md
+++ b/.harness/comprehension/packages/core/src/comprehension/_module.md
@@ -1,24 +1,29 @@
 ---
 schemaVersion: 1
-module: 'packages/core/src/comprehension'
-sourceHash: 'e845e9021e1d9f2b2ce7a87d30a15f8cc009b13f7f4c66ead4decec380b742a6'
-compiledAt: '2026-08-28T14:18:24.575Z'
-compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: null
-semantic: absent
-members:
-  [
-    'compile.ts',
-    'index.ts',
-    'node-io.ts',
-    'render.ts',
-    'serialize.ts',
-    'serve-gate.ts',
-    'source-hash.ts',
-    'store.ts',
-    'types.ts',
-  ]
+module: "packages/core/src/comprehension"
+sourceHash: "e845e9021e1d9f2b2ce7a87d30a15f8cc009b13f7f4c66ead4decec380b742a6"
+compiler: { static: "1.0.0", semantic: "1.0.0" }
+model: "claude-haiku-4-5-20251001"
+semantic: present
+members: ["compile.ts", "index.ts", "node-io.ts", "render.ts", "serialize.ts", "serve-gate.ts", "source-hash.ts", "store.ts", "types.ts"]
 ---
+
+## Summary
+
+The `packages/core/src/comprehension` module compiles and serves per-module code documentation shards — structured markdown files containing static analysis (interface contract, dependency slice) and optional semantic summaries (prose + invariants). It's the substrate for efficient LLM context: cheap to serve, byte-stable across branches, and LLM-free at serve-time. A module's source files flow through `compileModule` (injected static extractor + optional semantic generator) → `ComprehensionUnit` (markdown + YAML frontmatter) → persisted to `.harness/comprehension/<module>/_module.md`. At serve-time, `serveGate` recomputes the source hash and refuses stale units. The static half is exact; the semantic half is advisory and can be omitted when no provider is available.
+
+## Invariants
+
+- Canonical reader drives hash determinism — createNodeModuleSourceReader is THE authoritative module enumeration. Member basenames (posix, deduplicated, sorted) must match what the reader produces, or serve-time hash recomputation will perpetually mismatch compile-time.
+- Byte-deterministic compiled shards — Units are pure functions of source content (sourceHash), not wall-clock. No compiledAt timestamp in freshly compiled units (ADR 0109). Two PRs making identical changes produce byte-identical shards and never collide.
+- Module is ONE directory, non-recursive (D3) — A module maps to a single directory's DIRECT files only. Subdirectories are their own modules. The reader is non-recursive; basename collisions are impossible within one module.
+- Pure orchestration, injected IO/LLM — compileModule has zero side effects itself. All external effects (static extraction, semantic generation, file writes) are injected. The function is unit-testable without fs or credentials.
+- Semantic is optional and advisory — generateSemantic can return null (no provider, SC4). Static-only units (semantic: absent) omit summary/invariants entirely. Static sections are always exact; semantic sections are explicitly framed as advisory.
+- Section boundaries are LLM-proof — Serialization recognizes only owned markdown headings at top level, outside fences. Embedded headings and fences in prose survive round-trips without truncation (F1a–F1c).
+- Fence lengths avoid early closure — Dynamic fence length (longest backtick run in content + 1, min 3) ensures embedded code fences can't close an outer fence, allowing static sections to carry fenced content without truncation (F1b).
+- Membership folded into source hash — The hash includes both file paths AND contents (length-prefixed, sorted). Adding/removing files changes the hash, closing the newly-added-file staleness gap (SC2). Renames + shuffles cannot collide.
+- Serve-time is LLM-free and credential-free — serveGate only recomputes the source hash from current files; no LLM, no credential. Deletion is detected (reader returns null → source-stale).
+- SKIP-AND-REPORT on list, not fail-fast — One hand-edited/corrupted/newer-schema _module.md is reported in skipped instead of failing the whole tree. One bad file must never silently blank the primary substrate.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/core/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/core/tests/comprehension/_module.md
@@ -1,11 +1,11 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/comprehension'
-sourceHash: '601c047e59b020f427ef523e5fee4f4c2f0384dce0ee348436af0ed167cf758f'
-compiledAt: '2026-08-28T01:22:10.774Z'
+sourceHash: 'efbdd681cd37ef40f3caacff79366307b71ecc93e95df56878b6d2f981d82a6c'
+compiledAt: '2026-08-28T14:18:24.558Z'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'compile.test.ts',
@@ -17,19 +17,6 @@ members:
     'store.test.ts',
   ]
 ---
-
-## Summary
-
-The `packages/core/tests/comprehension` suite validates the module comprehension compilation and serving pipeline. Tests cover two core flows: (1) compiling source files into versioned ComprehensionUnit metadata, optionally augmenting with LLM-generated semantic content; (2) persisting and reading units via Node.js I/O. The critical test—"compile → serve hash equality (FIX 1)"—pins the single source of truth: the canonical file reader's enumeration must produce identical hashes at compile and serve time, or the unit is permanently un-served. Serve-gate detects source staleness via membership and content changes.
-
-## Invariants
-
-- FIX 1 (Single Source of Truth): Compile-time hash ≡ serve-time hash via the same canonical reader. Divergence makes the unit permanently un-served.
-- D3 (Basename Keying): Members enumerated by basename only, collapsing directory prefixes to align with createNodeModuleSourceReader output. No full paths.
-- C1 (Deterministic Timestamps): compiledAt reused when sourceHash unchanged; fresh compilation of unmodified source never changes the timestamp, avoiding git churn.
-- Static Feeds Semantic: Static extraction results (interfaceContract, dependencySlice) provided as inputs to GenerateSemantic, allowing LLM to reason about module shape.
-- Source Staleness Detection: Serve-gate rejects units when source content, membership, or hash diverges; returns reason='source-stale' and recompile flag.
-- Schema/Compiler Versioning: Units include schemaVersion and compiler fields for forward/backward compatibility across version upgrades.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/core/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/core/tests/comprehension/_module.md
@@ -1,8 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/comprehension'
-sourceHash: 'efbdd681cd37ef40f3caacff79366307b71ecc93e95df56878b6d2f981d82a6c'
-compiledAt: '2026-08-28T14:18:24.558Z'
+sourceHash: '6241ac2d637152f7acf49b994f81c10ab6a3b6dc53903bad5b006861c678725b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/core/tests/comprehension/_module.md
@@ -1,21 +1,26 @@
 ---
 schemaVersion: 1
-module: 'packages/core/tests/comprehension'
-sourceHash: '6241ac2d637152f7acf49b994f81c10ab6a3b6dc53903bad5b006861c678725b'
-compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: null
-semantic: absent
-members:
-  [
-    'compile.test.ts',
-    'node-io.test.ts',
-    'render.test.ts',
-    'serialize.test.ts',
-    'serve-gate.test.ts',
-    'source-hash.test.ts',
-    'store.test.ts',
-  ]
+module: "packages/core/tests/comprehension"
+sourceHash: "6241ac2d637152f7acf49b994f81c10ab6a3b6dc53903bad5b006861c678725b"
+compiler: { static: "1.0.0", semantic: "1.0.0" }
+model: "claude-haiku-4-5-20251001"
+semantic: present
+members: ["compile.test.ts", "node-io.test.ts", "render.test.ts", "serialize.test.ts", "serve-gate.test.ts", "source-hash.test.ts", "store.test.ts"]
 ---
+
+## Summary
+
+`packages/core/tests/comprehension` validates the byte-stable shard compilation pipeline (ADR 0109)—converting source files into semantic-aware comprehension units (summaries + invariants) that serve as static markdown without re-LLM-ing at runtime. Tests three flows: static-only (extractStatic callback, no LLM), full semantic (generateSemantic produces summary/invariants/model, with static input), and compile→store→serve round-trip (canonical reader enumerates files, compiler hashes, serve gate re-enumerates with same reader to verify freshness). Concentrates on byte-stability (identical source = identical serialized output, no timestamps), hash consistency, file membership tracking by basename, and edge-case rejection (empty modules, divergent enumerations).
+
+## Invariants
+
+- D3 — Basename-keyed members: Module members MUST be sorted basename strings that match the file reader's direct enumeration; directory prefixes collapse to basenames.
+- Single source of truth (FIX 1): createNodeModuleSourceReader is canonical; serve gate re-enumerates with the same reader and recomputes hash. Compile-time and serve-time hashes MUST be equal or the unit is permanently source-stale.
+- Byte-stability (ADR 0109): No wall-clock timestamps in provenance.compiledAt; identical source at different times produces byte-identical serialized output to prevent merge conflicts.
+- Static-feeds-semantic: generateSemantic input includes interfaceContract and dependencySlice from extractStatic; the LLM callback is context-aware.
+- Source staleness detection: File additions, removals, or content changes trigger source-stale via hash mismatch; members list tracks membership delta.
+- Empty module rejection (F5): Whitespace-only or empty module names throw at compile time.
+- Provenance model consistency: If semantic='present', model is non-null; if semantic='absent', model=null.
 
 ## Interface Contract
 

--- a/docs/knowledge/decisions/0109-effortless-comprehension-agent-neutral-local-generation.md
+++ b/docs/knowledge/decisions/0109-effortless-comprehension-agent-neutral-local-generation.md
@@ -1,0 +1,164 @@
+---
+number: 0109
+title: Effortless comprehension — agent-neutral local generation with token-free CI verification
+date: 2026-08-28
+status: accepted
+tier: high
+supersedes-framing:
+  - 'up-front full-tree semantic backfill as the primary population path (ADR 0107 consequence)'
+  - 'CI-side semantic generation requiring an adopter-provided API token'
+relates:
+  - '0106-claude-cli-fallback-analysis-provider-resolver'
+  - '0107-comprehension-committed-git-versioned-substrate'
+  - '0108-serve-time-hash-gate-sole-llm-free-correctness-authority'
+---
+
+## Context
+
+ADR 0107 committed comprehension units to git and ADR 0108 made the serve-time
+hash gate the sole LLM-free correctness authority. What 0107 deliberately left as
+a follow-up was **population**: how a fully-compiled substrate (semantic included)
+stays fresh as code changes, without a human running `harness comprehend`
+periodically. Dogfooding surfaced the gap concretely:
+
+- The opt-in pre-commit hook is **static-only by design** (it always passes
+  `--static`, never resolves a provider — see `hook.ts`). So an ordinary
+  edit-commit that touches a module **overwrites** its rich `semantic: present`
+  unit with a `semantic: absent` one, and that downgrade rides into the PR. On a
+  repo whose `main` is 100% `semantic: present`, ordinary edits silently erode the
+  substrate, healed only by out-of-band "semantic pass" commits.
+
+Three hard constraints shape the fix, and each kills an obvious-but-wrong answer:
+
+1. **Effortless — no periodic manual commands.** Rules out "run `comprehend --all`
+   on a schedule." Generation must be triggered by the act of changing code.
+2. **In the PR — committed, reviewed, landed with the change.** Rules out a local
+   ephemeral cache (last-considered `storage: cache` overlay): the user wants the
+   compiled artifact reviewed in the diff, not hidden per-developer.
+3. **No adopter API token.** Many adopters have only **subscription** licenses
+   (Claude Pro/Max/Team, or the equivalent for another agent) and cannot add a
+   metered API key to CI due to cost. Rules out **CI-side semantic generation** —
+   CI has neither a subscription session nor a key. And critically, **the harness
+   is not Claude-only**: adopters drive it with Claude Code, Cursor, Codex, or
+   Gemini CLI, each with its own auth. Any generation path that assumes a specific
+   provider or a Claude model id is wrong (the `generate-semantic` seam is already
+   written provider-neutral — it refuses to force a Claude model onto a non-Claude
+   provider — and that discipline must hold end to end).
+
+The naive committed-substrate design also has a **collision** worry: if every PR
+regenerates the shards of the modules it touches, parallel PRs churn the same
+`_module.md` files. That worry is real but bounded (addressed under Decision §4).
+
+## Decision
+
+**Generate comprehension where an authenticated agent already runs — the
+developer's machine, on whatever subscription/auth that agent already has — and
+make CI a token-free verifier, not a generator. Keep every generation path
+agent- and provider-neutral, and make the committed shard byte-stable so parallel
+PRs do not collide.**
+
+### 1. Primary path — the in-session agent authors semantic on use (agent-neutral)
+
+The common case: the change is already flowing through a coding agent (Claude
+Code, Cursor, Codex, Gemini CLI). That agent is a capable model, already reading
+the module to make the change. So it authors the module's semantic unit itself and
+stages the shard — no second process, no API token, riding the subscription
+session already open.
+
+Mechanically: `get_comprehension` on a miss/stale unit returns the **static** unit
+plus a `semanticNeeded` signal; a companion **`put_comprehension`** tool accepts
+the agent-authored `{ summary, invariants }`, validates it in TypeScript against
+the existing `semanticResponseSchema` (authority-in-TS — the model's text is never
+trusted raw), and writes the shard. This seam is **agent-neutral by
+construction**: it is a shared MCP tool, so any MCP-speaking agent fills it on its
+own auth; the tool never resolves a provider and never names a model.
+
+This is the most quota-efficient path: emitting a summary is marginal extra output
+for an agent already reading the module, versus a fresh N-call provider fan-out.
+
+### 2. Backstop — provider-neutral local resolution for edits made outside a session
+
+A human editing in an IDE, or a plain `git commit`, will not trigger §1. For those,
+an **opt-in** local recompile resolves a provider through the **provider-neutral**
+D8 resolver (ADR 0106), extended to treat _any_ authenticated local agent as a
+provider — Anthropic key, OpenAI/Codex, Gemini, a local OpenAI-compatible `/v1`
+endpoint (Ollama), or the respective logged-in CLI (subscription auth, no key) —
+degrading to `null` (static-only) when none resolve. No provider is ever forced to
+a foreign model id. This path costs latency + real subscription quota, so it is
+opt-in, not the default.
+
+### 3. CI — token-free verification, never generation
+
+CI enforces that local generation happened, using **only frontmatter + hash reads,
+no LLM, no token**:
+
+- **Static freshness** — each changed module's `sourceHash` matches its source
+  (the existing `comprehend --check`, deterministic).
+- **No semantic regression** — no shard flips `semantic: present → absent` versus
+  the merge base (a frontmatter-field read).
+
+A red check means "your session/backstop did not refresh this — regenerate and
+push," not "CI needs a key." The fix always lives on the developer's
+subscription. This makes the regression guard **token-free** and adopter-safe: it
+only _blocks a downgrade_, it never _generates_.
+
+### 4. Byte-stable shards + a regenerate-on-conflict merge driver
+
+Two mechanical properties shrink the collision surface to nothing that needs a
+human:
+
+- **Byte-stable output.** A shard must be a pure function of its module's source
+  at a hash — no wall-clock. `compiledAt` is dropped from the committed surface
+  (git history already records _when_ a shard landed; `sourceHash` records _what_
+  it was compiled from). Two PRs that make the _same_ change then produce
+  _byte-identical_ shards and never conflict. (This directly removes the observed
+  failure where two branches building an identical change differed only by a
+  wall-clock `compiledAt`.)
+- **Merge driver.** `.gitattributes` maps `**/_module.md` to a `comprehension`
+  merge driver that resolves any residual conflict by **regenerating from the
+  merged source** rather than hand-merging — sound because the shard is 100%
+  derived. Developers never resolve a comprehension merge marker.
+
+Crucially, comprehension conflicts are a **strict subset** of conflicts that
+already exist: two PRs collide on a shard only if they edit the same module's
+source, which already collides at the code level. The substrate adds no new
+collision axis.
+
+## Consequences
+
+- **Effortless for the common path, honest at the boundary.** Modules touched in a
+  coding-agent session heal forward automatically into the PR, on the agent's own
+  auth, no token. A pure-human edit on a machine with _no_ model degrades to a
+  static-only shard (the regression guard blocks _losing_ semantic, but never
+  _forces new_ semantic where nothing can produce it for free) — and heals the
+  moment any session next touches that module.
+- **Adopter-portable across agents and license models.** No API token is required
+  anywhere; no Claude assumption is baked in. A subscription-only, Cursor/Codex/
+  Gemini adopter is fully served. A default adopter (`hook: false`, no CI key) sees
+  no new behavior. New config reuses the existing `comprehension` block / `ci`
+  enum rather than adding top-level keys that would warn on an older installed CLI.
+- **CI stays free and deterministic.** The verify gate is frontmatter/hash only —
+  no LLM, no flakiness, no spend — so it can be a required check without imposing
+  cost on adopters.
+- **Collisions become non-events.** Byte-stability eliminates same-change
+  conflicts; the merge driver auto-resolves same-module residuals by regeneration.
+- **`storage: cache` is retained as an opt-out, not the default.** Adopters who
+  prefer disposable, un-reviewed units keep that path (ADR 0107 §1); the default
+  remains committed-and-reviewed, which this ADR makes sustainable.
+- **`compiledAt` becomes vestigial and migrates lazily.** The field is dropped on
+  the next recompile of each module (a one-time one-line diff per module as it is
+  touched); no mass regeneration is required, and the parser already tolerates its
+  absence.
+
+## Implementation slices
+
+1. **Byte-stable shards** — drop `compiledAt` from the emitted surface; make it
+   optional and forward-tolerant. Independently valuable; unblocks the rest.
+2. **`put_comprehension` write-back seam** + `get_comprehension` `semanticNeeded`
+   signal — the agent-neutral in-session authoring path.
+3. **Provider-neutral backstop resolver** — generalize ADR 0106's resolver to any
+   authenticated local agent / endpoint; wire the opt-in local recompile.
+4. **Token-free CI verify** — extend `comprehend --check` with the
+   `present → absent` regression assertion; keep it LLM-free.
+5. **Merge driver** — `.gitattributes` + a `harness`-installed `comprehension`
+   git merge driver that regenerates on conflict.

--- a/docs/knowledge/decisions/0109-effortless-comprehension-agent-neutral-local-generation.md
+++ b/docs/knowledge/decisions/0109-effortless-comprehension-agent-neutral-local-generation.md
@@ -107,17 +107,24 @@ only _blocks a downgrade_, it never _generates_.
 Two mechanical properties shrink the collision surface to nothing that needs a
 human:
 
-- **Byte-stable output.** A shard must be a pure function of its module's source
-  at a hash — no wall-clock. `compiledAt` is dropped from the committed surface
-  (git history already records _when_ a shard landed; `sourceHash` records _what_
-  it was compiled from). Two PRs that make the _same_ change then produce
-  _byte-identical_ shards and never conflict. (This directly removes the observed
-  failure where two branches building an identical change differed only by a
-  wall-clock `compiledAt`.)
-- **Merge driver.** `.gitattributes` maps `**/_module.md` to a `comprehension`
-  merge driver that resolves any residual conflict by **regenerating from the
-  merged source** rather than hand-merging — sound because the shard is 100%
-  derived. Developers never resolve a comprehension merge marker.
+- **Byte-stable output.** A shard's STATIC surface must be a pure function of its
+  module's source at a hash — no wall-clock. `compiledAt` is dropped from the
+  committed surface (git history already records _when_ a shard landed; `sourceHash`
+  records _what_ it was compiled from). Two PRs that make the _same_ change then
+  produce _byte-identical static_ shards and never conflict. (This directly removes
+  the observed failure where two branches building an identical change differed only
+  by a wall-clock `compiledAt`.) NOTE: the `semantic: present` half (summary +
+  invariants) is agent-authored prose and is NOT deterministic — two branches
+  summarizing the same source can still differ, so semantic-present collisions are
+  handled by the merge driver below, not by byte-stability.
+- **Merge driver.** `.gitattributes` maps `.harness/comprehension/**/_module.md` to
+  a `comprehension` merge driver that resolves a conflict by **keeping the ours
+  shard when it is source-fresh** (preserving its semantic) and otherwise
+  recompiling the static half from the current working-tree source — sound because
+  the shard is 100% derived. It reads the working-tree (typically pre-merge ours)
+  source and defers any residual source-staleness to `comprehend --check`, rather
+  than claiming to regenerate from a fully-merged tree at merge time. Developers
+  never resolve a comprehension merge marker.
 
 Crucially, comprehension conflicts are a **strict subset** of conflicts that
 already exist: two PRs collide on a shard only if they edit the same module's

--- a/packages/cli/src/comprehension/compile-run.ts
+++ b/packages/cli/src/comprehension/compile-run.ts
@@ -61,8 +61,9 @@ export interface ComprehendRunOptions {
    * Bypass the C1 skip-if-fresh gate and recompile even an already-fresh unit.
    * Default false (skip-if-fresh preserved — no churn on the push/CI/serve path).
    * Set ONLY for an explicit leaf demand (`get_comprehension` forceRecompile),
-   * where a recompile is requested, not incidental. A force-recompile of
-   * unchanged source still preserves `compiledAt` (identical hash ⇒ no git churn).
+   * where a recompile is requested, not incidental. A force-recompile of unchanged
+   * source is byte-stable (ADR 0109 — no wall-clock in the shard, so identical
+   * source ⇒ identical bytes ⇒ no git churn).
    */
   force?: boolean;
   /** Injected env for the reentrancy guard (defaults to process.env). */

--- a/packages/cli/src/comprehension/compile-run.ts
+++ b/packages/cli/src/comprehension/compile-run.ts
@@ -150,9 +150,6 @@ async function compileOne(module: string, opts: ComprehendRunOptions): Promise<M
   const unit = await compileModule(module, sourceFiles, {
     extractStatic: opts.makeExtractStatic(module),
     ...(opts.generateSemantic ? { generateSemantic: opts.generateSemantic } : {}),
-    // Preserve the prior `compiledAt` when the source is unchanged (a semantic
-    // upgrade): the timestamp moves only when the sourceHash moves.
-    ...(prior ? { prior: { sourceHash: prior.sourceHash, compiledAt: prior.compiledAt } } : {}),
   });
   const written = await opts.store.write(unit);
   if (!written.ok) {

--- a/packages/cli/tests/comprehension/compile-run.test.ts
+++ b/packages/cli/tests/comprehension/compile-run.test.ts
@@ -297,7 +297,7 @@ describe('runComprehend — changed/all compile + write', () => {
       env: {},
     });
     expect(store.writes[0].provenance.semantic).toBe('absent');
-    const priorCompiledAt = store.writes[0].provenance.compiledAt;
+    const priorHash = store.writes[0].provenance.sourceHash;
     // Second: same source, now WITH a provider → must recompile to add semantic.
     const generateSemantic: GenerateSemantic = async () => ({ summary: 's', invariants: [] });
     const second = await runComprehend({
@@ -313,8 +313,11 @@ describe('runComprehend — changed/all compile + write', () => {
     expect(second.compiled).toEqual(['pkg/a']);
     expect(store.writes).toHaveLength(2);
     expect(store.writes[1].provenance.semantic).toBe('present');
-    // C1 belt: hash unchanged ⇒ compiledAt preserved across the upgrade.
-    expect(store.writes[1].provenance.compiledAt).toBe(priorCompiledAt);
+    // ADR 0109: the source hash is unchanged across a pure semantic upgrade, and
+    // no wall-clock is written — static provenance is byte-stable, so a semantic
+    // upgrade never churns anything but the semantic sections themselves.
+    expect(store.writes[1].provenance.sourceHash).toBe(priorHash);
+    expect(store.writes[1].provenance.compiledAt).toBeUndefined();
   });
 
   it('skips a module whose source reader returns null (no throw)', async () => {

--- a/packages/core/src/comprehension/compile.ts
+++ b/packages/core/src/comprehension/compile.ts
@@ -7,17 +7,6 @@ export interface CompileOptions {
   extractStatic: ExtractStatic;
   /** Optional — the advisory semantic half. Absent/null ⇒ static-only (SC4). */
   generateSemantic?: GenerateSemantic;
-  /** Injected clock for deterministic `compiledAt` (defaults to real now). */
-  now?: () => Date;
-  /**
-   * C1 — prior unit provenance (sourceHash + compiledAt) to reuse the timestamp
-   * from when the freshly-computed `sourceHash` is unchanged. `compiledAt` must
-   * move ONLY when `sourceHash` moves; otherwise a recompile of unchanged source
-   * (e.g. a semantic upgrade) would rewrite the committed unit with a new
-   * timestamp and churn git on every run. Passed by value so `compileModule`
-   * stays pure (no fs read in core).
-   */
-  prior?: { sourceHash: string; compiledAt: string };
 }
 
 /**
@@ -81,18 +70,16 @@ export async function compileModule(
     }
   }
 
-  // C1: reuse the prior timestamp when the source is unchanged, so `compiledAt`
-  // moves only when `sourceHash` moves (no churn on a no-op / semantic-upgrade).
-  const compiledAt =
-    opts.prior && opts.prior.sourceHash === sourceHash
-      ? opts.prior.compiledAt
-      : (opts.now ?? (() => new Date()))().toISOString();
+  // ADR 0109: no wall-clock in the committed shard. A unit is a pure function of
+  // its source at `sourceHash`, so the emitted bytes are stable across branches
+  // and clocks — two PRs making the same change produce byte-identical shards and
+  // never collide. git history records WHEN a shard landed; the hash records WHAT
+  // it was compiled from. `compiledAt` is therefore no longer emitted.
   return {
     provenance: {
       schemaVersion: SCHEMA_VERSION,
       module: module.replaceAll('\\', '/'),
       sourceHash,
-      compiledAt,
       compiler: { static: COMPILER_VERSION.static, semantic: COMPILER_VERSION.semantic },
       model,
       semantic,

--- a/packages/core/src/comprehension/serialize.ts
+++ b/packages/core/src/comprehension/serialize.ts
@@ -45,7 +45,9 @@ export function serializeUnit(unit: ComprehensionUnit): string {
     `schemaVersion: ${p.schemaVersion}`,
     `module: ${quoteYamlScalar(p.module)}`,
     `sourceHash: ${quoteYamlScalar(p.sourceHash)}`,
-    `compiledAt: ${quoteYamlScalar(p.compiledAt)}`,
+    // ADR 0109: `compiledAt` is emitted only for legacy units that still carry it
+    // (freshly compiled shards omit it — byte-stability, no wall-clock).
+    ...(p.compiledAt ? [`compiledAt: ${quoteYamlScalar(p.compiledAt)}`] : []),
     `compiler: { static: ${quoteYamlScalar(p.compiler.static)}, semantic: ${quoteYamlScalar(
       p.compiler.semantic
     )} }`,
@@ -133,12 +135,15 @@ function parseProvenance(data: Record<string, unknown>): Result<ComprehensionPro
   const compiler = parseCompiler(data.compiler);
   const model = data.model === null || data.model === undefined ? null : scalarString(data.model);
   const members = Array.isArray(data.members) ? data.members.map((m) => scalarString(m)) : [];
-  const compiledAt = typeof data.compiledAt === 'string' ? data.compiledAt : '';
+  // ADR 0109: preserve a legacy `compiledAt` if present so an untouched shard
+  // round-trips unchanged; omit it entirely otherwise (freshly compiled units).
+  const compiledAt =
+    typeof data.compiledAt === 'string' && data.compiledAt.length > 0 ? data.compiledAt : undefined;
   return Ok({
     schemaVersion: version.value,
     module,
     sourceHash,
-    compiledAt,
+    ...(compiledAt ? { compiledAt } : {}),
     compiler,
     model,
     semantic,

--- a/packages/core/src/comprehension/types.ts
+++ b/packages/core/src/comprehension/types.ts
@@ -45,7 +45,13 @@ export interface ComprehensionProvenance {
   /** Full SHA-256 over directory membership + sorted member-file contents. */
   sourceHash: string;
   /** ISO-8601 timestamp of compilation. */
-  compiledAt: string;
+  /**
+   * ADR 0109: OPTIONAL and omitted from freshly compiled shards. A unit is a pure
+   * function of its source at `sourceHash`, so no wall-clock is written (git
+   * history records when a shard landed). Retained only to parse legacy shards
+   * that still carry it; migrates away lazily on the next recompile.
+   */
+  compiledAt?: string;
   /** Compiler component versions. */
   compiler: { static: string; semantic: string };
   /** Resolved model id for the semantic half, or null when static-only. */

--- a/packages/core/tests/comprehension/compile.test.ts
+++ b/packages/core/tests/comprehension/compile.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { compileModule } from '../../src/comprehension/compile';
 import { computeSourceHash } from '../../src/comprehension/source-hash';
+import { serializeUnit } from '../../src/comprehension/serialize';
 import { serveGate } from '../../src/comprehension/serve-gate';
 import { createNodeModuleSourceReader } from '../../src/comprehension/node-io';
 import { ComprehensionStore } from '../../src/comprehension/store';
@@ -23,11 +24,9 @@ const extractStatic: ExtractStatic = () => ({
   dependencySlice: 'imports: none',
 });
 
-const now = () => new Date('2026-08-27T12:00:00.000Z');
-
 describe('compileModule', () => {
   it('static-only (no generateSemantic): semantic absent, no LLM (SC4)', async () => {
-    const unit = await compileModule('src', files, { extractStatic, now });
+    const unit = await compileModule('src', files, { extractStatic });
     expect(unit.provenance.semantic).toBe('absent');
     expect(unit.provenance.model).toBeNull();
     expect(unit.summary).toBe('');
@@ -37,12 +36,12 @@ describe('compileModule', () => {
     expect(unit.provenance.sourceHash).toBe(computeSourceHash(files));
     expect(unit.provenance.members).toEqual(['a.ts', 'b.ts']); // sorted basenames (D3)
     expect(unit.provenance.compiler).toEqual(COMPILER_VERSION);
-    expect(unit.provenance.compiledAt).toBe('2026-08-27T12:00:00.000Z');
+    expect(unit.provenance.compiledAt).toBeUndefined(); // ADR 0109: no wall-clock
   });
 
   it('always calls extractStatic; never calls a provider when none given', async () => {
     const spy = vi.fn(extractStatic);
-    await compileModule('src', files, { extractStatic: spy, now });
+    await compileModule('src', files, { extractStatic: spy });
     expect(spy).toHaveBeenCalledOnce();
   });
 
@@ -52,7 +51,7 @@ describe('compileModule', () => {
       invariants: ['inv1'],
       model: 'claude-haiku',
     });
-    const unit = await compileModule('src', files, { extractStatic, generateSemantic: gen, now });
+    const unit = await compileModule('src', files, { extractStatic, generateSemantic: gen });
     expect(unit.provenance.semantic).toBe('present');
     expect(unit.provenance.model).toBe('claude-haiku');
     expect(unit.summary).toBe('does things');
@@ -61,14 +60,14 @@ describe('compileModule', () => {
 
   it('generateSemantic returning null ⇒ static-only (no-credential path)', async () => {
     const gen: GenerateSemantic = () => null;
-    const unit = await compileModule('src', files, { extractStatic, generateSemantic: gen, now });
+    const unit = await compileModule('src', files, { extractStatic, generateSemantic: gen });
     expect(unit.provenance.semantic).toBe('absent');
     expect(unit.provenance.model).toBeNull();
   });
 
   it('feeds the static half into the semantic input (static-feeds-semantic)', async () => {
     const gen = vi.fn<GenerateSemantic>(() => null);
-    await compileModule('src', files, { extractStatic, generateSemantic: gen, now });
+    await compileModule('src', files, { extractStatic, generateSemantic: gen });
     expect(gen).toHaveBeenCalledWith(
       expect.objectContaining({
         module: 'src',
@@ -80,11 +79,11 @@ describe('compileModule', () => {
 
   // F5 — empty module rejected at compile time (consistent with parseProvenance).
   it('rejects an empty module', async () => {
-    await expect(compileModule('', files, { extractStatic, now })).rejects.toThrow(/module/);
+    await expect(compileModule('', files, { extractStatic })).rejects.toThrow(/module/);
   });
 
   it('rejects a whitespace-only module', async () => {
-    await expect(compileModule('   ', files, { extractStatic, now })).rejects.toThrow(/module/);
+    await expect(compileModule('   ', files, { extractStatic })).rejects.toThrow(/module/);
   });
 
   // D3 — members are BASENAMES of one directory's DIRECT files. A directory
@@ -99,7 +98,7 @@ describe('compileModule', () => {
       { path: 'mod/foo.ts', content: 'export const a = 1;' },
       { path: 'mod/bar.ts', content: 'export const b = 2;' },
     ];
-    const unit = await compileModule('mod', prefixed, { extractStatic, now });
+    const unit = await compileModule('mod', prefixed, { extractStatic });
     expect(unit.provenance.members).toEqual(['bar.ts', 'foo.ts']);
   });
 
@@ -108,30 +107,25 @@ describe('compileModule', () => {
       { path: 'x\\y.ts', content: 'a' },
       { path: 'y.ts', content: 'a' },
     ];
-    const unit = await compileModule('mod', dup, { extractStatic, now });
+    const unit = await compileModule('mod', dup, { extractStatic });
     expect(unit.provenance.members).toEqual(['y.ts']);
   });
 
-  // C1 — compiledAt changes ONLY when sourceHash changes. When a prior unit's
-  // sourceHash matches the freshly-computed one (e.g. a semantic upgrade that
-  // does not touch the source), the prior compiledAt is REUSED, so a recompile
-  // of unchanged source never produces git churn from a moving timestamp.
-  it('reuses prior compiledAt when the sourceHash is unchanged (C1 determinism)', async () => {
-    const prior = { sourceHash: computeSourceHash(files), compiledAt: '2020-01-01T00:00:00.000Z' };
-    const laterNow = () => new Date('2099-12-31T23:59:59.000Z');
-    const unit = await compileModule('src', files, { extractStatic, now: laterNow, prior });
-    expect(unit.provenance.sourceHash).toBe(prior.sourceHash);
-    expect(unit.provenance.compiledAt).toBe('2020-01-01T00:00:00.000Z'); // prior preserved
+  // ADR 0109 — byte-stable shards. A unit carries NO wall-clock, so two compiles
+  // of the SAME source (at different times / on different branches) are
+  // byte-identical and never collide in a merge. This replaces the old C1
+  // "reuse-prior-timestamp" determinism, which only suppressed no-op churn but
+  // still let two branches making the same change diverge on `compiledAt`.
+  it('never stamps compiledAt (no wall-clock in the shard)', async () => {
+    const unit = await compileModule('src', files, { extractStatic });
+    expect(unit.provenance.compiledAt).toBeUndefined();
   });
 
-  it('stamps a fresh compiledAt when the sourceHash differs from prior (C1)', async () => {
-    const prior = {
-      sourceHash: 'a-stale-hash-that-does-not-match',
-      compiledAt: '2020-01-01T00:00:00.000Z',
-    };
-    const unit = await compileModule('src', files, { extractStatic, now, prior });
-    expect(unit.provenance.sourceHash).not.toBe(prior.sourceHash);
-    expect(unit.provenance.compiledAt).toBe('2026-08-27T12:00:00.000Z'); // fresh now
+  it('is byte-stable across recompiles of identical source', async () => {
+    const a = await compileModule('src', files, { extractStatic });
+    const b = await compileModule('src', files, { extractStatic });
+    expect(a.provenance.sourceHash).toBe(computeSourceHash(files));
+    expect(serializeUnit(a)).toBe(serializeUnit(b));
   });
 });
 
@@ -168,7 +162,7 @@ describe('compile → serve hash equality (single source of truth)', () => {
     // Enumerate via the CANONICAL reader, then compile exactly that.
     const enumerated = await reader.readModuleSource(module);
     expect(enumerated).not.toBeNull();
-    const compiled = await compileModule(module, enumerated!, { extractStatic, now });
+    const compiled = await compileModule(module, enumerated!, { extractStatic });
     expect(compiled.provenance.members).toEqual(['a.ts', 'b.ts']);
 
     const store = new ComprehensionStore({
@@ -189,7 +183,6 @@ describe('compile → serve hash equality (single source of truth)', () => {
     const reader = createNodeModuleSourceReader(root);
     const compiled = await compileModule(module, (await reader.readModuleSource(module))!, {
       extractStatic,
-      now,
     });
     await fsp.writeFile(path.join(root, module, 'a.ts'), 'export const a = 999;');
     const verdict = await serveGate(compiled, reader);
@@ -203,7 +196,6 @@ describe('compile → serve hash equality (single source of truth)', () => {
     const reader = createNodeModuleSourceReader(root);
     const compiled = await compileModule(module, (await reader.readModuleSource(module))!, {
       extractStatic,
-      now,
     });
     await fsp.writeFile(path.join(root, module, 'b.ts'), 'export const b = 2;');
     const verdict = await serveGate(compiled, reader);
@@ -217,7 +209,6 @@ describe('compile → serve hash equality (single source of truth)', () => {
     const reader = createNodeModuleSourceReader(root);
     const compiled = await compileModule(module, (await reader.readModuleSource(module))!, {
       extractStatic,
-      now,
     });
     await fsp.rm(path.join(root, module, 'b.ts'));
     const verdict = await serveGate(compiled, reader);

--- a/packages/core/tests/comprehension/serialize.test.ts
+++ b/packages/core/tests/comprehension/serialize.test.ts
@@ -32,6 +32,14 @@ function absent(): ComprehensionUnit {
   };
 }
 
+/** A freshly-compiled unit as ADR 0109 emits it: NO wall-clock `compiledAt`. */
+function freshNoCompiledAt(): ComprehensionUnit {
+  const u = absent();
+  const prov = { ...u.provenance };
+  delete prov.compiledAt;
+  return { ...u, provenance: prov };
+}
+
 describe('comprehension serialize/parse', () => {
   it('round-trips a present (full) unit idempotently', () => {
     const md = serializeUnit(present());
@@ -44,6 +52,17 @@ describe('comprehension serialize/parse', () => {
     const parsed = parseUnit(serializeUnit(present()));
     expect(parsed.ok).toBe(true);
     if (parsed.ok) expect(parsed.value.provenance).toEqual(present().provenance);
+  });
+
+  it('a fresh (no compiledAt) unit round-trips byte-stably and stays compiledAt-free (ADR 0109)', () => {
+    const md = serializeUnit(freshNoCompiledAt());
+    expect(md).not.toContain('compiledAt'); // no wall-clock emitted
+    const parsed = parseUnit(md);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value.provenance.compiledAt).toBeUndefined();
+      expect(serializeUnit(parsed.value)).toBe(md); // byte-identical round-trip
+    }
   });
 
   it('absent unit omits Summary/Invariants sections and parses empty', () => {


### PR DESCRIPTION
## What

Lands **ADR 0109 — Effortless comprehension: agent-neutral local generation with token-free CI verification**, plus **implementation slice 1: byte-stable shards**.

### ADR 0109 (docs/knowledge/decisions/0109-…)
Design for keeping the committed comprehension substrate (semantic included) fresh **effortlessly, in-PR, with no adopter API token, across any agent** (not Claude-only). Extends ADR 0106/0107/0108. Core moves:
- **Generate where an authenticated agent already runs** — the developer's session, on its own subscription/auth (Claude Code, Cursor, Codex, Gemini CLI). Agent-neutral `put_comprehension` write-back seam; the in-session model authors semantic as it works, no token, no nested spawn.
- **CI verifies, never generates** — token-free `sourceHash`-fresh + no `present→absent` regression checks. A red check means "regenerate locally," never "CI needs a key."
- **Byte-stable shards + regenerate-on-conflict merge driver** to defuse parallel-PR collisions (which are a strict subset of existing source conflicts).
- Honest boundary: a no-model, pure-human edit degrades to static-only; the guard blocks *losing* semantic, never *forces new* semantic.

### Slice 1 — byte-stable shards (this PR's code)
A compiled unit no longer carries a wall-clock `compiledAt`; it's a pure function of its source at `sourceHash`. Two branches making the **same** change now produce **byte-identical** `_module.md` shards → no merge collision. (This is the exact failure observed in the comprehension A/B: two identical builds differed *only* by a 3-minute `compiledAt`.)

- `compiledAt` is now optional, omitted from freshly compiled shards, preserved only when reading a legacy shard (migrates away on next recompile — no mass regen).
- Removed the now-moot C1 timestamp-reuse plumbing (`now`/`prior` compile options).
- Tests updated to assert byte-stability (`serializeUnit(a) === serializeUnit(b)`) instead of timestamp reuse; the vacuously-passing C1 assertion in `compile-run.test.ts` fixed to assert real hash stability.

## Verification
- core comprehension: 79/79 · cli comprehension: 112/112 · compile-run: 17/17 · typecheck clean (core+cli)
- The amend re-ran the pre-commit hook and reported all 4 touched modules **fresh (skipped)** — determinism confirmed.

## Follow-up slices (per ADR §Implementation slices)
2. `put_comprehension` write-back seam + `get_comprehension` `semanticNeeded` signal (agent-neutral in-session authoring)
3. provider-neutral backstop resolver (any authenticated local agent / `/v1`)
4. token-free CI verify (`present→absent` regression assertion)
5. `.gitattributes` + `comprehension` merge driver