### PR TITLE
fix(comprehend): format shards on the --all/non-stage write path (#1697)

### DIFF
--- a/.changeset/comprehend-all-write-formatting.md
+++ b/.changeset/comprehend-all-write-formatting.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(comprehend): apply write-time prettier formatting on the `--all` / non-`--stage`
+compile paths, not just the pre-commit `--stage`/hook path. A bulk
+`harness comprehend --all` (or any non-stage run) followed by a manual `git add` +
+commit previously wrote raw, double-quoted YAML frontmatter shards that an adopter's
+own prettier-on-markdown lint-staged step then reflowed at commit time — causing the
+lint-staged stash/restore "dribble" and a whole-tree `format:check` risk. Shard
+formatting is now path-independent: every freshly-compiled shard lands
+already-prettier-stable. Best-effort (a missing prettier never blocks a run).

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,25 +1,116 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/commands"
-sourceHash: "3d8534a32fc022e0b33aa4f92053d2683ca6a1104fe8f0e3e9ec40a42baf6b55"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["_registry.ts", "add.ts", "adoption.ts", "advise-skills.test.ts", "advise-skills.ts", "align-design-system.ts", "api-craft.ts", "audit-protected.ts", "backfill-skill-provenance.ts", "blueprint.ts", "check-arch.ts", "check-deployment.ts", "check-deps.ts", "check-design.ts", "check-docs.ts", "check-harness-strength.ts", "check-operational-drift.test.ts", "check-operational-drift.ts", "check-perf.ts", "check-phase-gate.ts", "check-security.ts", "check-vocabulary.ts", "cleanup-sessions.ts", "cleanup.ts", "cli-ergonomics-craft.ts", "code-craft.ts", "comprehend.ts", "comprehension-merge-driver.ts", "copy-craft.ts", "create-skill.ts", "cross-check.ts", "dashboard.ts", "design-pipeline.ts", "docs-craft.ts", "doctor.ts", "fix-drift.ts", "generate-agent-definitions.ts", "generate-slash-commands.ts", "generate.ts", "holiday-confidence.ts", "impact-preview.ts", "init-minimal.ts", "init.ts", "insights.ts", "install-constraints.ts", "install.ts", "knowledge-craft.ts", "knowledge-pipeline.test.ts", "knowledge-pipeline.ts", "maintenance-config.test.ts", "maintenance-config.ts", "maintenance-run.ts", "maintenance.ts", "mcp-guard.ts", "mcp.ts", "migrate-backends.ts", "migrate.ts", "models.ts", "naming-craft.ts", "operational-drift.test.ts", "operational-drift.ts", "orchestrator-black-box.test.ts", "orchestrator-black-box.ts", "orchestrator.ts", "outcome-eval-ci.ts", "perf.ts", "pre-merge-brief.ts", "predict.ts", "proposals.ts", "publish-analyses.ts", "recommend.ts", "rehearse.ts", "review-ci-local-adapter.ts", "review-ci.ts", "rollback.ts", "scan-config.ts", "search.ts", "security-craft.ts", "setup-mcp.ts", "setup-types.ts", "setup.ts", "share.ts", "skill-regression.test.ts", "skill-regression.ts", "snapshot.ts", "spec-craft.ts", "stale-constraints.ts", "sync-analyses.ts", "sync-main.ts", "taint.ts", "telemetry-wizard.ts", "test-craft.ts", "traceability.ts", "uninstall-constraints.ts", "uninstall.ts", "update.ts", "usage.ts", "validate-cross-check.ts", "validate-scope.ts", "validate.ts", "verify.test.ts", "verify.ts"]
+module: 'packages/cli/src/commands'
+sourceHash: '597af1fbcaf40c7fddb631734274b8e1152c553926181b61074ab87408df1e67'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    '_registry.ts',
+    'add.ts',
+    'adoption.ts',
+    'advise-skills.test.ts',
+    'advise-skills.ts',
+    'align-design-system.ts',
+    'api-craft.ts',
+    'audit-protected.ts',
+    'backfill-skill-provenance.ts',
+    'blueprint.ts',
+    'check-arch.ts',
+    'check-deployment.ts',
+    'check-deps.ts',
+    'check-design.ts',
+    'check-docs.ts',
+    'check-harness-strength.ts',
+    'check-operational-drift.test.ts',
+    'check-operational-drift.ts',
+    'check-perf.ts',
+    'check-phase-gate.ts',
+    'check-security.ts',
+    'check-vocabulary.ts',
+    'cleanup-sessions.ts',
+    'cleanup.ts',
+    'cli-ergonomics-craft.ts',
+    'code-craft.ts',
+    'comprehend.ts',
+    'comprehension-merge-driver.ts',
+    'copy-craft.ts',
+    'create-skill.ts',
+    'cross-check.ts',
+    'dashboard.ts',
+    'design-pipeline.ts',
+    'docs-craft.ts',
+    'doctor.ts',
+    'fix-drift.ts',
+    'generate-agent-definitions.ts',
+    'generate-slash-commands.ts',
+    'generate.ts',
+    'holiday-confidence.ts',
+    'impact-preview.ts',
+    'init-minimal.ts',
+    'init.ts',
+    'insights.ts',
+    'install-constraints.ts',
+    'install.ts',
+    'knowledge-craft.ts',
+    'knowledge-pipeline.test.ts',
+    'knowledge-pipeline.ts',
+    'maintenance-config.test.ts',
+    'maintenance-config.ts',
+    'maintenance-run.ts',
+    'maintenance.ts',
+    'mcp-guard.ts',
+    'mcp.ts',
+    'migrate-backends.ts',
+    'migrate.ts',
+    'models.ts',
+    'naming-craft.ts',
+    'operational-drift.test.ts',
+    'operational-drift.ts',
+    'orchestrator-black-box.test.ts',
+    'orchestrator-black-box.ts',
+    'orchestrator.ts',
+    'outcome-eval-ci.ts',
+    'perf.ts',
+    'pre-merge-brief.ts',
+    'predict.ts',
+    'proposals.ts',
+    'publish-analyses.ts',
+    'recommend.ts',
+    'rehearse.ts',
+    'review-ci-local-adapter.ts',
+    'review-ci.ts',
+    'rollback.ts',
+    'scan-config.ts',
+    'search.ts',
+    'security-craft.ts',
+    'setup-mcp.ts',
+    'setup-types.ts',
+    'setup.ts',
+    'share.ts',
+    'skill-regression.test.ts',
+    'skill-regression.ts',
+    'snapshot.ts',
+    'spec-craft.ts',
+    'stale-constraints.ts',
+    'sync-analyses.ts',
+    'sync-main.ts',
+    'taint.ts',
+    'telemetry-wizard.ts',
+    'test-craft.ts',
+    'traceability.ts',
+    'uninstall-constraints.ts',
+    'uninstall.ts',
+    'update.ts',
+    'usage.ts',
+    'validate-cross-check.ts',
+    'validate-scope.ts',
+    'validate.ts',
+    'verify.test.ts',
+    'verify.ts',
+  ]
 ---
-
-## Summary
-
-`packages/cli/src/commands` is the command factory and registry for the harness CLI. It exports ~90 command creators and auto-generates a single `commandCreators` array that allows registration of all commands without manual wiring. Each command is defined in its own file and re-exported here; the module serves as the primary discovery point for the CLI's command surface. Commands span operational checks (arch, perf, security, docs), AI-driven crafting tools (code, spec, test, design), infrastructure management (roadmap, orchestrator, deployment), and ecosystem tooling (skill management, MCP setup, graph operations).
-
-## Invariants
-
-- Auto-generated barrel — commandCreators and the complete export list are regenerated via pnpm run generate-barrel-exports; hand-edits are clobbered. Never modify _registry.ts directly.
-- Alphabetical order — commandCreators array must remain alphabetically sorted by command name; sorting breakage causes discoverability issues.
-- Factory function contract — Every createCommand function must return a Command (from commander.js); the array assumes this shape for uniform CLI registration.
-- Single source of truth per command — Each command has one file (add.ts, check-arch.ts, etc.). New commands require both a source file AND an export here to appear in the registry.
-- No orphaned imports — If a command file is deleted, its export must also be removed from _registry.ts. The generate-barrel-exports script is the only safe way to reconcile.
-- Command registration is declarative — The CLI iterates commandCreators to register each command. The array is the registration mechanism.
 
 ## Interface Contract
 
@@ -168,6 +259,7 @@ export findAllInstalls
 export findOutcomeVerdict
 export formatCapabilitiesByPermission
 export formatCapabilitiesTable
+export formatCompiledUnits
 export formatContextReport
 export gatherGuardianSafe
 export gatherSignalsSafe

--- a/.harness/comprehension/packages/cli/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/tests/comprehension/_module.md
@@ -1,29 +1,24 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/comprehension"
-sourceHash: "b037bc42e73fb4f9c23095872dc053ea8d5e2361307cdc95968d47be9ad06585"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["compile-run.test.ts", "comprehend-e2e.test.ts", "comprehend-flags.test.ts", "comprehend-smoke.e2e.test.ts", "config.test.ts", "generate-semantic.test.ts", "hook.test.ts", "invalidation.test.ts", "regression.test.ts", "static-extractor.test.ts"]
+module: 'packages/cli/tests/comprehension'
+sourceHash: '54f61610147abaec3fb09337c5bb4cef64e6c46786f0d0237cbe30c5b5ec4792'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'compile-run.test.ts',
+    'comprehend-e2e.test.ts',
+    'comprehend-flags.test.ts',
+    'comprehend-smoke.e2e.test.ts',
+    'config.test.ts',
+    'generate-semantic.test.ts',
+    'hook.test.ts',
+    'invalidation.test.ts',
+    'regression.test.ts',
+    'static-extractor.test.ts',
+  ]
 ---
-
-## Summary
-
-`packages/cli/tests/comprehension` validates the semantic-comprehension compiler pipeline that generates committed markdown documentation units (shards) from source code. The ~2000-line test suite across 10 files covers three core flows: (1) `runComprehend`—compiles modules with static extraction (interfaces, dependencies) and optional LLM semantic generation (summaries, invariants) in `--changed` or `--all` modes with pluggable concurrency and provider; (2) `runComprehendCheck`—token-free freshness gate comparing committed hashes vs live source for CI regression detection without LLM cost; (3) `runComprehendStats`—reports token compression savings. Tests use hermetic fake stores/readers/providers to track invocations, writes, and peaks. CLI tests validate flag precedence (`--static` disables semantic, `--stage` git-stages shards, hook mode skips on git-derivation failure). E2E tests drive real stores and config. Generate-semantic tests validate LLM interaction, budget enforcement, reentrancy guarding, and response schema validation.
-
-## Invariants
-
-- C1 — Fresh units never re-run: unchanged source hash must skip provider invocation and avoid rewrite. Hash divergence or semantic-upgrade (absent→present, same hash) unblocks recompile. Core mechanism for ~90% token savings.
-- ADR 0109 — Byte-stable semantic upgrade: upgrading semantic:absent → semantic:present with same source must recompile but preserve sourceHash and static provenance unchanged. No compiledAt wall-clock written.
-- Reentrancy refusal: REENTRANCY_ENV flag set during run and restored after (even on error). If set on entry, runComprehend refuses to compile (no writes). Prevents re-entry during provider calls.
-- SC3 — Changed mode precision: --changed recompiles exactly the named changed-module set (files → owning directories). Git failure falls back to --all with warning (non-hook) or skips (hook mode).
-- SC4 — Static-only by design: pre-commit hook always runs --static regardless of config. --static disables provider resolution, ensuring semantic:absent (no token cost). Semantic is opt-in via explicit generateSemantic argument.
-- Concurrency bounded: mapWithConcurrency and module-parallel compilation never exceed concurrency parameter. Peak in-flight operations ≤ concurrency.
-- Provider toggle: Presence of generateSemantic function determines semantic:absent (static-only, no provider) vs semantic:present (provider invoked). Null provider → no semantic seam.
-- Source reader nullability: modules returning null (deleted directories) silently skipped with no error. Not written, not recompiled.
-- Token-free check gate: runComprehendCheck compares hashes without provider interaction—validates freshness at merge time and gates CI regressions.
-- Semantic regression detection: detectSemanticRegressions only flags present→absent transitions. New modules and deleted modules ignored. Result sorted for deterministic output.
 
 ## Interface Contract
 
@@ -34,7 +29,7 @@ members: ["compile-run.test.ts", "comprehend-e2e.test.ts", "comprehend-flags.tes
 ## Dependency Slice
 
 ```
-import { createComprehendCommand, resolveChangedScope, resolveCompileProvider, resolveMode, stageCompiledUnits } from '../../src/commands/comprehend'
+import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, stageCompiledUnits } from '../../src/commands/comprehend'
 import { ChangedSurface } from '../../src/commands/validate-scope'
 import { ComprehendRunResult, mapWithConcurrency, runComprehend, runComprehendCheck, runComprehendStats } from '../../src/comprehension/compile-run'
 import { comprehensionEndpoint, readComprehensionConfig, selectSemanticModel } from '../../src/comprehension/config'
@@ -52,5 +47,6 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import * as fsp from 'node:fs/promises'
 import * as os, { tmpdir } from 'node:os'
 import * as path, path from 'node:path'
+import from 'prettier'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/docs/changes/comprehend-all-write-time-formatting/provenance.json
+++ b/docs/changes/comprehend-all-write-time-formatting/provenance.json
@@ -1,0 +1,16 @@
+{
+  "issues": [1697],
+  "route": "bug",
+  "stages": ["debugging"],
+  "assumptions": [
+    "Adopted proposed fix Option 1 (extend write-time prettier formatting to the --all / non-stage compile paths) as the minimal root-cause fix; Option 2 (prettier-stable serializer) is left as an optional belt-and-suspenders follow-up.",
+    "Freshness is determined by sourceHash (leniently parsed), not shard bytes, so reformatting a shard's YAML quotes does not make a subsequent run report it stale — the byte-identical no-churn invariant (C1) still holds.",
+    "stageCompiledUnits keeps formatting internally (FIX D); runCompileMode formats via formatCompiledUnits ONLY on the non-stage branch to avoid double-formatting.",
+    "Change scoped strictly to the write/format path (comprehend.ts); serve-time text-search code left untouched to avoid a same-region conflict with sibling issue #1692.",
+    "Formatting stays best-effort: a missing prettier or an unreadable shard is swallowed and never blocks a run (adopter without prettier is unaffected)."
+  ],
+  "reproducingTest": "packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts",
+  "reproducingTestCase": "harness comprehend --all — write-time shard formatting (#1697) > a shard written via the bulk --all path is already prettier-stable (no format:check drift)",
+  "rootCause": "The write-time prettier format() step was wired only into stageCompiledUnits (the --stage/hook path). A bulk `harness comprehend --all` (non-stage) followed by a manual git add + commit wrote raw, double-quoted YAML frontmatter shards that an adopter's prettier-on-markdown lint-staged step then reflowed at commit time (singleQuote), causing the lint-staged stash/restore dribble and a whole-tree format:check risk.",
+  "fix": "Extracted formatCompiledUnits() and invoked it on the non-stage compile branch in runCompileMode, making shard formatting path-independent so every freshly-compiled shard lands already prettier-stable."
+}

--- a/packages/cli/src/commands/comprehend.ts
+++ b/packages/cli/src/commands/comprehend.ts
@@ -177,6 +177,29 @@ async function defaultFormatPaths(paths: string[]): Promise<void> {
 }
 
 /**
+ * FIX #1697 — prettier-format the freshly-written shards for a compile run
+ * REGARDLESS of the `--stage` path. Write-time formatting used to live ONLY inside
+ * `stageCompiledUnits` (the pre-commit `--stage`/hook posture), so a bulk
+ * `harness comprehend --all` (or any non-stage run) followed by a manual
+ * `git add` + commit landed RAW, double-quoted shards that an adopter's own
+ * prettier-on-markdown lint-staged step then reflows at commit time — producing
+ * the "dribble" (a rotating handful of shards left modified-but-uncommitted after
+ * every commit) and a whole-tree `format:check` risk on push. Applying the same
+ * format step here makes shard formatting PATH-INDEPENDENT: every freshly-compiled
+ * shard lands already prettier-stable no matter how it was produced. No-op when
+ * nothing compiled; best-effort (the `format` seam swallows its own errors, so a
+ * missing prettier or an unreadable shard never blocks the run).
+ */
+export async function formatCompiledUnits(
+  result: Pick<ComprehendRunResult, 'compiled'>,
+  store: { path: (module: string) => string },
+  format: (paths: string[]) => void | Promise<void> = defaultFormatPaths
+): Promise<void> {
+  if (result.compiled.length === 0) return;
+  await format(result.compiled.map((module) => store.path(module)));
+}
+
+/**
  * SF1.2 — `--stage`: git-add the compiled units' shard paths so a static-only
  * pre-commit recompile lands the refreshed `_module.md` shards IN the same commit
  * as the source change. Stages EXACTLY the compiled modules' shards (`store.path`)
@@ -192,9 +215,8 @@ export async function stageCompiledUnits(
   format: (paths: string[]) => void | Promise<void> = defaultFormatPaths
 ): Promise<void> {
   if (result.compiled.length === 0) return;
-  const paths = result.compiled.map((module) => store.path(module));
-  await format(paths); // FIX D: prettier the shards BEFORE they are staged
-  stage(paths);
+  await formatCompiledUnits(result, store, format); // FIX D: prettier the shards BEFORE staging
+  stage(result.compiled.map((module) => store.path(module)));
 }
 
 /** Load the resolved HarnessConfig, or undefined when none resolves (best-effort). */
@@ -321,7 +343,13 @@ async function runCompileMode(
   // Pre-commit posture: stage the refreshed shards so they land in the SAME
   // commit as the source change (no-op when nothing compiled). Prettier-formats
   // the shards before git-add (FIX D) so they never trip the whole-tree format:check.
+  // FIX #1697: on every OTHER path (bulk `--all`, plain `--changed`, no `--stage`)
+  // still prettier-format the freshly-written shards so a later manual `git add` +
+  // commit lands them already-formatted — otherwise an adopter's prettier-on-markdown
+  // lint-staged reflows the double-quoted frontmatter at commit time (dribble +
+  // format:check risk). `stageCompiledUnits` already formats, so don't double up.
   if (opts.stage) await stageCompiledUnits(result, store);
+  else await formatCompiledUnits(result, store);
   logger.success(
     `Compiled ${result.compiled.length} module(s): ` +
       `${result.semanticPresent} semantic, ${result.semanticAbsent} static-only` +

--- a/packages/cli/tests/comprehension/comprehend-flags.test.ts
+++ b/packages/cli/tests/comprehension/comprehend-flags.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCompileProvider,
   resolveChangedScope,
   stageCompiledUnits,
+  formatCompiledUnits,
 } from '../../src/commands/comprehend';
 import type { ChangedSurface } from '../../src/commands/validate-scope';
 import { readComprehensionConfig } from '../../src/comprehension/config';
@@ -160,5 +161,30 @@ describe('stageCompiledUnits — SF1.2 (--stage)', () => {
       )
     ).resolves.toBeUndefined();
     expect(staged).toEqual(['.harness/comprehension/packages/core/src/_module.md']);
+  });
+});
+
+// --- #1697: formatCompiledUnits — write-time formatting on EVERY compile path ---
+
+describe('formatCompiledUnits — #1697 (path-independent shard formatting)', () => {
+  it('formats EXACTLY the compiled modules’ shard paths (via the injected seam)', async () => {
+    const formatted: string[] = [];
+    const store = { path: (m: string) => `.harness/comprehension/${m}/_module.md` };
+    await formatCompiledUnits(
+      runResult({ compiled: ['packages/core/src', 'packages/cli/src'] }),
+      store,
+      (paths) => formatted.push(...paths)
+    );
+    expect(formatted).toEqual([
+      '.harness/comprehension/packages/core/src/_module.md',
+      '.harness/comprehension/packages/cli/src/_module.md',
+    ]);
+  });
+
+  it('is a no-op when nothing compiled (never touches prettier)', async () => {
+    const format = vi.fn();
+    const store = { path: (m: string) => `.harness/comprehension/${m}/_module.md` };
+    await formatCompiledUnits(runResult({ compiled: [] }), store, format);
+    expect(format).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts
+++ b/packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts
@@ -117,6 +117,52 @@ describe.skipIf(!HAS_BIN)('harness comprehend — E2E smoke (static, no LLM)', (
   });
 });
 
+// --- #1697: `comprehend --all` lands already-prettier-formatted shards ---------
+// A bulk (`--all`, non-`--stage`) run must apply the SAME write-time prettier
+// formatting the `--stage`/hook path applies, so shards land prettier-stable and
+// don't "dribble" against an adopter's own prettier-on-markdown lint-staged /
+// pre-commit — which reflows the serializer's double-quoted YAML frontmatter to
+// single quotes (repo `singleQuote: true`) and trips the whole-tree `format:check`.
+describe.skipIf(!HAS_BIN)('harness comprehend --all — write-time shard formatting (#1697)', () => {
+  let proj: string;
+
+  beforeAll(() => {
+    proj = mkdtempSync(path.join(tmpdir(), 'comprehend-fmt-'));
+    mkdirSync(path.join(proj, 'math'), { recursive: true });
+    writeFileSync(
+      path.join(proj, 'math', 'add.ts'),
+      `/** Adds two numbers. */\nexport function add(a: number, b: number): number {\n  return a + b;\n}\n`
+    );
+    writeFileSync(path.join(proj, 'math', 'index.ts'), `export { add } from './add';\n`);
+    // A realistic adopter: prettier-on-markdown (singleQuote) with NO `.prettierignore`
+    // entry for the comprehension substrate — exactly who this bug bites.
+    writeFileSync(
+      path.join(proj, '.prettierrc.json'),
+      JSON.stringify({ singleQuote: true }, null, 2)
+    );
+  });
+
+  afterAll(() => {
+    if (proj) rmSync(proj, { recursive: true, force: true });
+  });
+
+  it('a shard written via the bulk --all path is already prettier-stable (no format:check drift)', async () => {
+    const r = comprehend(proj, ['--all', '--static']);
+    expect(r.status).toBe(0);
+
+    const unitPath = path.join(proj, UNIT);
+    const onDisk = readFileSync(unitPath, 'utf8');
+
+    // `format:check` equivalent: re-running prettier over the freshly-written shard
+    // must be a NO-OP. Before the fix the shard carried double-quoted YAML frontmatter
+    // that prettier (singleQuote) reflows → a guaranteed diff → dribble on every commit.
+    const prettier = await import('prettier');
+    const config = await prettier.resolveConfig(unitPath);
+    const formatted = await prettier.format(onDisk, { ...config, filepath: unitPath });
+    expect(formatted).toBe(onDisk);
+  });
+});
+
 // Deterministic SEMANTIC E2E — fake the LLM at the REAL boundary. We drop a fake
 // `claude` on PATH that emits a canned structured_output envelope, so the FULL
 // pipeline runs for real (D8 resolver → ClaudeCliAnalysisProvider spawn → parse →


### PR DESCRIPTION
## Summary

Root-cause fix for #1697. Write-time prettier formatting of comprehension
`_module.md` shards was wired **only** into the `--stage`/hook path
(`stageCompiledUnits`). A bulk `harness comprehend --all` (or any non-`--stage`
run) followed by a manual `git add` + commit wrote **raw, double-quoted** YAML
frontmatter shards. An adopter running prettier-on-markdown via lint-staged /
pre-commit (`singleQuote: true`, a common JS/TS convention) then reflows those
shards at commit time — producing the lint-staged stash/restore **"dribble"** (a
rotating handful of shards left modified-but-uncommitted after every commit) and
a whole-tree `format:check` risk on push.

## Fix (proposal Option 1 — minimal, preserves the "no `.prettierignore`" intent)

- Extract `formatCompiledUnits()` and invoke it on the **non-stage** compile
  branch in `runCompileMode`, making shard formatting **path-independent**: every
  freshly-compiled shard lands already prettier-stable no matter how it was produced.
- `stageCompiledUnits` reuses the same helper (FIX D preserved); the stage and
  non-stage branches never double-format.
- Formatting remains **best-effort** — a missing prettier or an unreadable shard
  is swallowed and never blocks a run, so an adopter without prettier is unaffected.
- Freshness is `sourceHash`-based (leniently parsed), so reformatting a shard's
  YAML quotes does **not** make a later run see it as stale — the byte-identical
  no-churn invariant (C1) still holds.

Scoped strictly to the write/format path (`comprehend.ts`); serve-time
text-search code is untouched to avoid a same-region conflict with #1692.

## Reproducing test (fails before, passes after)

`packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts` — drives the
**real built CLI** as a subprocess in a temp repo with an adopter-style
`.prettierrc.json` (`singleQuote: true`, no `.prettierignore`), runs
`comprehend --all --static`, and asserts the freshly-written shard is a prettier
**no-op** (the `format:check` equivalent). Before the fix it failed on the
double→single quote flip of the frontmatter; after the fix it passes. Plus unit
tests for `formatCompiledUnits` in `comprehend-flags.test.ts`.

## Assumptions made

- Adopted **Option 1** (extend write-time formatting) as the minimal root-cause
  fix; Option 2 (prettier-stable serializer) is left as an optional
  belt-and-suspenders follow-up.
- Freshness keyed on `sourceHash`, not shard bytes → reformatting doesn't churn.
- Best-effort formatting: adopters without prettier are unaffected.

Closes #1697