### PR TITLE
fix(comprehension): exclude committed units from raw text search (#1692)

### DIFF
--- a/.changeset/comprehension-units-search-pollution.md
+++ b/.changeset/comprehension-units-search-pollution.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+comprehension: committed compiled-comprehension units no longer pollute raw text search (issue #1692). Committed `_module.md` shards under `.harness/comprehension/` are TRACKED so the LLM-free serve-time hash gate can read them, but that made them show up in `rg` / `grep -r` / editor code search, doubling hits on any symbol that appears in both the source and its unit summary. A repo-root `.ignore` entry (`.harness/comprehension/`) now excludes the shard tree from ripgrep/fd/ag — which honor `.ignore` even for tracked files — WITHOUT untracking the units from git. `harness init` (CLI and MCP `init_project`) and MCP server startup now ensure this entry for new and existing projects via `ensureComprehensionSearchIgnore`. Adopters preferring `storage: "cache"` (gitignored) already sidestep the issue entirely.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,25 +1,116 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/commands"
-sourceHash: "3d8534a32fc022e0b33aa4f92053d2683ca6a1104fe8f0e3e9ec40a42baf6b55"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["_registry.ts", "add.ts", "adoption.ts", "advise-skills.test.ts", "advise-skills.ts", "align-design-system.ts", "api-craft.ts", "audit-protected.ts", "backfill-skill-provenance.ts", "blueprint.ts", "check-arch.ts", "check-deployment.ts", "check-deps.ts", "check-design.ts", "check-docs.ts", "check-harness-strength.ts", "check-operational-drift.test.ts", "check-operational-drift.ts", "check-perf.ts", "check-phase-gate.ts", "check-security.ts", "check-vocabulary.ts", "cleanup-sessions.ts", "cleanup.ts", "cli-ergonomics-craft.ts", "code-craft.ts", "comprehend.ts", "comprehension-merge-driver.ts", "copy-craft.ts", "create-skill.ts", "cross-check.ts", "dashboard.ts", "design-pipeline.ts", "docs-craft.ts", "doctor.ts", "fix-drift.ts", "generate-agent-definitions.ts", "generate-slash-commands.ts", "generate.ts", "holiday-confidence.ts", "impact-preview.ts", "init-minimal.ts", "init.ts", "insights.ts", "install-constraints.ts", "install.ts", "knowledge-craft.ts", "knowledge-pipeline.test.ts", "knowledge-pipeline.ts", "maintenance-config.test.ts", "maintenance-config.ts", "maintenance-run.ts", "maintenance.ts", "mcp-guard.ts", "mcp.ts", "migrate-backends.ts", "migrate.ts", "models.ts", "naming-craft.ts", "operational-drift.test.ts", "operational-drift.ts", "orchestrator-black-box.test.ts", "orchestrator-black-box.ts", "orchestrator.ts", "outcome-eval-ci.ts", "perf.ts", "pre-merge-brief.ts", "predict.ts", "proposals.ts", "publish-analyses.ts", "recommend.ts", "rehearse.ts", "review-ci-local-adapter.ts", "review-ci.ts", "rollback.ts", "scan-config.ts", "search.ts", "security-craft.ts", "setup-mcp.ts", "setup-types.ts", "setup.ts", "share.ts", "skill-regression.test.ts", "skill-regression.ts", "snapshot.ts", "spec-craft.ts", "stale-constraints.ts", "sync-analyses.ts", "sync-main.ts", "taint.ts", "telemetry-wizard.ts", "test-craft.ts", "traceability.ts", "uninstall-constraints.ts", "uninstall.ts", "update.ts", "usage.ts", "validate-cross-check.ts", "validate-scope.ts", "validate.ts", "verify.test.ts", "verify.ts"]
+module: 'packages/cli/src/commands'
+sourceHash: '0e07d967fb2bc640bf8a2e2f4c1884a78fa8dbfebf75865a13e307d9e00b72db'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    '_registry.ts',
+    'add.ts',
+    'adoption.ts',
+    'advise-skills.test.ts',
+    'advise-skills.ts',
+    'align-design-system.ts',
+    'api-craft.ts',
+    'audit-protected.ts',
+    'backfill-skill-provenance.ts',
+    'blueprint.ts',
+    'check-arch.ts',
+    'check-deployment.ts',
+    'check-deps.ts',
+    'check-design.ts',
+    'check-docs.ts',
+    'check-harness-strength.ts',
+    'check-operational-drift.test.ts',
+    'check-operational-drift.ts',
+    'check-perf.ts',
+    'check-phase-gate.ts',
+    'check-security.ts',
+    'check-vocabulary.ts',
+    'cleanup-sessions.ts',
+    'cleanup.ts',
+    'cli-ergonomics-craft.ts',
+    'code-craft.ts',
+    'comprehend.ts',
+    'comprehension-merge-driver.ts',
+    'copy-craft.ts',
+    'create-skill.ts',
+    'cross-check.ts',
+    'dashboard.ts',
+    'design-pipeline.ts',
+    'docs-craft.ts',
+    'doctor.ts',
+    'fix-drift.ts',
+    'generate-agent-definitions.ts',
+    'generate-slash-commands.ts',
+    'generate.ts',
+    'holiday-confidence.ts',
+    'impact-preview.ts',
+    'init-minimal.ts',
+    'init.ts',
+    'insights.ts',
+    'install-constraints.ts',
+    'install.ts',
+    'knowledge-craft.ts',
+    'knowledge-pipeline.test.ts',
+    'knowledge-pipeline.ts',
+    'maintenance-config.test.ts',
+    'maintenance-config.ts',
+    'maintenance-run.ts',
+    'maintenance.ts',
+    'mcp-guard.ts',
+    'mcp.ts',
+    'migrate-backends.ts',
+    'migrate.ts',
+    'models.ts',
+    'naming-craft.ts',
+    'operational-drift.test.ts',
+    'operational-drift.ts',
+    'orchestrator-black-box.test.ts',
+    'orchestrator-black-box.ts',
+    'orchestrator.ts',
+    'outcome-eval-ci.ts',
+    'perf.ts',
+    'pre-merge-brief.ts',
+    'predict.ts',
+    'proposals.ts',
+    'publish-analyses.ts',
+    'recommend.ts',
+    'rehearse.ts',
+    'review-ci-local-adapter.ts',
+    'review-ci.ts',
+    'rollback.ts',
+    'scan-config.ts',
+    'search.ts',
+    'security-craft.ts',
+    'setup-mcp.ts',
+    'setup-types.ts',
+    'setup.ts',
+    'share.ts',
+    'skill-regression.test.ts',
+    'skill-regression.ts',
+    'snapshot.ts',
+    'spec-craft.ts',
+    'stale-constraints.ts',
+    'sync-analyses.ts',
+    'sync-main.ts',
+    'taint.ts',
+    'telemetry-wizard.ts',
+    'test-craft.ts',
+    'traceability.ts',
+    'uninstall-constraints.ts',
+    'uninstall.ts',
+    'update.ts',
+    'usage.ts',
+    'validate-cross-check.ts',
+    'validate-scope.ts',
+    'validate.ts',
+    'verify.test.ts',
+    'verify.ts',
+  ]
 ---
-
-## Summary
-
-`packages/cli/src/commands` is the command factory and registry for the harness CLI. It exports ~90 command creators and auto-generates a single `commandCreators` array that allows registration of all commands without manual wiring. Each command is defined in its own file and re-exported here; the module serves as the primary discovery point for the CLI's command surface. Commands span operational checks (arch, perf, security, docs), AI-driven crafting tools (code, spec, test, design), infrastructure management (roadmap, orchestrator, deployment), and ecosystem tooling (skill management, MCP setup, graph operations).
-
-## Invariants
-
-- Auto-generated barrel — commandCreators and the complete export list are regenerated via pnpm run generate-barrel-exports; hand-edits are clobbered. Never modify _registry.ts directly.
-- Alphabetical order — commandCreators array must remain alphabetically sorted by command name; sorting breakage causes discoverability issues.
-- Factory function contract — Every createCommand function must return a Command (from commander.js); the array assumes this shape for uniform CLI registration.
-- Single source of truth per command — Each command has one file (add.ts, check-arch.ts, etc.). New commands require both a source file AND an export here to appear in the registry.
-- No orphaned imports — If a command file is deleted, its export must also be removed from _registry.ts. The generate-barrel-exports script is the only safe way to reconcile.
-- Command registration is declarative — The CLI iterates commandCreators to register each command. The array is the registration mechanism.
 
 ## Interface Contract
 
@@ -369,7 +460,7 @@ import { computeCodexSync, detectLegacyCodexOrphans } from '../slash-commands/sy
 import { GenerateOptions, Platform, SlashCommandSpec, VALID_PLATFORMS } from '../slash-commands/types'
 import { SpecCraftInput, SpecCraftOutput, SpecKind, runSpecCraft } from '../spec-craft/index.js'
 import { DetectedFramework, TemplateEngine } from '../templates/engine'
-import { appendFrameworkAgents, applyEcosystemAfterCreate, ensureHarnessGitignore, persistToolingConfig } from '../templates/post-write'
+import { appendFrameworkAgents, applyEcosystemAfterCreate, ensureComprehensionSearchIgnore, ensureHarnessGitignore, persistToolingConfig } from '../templates/post-write'
 import { TemplateMetadata } from '../templates/schema'
 import { TestCraftInput, TestCraftOutput, TestFramework, runTestCraft } from '../test-craft/index.js'
 import { mapWithConcurrency } from '../utils/concurrency'

--- a/.harness/comprehension/packages/cli/src/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/_module.md
@@ -1,25 +1,22 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/mcp"
-sourceHash: "d6216fc4ab82f5b1acb0f58158219d1cba7a5351cffde7b0e77d9139e9675ddd"
-compiledAt: "2026-08-29T14:14:27.819Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["context-surface.ts", "index.ts", "server.ts", "tool-capabilities.ts", "tool-capability-declarations.ts", "tool-tiers.ts", "tool-types.ts", "utils.ts"]
+module: 'packages/cli/src/mcp'
+sourceHash: '83f436e5244c88a373814eb39452ca6183816470b27a6a165689f978e7b86755'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'context-surface.ts',
+    'index.ts',
+    'server.ts',
+    'tool-capabilities.ts',
+    'tool-capability-declarations.ts',
+    'tool-tiers.ts',
+    'tool-types.ts',
+    'utils.ts',
+  ]
 ---
-
-## Summary
-
-The MCP module (`packages/cli/src/mcp`) is the harness's Model Context Protocol server and tool registry. It exposes the harness's full capability surface to Claude and other agents via MCP: ~150+ tools organized into functional domains (design, testing, security, architecture, docs, etc.), plus read-only resources (project config, skill catalog, roadmap, graph entities). The server handles tool dispatch, applies middleware (injection guards, context budgeting, compaction), and measures the harness's always-loaded context surface (tool schemas by tier, AGENTS.md, hooks). Tools are registered via a central `getToolDefinitions()` registry; each tool pairs a schema definition with a handler. Resources are best-effort file-based views of project state that degrade gracefully on read failures.
-
-## Invariants
-
-- Tool tier membership is fixed and context-sized: tools are partitioned into `core`, `standard`, and `full` tiers; tier-aware context-surface measurement is the authoritative cost model for schema bytes. Tool names must appear in exactly one of `CORE_TOOL_NAMES`, `STANDARD_TOOL_NAMES` or neither.
-- Tool definition ↔ handler pairs must stay in sync: each tool in `getToolDefinitions()` must have a matching handler (registered in `CallToolRequest` dispatch) with compatible input schema; missing or mismatched handlers cause silent failures at runtime.
-- MCP resources degrade gracefully: file reads for AGENTS.md, hooks, skill trees use try-catch and return null on failure; resource gathering is best-effort and never blocks server startup.
-- Middleware ordering is load-bearing: injection-guard runs first (rejects unsafe patterns), then compaction (shrinks responses), then context-budget (enforces token limits); reordering changes security or budget semantics.
-- Project config resolution is mandatory before tool dispatch: `resolveProjectConfig` must succeed for tools to access harness state (roadmap, ADRs, rules); tools without config context fail gracefully.
 
 ## Interface Contract
 
@@ -34,7 +31,7 @@ export startServer
 ## Dependency Slice
 
 ```
-import { ensureHarnessGitignore } from '../templates/post-write.js'
+import { ensureComprehensionSearchIgnore, ensureHarnessGitignore } from '../templates/post-write.js'
 import from '../version.js'
 import { getToolDefinitions } from './index.js'
 import { applyCompaction } from './middleware/compaction.js'

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,31 +1,111 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/mcp/tools"
-sourceHash: "8bf328a2311348a36dfe4c755cb3ea5c83d7361b1675dd39c14ac60d11b6c487"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["acceptance-eval.ts", "adr-store.ts", "adr.ts", "advise-skills.test.ts", "advise-skills.ts", "agent-definitions.ts", "agent.ts", "align-design-system.ts", "api-craft.ts", "architecture.ts", "assess-project.ts", "audit-anatomy.ts", "audit-brand.ts", "blueprint.test.ts", "blueprint.ts", "canary.test.ts", "canary.ts", "ci.ts", "cli-ergonomics-craft.ts", "code-craft.ts", "code-nav.ts", "compact.ts", "compound.test.ts", "compound.ts", "conflict-prediction.ts", "constraint-emergence.ts", "copy-craft.ts", "cross-check.test.ts", "cross-check.ts", "decay-trends.ts", "design-craft.ts", "design-pipeline.ts", "detect-drift.ts", "dispatch-skills.ts", "docs-craft.ts", "docs-publish.ts", "docs.ts", "edit-file.test.ts", "edit-file.ts", "entropy.ts", "event-emitter.ts", "feedback.ts", "gateway-tools.test.ts", "gateway-tools.ts", "gather-context.ts", "generate-slash-commands.ts", "get-comprehension.test.ts", "get-comprehension.ts", "hermes-tools.test.ts", "init.ts", "insights-summary.ts", "instruction-density.test.ts", "instruction-density.ts", "interaction-renderer.test.ts", "interaction-renderer.ts", "interaction-schemas.ts", "interaction.ts", "knowledge-craft.ts", "linter.ts", "naming-craft.ts", "outcome-eval.ts", "parallelization.test.ts", "parallelization.ts", "performance.ts", "persona.ts", "phase-gate.ts", "predict-failures.ts", "pulse.test.ts", "pulse.ts", "put-comprehension.ts", "recommend-skills.ts", "review-changes.ts", "review-pipeline.ts", "roadmap-auto-sync.ts", "roadmap-file-less.ts", "roadmap.ts", "search-sessions.ts", "search-skills.ts", "security-craft.ts", "security.ts", "skill-proposal.ts", "skill-telemetry.ts", "skill.ts", "spec-craft.ts", "stale-constraints.ts", "state.ts", "strategy.test.ts", "strategy.ts", "summarize-session.ts", "task-independence.ts", "test-craft.ts", "traceability.ts", "uat-signoff.test.ts", "uat-signoff.ts", "validate.ts", "webhook-tools.test.ts", "webhook-tools.ts"]
+module: 'packages/cli/src/mcp/tools'
+sourceHash: '0ad5616716cf45dd20d666a7574c164fb78a89cbb101d48b2d4e40b793d5dc8d'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'acceptance-eval.ts',
+    'adr-store.ts',
+    'adr.ts',
+    'advise-skills.test.ts',
+    'advise-skills.ts',
+    'agent-definitions.ts',
+    'agent.ts',
+    'align-design-system.ts',
+    'api-craft.ts',
+    'architecture.ts',
+    'assess-project.ts',
+    'audit-anatomy.ts',
+    'audit-brand.ts',
+    'blueprint.test.ts',
+    'blueprint.ts',
+    'canary.test.ts',
+    'canary.ts',
+    'ci.ts',
+    'cli-ergonomics-craft.ts',
+    'code-craft.ts',
+    'code-nav.ts',
+    'compact.ts',
+    'compound.test.ts',
+    'compound.ts',
+    'conflict-prediction.ts',
+    'constraint-emergence.ts',
+    'copy-craft.ts',
+    'cross-check.test.ts',
+    'cross-check.ts',
+    'decay-trends.ts',
+    'design-craft.ts',
+    'design-pipeline.ts',
+    'detect-drift.ts',
+    'dispatch-skills.ts',
+    'docs-craft.ts',
+    'docs-publish.ts',
+    'docs.ts',
+    'edit-file.test.ts',
+    'edit-file.ts',
+    'entropy.ts',
+    'event-emitter.ts',
+    'feedback.ts',
+    'gateway-tools.test.ts',
+    'gateway-tools.ts',
+    'gather-context.ts',
+    'generate-slash-commands.ts',
+    'get-comprehension.test.ts',
+    'get-comprehension.ts',
+    'hermes-tools.test.ts',
+    'init.ts',
+    'insights-summary.ts',
+    'instruction-density.test.ts',
+    'instruction-density.ts',
+    'interaction-renderer.test.ts',
+    'interaction-renderer.ts',
+    'interaction-schemas.ts',
+    'interaction.ts',
+    'knowledge-craft.ts',
+    'linter.ts',
+    'naming-craft.ts',
+    'outcome-eval.ts',
+    'parallelization.test.ts',
+    'parallelization.ts',
+    'performance.ts',
+    'persona.ts',
+    'phase-gate.ts',
+    'predict-failures.ts',
+    'pulse.test.ts',
+    'pulse.ts',
+    'put-comprehension.ts',
+    'recommend-skills.ts',
+    'review-changes.ts',
+    'review-pipeline.ts',
+    'roadmap-auto-sync.ts',
+    'roadmap-file-less.ts',
+    'roadmap.ts',
+    'search-sessions.ts',
+    'search-skills.ts',
+    'security-craft.ts',
+    'security.ts',
+    'skill-proposal.ts',
+    'skill-telemetry.ts',
+    'skill.ts',
+    'spec-craft.ts',
+    'stale-constraints.ts',
+    'state.ts',
+    'strategy.test.ts',
+    'strategy.ts',
+    'summarize-session.ts',
+    'task-independence.ts',
+    'test-craft.ts',
+    'traceability.ts',
+    'uat-signoff.test.ts',
+    'uat-signoff.ts',
+    'validate.ts',
+    'webhook-tools.test.ts',
+    'webhook-tools.ts',
+  ]
 ---
-
-## Summary
-
-packages/cli/src/mcp/tools is a ~100-file comprehensive MCP tool implementation layer for the harness engineering platform. Each file exports a tool definition (with inputSchema), a handler function, and supporting types. Tools are grouped by domain (design-craft, spec-craft, code-craft, comprehension, roadmap management, graph queries, etc.) and registered in server.ts with middleware (injection guard → compaction → context budget). Recent additions include ADR 0109 tools (get/put_comprehension) for provider-neutral, agent-authored semantic understanding write-back. All tools return internal project content, validate inputs before computing, and never throw—every failure wraps in `{ content: [...], isError: true }` envelopes. Capability declarations (tool-capability-declarations.js) tie each tool to declared scopes; missing declarations fall back to name heuristics. The put_comprehension tool enforces source-fresh static units via serveGate, validates semantic payloads against zod schema before disk writes, and rejects owned heading markers to prevent serialization corruption.
-
-## Invariants
-
-- Handler registry match: every tool definition in TOOL_DEFINITIONS must have a corresponding handler in TOOL_HANDLERS with exact snake_case name key; definition names must be tool-unique and map precisely.
-- Middleware order is strict: injection-guard → compaction → context-budget. Output must pass all layers in order for consistency.
-- No-throw contract: tool handlers never throw. All errors wrap in `{ content: [...], isError: true }` envelopes matching get_comprehension/put_comprehension pattern.
-- Capability declaration binding: TOOL_CAPABILITY_DECLARATIONS keys must match definition.name exactly for capability to merge; missing declarations fall back to name heuristic in tool-capabilities.ts.
-- Semantic schema authority: put_comprehension validates `semanticResponseSchema` before any disk write; agent-supplied payloads must pass zod validation or return invalid status—never written malformed.
-- Source-fresh gate: put_comprehension refuses stale units (serveGate verdict); semantic attaches only to source-fresh static units, forcing recompile via get_comprehension for stale units.
-- Owned heading prohibition: put_comprehension rejects payloads with top-level section headings (##) to prevent serialization corruption on round-trip; agents must not supply these in summary/invariants.
-- Provider-neutral comprehension: get_comprehension defers semantic provider resolution lazily (only on recompile branch), so fresh serves never load config; put_comprehension never resolves a provider (write-back only).
-- Reentrancy guard: get_comprehension respects `withComprehensionActive` guard from canonical driver; reentrant calls return `{ status: 'reentrant' }` not errors.
-- Definition completeness: every exported tool symbol (XXXDefinition, handleXXX, XXXInput/Output) must appear in both its file AND server.ts registry; missing registrations cause silent tool omission from MCP listing.
-- trustedOutput marking: all harness MCP tools return internal project content marked `trustedOutput: true`; external-proxying tools must omit this flag (defaults to untrusted). Injection guard skips scanning trusted output.
-- Handler input validation: tool handlers must validate input shape before any computation (typeof checks, Array.isArray); malformed inputs return `isError: true`, never throw.
 
 ## Interface Contract
 
@@ -426,7 +506,7 @@ import { recommend } from '../../skill/recommendation-engine.js'
 import { loadOrGenerateProfile } from '../../skill/stack-profile.js'
 import { CollectPromptsOutput, FinalizeSpecCraftInput, SpecCraftInput, SpecCraftMode, SpecCraftOutput, collectSpecCraftPrompts, finalizeSpecCraft, runSpecCraft } from '../../spec-craft/index.js'
 import from '../../templates/engine.js'
-import { appendFrameworkAgents, ensureHarnessGitignore, persistToolingConfig } from '../../templates/post-write.js'
+import { appendFrameworkAgents, ensureComprehensionSearchIgnore, ensureHarnessGitignore, persistToolingConfig } from '../../templates/post-write.js'
 import { TemplateMetadata } from '../../templates/schema.js'
 import { CollectPromptsOutput, FinalizeTestCraftInput, TestCraftInput, TestCraftOutput, collectTestCraftPrompts, finalizeTestCraft, runTestCraft } from '../../test-craft/index.js'
 import { envEnabled } from '../../utils/env-flag.js'

--- a/.harness/comprehension/packages/cli/src/templates/_module.md
+++ b/.harness/comprehension/packages/cli/src/templates/_module.md
@@ -1,32 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/templates'
-sourceHash: 'f078ed2a91343cbdee765b1efe7a2ab9bee2ea358e931bb8b482d9e843da0765'
-compiledAt: '2026-08-28T01:22:09.439Z'
+sourceHash: '0cd00c7621dedc292c493b046b70aba42d2f7cc2ea5ba02fbd6fb6d5c445fb15'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['agents-append.ts', 'engine.ts', 'merger.ts', 'post-write.ts', 'schema.ts']
 ---
-
-## Summary
-
-**`packages/cli/src/templates`** is the project scaffolding engine. It resolves a template based on adoption level (JS/TS) or language family (Python, Go, Rust, Java, etc.), optionally overlays a framework (Next.js, FastAPI, Gin, Spring Boot, etc.), renders Handlebars templates with supplied context, and writes files with smart merge logic for JSON configs and README sections.
-
-The module is split into:
-
-- **engine.ts**: Core `TemplateEngine` class — template discovery, resolution, framework detection, Handlebars rendering, JSON merging, and intelligent file writing
-- **agents-append.ts**: Framework convention snippets (title + content blocks for ~10 stacks) appended to project README
-- **schema.ts** / **merger.ts** / **ecosystem.ts**: Zod schemas, deep-merge logic, and post-write ecosystem wiring (e.g., adding framework agents to AGENTS.md)
-
-## Invariants
-
-- Template resolution hierarchy: JS/TS requires `level` (adoption tier) → may extend to named templates or framework overlays; non-JS uses `language` → `language-base` + optional framework overlay; fallback to named-template mode for standalone tools
-- Framework detection is scored by pattern matching (e.g., file presence, content sniffing in first 64KB), not binary; highest score wins; ties break on declaration order
-- File categorization gates write behavior: HARNESS_CONFIG_FILES always written; if any PROJECT_MARKERS exist in target, project is pre-existing → scaffold files skipped to avoid clobbering user code
-- JSON merge is path-aware: package.json calls mergePackageJson (handles deps, scripts, fields); other JSON uses deepMergeJson (recursive object merge); multiple JSON files for same output accumulate in buffer → merged at end
-- Framework sections are append-only, guarded against duplication via HTML comment markers (<!-- harness:framework-conventions:nextjs -->); idempotent
-- Handlebars strict mode enforced: templates reference named variables (runner, blockOn, baseBranch); caller must supply all referenced variables or render fails; no falsy defaults
 
 ## Interface Contract
 
@@ -42,6 +22,7 @@ export appendFrameworkSection
 export applyEcosystemAfterCreate
 export buildFrameworkSection
 export deepMergeJson
+export ensureComprehensionSearchIgnore
 export ensureHarnessGitignore
 export mergePackageJson
 export persistToolingConfig
@@ -54,7 +35,7 @@ import { appendFrameworkSection } from './agents-append.js'
 import { ResolvedTemplate } from './engine.js'
 import { deepMergeJson, mergePackageJson } from './merger'
 import { TemplateMetadata, TemplateMetadataSchema } from './schema'
-import { Err, Ok, Result } from '@harness-engineering/core'
+import { COMPREHENSION_ROOT, Err, Ok, Result } from '@harness-engineering/core'
 import { Ecosystem, detectEcosystem } from '@harness-engineering/orchestrator'
 import * as fs from 'fs'
 import Handlebars from 'handlebars'

--- a/.harness/comprehension/packages/cli/tests/templates/_module.md
+++ b/.harness/comprehension/packages/cli/tests/templates/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/templates'
-sourceHash: '595ccb5ac9cae515871f369420c23e0b39d4ab4887b40bef6390023e8a361443'
-compiledAt: '2026-08-28T01:22:10.188Z'
+sourceHash: '6454bb658ab4c8decd1c64fffdcd9a35bea3c5f3e5b24abd0fa4cff4e697c96d'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'agents-append.test.ts',
@@ -21,19 +20,6 @@ members:
   ]
 ---
 
-## Summary
-
-The `packages/cli/tests/templates` module validates the template system that bootstraps harness projects. It covers framework convention management (appending FastAPI, Django, Express, etc. sections to AGENTS.md without duplication), CI workflow templates (rendering Handlebars with context substitution while preserving GitHub Actions expressions), and template discovery/resolution through the init pipeline. The system manages template metadata, merge strategies (deep-merge for JSON, overlay-wins for files), and ensures rendered YAML is valid.
-
-## Invariants
-
-- GitHub expressions survive rendering: ${{ secrets.X }} and ${{ github.base_ref }} pass through Handlebars untouched; {{ variable }} tokens are substituted; both can coexist on one line
-- Job name ↔ ruleset context bijection: Workflow job names (e.g., pre-merge-brief, required-review) must exactly match required_status_checks contexts in paired .ruleset.json files
-- Base branch must use runtime GitHub context: CI workflows use ${{ github.base_ref }} (resolved at workflow runtime), never CLI's origin/HEAD fallback, to avoid reviewing wrong diffs on pull_request events
-- Framework section idempotency: appendFrameworkSection() is no-op if framework marker already exists (e.g., <!-- harness:framework-conventions:fastapi -->); different frameworks can coexist
-- File extension stripping: .hbs extensions are stripped during rendering; pre-merge-brief.yml.hbs → pre-merge-brief.yml
-- No level-scaffold leakage: Named standalone templates (e.g., ci-pre-merge-brief) resolve only their own files, not base-level scaffolds like harness.config.json
-
 ## Interface Contract
 
 ```ts
@@ -47,9 +33,11 @@ import { HarnessConfigSchema } from '../../src/config/schema'
 import { appendFrameworkSection, buildFrameworkSection } from '../../src/templates/agents-append'
 import { TemplateContext, TemplateEngine } from '../../src/templates/engine'
 import { deepMergeJson, mergePackageJson } from '../../src/templates/merger'
-import { applyEcosystemAfterCreate, ensureHarnessGitignore } from '../../src/templates/post-write'
+import { applyEcosystemAfterCreate, ensureComprehensionSearchIgnore, ensureHarnessGitignore } from '../../src/templates/post-write'
 import { TemplateMetadataSchema } from '../../src/templates/schema'
+import { COMPREHENSION_ROOT } from '@harness-engineering/core'
 import * as fs from 'fs'
+import { spawnSync } from 'node:child_process'
 import * as os from 'os'
 import * as path from 'path'
 import { beforeEach, describe, expect, it } from 'vitest'

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,9 @@
+# harness: committed compiled-comprehension units
+# Committed compiled-comprehension shards under .harness/comprehension/ are TRACKED
+# on purpose (the LLM-free serve-time hash gate reads them from git), but that makes
+# them pollute raw text search — `rg <symbol>` / `grep -r` / editor code search would
+# otherwise double every hit across the source AND its unit summary. ripgrep, fd, and
+# ag honor this `.ignore` file and skip these patterns even for tracked files, hiding
+# the units from raw search WITHOUT untracking them from git (issue #1692). Delete the
+# line below if you deliberately want raw search to include the comprehension units.
+.harness/comprehension/

--- a/docs/changes/comprehension-units-search-pollution/provenance.json
+++ b/docs/changes/comprehension-units-search-pollution/provenance.json
@@ -1,0 +1,12 @@
+{
+  "issues": [1692],
+  "route": "bug",
+  "stages": ["debugging"],
+  "assumptions": [
+    "The fix must keep committed comprehension units TRACKED in git (the LLM-free serve-time hash gate reads them), so a `.gitignore` approach is out; `.ignore` (honored by ripgrep/fd/ag even for tracked files) is the search-layer mechanism the issue recommends.",
+    "A repo-root `.ignore` with `.harness/comprehension/` is the least-invasive fix: git, prettier, eslint, and vitest ignore `.ignore`, so only raw code-search tools are affected. Harness's own graph-scoped tools never ingest `.harness/`, so they are unaffected.",
+    "Wiring `ensureComprehensionSearchIgnore` into the same seams as `ensureHarnessGitignore` (CLI init, MCP init_project, and MCP server startup for existing projects) makes the fix portable to every adopter without touching the comprehension write/format path that sibling #1697 (PR #1720) changed, avoiding a same-region merge conflict.",
+    "The committed repo-root `.ignore` in this PR fixes THIS repo immediately (it will not re-run init); the wiring covers all future adopters."
+  ],
+  "reproducingTest": "packages/cli/tests/templates/post-write.test.ts"
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,6 +10,7 @@ import {
   persistToolingConfig,
   appendFrameworkAgents,
   ensureHarnessGitignore,
+  ensureComprehensionSearchIgnore,
   applyEcosystemAfterCreate,
 } from '../templates/post-write';
 import { logger } from '../output/logger';
@@ -191,6 +192,7 @@ async function scaffoldProject(
   persistToolingConfig(cwd, resolveResult.value, options.framework);
   appendFrameworkAgents(cwd, options.framework, language);
   ensureHarnessGitignore(cwd);
+  ensureComprehensionSearchIgnore(cwd);
 
   const eco = applyEcosystemAfterCreate(cwd, writeResult.value.written);
   if (eco.rewritten) {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -7,7 +7,10 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { resolveProjectConfig } from './utils/config-resolver.js';
-import { ensureHarnessGitignore } from '../templates/post-write.js';
+import {
+  ensureHarnessGitignore,
+  ensureComprehensionSearchIgnore,
+} from '../templates/post-write.js';
 import { applyInjectionGuard } from './middleware/injection-guard.js';
 import { applyCompaction } from './middleware/compaction.js';
 import { applyContextBudget } from './middleware/context-budget.js';
@@ -769,6 +772,9 @@ export function createHarnessServer(projectRoot?: string, toolFilter?: string[])
 
   // Ensure .harness/.gitignore exists for existing projects (not just new ones)
   ensureHarnessGitignore(resolvedRoot);
+  // Ensure the repo-root `.ignore` hides committed comprehension units from raw
+  // text search for existing projects too (issue #1692).
+  ensureComprehensionSearchIgnore(resolvedRoot);
 
   const { definitions, handlers } = buildFilteredTools(toolFilter);
 

--- a/packages/cli/src/mcp/tools/init.ts
+++ b/packages/cli/src/mcp/tools/init.ts
@@ -7,6 +7,7 @@ import {
   persistToolingConfig,
   appendFrameworkAgents,
   ensureHarnessGitignore,
+  ensureComprehensionSearchIgnore,
 } from '../../templates/post-write.js';
 import type { TemplateMetadata } from '../../templates/schema.js';
 
@@ -130,6 +131,7 @@ function scaffoldMcp(
     persistToolingConfig(safePath, resolveResult.value, i.framework);
     appendFrameworkAgents(safePath, i.framework, language);
     ensureHarnessGitignore(safePath);
+    ensureComprehensionSearchIgnore(safePath);
   }
 
   if (writeResult.ok && writeResult.value.skippedConfigs.length > 0) {

--- a/packages/cli/src/templates/post-write.ts
+++ b/packages/cli/src/templates/post-write.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { detectEcosystem, type Ecosystem } from '@harness-engineering/orchestrator';
+import { COMPREHENSION_ROOT } from '@harness-engineering/core';
 import type { ResolvedTemplate } from './engine.js';
 import { appendFrameworkSection } from './agents-append.js';
 
@@ -119,6 +120,55 @@ security/*
   if (missing.length > 0) {
     const prefix = existing.endsWith('\n') ? '' : '\n';
     fs.appendFileSync(gitignorePath, prefix + missing.join('\n') + '\n');
+  }
+}
+
+/** Marker line prefixed to the harness-managed block in the repo-root `.ignore`. */
+const SEARCH_IGNORE_MARKER = '# harness: committed compiled-comprehension units';
+
+/** The single ignore pattern that excludes the committed comprehension shard tree. */
+const COMPREHENSION_SEARCH_IGNORE_PATTERN = `${COMPREHENSION_ROOT}/`;
+
+/**
+ * Ensure a repo-root `.ignore` excludes the committed compiled-comprehension shard
+ * tree (`.harness/comprehension/`) from raw text/file search (issue #1692).
+ *
+ * The units are TRACKED on purpose (the LLM-free serve-time hash gate needs them
+ * committed), but that makes them show up in `rg` / `grep -r` / editor code search,
+ * doubling hits on any symbol that appears in both the source and its unit's
+ * summary/interface-contract — ironic for a context-reduction feature. Ripgrep,
+ * `fd`, and `ag` all honor a `.ignore` file and skip its patterns EVEN for tracked
+ * files, so a `.harness/comprehension/` entry there hides the units from raw search
+ * WITHOUT untracking them from git. Harness's own graph-scoped tools never ingest
+ * `.harness/`, so they are unaffected.
+ *
+ * `.ignore` (not `.gitignore`) is deliberate: `.gitignore` would untrack the units
+ * and break the serve-time gate. `.ignore` is a search-layer concern only.
+ *
+ * Never throws — a read/write failure degrades to a no-op so scaffolding never fails
+ * on this advisory step. Preserves user customizations: creates the file when absent,
+ * otherwise appends the pattern only when it is not already present.
+ */
+export function ensureComprehensionSearchIgnore(targetDir: string): void {
+  try {
+    const ignorePath = path.join(targetDir, '.ignore');
+    const block = `${SEARCH_IGNORE_MARKER}\n${COMPREHENSION_SEARCH_IGNORE_PATTERN}\n`;
+
+    if (!fs.existsSync(ignorePath)) {
+      fs.writeFileSync(ignorePath, block);
+      return;
+    }
+
+    const existing = fs.readFileSync(ignorePath, 'utf8');
+    const present = existing
+      .split('\n')
+      .some((l) => l.trim() === COMPREHENSION_SEARCH_IGNORE_PATTERN);
+    if (present) return;
+
+    const prefix = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+    fs.appendFileSync(ignorePath, prefix + block);
+  } catch {
+    // Advisory step — a read/write/permission failure must never fail scaffolding.
   }
 }
 

--- a/packages/cli/tests/templates/post-write.test.ts
+++ b/packages/cli/tests/templates/post-write.test.ts
@@ -1,7 +1,22 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { ensureHarnessGitignore, applyEcosystemAfterCreate } from '../../src/templates/post-write';
+import { spawnSync } from 'node:child_process';
+import {
+  ensureHarnessGitignore,
+  ensureComprehensionSearchIgnore,
+  applyEcosystemAfterCreate,
+} from '../../src/templates/post-write';
+import { COMPREHENSION_ROOT } from '@harness-engineering/core';
+
+/** Whether `rg` (ripgrep) is on PATH — the true-repro assertions need it. */
+function ripgrepAvailable(): boolean {
+  try {
+    return spawnSync('rg', ['--version'], { stdio: 'ignore' }).status === 0;
+  } catch {
+    return false;
+  }
+}
 
 describe('ensureHarnessGitignore', () => {
   let tmpDir: string;
@@ -122,6 +137,113 @@ describe('ensureHarnessGitignore', () => {
     expect(lines).toContain('craft/');
     expect(lines).toContain('spill/');
     expect(lines).toContain('tokens.json*');
+  });
+});
+
+// Issue #1692: committed compiled-comprehension units are TRACKED (so the LLM-free
+// serve-time hash gate can read them) but that makes them pollute raw text search —
+// `rg <symbol>` doubles hits across the source AND the unit's summary. A repo-root
+// `.ignore` excludes the shard tree from ripgrep/fd/ag WITHOUT untracking it.
+describe('ensureComprehensionSearchIgnore (issue #1692)', () => {
+  let tmpDir: string;
+  const pattern = `${COMPREHENSION_ROOT}/`;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-search-ignore-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Lay down a source file + a committed comprehension unit that share a symbol. */
+  function seedRepoWithSharedSymbol(symbol: string): { src: string; unit: string } {
+    const src = path.join(tmpDir, 'src', 'widget.ts');
+    fs.mkdirSync(path.dirname(src), { recursive: true });
+    fs.writeFileSync(src, `export function ${symbol}() {\n  return 42;\n}\n`);
+
+    const unit = path.join(tmpDir, COMPREHENSION_ROOT, 'src', '_module.md');
+    fs.mkdirSync(path.dirname(unit), { recursive: true });
+    fs.writeFileSync(unit, `# src\n\nInterface contract: \`${symbol}\` returns a widget.\n`);
+    return { src, unit };
+  }
+
+  it('creates a repo-root .ignore excluding the comprehension shard tree', () => {
+    ensureComprehensionSearchIgnore(tmpDir);
+    const ignorePath = path.join(tmpDir, '.ignore');
+    expect(fs.existsSync(ignorePath)).toBe(true);
+    const lines = fs.readFileSync(ignorePath, 'utf8').split(/\r?\n/);
+    expect(lines).toContain(pattern);
+  });
+
+  // The core reproduction. The units live under a HIDDEN dir (`.harness/`), which
+  // ripgrep skips by default — but the tracked tree is still reached by `grep -r`,
+  // by editor / GitHub code search, and by `rg --hidden`, all of which descend into
+  // tracked dotfiles. `rg --hidden` is the faithful stand-in here: a shared symbol
+  // matches BOTH files before the fix (pollution) and ONLY the source after it,
+  // because `.ignore` filters the tree even when the hidden-file filter is disabled.
+  // The unit stays on disk (still committable for the serve-time hash gate).
+  (ripgrepAvailable() ? it : it.skip)(
+    'hides committed units from ripgrep (--hidden) while keeping them on disk',
+    () => {
+      const symbol = 'assembleWidgetZZ';
+      const { unit } = seedRepoWithSharedSymbol(symbol);
+
+      const rgFiles = (): string[] => {
+        const res = spawnSync('rg', ['--hidden', '-l', symbol, '.'], {
+          cwd: tmpDir,
+          encoding: 'utf8',
+        });
+        return (res.stdout ?? '')
+          .split(/\r?\n/)
+          .map((l) => l.replace(/^\.[/\\]/, '').replaceAll('\\', '/'))
+          .filter(Boolean)
+          .sort();
+      };
+
+      // Before the fix: the tracked unit pollutes raw search (both files match).
+      const before = rgFiles();
+      expect(before).toContain(`${COMPREHENSION_ROOT}/src/_module.md`);
+      expect(before).toContain('src/widget.ts');
+
+      ensureComprehensionSearchIgnore(tmpDir);
+
+      // After the fix: only the real source matches; the unit is filtered out.
+      const after = rgFiles();
+      expect(after).toContain('src/widget.ts');
+      expect(after).not.toContain(`${COMPREHENSION_ROOT}/src/_module.md`);
+
+      // The unit is untouched on disk — the fix is search-layer only, never `.gitignore`.
+      expect(fs.existsSync(unit)).toBe(true);
+    }
+  );
+
+  it('does not untrack units via .gitignore (search-layer only)', () => {
+    ensureComprehensionSearchIgnore(tmpDir);
+    // No root .gitignore is created, and no .harness/.gitignore entry for the tree.
+    expect(fs.existsSync(path.join(tmpDir, '.gitignore'))).toBe(false);
+  });
+
+  it('appends to an existing .ignore, preserving custom entries, without duplicating', () => {
+    const ignorePath = path.join(tmpDir, '.ignore');
+    fs.writeFileSync(ignorePath, 'dist/\nmy-scratch-notes/\n');
+
+    ensureComprehensionSearchIgnore(tmpDir);
+    ensureComprehensionSearchIgnore(tmpDir); // idempotent — second call is a no-op
+
+    const lines = fs.readFileSync(ignorePath, 'utf8').split(/\r?\n/);
+    expect(lines).toContain('dist/');
+    expect(lines).toContain('my-scratch-notes/');
+    expect(lines.filter((l) => l === pattern)).toHaveLength(1);
+  });
+
+  it('is a no-op when the pattern is already present', () => {
+    const ignorePath = path.join(tmpDir, '.ignore');
+    fs.writeFileSync(ignorePath, `${pattern}\n`);
+    const before = fs.readFileSync(ignorePath, 'utf8');
+
+    ensureComprehensionSearchIgnore(tmpDir);
+    expect(fs.readFileSync(ignorePath, 'utf8')).toBe(before);
   });
 });
 


### PR DESCRIPTION
## Summary

Committed compiled-comprehension shards under `.harness/comprehension/**/_module.md` are TRACKED on purpose (the LLM-free serve-time hash gate reads them from git), but that makes them pollute raw text/file search — `grep -r`, `rg --hidden`, and editor / GitHub code search descend into the tracked hidden tree and match a symbol in BOTH the source and its unit's summary, doubling hits (ironic for a context-reduction feature). A raw hit also bypasses the serve-time hash gate, so it could surface a stale summary.

## Fix

A repo-root `.ignore` entry (`.harness/comprehension/`) excludes the shard tree from ripgrep / `fd` / `ag`, which honor `.ignore` **even for tracked files**, WITHOUT untracking the units from git — so the serve-time gate is fully preserved. This is a **search-layer-only** change: it never touches `.gitignore`.

- New `ensureComprehensionSearchIgnore(targetDir)` in `templates/post-write.ts`, co-located with `ensureHarnessGitignore` and modeled on it (create-or-append, idempotent, never throws).
- Wired into the same seams: CLI `harness init`, MCP `init_project`, and MCP server startup (so existing projects get it too).
- A committed repo-root `.ignore` fixes THIS repo immediately (it will not re-run init).
- Adopters preferring `storage: "cache"` (gitignored) already sidestep the issue.

## Reproducing test

`packages/cli/tests/templates/post-write.test.ts` drives **real ripgrep** (`--hidden`, the faithful stand-in for grep/editor/GitHub search over the tracked hidden tree): a shared symbol matches both the source and the committed unit **before** the fix and only the source **after**, while the unit stays on disk. Verified fail-before (3 tests fail with a stubbed no-op, including the rg repro) / pass-after (19/19). Skips gracefully where `rg` is absent, backed by deterministic mechanism assertions.

## Merge-order note

Based on `origin/main` (does NOT contain sibling #1697 / PR #1720). This PR stays entirely in the SERVE / text-search region and does NOT edit the comprehension write/format path (`comprehend.ts` / `formatCompiledUnits`) that #1697 changed. The only overlap is the pre-commit-hook-refreshed `.harness/comprehension/packages/cli/src/commands/_module.md` shard, which the `merge=comprehension` git driver (ADR 0109 slice 5) auto-resolves by recompiling from the merged source.

## Assumptions made

- Keeping units TRACKED is a hard constraint (serve-time hash gate), so `.gitignore` is out; `.ignore` is the search-layer mechanism the issue recommends.
- A repo-root `.ignore` is least-invasive: git, prettier, eslint, and vitest all ignore `.ignore`; only raw code-search tools are affected; harness graph-scoped tools never ingest `.harness/`.
- Wiring alongside `ensureHarnessGitignore` makes the fix portable to every adopter without touching the #1697 write/format region.

Closes #1692