### PR TITLE
test(cli): characterize the performance MCP tool handlers

### DIFF
--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,29 +1,92 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/mcp/tools"
-sourceHash: "ebc8c4ae0e5408f9bdad2db0dc7fbf806269da79600dd4bdcc36740eb24e58d7"
-compiledAt: "2026-08-29T15:51:34.908Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["acceptance-eval.test.ts", "adr.test.ts", "agent.test.ts", "api-craft.test.ts", "architecture.test.ts", "assess-project-error-handling.test.ts", "assess-project.test.ts", "brainstorming-file-less-smoke.test.ts", "cli-ergonomics-craft.test.ts", "code-craft.test.ts", "code-nav-handlers.test.ts", "code-nav.test.ts", "compact.test.ts", "conflict-prediction.test.ts", "constraint-emergence.test.ts", "copy-craft.test.ts", "cross-check.test.ts", "decay-trends.test.ts", "docs-craft.test.ts", "docs.test.ts", "entropy-config-threading.test.ts", "entropy.test.ts", "event-emitter.test.ts", "events-jsonl-retired.guard.test.ts", "feedback.test.ts", "gather-context-comprehension.test.ts", "gather-context-extra.test.ts", "gather-context-session.test.ts", "gather-context.test.ts", "generate-slash-commands.test.ts", "graph-anomaly.test.ts", "graph-ask.test.ts", "graph-blast-radius.test.ts", "graph.test.ts", "init.test.ts", "interaction.test.ts", "knowledge-craft.test.ts", "linter.test.ts", "naming-craft.test.ts", "outcome-eval.test.ts", "pagination-integration.test.ts", "persona-handlers.test.ts", "persona.security.test.ts", "persona.test.ts", "phase-gate.test.ts", "predict-failures.test.ts", "put-comprehension.test.ts", "recommend-skills.test.ts", "review-changes.test.ts", "review-pipeline.test.ts", "roadmap-auto-sync.test.ts", "roadmap-groom-sharded.test.ts", "roadmap-groom.test.ts", "roadmap-scoped-sync.test.ts", "roadmap.file-backed-regression.test.ts", "roadmap.file-less-stub.test.ts", "roadmap.file-less.test.ts", "roadmap.sharded.test.ts", "roadmap.test.ts", "search-skills.test.ts", "security-craft.test.ts", "skill-progressive-loading.test.ts", "skill-proposal.test.ts", "skill-telemetry.test.ts", "skill.security.test.ts", "skill.test.ts", "spec-craft.test.ts", "stale-constraints.test.ts", "state-events.test.ts", "state-extra.test.ts", "state-sc1-guard.test.ts", "state.test.ts", "task-independence.test.ts", "test-craft.test.ts", "traceability.test.ts", "validate.test.ts", "workflow-e2e.test.ts"]
+module: 'packages/cli/tests/mcp/tools'
+sourceHash: '5c367705e0e9675b9d7e4df46b982e50ba7452cfaaf60aa3c6b36bd0d5625c8f'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'acceptance-eval.test.ts',
+    'adr.test.ts',
+    'agent.test.ts',
+    'api-craft.test.ts',
+    'architecture.test.ts',
+    'assess-project-error-handling.test.ts',
+    'assess-project.test.ts',
+    'brainstorming-file-less-smoke.test.ts',
+    'cli-ergonomics-craft.test.ts',
+    'code-craft.test.ts',
+    'code-nav-handlers.test.ts',
+    'code-nav.test.ts',
+    'compact.test.ts',
+    'conflict-prediction.test.ts',
+    'constraint-emergence.test.ts',
+    'copy-craft.test.ts',
+    'cross-check.test.ts',
+    'decay-trends.test.ts',
+    'docs-craft.test.ts',
+    'docs.test.ts',
+    'entropy-config-threading.test.ts',
+    'entropy.test.ts',
+    'event-emitter.test.ts',
+    'events-jsonl-retired.guard.test.ts',
+    'feedback.test.ts',
+    'gather-context-comprehension.test.ts',
+    'gather-context-extra.test.ts',
+    'gather-context-session.test.ts',
+    'gather-context.test.ts',
+    'generate-slash-commands.test.ts',
+    'graph-anomaly.test.ts',
+    'graph-ask.test.ts',
+    'graph-blast-radius.test.ts',
+    'graph.test.ts',
+    'init.test.ts',
+    'interaction.test.ts',
+    'knowledge-craft.test.ts',
+    'linter.test.ts',
+    'naming-craft.test.ts',
+    'outcome-eval.test.ts',
+    'pagination-integration.test.ts',
+    'performance.test.ts',
+    'persona-handlers.test.ts',
+    'persona.security.test.ts',
+    'persona.test.ts',
+    'phase-gate.test.ts',
+    'predict-failures.test.ts',
+    'put-comprehension.test.ts',
+    'recommend-skills.test.ts',
+    'review-changes.test.ts',
+    'review-pipeline.test.ts',
+    'roadmap-auto-sync.test.ts',
+    'roadmap-groom-sharded.test.ts',
+    'roadmap-groom.test.ts',
+    'roadmap-scoped-sync.test.ts',
+    'roadmap.file-backed-regression.test.ts',
+    'roadmap.file-less-stub.test.ts',
+    'roadmap.file-less.test.ts',
+    'roadmap.sharded.test.ts',
+    'roadmap.test.ts',
+    'search-skills.test.ts',
+    'security-craft.test.ts',
+    'skill-progressive-loading.test.ts',
+    'skill-proposal.test.ts',
+    'skill-telemetry.test.ts',
+    'skill.security.test.ts',
+    'skill.test.ts',
+    'spec-craft.test.ts',
+    'stale-constraints.test.ts',
+    'state-events.test.ts',
+    'state-extra.test.ts',
+    'state-sc1-guard.test.ts',
+    'state.test.ts',
+    'task-independence.test.ts',
+    'test-craft.test.ts',
+    'traceability.test.ts',
+    'validate.test.ts',
+    'workflow-e2e.test.ts',
+  ]
 ---
-
-## Summary
-
-This module is a comprehensive integration test suite for all MCP (Model Context Protocol) tools exposed by the harness CLI. It contains 77 test files validating tool definitions, input contracts, error handling, file I/O operations, and state mutation guarantees across features like acceptance evaluation, ADR management, roadmap (sharded and file-backed), roadmap syncing, personas, skills, and semantic analysis.
-
-Common test patterns verify (1) tool schemas and required parameters, (2) input validation with clear error messages, (3) graceful degradation when external services (LLM, graph) are unavailable, (4) transactional correctness—mutations touch only the claimed shard or feature, not collateral files, and (5) state fidelity by comparing disk snapshots before/after operations. Tests use isolated temp directories per test and clean up rigorously. The three exported utilities (`writeShardedProject`, `snapshotShardDir`, `changedShards`) are test helpers for roadmap sharding that verify the single-shard write guarantee: a feature mutation rewrites exactly its own shard, never another.
-
-## Invariants
-
-- Single-shard write guarantee: A feature mutation (add/update/remove/promote) writes exactly one shard file; unrelated shards remain untouched. Violations break incremental sync and conflict detection.
-- Tool definition contract immutable: Each tool's MCP definition (name, required fields, schema) is hardcoded and must not drift from implementation; tests assert exact match to catch breaking renames or field-requirement changes.
-- No collateral state mutation: Roadmap operations that fail (e.g., blocked claim refusal, duplicate ADR number) commit zero disk writes; test snapshots verify no shard/file changed before vs. after.
-- Degrade-safe fallback: When no LLM provider is configured, tools must return low-confidence advisory verdicts (e.g., INCONCLUSIVE), never crash or hang; acceptance_eval sets authority via TypeScript logic, not LLM, so it's computable offline.
-- Collision-safe ADR numbering: Next number = max(existing)+1, not count+1, tolerating gaps and duplicates; sequential creates never collide even under concurrent allocation.
-- Cascade unblock-only: Marking a blocker done flips a blocked dependent to planned; re-blocking requires an explicit action, never automatic (issue #610).
-- Store parity: Sharded reads (show/query) load from docs/roadmap.d/*.md and reconstruct the same logical state as the monolithic docs/roadmap.md; aggregate is regenerated on every write.
 
 ## Interface Contract
 
@@ -72,6 +135,7 @@ import { handleKnowledgeCraft, handleKnowledgeCraftFinalize, knowledgeCraftDefin
 import { generateLinterDefinition, handleGenerateLinter, handleValidateLinterConfig, validateLinterConfigDefinition } from '../../../src/mcp/tools/linter'
 import { handleNamingCraft, handleNamingCraftFinalize, namingCraftDefinition, namingCraftFinalizeDefinition } from '../../../src/mcp/tools/naming-craft'
 import { handleOutcomeEval, outcomeEvalDefinition } from '../../../src/mcp/tools/outcome-eval.js'
+import { checkPerformanceDefinition, getCriticalPathsDefinition, getPerfBaselinesDefinition, handleCheckPerformance, handleGetCriticalPaths, handleGetPerfBaselines, handleUpdatePerfBaselines, updatePerfBaselinesDefinition } from '../../../src/mcp/tools/performance'
 import { generatePersonaArtifactsDefinition, handleGeneratePersonaArtifacts, handleListPersonas, handleRunPersona, listPersonasDefinition, runPersonaDefinition } from '../../../src/mcp/tools/persona'
 import { checkPhaseGateDefinition } from '../../../src/mcp/tools/phase-gate'
 import { handlePredictFailures, predictFailuresDefinition } from '../../../src/mcp/tools/predict-failures.js'
@@ -116,10 +180,10 @@ import { deriveAcceptanceAuthority } from '@harness-engineering/intelligence'
 import { Err, Ok, Result } from '@harness-engineering/types'
 import * as fs from 'fs'
 import * as fs from 'fs/promises'
-import * as fs from 'node:fs'
+import * as fs, { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import * as fsp from 'node:fs/promises'
-import * as os from 'node:os'
-import * as path from 'node:path'
+import * as os, { tmpdir } from 'node:os'
+import * as path, { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as os, { tmpdir } from 'os'
 import * as path, { join, resolve } from 'path'

--- a/packages/cli/tests/mcp/tools/performance.test.ts
+++ b/packages/cli/tests/mcp/tools/performance.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  checkPerformanceDefinition,
+  getPerfBaselinesDefinition,
+  updatePerfBaselinesDefinition,
+  getCriticalPathsDefinition,
+  handleCheckPerformance,
+  handleGetPerfBaselines,
+  handleUpdatePerfBaselines,
+  handleGetCriticalPaths,
+} from '../../../src/mcp/tools/performance';
+
+// Behavior characterization of the four performance MCP tool handlers.
+//
+// Before this file the tool was only smoke-tested at the server level
+// (`names.toContain('check_performance')`); none of the handler behavior —
+// baseline round-trips, critical-path resolution, the check-type routing, or
+// the shared error envelope — was asserted. These tests exercise the handlers
+// against real temp projects.
+//
+// Assumptions made: coverage authored via the test-fleet tdd/test-craft flow;
+// the knowledge graph was unavailable at selection time (static-analysis
+// fallback), so graph-augmented code paths are exercised via the "graph not
+// available — proceed without" branch that the handlers already tolerate.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'perf-tool-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Parse the JSON payload out of a successful MCP tool response. */
+function payload(res: { content: Array<{ text: string }>; isError?: boolean }) {
+  expect(res.isError).toBeFalsy();
+  return JSON.parse(res.content[0].text);
+}
+
+describe('performance tool definitions', () => {
+  it('check_performance declares its name, path, and the type enum', () => {
+    expect(checkPerformanceDefinition.name).toBe('check_performance');
+    expect(checkPerformanceDefinition.inputSchema.required).toContain('path');
+    expect(checkPerformanceDefinition.inputSchema.properties.type.enum).toEqual([
+      'structural',
+      'coupling',
+      'size',
+      'all',
+    ]);
+  });
+
+  it('the baseline + critical-path tools declare stable names and required inputs', () => {
+    expect(getPerfBaselinesDefinition.name).toBe('get_perf_baselines');
+    expect(getPerfBaselinesDefinition.inputSchema.required).toEqual(['path']);
+
+    expect(updatePerfBaselinesDefinition.name).toBe('update_perf_baselines');
+    expect(updatePerfBaselinesDefinition.inputSchema.required).toEqual([
+      'path',
+      'commitHash',
+      'results',
+    ]);
+
+    expect(getCriticalPathsDefinition.name).toBe('get_critical_paths');
+    expect(getCriticalPathsDefinition.inputSchema.required).toEqual(['path']);
+  });
+});
+
+describe('handleGetPerfBaselines', () => {
+  it('returns an empty default baselines file when none exists on disk', async () => {
+    const res = await handleGetPerfBaselines({ path: dir });
+    const baselines = payload(res);
+    expect(baselines).toEqual({
+      version: 1,
+      updatedAt: '',
+      updatedFrom: '',
+      benchmarks: {},
+    });
+  });
+
+  it('returns an error envelope (never throws) on an invalid path', async () => {
+    // sanitizePath rejects the filesystem root; the handler must catch it.
+    const res = await handleGetPerfBaselines({ path: '/' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Error:');
+  });
+});
+
+describe('handleUpdatePerfBaselines', () => {
+  it('persists benchmark results keyed by file::name and round-trips on read', async () => {
+    const results = [
+      {
+        name: 'parse-large-file',
+        file: 'src/parser.ts',
+        opsPerSec: 1200,
+        meanMs: 0.83,
+        p99Ms: 1.1,
+        marginOfError: 0.02,
+      },
+    ];
+
+    const updateRes = await handleUpdatePerfBaselines({
+      path: dir,
+      commitHash: 'abc123',
+      results,
+    });
+    const saved = payload(updateRes);
+    expect(saved.updatedFrom).toBe('abc123');
+    expect(saved.benchmarks['src/parser.ts::parse-large-file']).toMatchObject({
+      opsPerSec: 1200,
+      meanMs: 0.83,
+      p99Ms: 1.1,
+      marginOfError: 0.02,
+    });
+
+    // The write is real: a subsequent read observes the same benchmark.
+    const readBack = payload(await handleGetPerfBaselines({ path: dir }));
+    expect(readBack.benchmarks['src/parser.ts::parse-large-file'].opsPerSec).toBe(1200);
+    // And it landed at the documented location.
+    const onDisk = JSON.parse(
+      readFileSync(join(dir, '.harness', 'perf', 'baselines.json'), 'utf-8')
+    );
+    expect(onDisk.updatedFrom).toBe('abc123');
+  });
+});
+
+describe('handleGetCriticalPaths', () => {
+  it('reports zero entries for a project with no @perf-critical annotations', async () => {
+    writeFileSync(join(dir, 'plain.ts'), 'export const add = (a: number, b: number) => a + b;\n');
+    const set = payload(await handleGetCriticalPaths({ path: dir }));
+    expect(set.stats.total).toBe(0);
+    expect(set.entries).toEqual([]);
+  });
+
+  it('surfaces functions carrying a @perf-critical annotation', async () => {
+    writeFileSync(
+      join(dir, 'hot.ts'),
+      ['// @perf-critical', 'export function hotLoop(): void {', '  /* ... */', '}', ''].join('\n')
+    );
+    const set = payload(await handleGetCriticalPaths({ path: dir }));
+    expect(set.stats.annotated).toBeGreaterThan(0);
+    expect(set.entries.some((e: { file: string }) => e.file.endsWith('hot.ts'))).toBe(true);
+  });
+});
+
+describe('handleCheckPerformance', () => {
+  it('analyzes a project with a resolvable entry point and returns a JSON report', async () => {
+    // A conventional src/index.ts + package.json is enough for entry-point
+    // resolution; the analyzer then runs and returns a report payload.
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'package.json'), '{}');
+    writeFileSync(
+      join(dir, 'src', 'index.ts'),
+      'export function a(x: number): number {\n  return x + 1;\n}\n'
+    );
+    const res = await handleCheckPerformance({ path: dir, type: 'size' });
+    expect(res.isError).toBeFalsy();
+    expect(() => JSON.parse(res.content[0].text)).not.toThrow();
+  });
+
+  it('returns an error envelope when entry points cannot be resolved', async () => {
+    // A bare directory has no resolvable entry point; the handler reports the
+    // failure through the shared error envelope rather than throwing.
+    const res = await handleCheckPerformance({ path: dir, type: 'all' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Could not resolve entry points');
+  });
+
+  it('returns an error envelope (never throws) on an invalid path', async () => {
+    const res = await handleCheckPerformance({ path: '/', type: 'all' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Error:');
+  });
+});


### PR DESCRIPTION
## What

Adds behavior-asserting test coverage for the four handlers in `packages/cli/src/mcp/tools/performance.ts` (215 LOC). The tool was previously only **registration-smoke-tested** (`server-integration.test.ts` asserts the name appears in the tool list); **no handler behavior was asserted**.

Authored by **test-fleet** (wave-2 quality sweep). test-fleet characterizes existing behavior; **no code under test was modified**.

## Coverage added (10 tests, all green locally)

- Tool definitions — names, required inputs, the `structural|coupling|size|all` enum
- `handleGetPerfBaselines` — empty-default when no baselines file exists; shared error envelope on an invalid path (never throws)
- `handleUpdatePerfBaselines` — results persist keyed by `${file}::${name}`, round-trip on read, land at `.harness/perf/baselines.json`
- `handleGetCriticalPaths` — zero entries without annotations; surfaces a `@perf-critical`-annotated function
- `handleCheckPerformance` — JSON report for a project with a resolvable entry point; error envelope when entry points can't be resolved; error envelope on an invalid path

## Assumptions

- The knowledge graph was unavailable at selection time (test-advisor static-analysis fallback); `handleCheckPerformance`'s graph-augmented branch is exercised via the handler's own "graph not available — proceed without" fallback.
- Coverage delta: registration-only → handler behavior covered for all four tools.

Not for merge by the fleet — handed back for review.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga