### PR TITLE
fix(fleet): isolate lane user-global ~/.claude state via per-lane CLAUDE_CONFIG_DIR (#1299)

### DIFF
--- a/.changeset/worktree-lane-claude-config-isolation.md
+++ b/.changeset/worktree-lane-claude-config-isolation.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/burn': patch
+'@harness-engineering/core': patch
+'@harness-engineering/orchestrator': patch
+---
+
+fleet: extend a build lane's isolation boundary beyond the git worktree to user-global `~/.claude` state via a per-lane `CLAUDE_CONFIG_DIR` config-dir override (#1299, ADR 0098).
+
+- `@harness-engineering/core` adds a pure primitive `fleet/lane-state-isolation.ts` (`buildLaneStateEnvOverride` / `applyLaneStateEnv` / `resolveLaneClaudeConfigDir`) that redirects `~/.claude` into a sandbox under the worktree's gitignored `.harness/lane-state/`.
+- `@harness-engineering/burn` `resolvePaths()` now derives the HUD store base from `CLAUDE_CONFIG_DIR` before falling back to `$HOME/.claude`, so a lane's HUD verification writes land in its sandbox instead of the operator's real store. Explicit `CLAUDE_HUD_*` overrides still win.
+- `@harness-engineering/orchestrator` `buildSubprocessEnv` gains a `laneStateScope` option applying the override; `ClaudeBackend` threads it in, opt-in via `laneStateIsolation` / the `HARNESS_LANE_STATE_ISOLATION` flag (off by default so a normal single-run agent keeps its real login/credentials).

--- a/.harness/comprehension/packages/burn/src/_module.md
+++ b/.harness/comprehension/packages/burn/src/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/burn/src'
-sourceHash: '7cb81e7d62c032ecf166a9c901586e79f6721884339a404300d45786b626f601'
-compiledAt: '2026-08-28T01:22:08.701Z'
+sourceHash: 'de6f46148b24da899c9efbd33e4192876e2e63b2b4a41d85a4d5aaefe907ee50'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'config.ts',
@@ -27,25 +26,6 @@ members:
     'window.ts',
   ]
 ---
-
-## Summary
-
-The `burn` package tracks API token usage across Claude Code fleet runs, projects spend against budgets, and links cost to shipped work (merged PRs). It replaces a Python HUD with a Node implementation using fault-tolerant atomic writes, cross-process locking, and timezone-aware week arithmetic. The module exports snake_cased JSON shapes for backward compatibility and maintains two orthogonal spend views (by skill, by agent type) that reconcile to a single total.
-
-## Invariants
-
-- Atomic writes (temp→rename) prevent data loss on concurrent or crashed writes
-- Cross-process lock via atomic mkdir + staleness reclaim prevents concurrent scan races
-- Config parse failures silently fall back to defaults; a broken config cannot crash the HUD
-- Store version compatibility must be checked before upgrade to prevent silent corruption
-- Week reset timezone arithmetic must exactly match /usage; weekday 0=Mon..6=Sun
-- Non-skill labels (main, unattributed, pre-migration) are never cost-per-PR candidates
-- Cost attribution keys on laneId match in both fleet record and provenance entry
-- Price lookup defaults to 0 USD for missing models; incomplete pricing is surfaced
-- Projection escalation is confidence-weighted; low-confidence forecasts cap at OK status
-- Degradation flag fires only on current-week unattributed subagent spend
-- Window bounds accept NaN for unbounded (no limit) time windows
-- LinkResult.ok=false means gh CLI failed; entry treated as unlinked, not zero-PRs
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/burn/tests/_module.md
+++ b/.harness/comprehension/packages/burn/tests/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/burn/tests'
-sourceHash: 'e4bb840f6cade708ebc7d59761300cc6baf4760193b25351a260e75e703d90bb'
-compiledAt: '2026-08-28T01:22:08.700Z'
+sourceHash: '2ccdcad3ef4e4fb09de88e0303160aad953f74f5105facf2a7f83d74bd7e685a'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'bin-startup.test.ts',
@@ -16,6 +15,7 @@ members:
     'cost-per-pr.test.ts',
     'helpers.ts',
     'hooks.test.ts',
+    'lane-isolation.test.ts',
     'pr-linkage.test.ts',
     'provenance.test.ts',
     'robustness.test.ts',
@@ -28,19 +28,6 @@ members:
     'summary-rollup.test.ts',
   ]
 ---
-
-## Summary
-
-packages/burn/tests is the test suite for the burn HUD, a token-cost and budget-management tool that tracks LLM spend across a week, forecasts remaining capacity, and escalates alarms. The tests verify four critical concerns: (1) binary performance—the harness-burn-hud CLI must stay fast (< 8× bare node startup) by bundling all dependencies; (2) budget and escalation logic—spend is fact (escalates immediately), forecasts are evidence (gain confidence over the week), with early-week alerts suppressing noise while still catching real overspend; (3) calibration lifecycle—calibrations expire and lose validity; (4) concurrent store safety—atomic writes and process-level locking prevent corruption when multiple agents update the spend record simultaneously. The suite uses makeHud() to set up isolated temporary filesystems, then drives the binary and library functions through realistic scenarios.
-
-## Invariants
-
-- No harness imports in binary — any @harness-engineering/\* import triggers a startup regression that breaks the statusline UX silently
-- Noise suppression is asymmetric — early-week spend < 15% of week should never escalate; but spending 100% of budget early still escalates immediately (incurred spend is a fact)
-- Forecast shrinkage toward baseline — when confidence is low, pulled forecast sits between linear extrapolation and prior-week median to avoid chasing spurious trends
-- Per-model limits are hard constraints — a model can exhaust while pooled budget looks safe; exhaustion escalates independently
-- Calibration validity gates reporting — expired calibrations must flag explicitly; fresh ones report days-until-expiry
-- Atomic writes under concurrency — locking via withScanLock ensures transcript appends and store updates don't corrupt across parallel agent runs
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/core/src/fleet/_module.md
+++ b/.harness/comprehension/packages/core/src/fleet/_module.md
@@ -1,25 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/fleet'
-sourceHash: 'ba21fc0f4e4d1e0b87df798ca16269e7114589c18e25aee415388d5a69f524f8'
-compiledAt: '2026-08-28T01:22:10.385Z'
+sourceHash: '1530bc311d4228e6fee509e8d783e0de5e205b2e6832cf46289d4a2680080f9b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['index.ts']
+model: null
+semantic: absent
+members: ['index.ts', 'lane-state-isolation.test.ts', 'lane-state-isolation.ts']
 ---
-
-## Summary
-
-The `fleet` module provides cross-run coordination primitives for managing resource constraints and fan-out during multi-run orchestration. It exports four subsystems: Claims (foundational lease/claim mechanism), Context Budget (per-leaf context-replay budget enforcement to prevent single nodes from overrunning budgets), Rate Budget (per-resource fan-out rate-limiting to cap concurrent work), and Spend Budget (shared spend-envelope decision primitive consulted by both orchestrator engine loop and skill/fleet-command dispatch). This is the load-bearing plumbing that keeps fleet runs from overrunning token budgets or hammering downstream APIs.
-
-## Invariants
-
-- Spend-budget is the single gate: orchestrator engine loop (#1525) and fleet-command dispatch (#1600) must both consult spend-budget before dispatching further work; it is the authoritative spend envelope
-- Context-budget is per-leaf, not global: each orchestrator node has its own context-replay budget (#1524); runs can coexist without sharing a single pool
-- Rate-budget is per-resource: fan-out across a specific resource is rate-limited independently from spend (#1532)
-- Claims are the foundation: lease/claim primitives underpin everything else; without them, concurrent runs collide on resource allocation
-- Index re-exports all four: the module's contract is to export all four subsystems; downstream code accesses them via @harness-engineering/core/fleet
 
 ## Interface Contract
 
@@ -30,5 +17,7 @@ export *
 ## Dependency Slice
 
 ```
-
+import { LANE_STATE_DIRNAME, applyLaneStateEnv, buildLaneStateEnvOverride, resolveLaneClaudeConfigDir, resolveLaneStateDir } from './lane-state-isolation'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
 ```

--- a/.harness/comprehension/packages/orchestrator/src/agent/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/agent/_module.md
@@ -1,28 +1,63 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/agent"
-sourceHash: "690ac7311a1629604330b471e92b1e5f405b13c04df751eff6de141922cdd6fc"
-compiledAt: "2026-08-28T01:22:12.315Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["adaptive-router.budget-terminal.test.ts", "adaptive-router.default-off.test.ts", "adaptive-router.live-classify.test.ts", "adaptive-router.phase5.test.ts", "adaptive-router.privacy-boundary.test.ts", "adaptive-router.privacy-terminal.test.ts", "adaptive-router.spend.test.ts", "adaptive-router.status.test.ts", "adaptive-router.test.ts", "adaptive-router.ts", "analysis-env.ts", "analysis-provider-factory.ts", "backend-factory.ts", "backend-resolver.test.ts", "backend-resolver.ts", "backend-router.ts", "brainstorm-wiring.test.ts", "brainstorm-wiring.ts", "capability-registry.test.ts", "capability-registry.ts", "complexity-request.test.ts", "complexity-request.ts", "config-migration.ts", "cost-estimator.test.ts", "cost-estimator.ts", "escalation-outcome.test.ts", "escalation-state.test.ts", "escalation-state.ts", "harness-fit-runner.composition.test.ts", "harness-fit-runner.test.ts", "harness-fit-runner.ts", "intelligence-factory.ts", "live-classify.test.ts", "live-classify.ts", "local-model-resolver.ts", "orchestrator-backend-factory.ts", "quality-verdict.test.ts", "quality-verdict.ts", "runner.ts", "subprocess-env.test.ts", "subprocess-env.ts", "triage-mark.test.ts", "triage-mark.ts", "triage-outcome.test.ts", "triage-outcome.ts", "triage-skill-mapping.ts", "triage-wiring.test.ts", "triage-wiring.ts", "use-case-builder.ts"]
+module: 'packages/orchestrator/src/agent'
+sourceHash: '5ae6f45ea32e1db96d6f8f5c651ebc643bc51fd18c9708d35118c26bc1d11001'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'adaptive-router.budget-terminal.test.ts',
+    'adaptive-router.default-off.test.ts',
+    'adaptive-router.live-classify.test.ts',
+    'adaptive-router.phase5.test.ts',
+    'adaptive-router.privacy-boundary.test.ts',
+    'adaptive-router.privacy-terminal.test.ts',
+    'adaptive-router.spend.test.ts',
+    'adaptive-router.status.test.ts',
+    'adaptive-router.test.ts',
+    'adaptive-router.ts',
+    'analysis-env.ts',
+    'analysis-provider-factory.ts',
+    'backend-factory.ts',
+    'backend-resolver.test.ts',
+    'backend-resolver.ts',
+    'backend-router.ts',
+    'brainstorm-wiring.test.ts',
+    'brainstorm-wiring.ts',
+    'capability-registry.test.ts',
+    'capability-registry.ts',
+    'complexity-request.test.ts',
+    'complexity-request.ts',
+    'config-migration.ts',
+    'cost-estimator.test.ts',
+    'cost-estimator.ts',
+    'escalation-outcome.test.ts',
+    'escalation-state.test.ts',
+    'escalation-state.ts',
+    'harness-fit-runner.composition.test.ts',
+    'harness-fit-runner.test.ts',
+    'harness-fit-runner.ts',
+    'intelligence-factory.ts',
+    'live-classify.test.ts',
+    'live-classify.ts',
+    'local-model-resolver.ts',
+    'orchestrator-backend-factory.ts',
+    'quality-verdict.test.ts',
+    'quality-verdict.ts',
+    'runner.ts',
+    'subprocess-env.test.ts',
+    'subprocess-env.ts',
+    'triage-mark.test.ts',
+    'triage-mark.ts',
+    'triage-outcome.test.ts',
+    'triage-outcome.ts',
+    'triage-skill-mapping.ts',
+    'triage-wiring.test.ts',
+    'triage-wiring.ts',
+    'use-case-builder.ts',
+  ]
 ---
-
-## Summary
-
-`packages/orchestrator/src/agent` is the intelligent routing and execution layer for the orchestrator. It decides which backend and tier to use for a given task, executes agents against those backends, and evaluates output quality. The module splits into five concerns: (1) **Backend Resolution** via `AdaptiveRouter` and `BackendRouter` — routes work to Claude, OpenAI, Gemini, Ollama, or local models based on cost/privacy/capability constraints; (2) **Agent Execution** via `AgentRunner` and `HarnessFitProbeRunner` — manages backend session lifecycle and turn management; (3) **Intelligent Classification** via `triageIssue` and `classify` — analyzes issues to predict work type and tier, building LLM-backed analysis providers; (4) **Quality Verdicts** via `hasIntroducedSecurityDefect` and `parseIntroducedHunks` — post-execution security and code scanning; (5) **Spec Wiring** via `brainstormInputFromIssue` and `runBrainstormForIssue` — converts issues to reasoning prompts and executes specification generation.
-
-## Invariants
-
-- Budget exhaustion is terminal, not a retry loop. When onBudgetExhausted='human', route() throws RoutingError('budget-exhausted'), surfaces ONE steward escalation, enqueues zero retries, and reaches terminal state immediately.
-- Default-off adopter-portability: with no routing.policy configured, AdaptiveRouter must NOT construct and dispatch resolution must be byte-identical to BackendRouter.
-- Privacy and budget fail-closed are terminal paths. Both surface steward escalation, no auto-retry, and drive units to terminal state without fallthrough to retry branches.
-- Per-phase backend routing enforced: design phase routes to thinking-enabled backends; execution phase routes to non-thinking coders (e.g. Codex). Split enforced via deriveAnalysisEnv + buildAnalysisProviderForLayer.
-- Environment variable allowlisting is mandatory. Subprocess spawns (local models, Docker, SSH) pass only allowlisted keys via isEnvKeyAllowed + buildSubprocessEnv to prevent credential leakage.
-- Analysis provider routing is config-aware. buildAnalysisProvider routes to correct provider (Anthropic, Claude CLI, OpenAI, OllamaBackend) based on backend config and execution layer. Mismatch breaks intelligence gates.
-- Local model normalization is stable. LocalModelResolver canonicalizes endpoint URIs and LocalModelStatus enum (ready, loading, failed, not-installed). Stale or mismatched status breaks pool dispatch.
-- Security defects block ship. hasIntroducedSecurityDefect + parseIntroducedHunks scan for introduced vulnerabilities; any defect surfaces via outcomeVerdictToQualityFail to block gates without explicit override.
 
 ## Interface Contract
 
@@ -33,6 +68,7 @@ export BRAINSTORM_RUBRIC
 export BackendRouter
 export EscalationState
 export HarnessFitProbeRunner
+export LANE_STATE_ISOLATION_VAR
 export LocalModelResolver
 export LocalModelStatus
 export OrchestratorBackendFactory
@@ -63,6 +99,7 @@ export enrichIssueWithSpec
 export estimateCost
 export hasIntroducedSecurityDefect
 export isEnvKeyAllowed
+export isLaneStateIsolationEnabled
 export isLocalEndpointBackend
 export isLocalExecutionBackend
 export layerOfPath
@@ -132,12 +169,12 @@ import { IntroducedHunk } from './quality-verdict.js'
 import { AgentRunner } from './runner.js'
 import { DockerRuntime } from './runtime/docker.js'
 import { createSecretBackend } from './secrets/index.js'
-import { SUBPROCESS_ENV_ALLOW_VAR, SUBPROCESS_ENV_PASSTHROUGH_VAR, buildSubprocessEnv, isEnvKeyAllowed } from './subprocess-env'
+import { LANE_STATE_ISOLATION_VAR, SUBPROCESS_ENV_ALLOW_VAR, SUBPROCESS_ENV_PASSTHROUGH_VAR, buildSubprocessEnv, isEnvKeyAllowed, isLaneStateIsolationEnabled } from './subprocess-env'
 import { TriageMarkItem, markApprovedForDispatch } from './triage-mark.js'
 import { buildTriageOutcomeInput, layerOfPath, precedentLookupFromStored, runRetrospective, signalsFromDiff } from './triage-outcome.js'
 import { resolveSkillForTriage } from './triage-skill-mapping'
 import { TriageWiringDeps, buildProbeInput, makeGraphScope, triageIssue } from './triage-wiring.js'
-import { CacheMetricsRecorder, FeatureMutation, RoadmapStore, SecurityScanner, eventSourcing, slugifyFeatureName } from '@harness-engineering/core'
+import { CacheMetricsRecorder, FeatureMutation, RoadmapStore, SecurityScanner, buildLaneStateEnvOverride, eventSourcing, slugifyFeatureName } from '@harness-engineering/core'
 import { CascadeSimulator, GraphNode, GraphStore } from '@harness-engineering/graph'
 import { AnalysisProvider, AnalysisResponse, AnthropicAnalysisProvider, BrainstormInput, BrainstormOutcome, ClassifyInput, ClaudeCliAnalysisProvider, ComplexitySignals, DEFAULT_DEGRADE_AT_PCT, Fork, ForkConfidence, ForkDecision, ForkGenerator, GoNoGoCandidate, GraphScope, IntelligencePipeline, OpenAICompatibleAnalysisProvider, OutcomeVerdict, PrecedentLookup, PrecedentRate, ProbeConfig, ProbeInput, RANK_TIER, RankableCandidate, ResolvedEntity, RetrospectiveComparison, RetrospectiveConfig, SpecDraft, TIER_RANK, TriagePrediction, TriageVerdict, aggregatePrecedent, classify, compareToPrediction, depthForLevel, deriveRequiredTier, dispatchableShapeKey, extractEntities, pilotScore, rankTriageCandidates, runAutoBrainstorm, runScopingProbe } from '@harness-engineering/intelligence'
 import { HarnessFitProbeTask, HarnessFitResult, HarnessFitRunner, PoolCandidateOptions, PoolStateProvider, RankProfile, poolStateToCandidates, scoreBuildQuality } from '@harness-engineering/local-models'
@@ -146,7 +183,7 @@ import * as childProcess, { execFile, execSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
-import * as path from 'node:path'
+import * as path, path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 ```

--- a/.harness/comprehension/packages/orchestrator/src/agent/backends/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/agent/backends/_module.md
@@ -1,27 +1,31 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/agent/backends"
-sourceHash: "3766dca9e6f6eaf8eb24afd277a738ed6f0ddb6c9c1985cc61ca67fed1dcb694"
-compiledAt: "2026-08-28T01:22:12.177Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["anthropic.ts", "claude.policy-envelope.test.ts", "claude.ts", "codex-agent-message.test.ts", "codex.policy-envelope.test.ts", "codex.test.ts", "codex.ts", "container.ts", "gemini.ts", "local.ts", "mock.ts", "ollama.ts", "openai.ts", "pi.ts", "serverless.ts", "ssh.ts"]
+module: 'packages/orchestrator/src/agent/backends'
+sourceHash: '2bc26b4ebac60fa269b5094e0be042bca76fb5781cc7a1adf0d217fad813434b'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'anthropic.ts',
+    'claude.lane-isolation.test.ts',
+    'claude.policy-envelope.test.ts',
+    'claude.ts',
+    'codex-agent-message.test.ts',
+    'codex.policy-envelope.test.ts',
+    'codex.test.ts',
+    'codex.ts',
+    'container.ts',
+    'gemini.ts',
+    'local.ts',
+    'mock.ts',
+    'ollama.ts',
+    'openai.ts',
+    'pi.ts',
+    'serverless.ts',
+    'ssh.ts',
+  ]
 ---
-
-## Summary
-
-This module provides a polymorphic backend layer for running agents across 11+ execution environments (Anthropic, Claude CLI, Codex, Gemini, Ollama, OpenAI, Pi, SSH, Container, OCI Serverless, Mock). Each backend implements a common `AgentBackend` interface with lifecycle methods: `startSession()`, `runTurn()` (async generator streaming events), and `stopSession()`. Backends translate provider-specific protocols (REST APIs, CLI spawns, MCP servers) into a normalized shape. The module includes governance plumbing to audit policy enforcement at spawn time, normalize token usage and cache metrics across providers, and parse subscription-limit notifications with fallback semantics.
-
-## Invariants
-
-- Backend contract is symmetric: all implementations must expose startSession | runTurn | stopSession | healthCheck; callers dispatch polymorphically by backendName.
-- Session identity is immutable: sessionId, backendName, startedAt, and workspacePath are set once and never mutated; all downstream usage tracking keys off sessionId.
-- Token usage must surface on yielded events: TurnResult.usage alone is dropped by async-generator consumers; usage must be yielded as a separate { type: 'usage', usage: {...} } event so the orchestrator advances rate-limit windows.
-- Policy audit stamps at spawn time before execution: PolicyAuditRecord is handed to the sink synchronously before subprocess runs; it records metadata and stripped env key names only (never values), so no secrets leak into audit logs even on failure.
-- Provider credentials are NOT stripped from env: ANTHROPIC_API_KEY, OPENAI_API_KEY etc. always pass to subprocess; only user-app secrets (DATABASE_URL, custom tokens) are withheld and named in the audit record.
-- Subscription-limit detection has fallback semantics: PRIMARY_LIMIT_RE is strict (captures reset time + timezone); looksLikeUnparsedLimit() catches format drift; fallback resolution returns { resolved: 'fallback', resetsAtMs: now + 1h } when timezone parse fails, and callers must surface the distinction.
-- Cache metrics are provider-agnostic: AnthropicCacheAdapter, GeminiCacheAdapter, and OpenAICacheAdapter normalize to common { cacheCreationTokens, cacheReadTokens } on TurnResult.usage.
 
 ## Interface Contract
 
@@ -53,7 +57,7 @@ export truncate
 ```
 import { BackendDefSchema } from '../../workflow/schema'
 import { createBackend, isLocalEndpointBackend, isLocalExecutionBackend } from '../backend-factory'
-import { buildSubprocessEnv } from '../subprocess-env.js'
+import { buildSubprocessEnv, isLaneStateIsolationEnabled } from '../subprocess-env.js'
 import { ClaudeBackend, PolicyAuditRecord } from './claude'
 import { PolicyAuditSink } from './claude.js'
 import { CodexBackend, buildMcpConfigArgs, extractCodexAgentMessage } from './codex'

--- a/docs/changes/worktree-lane-claude-config-isolation/provenance.json
+++ b/docs/changes/worktree-lane-claude-config-isolation/provenance.json
@@ -1,0 +1,7 @@
+{
+  "issues": [1299],
+  "route": "bug",
+  "stages": ["debugging"],
+  "assumptions": ["F1=b per-lane CLAUDE_CONFIG_DIR/HOME override"],
+  "reproducingTest": "packages/burn/tests/lane-isolation.test.ts"
+}

--- a/docs/knowledge/decisions/0098-worktree-isolation-user-global-state.md
+++ b/docs/knowledge/decisions/0098-worktree-isolation-user-global-state.md
@@ -2,10 +2,21 @@
 number: 0098
 title: The worktree isolation boundary vs user-global state
 date: 2026-08-18
-status: proposed
+status: accepted
 tier: medium
 source: 'design routing of bug-backlog issue #1299'
 ---
+
+> **Implemented (#1299).** The chosen per-lane override is **`CLAUDE_CONFIG_DIR`** — Claude
+> Code's own config-dir relocation var, honored natively by Claude Code and now by the
+> harness's own user-global writers (`packages/burn/src/config.ts` `resolvePaths()` derives
+> its HUD store from `CLAUDE_CONFIG_DIR` before `$HOME/.claude`). The pure primitive lives in
+> `@harness-engineering/core` (`fleet/lane-state-isolation.ts`: `buildLaneStateEnvOverride` /
+> `applyLaneStateEnv`, sandbox under the worktree's gitignored `.harness/lane-state/`); the
+> orchestrator subprocess air-gap applies it via `buildSubprocessEnv({ laneStateScope })`, and
+> the `ClaudeBackend` threads it in (opt-in via `laneStateIsolation` / the
+> `HARNESS_LANE_STATE_ISOLATION` flag, OFF by default so a normal single-run agent keeps its
+> real login/credentials). `docs/reference/fleet-family.md` states the contract.
 
 ## Context
 

--- a/docs/reference/fleet-family.md
+++ b/docs/reference/fleet-family.md
@@ -181,6 +181,18 @@ The concurrency governor caps _how many_ leaves run at once and the per-leaf con
 
 **Provenance.** The envelope in force and the per-lane spend consulted are recorded in the run's assumptions-made / budget-accounting note, alongside the slot allocation (`--concurrency`) the lane was dispatched with.
 
+## The lane isolation boundary (repo _and_ user-global state)
+
+The fan-out gives each lane its own **git worktree** so lanes cannot collide, and it is that isolation guarantee which lets a fleet run N lanes concurrently _without reasoning about interference between them_. But a git worktree isolates exactly **one** thing: the repository working tree. It does **not** isolate the process's `$HOME`, its XDG dirs, or `~/.claude/`. A lane whose feature — or whose **verification run** — exercises a code path that writes **user-global state** writes straight through the worktree boundary to the operator's real, live state. (This is not hypothetical: a `roadmap-fleet` lane's `burn` verification once rewrote the operator's live `~/.claude/hud/state/summary.json`; see #1299.)
+
+**Lane isolation therefore covers repo _and_ user-global state — the worktree alone is not the boundary.** A lane is isolated only when neither its execution nor its verification can reach the operator's real `~/.claude`. The worktree covers the repo; a **per-lane config-dir env override covers everything the worktree does not**, and the two together are "lane isolation."
+
+- **Mechanism — a per-lane `CLAUDE_CONFIG_DIR`.** For the duration of a lane, redirect `~/.claude` into a sandbox under the lane's own worktree by setting `CLAUDE_CONFIG_DIR` in the environment the lane and its child processes inherit (`@harness-engineering/core`'s `buildLaneStateEnvOverride(worktreePath)` computes the value; the sandbox lives under the worktree's gitignored `.harness/lane-state/`). One generic override isolates **every** writer that honors it at once, rather than teaching each user-global writer about workspaces one at a time. Claude Code honors `CLAUDE_CONFIG_DIR` natively; the harness's own state-writers honor it too (e.g. `burn`'s `resolvePaths()` derives its HUD store from `CLAUDE_CONFIG_DIR` before falling back to `$HOME/.claude`).
+- **The override must be in force for VERIFY as well as DISPATCH.** The incident's write came from a _verification_ run — the phase that exercises the built code against real writers is exactly where the boundary must hold.
+- **A user-global writer that hardcodes `homedir()` instead of reading the override escapes the sandbox silently.** Closing the hole fully means holding writers to honoring `CLAUDE_CONFIG_DIR`; any writer that ignores it is a latent leak.
+
+The canonical statement is **ADR 0098** — members reference it rather than restate it.
+
 ## The worktree push-path caveat
 
 A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
@@ -246,5 +258,6 @@ The authority model behind those five — coordinator plus global governor, neve
 - **ADR 0089** — The `pr-fleet` land-stage human-merge-gate model.
 - **ADR 0090** — The `adr-fleet` decide-stage batch-sign-off-gate model.
 - **ADR 0091** — The `fleet-command` conductor-tier authority model (coordinator + global governor above the members).
+- **ADR 0098** — The lane isolation boundary extends beyond the git worktree to user-global state, via a per-lane `CLAUDE_CONFIG_DIR` config-dir override.
 - **ADR 0103** — Item-type routing for build-shaped members (`roadmap-fleet`, `security-fleet` route bug/spec-ready/feature items to `debugging` / `autopilot` / `brainstorming`→`autopilot`).
 - **ADR 0105** — Cross-run advisory work-claim lease for the ID-based members (soft-reservation GitHub-backed lease bridging the `SELECT → PR-open` window; why not an exactly-once CAS lock).

--- a/packages/burn/src/config.ts
+++ b/packages/burn/src/config.ts
@@ -25,9 +25,18 @@ export interface BurnPaths {
 
 export function resolvePaths(env: NodeJS.ProcessEnv = process.env): BurnPaths {
   const home = env.HOME || homedir();
-  const hud = env.CLAUDE_HUD_HOME || path.join(home, '.claude', 'hud');
+  // The `~/.claude` base honors `CLAUDE_CONFIG_DIR` (Claude Code's own config-dir
+  // relocation var) before falling back to `$HOME/.claude`. This is what lets a
+  // `-fleet` build lane redirect the HUD store into its per-lane worktree sandbox
+  // instead of the operator's real, live store: the lane sets a per-lane
+  // `CLAUDE_CONFIG_DIR` and every HUD path below derives from it. Without this,
+  // burn keyed off `$HOME` alone and a lane's verification run wrote straight
+  // through the worktree isolation boundary to `~/.claude/hud/` (issue #1299 /
+  // ADR 0098). The explicit `CLAUDE_HUD_*` vars still win over the derived base.
+  const claudeDir = env.CLAUDE_CONFIG_DIR || path.join(home, '.claude');
+  const hud = env.CLAUDE_HUD_HOME || path.join(claudeDir, 'hud');
   const state = env.CLAUDE_HUD_STATE || path.join(hud, 'state');
-  const projects = env.CLAUDE_HUD_PROJECTS || path.join(home, '.claude', 'projects');
+  const projects = env.CLAUDE_HUD_PROJECTS || path.join(claudeDir, 'projects');
   return {
     hud,
     state,

--- a/packages/burn/tests/lane-isolation.test.ts
+++ b/packages/burn/tests/lane-isolation.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression: a `-fleet` build lane must not write the HUD store through the
+ * worktree isolation boundary to the operator's real `~/.claude/hud/` (#1299).
+ *
+ * A lane redirects user-global state by setting a per-lane `CLAUDE_CONFIG_DIR`
+ * (ADR 0098). `resolvePaths()` must honor that override so every HUD path lands
+ * inside the lane's sandbox instead of `$HOME/.claude`.
+ *
+ * BEFORE the fix `resolvePaths()` keyed the HUD base off `$HOME` alone and
+ * ignored `CLAUDE_CONFIG_DIR`, so a lane's verification run wrote straight to
+ * the operator's live `~/.claude/hud/state/summary.json` — the exact incident
+ * that opened #1299. The "redirects ... into a per-lane CLAUDE_CONFIG_DIR" case
+ * below fails before the fix and passes after.
+ */
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolvePaths } from '../src/config';
+
+// The per-lane sandbox path @harness-engineering/core's
+// `resolveLaneClaudeConfigDir()` produces for a worktree. Inlined (not imported)
+// because `@harness-engineering/burn` is deliberately dependency-free; this test
+// asserts only burn-local behavior — that `resolvePaths()` honors whatever
+// `CLAUDE_CONFIG_DIR` a lane hands it.
+function laneClaudeConfigDir(worktree: string): string {
+  return path.join(worktree, '.harness', 'lane-state', '.claude');
+}
+
+describe('burn HUD path resolution — per-lane state isolation (#1299)', () => {
+  const realHome = path.join(path.sep, 'Users', 'operator');
+
+  it('falls back to $HOME/.claude when no CLAUDE_CONFIG_DIR is set', () => {
+    const paths = resolvePaths({ HOME: realHome });
+    expect(paths.summary).toBe(path.join(realHome, '.claude', 'hud', 'state', 'summary.json'));
+  });
+
+  it('redirects the HUD store into a per-lane CLAUDE_CONFIG_DIR (isolation boundary)', () => {
+    // A lane sandbox under its own (gitignored) worktree `.harness/` dir.
+    const worktree = path.join(path.sep, 'tmp', 'lane-worktree-abc');
+    const laneConfigDir = laneClaudeConfigDir(worktree);
+
+    const paths = resolvePaths({ HOME: realHome, CLAUDE_CONFIG_DIR: laneConfigDir });
+
+    // Every HUD artifact must land inside the lane sandbox ...
+    expect(paths.hud).toBe(path.join(laneConfigDir, 'hud'));
+    expect(paths.state).toBe(path.join(laneConfigDir, 'hud', 'state'));
+    expect(paths.summary).toBe(path.join(laneConfigDir, 'hud', 'state', 'summary.json'));
+    expect(paths.projects).toBe(path.join(laneConfigDir, 'projects'));
+    expect(paths.config).toBe(path.join(laneConfigDir, 'hud', 'config.json'));
+
+    // ... and NONE of it may touch the operator's real home.
+    for (const p of Object.values(paths)) {
+      expect(p.startsWith(path.join(realHome, '.claude'))).toBe(false);
+    }
+    expect(paths.summary.startsWith(worktree)).toBe(true);
+  });
+
+  it('still lets explicit CLAUDE_HUD_* vars win over the derived base', () => {
+    const explicitState = path.join(path.sep, 'tmp', 'explicit-state');
+    const paths = resolvePaths({
+      HOME: realHome,
+      CLAUDE_CONFIG_DIR: path.join(path.sep, 'tmp', 'lane', '.claude'),
+      CLAUDE_HUD_STATE: explicitState,
+    });
+    expect(paths.state).toBe(explicitState);
+    expect(paths.summary).toBe(path.join(explicitState, 'summary.json'));
+  });
+});

--- a/packages/core/src/fleet/index.ts
+++ b/packages/core/src/fleet/index.ts
@@ -7,3 +7,6 @@ export * from './rate-budget';
 // Shared spend-envelope decision primitive — consulted by BOTH the orchestrator
 // engine loop (#1525) and the skill/fleet-command dispatch path (#1600).
 export * from './spend-budget';
+// Per-lane user-global (~/.claude) state isolation — the config-dir env override
+// that extends a lane's worktree boundary to cover user-global state (#1299 / ADR 0098).
+export * from './lane-state-isolation';

--- a/packages/core/src/fleet/lane-state-isolation.test.ts
+++ b/packages/core/src/fleet/lane-state-isolation.test.ts
@@ -1,0 +1,51 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  LANE_STATE_DIRNAME,
+  applyLaneStateEnv,
+  buildLaneStateEnvOverride,
+  resolveLaneClaudeConfigDir,
+  resolveLaneStateDir,
+} from './lane-state-isolation';
+
+describe('lane-state-isolation (#1299 / ADR 0098)', () => {
+  const worktree = path.join(path.sep, 'tmp', 'wt', 'lane-42');
+
+  it('places the sandbox under the worktree gitignored .harness dir', () => {
+    expect(resolveLaneStateDir(worktree)).toBe(path.join(worktree, '.harness', LANE_STATE_DIRNAME));
+  });
+
+  it('resolves the per-lane CLAUDE_CONFIG_DIR inside the sandbox', () => {
+    expect(resolveLaneClaudeConfigDir(worktree)).toBe(
+      path.join(worktree, '.harness', LANE_STATE_DIRNAME, '.claude')
+    );
+  });
+
+  it('builds an override that redirects CLAUDE_CONFIG_DIR into the lane', () => {
+    const override = buildLaneStateEnvOverride(worktree);
+    expect(override).toEqual({ CLAUDE_CONFIG_DIR: resolveLaneClaudeConfigDir(worktree) });
+    expect(override.CLAUDE_CONFIG_DIR.startsWith(worktree)).toBe(true);
+  });
+
+  it('applies the override without mutating the base env, and wins over an inherited value', () => {
+    const base: NodeJS.ProcessEnv = {
+      HOME: '/Users/operator',
+      CLAUDE_CONFIG_DIR: '/Users/operator/.claude', // the operator's real store
+    };
+    const applied = applyLaneStateEnv(base, worktree);
+
+    // base is untouched (pure)
+    expect(base.CLAUDE_CONFIG_DIR).toBe('/Users/operator/.claude');
+    // the lane override wins so each lane gets its OWN sandbox
+    expect(applied.CLAUDE_CONFIG_DIR).toBe(resolveLaneClaudeConfigDir(worktree));
+    expect(applied.HOME).toBe('/Users/operator');
+  });
+
+  it('gives two different worktrees two disjoint sandboxes', () => {
+    const a = buildLaneStateEnvOverride(path.join(path.sep, 'tmp', 'wt', 'lane-a'));
+    const b = buildLaneStateEnvOverride(path.join(path.sep, 'tmp', 'wt', 'lane-b'));
+    expect(a.CLAUDE_CONFIG_DIR).not.toBe(b.CLAUDE_CONFIG_DIR);
+  });
+});

--- a/packages/core/src/fleet/lane-state-isolation.ts
+++ b/packages/core/src/fleet/lane-state-isolation.ts
@@ -1,0 +1,77 @@
+// packages/core/src/fleet/lane-state-isolation.ts
+//
+// Per-lane user-global state isolation (issue #1299, ADR 0098).
+//
+// A `-fleet` build lane runs in its own git worktree so its REPO writes cannot
+// collide with a sibling lane. But a git worktree isolates exactly one thing:
+// the repository working tree. It does NOT isolate the process's `$HOME` or
+// `~/.claude/`: a lane whose feature — or whose VERIFICATION run — exercises a
+// user-global writer writes straight through the worktree boundary to the
+// operator's real, live state. (#1299: a `roadmap-fleet` lane's `burn`
+// verification rewrote the operator's live `~/.claude/hud/state/summary.json`.)
+//
+// The fix is a per-lane CONFIG-DIR ENV OVERRIDE. Redirect the `~/.claude` config
+// dir into a sandbox under the lane's own worktree by setting `CLAUDE_CONFIG_DIR`
+// in the environment the lane and its child processes inherit. Every writer that
+// keys off `CLAUDE_CONFIG_DIR` — Claude Code itself, and the harness
+// state-writers taught to honor it (see `packages/burn/src/config.ts`) — then
+// lands inside the lane's sandbox instead of the operator's home. One generic
+// override isolates every such writer at once, rather than teaching each writer
+// about workspaces one at a time (ADR 0098 §2; the rejected per-tool alternative
+// re-opens the hole every time a new user-global writer is added).
+//
+// Pure: computes paths and an env delta. Performs no I/O and mutates nothing.
+
+import path from 'node:path';
+
+/**
+ * Directory name (under a worktree's gitignored `.harness/`) that holds a lane's
+ * sandboxed user-global state. Placing the sandbox under `.harness/` keeps it out
+ * of the lane's tracked tree, so it never dirties `git status` nor trips the
+ * whole-tree pre-push gates the fleet depends on.
+ */
+export const LANE_STATE_DIRNAME = 'lane-state';
+
+/** Resolve the per-lane state sandbox root for a worktree. */
+export function resolveLaneStateDir(worktreePath: string): string {
+  return path.join(worktreePath, '.harness', LANE_STATE_DIRNAME);
+}
+
+/**
+ * Resolve the per-lane `CLAUDE_CONFIG_DIR` — the sandboxed `~/.claude` equivalent
+ * a lane redirects its user-global config/state into.
+ */
+export function resolveLaneClaudeConfigDir(worktreePath: string): string {
+  return path.join(resolveLaneStateDir(worktreePath), '.claude');
+}
+
+/** The env-var overrides that redirect a lane's user-global state into its sandbox. */
+export interface LaneStateEnvOverride {
+  /** Claude Code's config-dir relocation var — moves `~/.claude` for the lane. */
+  CLAUDE_CONFIG_DIR: string;
+}
+
+/**
+ * Build the per-lane env override that redirects user-global (`~/.claude`) state
+ * into the lane's worktree sandbox. Merge it into the environment a lane and its
+ * child processes inherit — see {@link applyLaneStateEnv}.
+ */
+export function buildLaneStateEnvOverride(worktreePath: string): LaneStateEnvOverride {
+  return { CLAUDE_CONFIG_DIR: resolveLaneClaudeConfigDir(worktreePath) };
+}
+
+/**
+ * Apply the per-lane state override on top of a base environment, returning a
+ * NEW env (the base is never mutated).
+ *
+ * The lane override WINS over any inherited `CLAUDE_CONFIG_DIR`: each lane must
+ * get its OWN sandbox even when the parent process already relocated its config
+ * dir, otherwise two concurrent lanes would share one store — the very
+ * interference the worktree exists to prevent.
+ */
+export function applyLaneStateEnv(
+  base: NodeJS.ProcessEnv,
+  worktreePath: string
+): NodeJS.ProcessEnv {
+  return { ...base, ...buildLaneStateEnvOverride(worktreePath) };
+}

--- a/packages/orchestrator/src/agent/backends/claude.lane-isolation.test.ts
+++ b/packages/orchestrator/src/agent/backends/claude.lane-isolation.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { ClaudeBackend, type PolicyAuditRecord } from './claude';
+
+/**
+ * Wiring for per-lane user-global state isolation (#1299 / ADR 0098).
+ *
+ * The precise `CLAUDE_CONFIG_DIR` redirect that isolation performs is unit-tested
+ * against the pure builder in `subprocess-env.test.ts`; this file proves the
+ * ClaudeBackend actually THREADS the opt-in through to that builder — the option
+ * is read, the branch is taken when a workspace is present, and the spawn path
+ * still completes and audits cleanly. Spawns `process.execPath` (see
+ * `claude.policy-envelope.test.ts` for why) so the turn terminates at once.
+ */
+describe('ClaudeBackend — per-lane state isolation wiring', () => {
+  it('runs a turn with lane isolation enabled (opt-in via option) without breaking spawn', async () => {
+    const records: PolicyAuditRecord[] = [];
+    const backend = new ClaudeBackend(process.execPath, {
+      laneStateIsolation: true,
+      policyAudit: (r) => records.push(r),
+      envSource: { PATH: '/usr/bin', CLAUDE_CONFIG_DIR: '/home/agent/.claude' },
+    });
+    const started = await backend.startSession({
+      workspacePath: '/tmp',
+      permissionMode: 'full',
+    });
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+    for await (const _ of backend.runTurn(started.value, {
+      sessionId: started.value.sessionId,
+      prompt: 'x',
+      isContinuation: false,
+    })) {
+      void _;
+    }
+    // The lane-isolation branch executed and the audit stamp was still emitted.
+    expect(records).toHaveLength(1);
+    expect(records[0]!.enforced).toBe(true);
+  });
+
+  it('defaults the opt-in from the HARNESS_LANE_STATE_ISOLATION env flag', async () => {
+    const records: PolicyAuditRecord[] = [];
+    const backend = new ClaudeBackend(process.execPath, {
+      policyAudit: (r) => records.push(r),
+      envSource: { PATH: '/usr/bin', HARNESS_LANE_STATE_ISOLATION: '1' },
+    });
+    const started = await backend.startSession({
+      workspacePath: '/tmp',
+      permissionMode: 'full',
+    });
+    if (!started.ok) return;
+    for await (const _ of backend.runTurn(started.value, {
+      sessionId: started.value.sessionId,
+      prompt: 'x',
+      isContinuation: false,
+    })) {
+      void _;
+    }
+    expect(records).toHaveLength(1);
+  });
+});

--- a/packages/orchestrator/src/agent/backends/claude.ts
+++ b/packages/orchestrator/src/agent/backends/claude.ts
@@ -19,7 +19,7 @@ import type {
   PolicyNetworkMode,
 } from '@harness-engineering/types';
 import type { CacheMetricsRecorder } from '@harness-engineering/core';
-import { buildSubprocessEnv } from '../subprocess-env.js';
+import { buildSubprocessEnv, isLaneStateIsolationEnabled } from '../subprocess-env.js';
 
 /**
  * Governance record handed to a {@link ClaudeBackendOptions.policyAudit} sink at
@@ -441,6 +441,15 @@ export interface ClaudeBackendOptions {
   subprocessEnvAllow?: readonly string[];
   /** Test seam: override the env source read for the allowlist. Defaults to `process.env`. */
   envSource?: NodeJS.ProcessEnv;
+  /**
+   * Per-lane user-global state isolation. When true, and the session runs in a
+   * worktree (`workspacePath` set), the spawned agent's `~/.claude` is redirected
+   * into a per-lane sandbox under the worktree so it cannot write through the
+   * isolation boundary to the operator's real store (issue #1299 / ADR 0098).
+   * Defaults to the {@link LANE_STATE_ISOLATION_VAR} flag in `envSource`; OFF by
+   * default so a normal single-run agent keeps its real login/credentials.
+   */
+  laneStateIsolation?: boolean;
 }
 
 export class ClaudeBackend implements AgentBackend {
@@ -453,6 +462,7 @@ export class ClaudeBackend implements AgentBackend {
   private policyAudit?: PolicyAuditSink;
   private subprocessEnvAllow?: readonly string[];
   private envSource: NodeJS.ProcessEnv;
+  private laneStateIsolation: boolean;
 
   constructor(command = 'claude', options: ClaudeBackendOptions = {}) {
     this.command = options.command ?? command;
@@ -463,6 +473,8 @@ export class ClaudeBackend implements AgentBackend {
     if (options.policyAudit) this.policyAudit = options.policyAudit;
     if (options.subprocessEnvAllow) this.subprocessEnvAllow = options.subprocessEnvAllow;
     this.envSource = options.envSource ?? process.env;
+    this.laneStateIsolation =
+      options.laneStateIsolation ?? isLaneStateIsolationEnabled(this.envSource);
   }
 
   async startSession(params: SessionStartParams): Promise<Result<AgentSession, AgentError>> {
@@ -500,10 +512,12 @@ export class ClaudeBackend implements AgentBackend {
     // parent `process.env`, so unrelated host secrets never leak into the spawned
     // CLI. Provider creds / HARNESS_* / runtime plumbing still pass through — see
     // subprocess-env.ts. Stripping is unconditional; the audit sink is optional.
-    const { env, stripped, enforced } = buildSubprocessEnv(
-      this.envSource,
-      this.subprocessEnvAllow ? { extraAllow: this.subprocessEnvAllow } : {}
-    );
+    const laneStateScope =
+      this.laneStateIsolation && session.workspacePath ? session.workspacePath : undefined;
+    const { env, stripped, enforced } = buildSubprocessEnv(this.envSource, {
+      ...(this.subprocessEnvAllow ? { extraAllow: this.subprocessEnvAllow } : {}),
+      ...(laneStateScope ? { laneStateScope } : {}),
+    });
 
     // Stamp the per-call policy envelope into the governance audit trail. The
     // permission-mode flag below is a permission-bypassing ("dangerous") flag,

--- a/packages/orchestrator/src/agent/subprocess-env.test.ts
+++ b/packages/orchestrator/src/agent/subprocess-env.test.ts
@@ -1,7 +1,11 @@
+import path from 'node:path';
+
 import { describe, it, expect } from 'vitest';
 import {
   buildSubprocessEnv,
   isEnvKeyAllowed,
+  isLaneStateIsolationEnabled,
+  LANE_STATE_ISOLATION_VAR,
   SUBPROCESS_ENV_ALLOW_VAR,
   SUBPROCESS_ENV_PASSTHROUGH_VAR,
 } from './subprocess-env';
@@ -150,5 +154,42 @@ describe('buildSubprocessEnv (subprocess air-gap)', () => {
     expect(isEnvKeyAllowed('ComSpec', extra)).toBe(true);
     // A case-insensitive extraAllow name resolves regardless of OS casing.
     expect(isEnvKeyAllowed('My_Custom', new Set(['MY_CUSTOM']))).toBe(true);
+  });
+});
+
+describe('per-lane state isolation (#1299 / ADR 0098)', () => {
+  const worktree = path.join(path.sep, 'tmp', 'wt', 'lane-7');
+  const laneConfigDir = path.join(worktree, '.harness', 'lane-state', '.claude');
+
+  it('leaves CLAUDE_CONFIG_DIR untouched when no laneStateScope is given', () => {
+    const { env } = buildSubprocessEnv({
+      HOME: '/home/agent',
+      CLAUDE_CONFIG_DIR: '/home/agent/.claude',
+    });
+    // Default single-run behavior: the agent keeps its real config/credentials.
+    expect(env.CLAUDE_CONFIG_DIR).toBe('/home/agent/.claude');
+  });
+
+  it('redirects CLAUDE_CONFIG_DIR into the lane sandbox when laneStateScope is set', () => {
+    const { env } = buildSubprocessEnv(
+      { HOME: '/home/agent', CLAUDE_CONFIG_DIR: '/home/agent/.claude' },
+      { laneStateScope: worktree }
+    );
+    expect(env.CLAUDE_CONFIG_DIR).toBe(laneConfigDir);
+    expect(env.CLAUDE_CONFIG_DIR?.startsWith(worktree)).toBe(true);
+    // HOME and other allowlisted vars still pass through unchanged.
+    expect(env.HOME).toBe('/home/agent');
+  });
+
+  it('lane override wins even when CLAUDE_CONFIG_DIR was not present in the source', () => {
+    const { env } = buildSubprocessEnv({ HOME: '/home/agent' }, { laneStateScope: worktree });
+    expect(env.CLAUDE_CONFIG_DIR).toBe(laneConfigDir);
+  });
+
+  it('reads the opt-in flag from the env source', () => {
+    expect(isLaneStateIsolationEnabled({})).toBe(false);
+    expect(isLaneStateIsolationEnabled({ [LANE_STATE_ISOLATION_VAR]: '1' })).toBe(true);
+    expect(isLaneStateIsolationEnabled({ [LANE_STATE_ISOLATION_VAR]: 'true' })).toBe(true);
+    expect(isLaneStateIsolationEnabled({ [LANE_STATE_ISOLATION_VAR]: 'off' })).toBe(false);
   });
 });

--- a/packages/orchestrator/src/agent/subprocess-env.ts
+++ b/packages/orchestrator/src/agent/subprocess-env.ts
@@ -19,6 +19,8 @@
 // This mirrors the `analysis-env.ts` pattern (pure functions over env) and is
 // reused by any backend that spawns an agent CLI.
 
+import { buildLaneStateEnvOverride } from '@harness-engineering/core';
+
 /**
  * Exact env var names always forwarded to an agent subprocess. These are the
  * "runtime plumbing" vars a CLI, git, node, and the OS need to function — none
@@ -168,6 +170,21 @@ export const SUBPROCESS_ENV_ALLOW_VAR = 'HARNESS_SUBPROCESS_ENV_ALLOW';
  */
 export const SUBPROCESS_ENV_PASSTHROUGH_VAR = 'HARNESS_SUBPROCESS_ENV_UNSAFE_PASSTHROUGH';
 
+/**
+ * Opt-in flag for per-lane user-global state isolation. When truthy, a backend
+ * that spawns an agent in a worktree redirects that subprocess's `~/.claude`
+ * into a per-lane sandbox (see {@link BuildSubprocessEnvOptions.laneStateScope}).
+ * Default (unset) leaves `~/.claude` pointing at the operator's real store so a
+ * normal single-run agent keeps its login/credentials; a fleet fan-out parent
+ * turns it on so lanes cannot write through the worktree boundary (#1299).
+ */
+export const LANE_STATE_ISOLATION_VAR = 'HARNESS_LANE_STATE_ISOLATION';
+
+/** Is the {@link LANE_STATE_ISOLATION_VAR} opt-in flag truthy in `source`? */
+export function isLaneStateIsolationEnabled(source: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyFlag(source[LANE_STATE_ISOLATION_VAR]);
+}
+
 export interface BuildSubprocessEnvOptions {
   /** Extra exact var names to allow (merged with the built-in allowlist). */
   extraAllow?: readonly string[];
@@ -177,6 +194,16 @@ export interface BuildSubprocessEnvOptions {
    * {@link SUBPROCESS_ENV_PASSTHROUGH_VAR} in `source`.
    */
   passthrough?: boolean;
+  /**
+   * When set, redirect the subprocess's user-global (`~/.claude`) state into a
+   * per-lane sandbox under this worktree path by overriding `CLAUDE_CONFIG_DIR`
+   * in the built env. This extends a fleet lane's git-worktree isolation to
+   * cover user-global state, so a lane's execution/verification cannot write
+   * through to the operator's real `~/.claude` store (issue #1299 / ADR 0098).
+   * The override is applied AFTER stripping and WINS over any inherited
+   * `CLAUDE_CONFIG_DIR`, so each lane always gets its own sandbox.
+   */
+  laneStateScope?: string;
 }
 
 export interface SubprocessEnvResult {
@@ -257,6 +284,15 @@ export function buildSubprocessEnv(
     if (!allowed) {
       stripped.push(key);
     }
+  }
+
+  // Per-lane user-global state isolation: redirect `~/.claude` into the lane's
+  // worktree sandbox. Applied AFTER the allowlist loop and unconditionally
+  // overriding any inherited/passed-through `CLAUDE_CONFIG_DIR`, so each lane
+  // always gets its OWN sandbox — the config-dir override cannot be defeated by
+  // a value the parent process happened to carry (issue #1299 / ADR 0098).
+  if (options.laneStateScope) {
+    Object.assign(env, buildLaneStateEnvOverride(options.laneStateScope));
   }
 
   stripped.sort();


### PR DESCRIPTION
## What

A `-fleet` build lane runs in its own git worktree so its **repo** writes cannot collide, but a worktree isolates only the working tree — not the process's `$HOME` or `~/.claude`. A lane's execution or **verification** that exercises a user-global writer wrote straight through the worktree boundary to the operator's real, live state.

Concrete incident (#1299): a `roadmap-fleet` lane building per-subagent token attribution for `burn` ran its verification through `burn`'s own writer, which resolved its store from `$HOME` → `~/.claude/hud/state/summary.json`, rewriting the operator's live HUD summary with fields present in neither the released CLI nor `origin/main`.

## Fix

Extend the lane isolation boundary to cover user-global state via a **per-lane config-dir env override** (`CLAUDE_CONFIG_DIR`), per **ADR 0098**:

- **core** — new pure primitive `fleet/lane-state-isolation.ts` (`buildLaneStateEnvOverride` / `applyLaneStateEnv` / `resolveLaneClaudeConfigDir`): redirects `~/.claude` into a sandbox under the worktree's gitignored `.harness/lane-state/`. The override wins over any inherited `CLAUDE_CONFIG_DIR` so each lane gets its own sandbox.
- **burn** — `resolvePaths()` derives its HUD store base from `CLAUDE_CONFIG_DIR` before falling back to `$HOME/.claude`, so a lane's HUD writes land in its sandbox. Explicit `CLAUDE_HUD_*` overrides still win.
- **orchestrator** — `buildSubprocessEnv` gains a `laneStateScope` option applying the override; `ClaudeBackend` threads it in, opt-in via `laneStateIsolation` / the `HARNESS_LANE_STATE_ISOLATION` flag (**OFF by default** so a normal single-run agent keeps its real login/credentials).
- **docs** — `fleet-family.md` states the repo + user-global isolation contract; ADR 0098 marked accepted.

## Reproducing test

`packages/burn/tests/lane-isolation.test.ts` — the case "redirects the HUD store into a per-lane CLAUDE_CONFIG_DIR" **fails before** the burn fix (HUD resolves to `/Users/operator/.claude/hud`) and **passes after**. Verified by reverting `config.ts` to `HEAD` and re-running. Companion tests: `packages/core/src/fleet/lane-state-isolation.test.ts`, `packages/orchestrator/src/agent/subprocess-env.test.ts`, `packages/orchestrator/src/agent/backends/claude.lane-isolation.test.ts`.

## Assumptions made

- **F1 = (b)**: isolate via a per-lane `CLAUDE_CONFIG_DIR` / `HOME` environment override so each lane's `~/.claude` writes are redirected into its own worktree/tmp scope, rather than redirecting to a worktree-local state dir. The fix is designed around a per-lane **config-dir env override** (`CLAUDE_CONFIG_DIR`), leaving `HOME` untouched so git/ssh/nvm keep working; the orchestrator wiring is opt-in and off by default to avoid breaking agent auth for single runs.

Provenance: `docs/changes/worktree-lane-claude-config-isolation/provenance.json`.

Closes #1299

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga
