### PR TITLE
test(orchestrator): characterize the /api/v1 OpenAPI registry

### DIFF
--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,29 +1,92 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/mcp/tools"
-sourceHash: "ebc8c4ae0e5408f9bdad2db0dc7fbf806269da79600dd4bdcc36740eb24e58d7"
-compiledAt: "2026-08-29T15:51:34.908Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["acceptance-eval.test.ts", "adr.test.ts", "agent.test.ts", "api-craft.test.ts", "architecture.test.ts", "assess-project-error-handling.test.ts", "assess-project.test.ts", "brainstorming-file-less-smoke.test.ts", "cli-ergonomics-craft.test.ts", "code-craft.test.ts", "code-nav-handlers.test.ts", "code-nav.test.ts", "compact.test.ts", "conflict-prediction.test.ts", "constraint-emergence.test.ts", "copy-craft.test.ts", "cross-check.test.ts", "decay-trends.test.ts", "docs-craft.test.ts", "docs.test.ts", "entropy-config-threading.test.ts", "entropy.test.ts", "event-emitter.test.ts", "events-jsonl-retired.guard.test.ts", "feedback.test.ts", "gather-context-comprehension.test.ts", "gather-context-extra.test.ts", "gather-context-session.test.ts", "gather-context.test.ts", "generate-slash-commands.test.ts", "graph-anomaly.test.ts", "graph-ask.test.ts", "graph-blast-radius.test.ts", "graph.test.ts", "init.test.ts", "interaction.test.ts", "knowledge-craft.test.ts", "linter.test.ts", "naming-craft.test.ts", "outcome-eval.test.ts", "pagination-integration.test.ts", "persona-handlers.test.ts", "persona.security.test.ts", "persona.test.ts", "phase-gate.test.ts", "predict-failures.test.ts", "put-comprehension.test.ts", "recommend-skills.test.ts", "review-changes.test.ts", "review-pipeline.test.ts", "roadmap-auto-sync.test.ts", "roadmap-groom-sharded.test.ts", "roadmap-groom.test.ts", "roadmap-scoped-sync.test.ts", "roadmap.file-backed-regression.test.ts", "roadmap.file-less-stub.test.ts", "roadmap.file-less.test.ts", "roadmap.sharded.test.ts", "roadmap.test.ts", "search-skills.test.ts", "security-craft.test.ts", "skill-progressive-loading.test.ts", "skill-proposal.test.ts", "skill-telemetry.test.ts", "skill.security.test.ts", "skill.test.ts", "spec-craft.test.ts", "stale-constraints.test.ts", "state-events.test.ts", "state-extra.test.ts", "state-sc1-guard.test.ts", "state.test.ts", "task-independence.test.ts", "test-craft.test.ts", "traceability.test.ts", "validate.test.ts", "workflow-e2e.test.ts"]
+module: 'packages/cli/tests/mcp/tools'
+sourceHash: '5c367705e0e9675b9d7e4df46b982e50ba7452cfaaf60aa3c6b36bd0d5625c8f'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'acceptance-eval.test.ts',
+    'adr.test.ts',
+    'agent.test.ts',
+    'api-craft.test.ts',
+    'architecture.test.ts',
+    'assess-project-error-handling.test.ts',
+    'assess-project.test.ts',
+    'brainstorming-file-less-smoke.test.ts',
+    'cli-ergonomics-craft.test.ts',
+    'code-craft.test.ts',
+    'code-nav-handlers.test.ts',
+    'code-nav.test.ts',
+    'compact.test.ts',
+    'conflict-prediction.test.ts',
+    'constraint-emergence.test.ts',
+    'copy-craft.test.ts',
+    'cross-check.test.ts',
+    'decay-trends.test.ts',
+    'docs-craft.test.ts',
+    'docs.test.ts',
+    'entropy-config-threading.test.ts',
+    'entropy.test.ts',
+    'event-emitter.test.ts',
+    'events-jsonl-retired.guard.test.ts',
+    'feedback.test.ts',
+    'gather-context-comprehension.test.ts',
+    'gather-context-extra.test.ts',
+    'gather-context-session.test.ts',
+    'gather-context.test.ts',
+    'generate-slash-commands.test.ts',
+    'graph-anomaly.test.ts',
+    'graph-ask.test.ts',
+    'graph-blast-radius.test.ts',
+    'graph.test.ts',
+    'init.test.ts',
+    'interaction.test.ts',
+    'knowledge-craft.test.ts',
+    'linter.test.ts',
+    'naming-craft.test.ts',
+    'outcome-eval.test.ts',
+    'pagination-integration.test.ts',
+    'performance.test.ts',
+    'persona-handlers.test.ts',
+    'persona.security.test.ts',
+    'persona.test.ts',
+    'phase-gate.test.ts',
+    'predict-failures.test.ts',
+    'put-comprehension.test.ts',
+    'recommend-skills.test.ts',
+    'review-changes.test.ts',
+    'review-pipeline.test.ts',
+    'roadmap-auto-sync.test.ts',
+    'roadmap-groom-sharded.test.ts',
+    'roadmap-groom.test.ts',
+    'roadmap-scoped-sync.test.ts',
+    'roadmap.file-backed-regression.test.ts',
+    'roadmap.file-less-stub.test.ts',
+    'roadmap.file-less.test.ts',
+    'roadmap.sharded.test.ts',
+    'roadmap.test.ts',
+    'search-skills.test.ts',
+    'security-craft.test.ts',
+    'skill-progressive-loading.test.ts',
+    'skill-proposal.test.ts',
+    'skill-telemetry.test.ts',
+    'skill.security.test.ts',
+    'skill.test.ts',
+    'spec-craft.test.ts',
+    'stale-constraints.test.ts',
+    'state-events.test.ts',
+    'state-extra.test.ts',
+    'state-sc1-guard.test.ts',
+    'state.test.ts',
+    'task-independence.test.ts',
+    'test-craft.test.ts',
+    'traceability.test.ts',
+    'validate.test.ts',
+    'workflow-e2e.test.ts',
+  ]
 ---
-
-## Summary
-
-This module is a comprehensive integration test suite for all MCP (Model Context Protocol) tools exposed by the harness CLI. It contains 77 test files validating tool definitions, input contracts, error handling, file I/O operations, and state mutation guarantees across features like acceptance evaluation, ADR management, roadmap (sharded and file-backed), roadmap syncing, personas, skills, and semantic analysis.
-
-Common test patterns verify (1) tool schemas and required parameters, (2) input validation with clear error messages, (3) graceful degradation when external services (LLM, graph) are unavailable, (4) transactional correctness—mutations touch only the claimed shard or feature, not collateral files, and (5) state fidelity by comparing disk snapshots before/after operations. Tests use isolated temp directories per test and clean up rigorously. The three exported utilities (`writeShardedProject`, `snapshotShardDir`, `changedShards`) are test helpers for roadmap sharding that verify the single-shard write guarantee: a feature mutation rewrites exactly its own shard, never another.
-
-## Invariants
-
-- Single-shard write guarantee: A feature mutation (add/update/remove/promote) writes exactly one shard file; unrelated shards remain untouched. Violations break incremental sync and conflict detection.
-- Tool definition contract immutable: Each tool's MCP definition (name, required fields, schema) is hardcoded and must not drift from implementation; tests assert exact match to catch breaking renames or field-requirement changes.
-- No collateral state mutation: Roadmap operations that fail (e.g., blocked claim refusal, duplicate ADR number) commit zero disk writes; test snapshots verify no shard/file changed before vs. after.
-- Degrade-safe fallback: When no LLM provider is configured, tools must return low-confidence advisory verdicts (e.g., INCONCLUSIVE), never crash or hang; acceptance_eval sets authority via TypeScript logic, not LLM, so it's computable offline.
-- Collision-safe ADR numbering: Next number = max(existing)+1, not count+1, tolerating gaps and duplicates; sequential creates never collide even under concurrent allocation.
-- Cascade unblock-only: Marking a blocker done flips a blocked dependent to planned; re-blocking requires an explicit action, never automatic (issue #610).
-- Store parity: Sharded reads (show/query) load from docs/roadmap.d/*.md and reconstruct the same logical state as the monolithic docs/roadmap.md; aggregate is regenerated on every write.
 
 ## Interface Contract
 
@@ -72,6 +135,7 @@ import { handleKnowledgeCraft, handleKnowledgeCraftFinalize, knowledgeCraftDefin
 import { generateLinterDefinition, handleGenerateLinter, handleValidateLinterConfig, validateLinterConfigDefinition } from '../../../src/mcp/tools/linter'
 import { handleNamingCraft, handleNamingCraftFinalize, namingCraftDefinition, namingCraftFinalizeDefinition } from '../../../src/mcp/tools/naming-craft'
 import { handleOutcomeEval, outcomeEvalDefinition } from '../../../src/mcp/tools/outcome-eval.js'
+import { checkPerformanceDefinition, getCriticalPathsDefinition, getPerfBaselinesDefinition, handleCheckPerformance, handleGetCriticalPaths, handleGetPerfBaselines, handleUpdatePerfBaselines, updatePerfBaselinesDefinition } from '../../../src/mcp/tools/performance'
 import { generatePersonaArtifactsDefinition, handleGeneratePersonaArtifacts, handleListPersonas, handleRunPersona, listPersonasDefinition, runPersonaDefinition } from '../../../src/mcp/tools/persona'
 import { checkPhaseGateDefinition } from '../../../src/mcp/tools/phase-gate'
 import { handlePredictFailures, predictFailuresDefinition } from '../../../src/mcp/tools/predict-failures.js'
@@ -116,10 +180,10 @@ import { deriveAcceptanceAuthority } from '@harness-engineering/intelligence'
 import { Err, Ok, Result } from '@harness-engineering/types'
 import * as fs from 'fs'
 import * as fs from 'fs/promises'
-import * as fs from 'node:fs'
+import * as fs, { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import * as fsp from 'node:fs/promises'
-import * as os from 'node:os'
-import * as path from 'node:path'
+import * as os, { tmpdir } from 'node:os'
+import * as path, { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as os, { tmpdir } from 'os'
 import * as path, { join, resolve } from 'path'

--- a/.harness/comprehension/packages/orchestrator/tests/gateway/openapi/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/gateway/openapi/_module.md
@@ -1,0 +1,23 @@
+---
+schemaVersion: 1
+module: 'packages/orchestrator/tests/gateway/openapi'
+sourceHash: '13eb56a6fa46c6f7e7f482d29fa4ea781c2106f48d137858c28900bd949c0ec3'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members: ['v1-registry.test.ts']
+---
+
+## Interface Contract
+
+```ts
+
+```
+
+## Dependency Slice
+
+```
+import { buildV1Document, buildV1Registry } from '../../../src/gateway/openapi/v1-registry'
+import { OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi'
+import { describe, expect, it } from 'vitest'
+```

--- a/packages/orchestrator/tests/gateway/openapi/v1-registry.test.ts
+++ b/packages/orchestrator/tests/gateway/openapi/v1-registry.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi';
+import { buildV1Registry, buildV1Document } from '../../../src/gateway/openapi/v1-registry';
+
+// Behavior characterization of the Phase-2 /api/v1 OpenAPI surface.
+//
+// FORK A (resolved: characterize current Phase-2 output as-is): the legacy-alias
+// GET paths are intentionally lightweight in Phase 2 (path + method + 200/4xx,
+// with a loose `z.unknown()` 200 body). These tests pin that current contract;
+// when Phase 4 narrows the alias schemas into @harness-engineering/types the
+// "lightweight body" assertions below are the ones expected to tighten.
+//
+// Assumptions made: coverage authored via the test-fleet tdd/test-craft flow;
+// knowledge graph was unavailable at selection time (static-analysis fallback),
+// so this target was characterized directly from source.
+
+/** Generate the OpenAPI 3.1 document from the built registry's definitions. */
+function generateDoc() {
+  const generator = new OpenApiGeneratorV31(buildV1Registry().definitions);
+  return generator.generateDocument({
+    openapi: '3.1.0',
+    info: { title: 'test', version: '0.0.0' },
+  });
+}
+
+describe('buildV1Registry — legacy alias GET paths', () => {
+  const doc = generateDoc();
+  const paths = doc.paths ?? {};
+
+  const legacyAliases = [
+    '/api/v1/state',
+    '/api/v1/interactions',
+    '/api/v1/plans',
+    '/api/v1/analyses',
+    '/api/v1/maintenance/status',
+    '/api/v1/maintenance/history',
+    '/api/v1/sessions',
+    '/api/v1/streams',
+    '/api/v1/local-model',
+    '/api/v1/local-models',
+  ];
+
+  it('registers all 10 legacy GET aliases', () => {
+    for (const alias of legacyAliases) {
+      expect(paths[alias], `missing path ${alias}`).toBeDefined();
+      expect(paths[alias].get, `${alias} should expose GET`).toBeDefined();
+    }
+  });
+
+  it('guards every legacy alias with BearerAuth security', () => {
+    for (const alias of legacyAliases) {
+      expect(paths[alias].get.security).toEqual([{ BearerAuth: [] }]);
+    }
+  });
+
+  it('documents 200/401/403 responses on every legacy alias', () => {
+    for (const alias of legacyAliases) {
+      const responses = paths[alias].get.responses;
+      expect(Object.keys(responses).sort()).toEqual(['200', '401', '403']);
+    }
+  });
+
+  it('carries the scope hint in each alias description', () => {
+    // Scope text is how consumers learn which token scope a route needs.
+    expect(paths['/api/v1/state'].get.description).toContain('Scope: read-status.');
+    expect(paths['/api/v1/interactions'].get.description).toContain('Scope: resolve-interaction.');
+    expect(paths['/api/v1/maintenance/status'].get.description).toContain('Scope: trigger-job.');
+  });
+
+  it('keeps the legacy alias 200 body intentionally lightweight (Phase-2 as-is)', () => {
+    // FORK A characterization: Phase 2 leaves the success body schema wide open.
+    // Phase 4 is expected to replace this loose object with a narrowed schema.
+    const schema = paths['/api/v1/state'].get.responses['200'].content['application/json'].schema;
+    expect(schema).toBeDefined();
+    // A narrowed schema would carry `type`/`properties`; the lightweight Phase-2
+    // body does not constrain the payload shape.
+    expect(schema.properties).toBeUndefined();
+  });
+});
+
+describe('buildV1Registry — bridge primitives', () => {
+  const doc = generateDoc();
+  const paths = doc.paths ?? {};
+
+  it('exposes POST /api/v1/jobs/maintenance with a taskId request body', () => {
+    const op = paths['/api/v1/jobs/maintenance']?.post;
+    expect(op).toBeDefined();
+    const reqSchema = op.requestBody.content['application/json'].schema;
+    expect(reqSchema.type).toBe('object');
+    expect(Object.keys(reqSchema.properties)).toContain('taskId');
+    // Response documents ok/taskId/runId.
+    const resSchema = op.responses['200'].content['application/json'].schema;
+    expect(Object.keys(resSchema.properties).sort()).toEqual(['ok', 'runId', 'taskId']);
+  });
+
+  it('exposes POST /api/v1/interactions/{id}/resolve with a path param and 404/409', () => {
+    const op = paths['/api/v1/interactions/{id}/resolve']?.post;
+    expect(op).toBeDefined();
+    // {id} path parameter is documented.
+    expect(
+      op.parameters.some((p: { name: string; in: string }) => p.name === 'id' && p.in === 'path')
+    ).toBe(true);
+    expect(op.responses['404']).toBeDefined();
+    expect(op.responses['409']).toBeDefined();
+  });
+
+  it('exposes GET /api/v1/events as a text/event-stream SSE endpoint', () => {
+    const op = paths['/api/v1/events']?.get;
+    expect(op).toBeDefined();
+    expect(op.responses['200'].content['text/event-stream']).toBeDefined();
+  });
+});
+
+describe('buildV1Registry — webhook surface', () => {
+  const doc = generateDoc();
+  const paths = doc.paths ?? {};
+
+  it('exposes POST and GET on /api/v1/webhooks and DELETE on /api/v1/webhooks/{id}', () => {
+    expect(paths['/api/v1/webhooks']?.post).toBeDefined();
+    expect(paths['/api/v1/webhooks']?.get).toBeDefined();
+    expect(paths['/api/v1/webhooks/{id}']?.delete).toBeDefined();
+  });
+
+  it('validates the webhook subscription request body (url + non-empty events)', () => {
+    const reqSchema = paths['/api/v1/webhooks'].post.requestBody.content['application/json'].schema;
+    expect(reqSchema.properties.url.format).toBe('uri');
+    expect(reqSchema.properties.events.type).toBe('array');
+    expect(reqSchema.properties.events.minItems).toBe(1);
+  });
+
+  it('returns the secret once in the webhook creation response', () => {
+    const resSchema =
+      paths['/api/v1/webhooks'].post.responses['200'].content['application/json'].schema;
+    expect(Object.keys(resSchema.properties)).toContain('secret');
+  });
+
+  it('documents GET /api/v1/webhooks/queue/stats with a 503 for an unavailable queue', () => {
+    const op = paths['/api/v1/webhooks/queue/stats']?.get;
+    expect(op).toBeDefined();
+    expect(op.responses['503']).toBeDefined();
+    const counters = op.responses['200'].content['application/json'].schema.properties;
+    expect(Object.keys(counters).sort()).toEqual([
+      'dead',
+      'delivered',
+      'failed',
+      'inFlight',
+      'pending',
+    ]);
+  });
+
+  it('documents GET /api/v1/telemetry/cache/stats with a 503 for a missing recorder', () => {
+    const op = paths['/api/v1/telemetry/cache/stats']?.get;
+    expect(op).toBeDefined();
+    expect(op.responses['503']).toBeDefined();
+    expect(op.responses['200'].content['application/json'].schema).toBeDefined();
+  });
+});
+
+describe('buildV1Registry — composition with the auth registry', () => {
+  it('includes the Phase-1 auth registry paths alongside the v1 surface', () => {
+    const doc = generateDoc();
+    const pathKeys = Object.keys(doc.paths ?? {});
+    // The v1 registry extends buildAuthRegistry(); auth paths live under
+    // /api/v1/auth/*. Their presence proves the v1 surface is composed on top
+    // of the Phase-1 auth registry rather than replacing it.
+    expect(pathKeys).toContain('/api/v1/auth/token');
+    expect(pathKeys).toContain('/api/v1/auth/tokens');
+    expect(pathKeys).toContain('/api/v1/auth/tokens/{id}');
+  });
+});
+
+describe('buildV1Document', () => {
+  it('produces a valid OpenAPI 3.1.0 document with info and servers', () => {
+    const doc = buildV1Document();
+    expect(doc.openapi).toBe('3.1.0');
+    expect(doc.info.title).toBe('Harness Gateway API');
+    expect(doc.info.version).toBe('0.3.0');
+    expect(doc.servers?.[0]?.url).toBe('http://127.0.0.1:8080');
+  });
+
+  it('documents the full versioned surface (auth + legacy + bridge + webhooks)', () => {
+    const doc = buildV1Document();
+    const pathKeys = Object.keys(doc.paths ?? {});
+    // A representative path from each cohort must be present in one document.
+    expect(pathKeys).toContain('/api/v1/state');
+    expect(pathKeys).toContain('/api/v1/jobs/maintenance');
+    expect(pathKeys).toContain('/api/v1/webhooks');
+    expect(pathKeys).toContain('/api/v1/telemetry/cache/stats');
+  });
+
+  it('registers the BearerAuth security scheme in components', () => {
+    const doc = buildV1Document();
+    expect(doc.components?.securitySchemes?.BearerAuth).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Adds behavior-asserting test coverage for `buildV1Registry` / `buildV1Document` in `packages/orchestrator/src/gateway/openapi/v1-registry.ts` — a 244-LOC module that had **no test**.

Authored by **test-fleet** (wave-2 quality sweep). test-fleet characterizes existing behavior; **no code under test was modified**.

## Coverage added (17 tests, all green locally)

- 10 legacy GET aliases — method, `BearerAuth` security, exact `200/401/403` responses, scope-hint descriptions
- Bridge primitives — `POST /jobs/maintenance` (request/response schema), `POST /interactions/{id}/resolve` (path param + 404/409), `GET /events` (text/event-stream SSE)
- Webhook surface — `POST`/`GET` `/webhooks`, `DELETE /webhooks/{id}`, request validation (url + non-empty events), secret-returned-once, `/webhooks/queue/stats` and `/telemetry/cache/stats` 503 branches
- Auth-registry composition (`/api/v1/auth/*` present)
- `buildV1Document` — openapi 3.1.0, info, servers, `BearerAuth` security scheme

## Decision fork (answered at CONFIRM)

**FORK A — resolved: characterize the current Phase-2 output as-is.** The legacy-alias `200` bodies are intentionally lightweight in Phase 2; one test pins that loose contract and notes that **Phase 4 is expected to narrow it** (that assertion is the one that will change then).

## Assumptions

- The knowledge graph was unavailable at selection time, so this target was enumerated via test-advisor's static-analysis fallback and characterized directly from source.
- Coverage delta: 0 → behavior-covered for `buildV1Registry`/`buildV1Document`.

Not for merge by the fleet — handed back for review.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga