### PR TITLE
fix(review-ci): credit test files present in the diff (#1501)

### DIFF
--- a/.changeset/review-ci-test-file-detection.md
+++ b/.changeset/review-ci-test-file-detection.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+review-ci: fix "No test files found" false finding on diffs that add or modify test files (#1501). The bug-detection agent now credits `*.test.*` / `*.spec.*` / `*_test.*` files present in the diff itself — not only those pulled in as review context — so a PR whose purpose is adding tests is no longer told it has none. The source classifier that lists "files without tests" now also excludes test-support scaffolding (anything under `test/` / `tests/` / `__tests__/` / `__mocks__/` / `fixtures/`, `*-testkit.*`, `conftest.py`) and non-code files (`.md`, `.json`, lockfiles, etc.), so a `CHANGELOG.md` no longer reaches the classifier or attracts a file-size complaint.

--- a/.harness/comprehension/packages/core/src/review/agents/_module.md
+++ b/.harness/comprehension/packages/core/src/review/agents/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/review/agents'
-sourceHash: 'bc85129887729a61c41a9b0672d7aa4a005af9a8844be1ccee93e7d29b6e4b02'
-compiledAt: '2026-08-28T01:22:10.482Z'
+sourceHash: 'aa81ed678f95be59e8cfac51653a9c2b6d35c6286bd672d7b6d7ff4317166fb1'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'adversarial-agent.ts',
@@ -19,21 +18,6 @@ members:
     'typescript-strict-agent.ts',
   ]
 ---
-
-## Summary
-
-`packages/core/src/review/agents` is the pluggable review agent framework. It exports 8 domain-specific agents (Adversarial, Architecture, Bug Detection, Compliance, Frontend Races, Learnings, Security, TypeScript Strict), each as a descriptor + runner function pair. Agents scan changed files for anti-patterns using regex/heuristics or parse external context (e.g., check-deps output), then emit structured `ReviewFinding` objects keyed by file/line/category. Findings flow through dedup and synthesis logic downstream; the coordinator composes agents to handle different code dimensions in parallel, with optional depth-gating (e.g., cascade detection on Deep tier only).
-
-## Invariants
-
-- Finding IDs are deterministic and unique via makeFindingId(agentName, file, line, category) — collisions suppress duplicates; non-determinism breaks idempotency
-- Each agent exports both *\_DESCRIPTOR and run*Agent() — descriptor declares domain/tier/UI; runner executes detection logic; mismatch breaks routing
-- Findings must populate domain, severity, and validatedBy fields — review system keys on domain for filtering, severity gates PR comments, validatedBy signals confidence; omission breaks downstream synthesis
-- Confidence scores affect severity mapping (agent-local contract) — e.g., adversarial maps ≥75 → 'important', <75 → 'suggestion'
-- Architecture agent silently skips layer violations if harness-check-deps-output is absent from contextFiles — caller must inject check-deps result before dispatch
-- File base-name normalization is required for circular-import detection — relative imports stripped of ./ and ../ prefixes, paths matched by base name; mismatch causes false negatives
-- runCascades option gates Promise-constructor detection for depth-aware review — Standard-depth reviews must pass { runCascades: false } to skip expensive check; omission defaults to true (suitable for Deep/Max)
-- Findings are immutable post-emission — agents return findings once; edits must happen in coordinator, not agent
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/core/tests/review/agents/_module.md
+++ b/.harness/comprehension/packages/core/tests/review/agents/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/review/agents'
-sourceHash: 'fa7fdbc40b67d5af70be1fc3e4469d717aecfc6b4d939a03207cc792b467144a'
-compiledAt: '2026-08-28T01:22:10.905Z'
+sourceHash: 'd3afc96de25ecca1bb6ef0891208db1ca355987743f1fd30b0a1d0c640a1aa59'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'architecture-agent.test.ts',
@@ -15,44 +14,6 @@ members:
     'security-agent.test.ts',
   ]
 ---
-
-## Summary
-
-# Module Summary: `packages/core/tests/review/agents`
-
-This test suite validates seven specialized code-review agents that implement heuristic-based static analysis. Each agent takes a `ContextBundle` (changed/context files, diff size, commit history) and produces `ReviewFinding[]` with domain-specific insights.
-
-**The Agents:**
-
-1. **Architecture** — detects layer violations (via harness-check-deps), large files (400+ lines), circular imports; tier=standard
-2. **Bug Detection** — flags division by zero, empty catch blocks, missing tests; tier=strong
-3. **Security** — detects eval, hardcoded secrets, SQL injection, command injection; tier=strong; heavily guarded against false positives (test files, comments, shell variables, CI expressions)
-4. **Compliance** — validates code against project conventions (JSDoc, Result types) read from CLAUDE.md; tier=standard
-5. **Typescript Strict** — flags `any` types, `@ts-ignore`, double casts, vague function names; skips test/declaration files
-6. **Adversarial** — flags JSON.parse on untrusted input, floating promises, fetch without abort signals; emits confidence scores
-7. **Frontend Races** — detects lifecycle gaps (setInterval without clearInterval, addEventListener without removeEventListener, fetch without abort before setState)
-
-All agents use heuristic validation (no AST analysis) and skip test files by default. Findings carry metadata (severity, title, evidence, cweId/owaspCategory for security, confidence for conditional subagents) and must have unique IDs per agent.
-
-The security agent is the most mature, with sophisticated false-positive suppression: distinguishes SQL keywords in prose vs. queries (companion-token detection), ignores shell variable references and CI expressions, skips comment-only lines, and guards secrets detection with test-file and comment-scope logic.
-
-## Invariants
-
-- All findings from an agent's domain must match the agent's declared domain (architecture → domain='architecture', etc.)
-- Each agent must generate globally-unique finding IDs within its output set; duplicates = hard test failure
-- Every finding must carry: id, title, domain, severity, validatedBy='heuristic', and evidence array
-- Security findings that pass detector heuristics must survive enforceFindingIntegrity without downgrade/drop (especially SQL injections with companion tokens)
-- Agent descriptors must export: domain, tier ('standard'|'strong'), displayName, and focusAreas array
-- Test files are skipped entirely by most agents (typescript-strict, adversarial, security SQL/eval/exec detectors)
-- Architecture agent can consume harness-check-deps-output context files to surface layer violations
-- Adversarial/typescript-strict/frontend-races findings emit confidence >= 50 and carry subagent field
-- Security agent's comment-skip guard applies ONLY to comment-only lines, not code lines with trailing comments
-- SQL injection detection requires BOTH a SQL keyword AND structural companion (FROM/WHERE/SET/VALUES/INSERT/UPDATE/DELETE/JOIN); keywords alone in prose = false positive
-- Hardcoded secret detection skips shell variable references ($VAR, ${VAR}), CI expressions (${{ ... }}), and command substitutions ($(...), backticks)
-- Scoped package imports (@scope/pkg) must not trigger division-by-zero heuristic; real division is spaced (a / b)
-- Test fixture markers (test files, JSDoc blocks) suppress secrets detection only in code files, not .env/\*.md files
-- Finding severity must be in set: ['critical', 'important', 'suggestion']
-- Compliance agent must produce at least one finding when conventions are present and violated
 
 ## Interface Contract
 

--- a/docs/changes/review-ci-test-file-detection/provenance.json
+++ b/docs/changes/review-ci-test-file-detection/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issues": [1501],
+  "route": "bug",
+  "stages": ["debugging"],
+  "assumptions": [
+    "The 'No test files found' finding originates in detectMissingTests() in packages/core/src/review/agents/bug-agent.ts, which review-ci's floor-only path invokes.",
+    "Crediting a test file is path-based: a diff entry whose path carries a .test./.spec./_test./_spec. infix counts as accompanying tests, regardless of the ContextFile.reason value (the review-ci path lists diff files with reason 'changed', not 'test').",
+    "Test-support scaffolding (files under test/ tests/ __tests__/ __mocks__/ fixtures/, *-testkit.*, conftest.py) is non-source and must not be asked to have its own test (matches canary#565).",
+    "Non-code files (.md/.markdown/.txt/.json/.yaml/.yml/.lock and lockfiles) are never source requiring tests, so CHANGELOG.md must not reach the source classifier.",
+    "Scope limited to the primary defect that inverts the signal (defects 1-3 in the issue). The 'abstain instead of assert absence' vocabulary change and the separate mismatched-title/rationale finding are out of scope for this fix; the reporter offered to split the latter into its own issue."
+  ],
+  "reproducingTest": "packages/core/tests/review/agents/bug-agent.test.ts"
+}

--- a/packages/core/src/review/agents/bug-agent.ts
+++ b/packages/core/src/review/agents/bug-agent.ts
@@ -30,6 +30,48 @@ function isCodeFile(path: string): boolean {
 }
 
 /**
+ * True when `path` is itself a test file — carries a `.test.` / `.spec.` /
+ * `_test.` / `_spec.` infix (language-agnostic: `.test.ts`, `_test.py`,
+ * `_test.go`, `.spec.tsx`, …). These are the files that *provide* coverage, so
+ * their presence in a diff means the change is accompanied by tests.
+ */
+function isTestFile(path: string): boolean {
+  return /(?:\.|_)(?:test|spec)\.[^./]+$/i.test(path);
+}
+
+/**
+ * True when `path` is test-support scaffolding rather than a unit of production
+ * code — it lives under a `test/` / `tests/` / `__tests__/` / `__mocks__/` /
+ * `fixtures/` tree, is a `*-testkit.*` module, or is a `conftest.py`. Asking a
+ * test kit to have its own test is a category error, so these must not land in
+ * the "source files without tests" list (regression class fixed in canary#565).
+ */
+function isTestSupportFile(path: string): boolean {
+  const p = path.toLowerCase();
+  return (
+    /(?:^|\/)(?:tests?|__tests__|__mocks__|fixtures?)\//.test(p) ||
+    /-testkit\.[^./]+$/.test(p) ||
+    /(?:^|\/)conftest\.py$/.test(p)
+  );
+}
+
+/** Non-code suffixes / lockfiles that are never "source files requiring tests". */
+const NON_SOURCE_EXTENSIONS = ['.md', '.markdown', '.txt', '.json', '.yaml', '.yml', '.lock'];
+const LOCKFILE_BASENAMES = new Set(['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock']);
+
+/**
+ * True when `path` is not source code that could carry tests — documentation,
+ * config, or a lockfile. A `CHANGELOG.md` must not reach the source classifier
+ * (it is not testable and also should not attract a file-size complaint).
+ */
+function isNonSourceFile(path: string): boolean {
+  const p = path.toLowerCase();
+  const base = p.split('/').pop() ?? p;
+  if (LOCKFILE_BASENAMES.has(base)) return true;
+  return NON_SOURCE_EXTENSIONS.some((ext) => p.endsWith(ext));
+}
+
+/**
  * Returns true when the lines preceding index i contain a zero-guard.
  */
 function hasPrecedingZeroCheck(lines: string[], i: number): boolean {
@@ -137,12 +179,20 @@ function detectEmptyCatch(bundle: ContextBundle): ReviewFinding[] {
  */
 function detectMissingTests(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
-  const hasTestFiles = bundle.contextFiles.some((f) => f.reason === 'test');
+  // Credit test files present in the DIFF itself, not only those pulled in as
+  // context. A PR whose purpose is adding tests carries them in `changedFiles`;
+  // the old code only inspected `contextFiles`, so it asserted "no test files
+  // found" about a diff that contained several — inverting its own signal.
+  const hasTestContext = bundle.contextFiles.some((f) => f.reason === 'test');
+  const diffContainsTests = bundle.changedFiles.some((f) => isTestFile(f.path));
+  const hasTestFiles = hasTestContext || diffContainsTests;
 
   if (!hasTestFiles) {
-    // Check if any changed files are source files (not test files themselves)
+    // A "source file requiring a test" is code that is not itself a test, not
+    // test-support scaffolding (test kits, fixtures, conftest), and not a
+    // non-code file (docs/config/lockfiles like CHANGELOG.md).
     const sourceFiles = bundle.changedFiles.filter(
-      (f) => !f.path.match(/\.(test|spec)\.(ts|tsx|js|jsx)$/)
+      (f) => !isTestFile(f.path) && !isTestSupportFile(f.path) && !isNonSourceFile(f.path)
     );
     if (sourceFiles.length > 0) {
       const firstFile = sourceFiles[0]!;

--- a/packages/core/tests/review/agents/bug-agent.test.ts
+++ b/packages/core/tests/review/agents/bug-agent.test.ts
@@ -193,3 +193,136 @@ describe('runBugDetectionAgent()', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 });
+
+// Regression: issue #1501 — `review-ci` emitted "No test files found" on a diff
+// that itself added/modified five `*.test.ts` files (two newly added), because
+// the detector credited test files only from `contextFiles`, never from the diff.
+describe('detectMissingTests — test files present in the diff (issue #1501)', () => {
+  it('does not report "no test files" when the diff itself adds/modifies test files', () => {
+    // Mirrors the issue diff: three source files + five test files (two new).
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'ts/src/guardian/analysis-emit.ts',
+          content: 'export const x = 1;',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'ts/src/guardian/cli.ts',
+          content: 'export const y = 2;',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'ts/src/guardian/pr-check.ts',
+          content: 'export const z = 3;',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'ts/test/guardian-analysis-emit.test.ts',
+          content: 'it("a", () => {});',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'ts/test/guardian-coverage-notice-surface.test.ts',
+          content: 'it("b", () => {});',
+          reason: 'changed',
+          lines: 1,
+        },
+        // Newly-added test files — the ones that must be credited.
+        {
+          path: 'ts/test/guardian-diff-provenance.test.ts',
+          content: 'it("c", () => {});',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'ts/test/guardian-provenance-integration.test.ts',
+          content: 'it("d", () => {});',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'ts/test/guardian-skipped-non-abstain.test.ts',
+          content: 'it("e", () => {});',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+      contextFiles: [], // nothing pulled in as context — tests live in the diff
+    });
+    const findings = runBugDetectionAgent(bundle);
+    expect(findings.filter((f) => f.title.toLowerCase().includes('no test')).length).toBe(0);
+  });
+
+  it('credits a newly-added test file even when it is the only companion', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/service.ts',
+          content: 'export function work() { return 1; }',
+          reason: 'changed',
+          lines: 1,
+        },
+        {
+          path: 'src/service.test.ts',
+          content: 'it("works", () => {});',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+      contextFiles: [],
+    });
+    const findings = runBugDetectionAgent(bundle);
+    expect(findings.filter((f) => f.title.toLowerCase().includes('no test')).length).toBe(0);
+  });
+
+  it('does not classify CHANGELOG.md / non-code files as source requiring tests', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        { path: 'CHANGELOG.md', content: '# Changelog\n- entry', reason: 'changed', lines: 2 },
+        { path: 'package-lock.json', content: '{}', reason: 'changed', lines: 1 },
+      ],
+      contextFiles: [],
+    });
+    const findings = runBugDetectionAgent(bundle);
+    // Only non-source files changed → no "source files without tests" finding,
+    // and CHANGELOG.md must not head the evidence list.
+    expect(findings.filter((f) => f.title.toLowerCase().includes('no test')).length).toBe(0);
+  });
+
+  it('treats a test-support module (test kit under test/) as non-source', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'ts/test/guardian-cli-testkit.ts',
+          content: 'export const kit = {};',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+      contextFiles: [],
+    });
+    const findings = runBugDetectionAgent(bundle);
+    expect(findings.filter((f) => f.title.toLowerCase().includes('no test')).length).toBe(0);
+  });
+
+  it('still flags a genuine source-only diff with no accompanying tests', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/service.ts',
+          content: 'export function work() { return 1; }',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+      contextFiles: [],
+    });
+    const findings = runBugDetectionAgent(bundle);
+    expect(findings.some((f) => f.title.toLowerCase().includes('no test'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`harness review-ci` reported **"No test files found for changed source files"** on diffs that themselves add or modify test files — inverting its own signal. A PR whose entire purpose was adding tests was told it had none.

Root cause in `packages/core/src/review/agents/bug-agent.ts` `detectMissingTests()`: the "has tests?" decision only inspected `bundle.contextFiles` for `reason === 'test'` and ignored the diff's own `changedFiles`. On the review-ci floor path the diff's test files arrive as `changedFiles` (reason `changed`), never crediting them. Separately, the source classifier's exclusion regex (`\.(test|spec)\.(ts|tsx|js|jsx)$`) let non-code files (`CHANGELOG.md`) and test-support modules (`*-testkit.ts`) fall into the "source files without tests" list.

## Fix (three defects from the issue)

1. **Credit test files in the diff.** `*.test.*` / `*.spec.* `/ `*_test.*` / `*_spec.*` paths in `changedFiles` now count; the finding is dropped when the diff contains any test file.
2. **Exclude non-code files** (`.md`/`.markdown`/`.txt`/`.json`/`.yaml`/`.yml`/`.lock` + lockfiles) from the source classifier, so `CHANGELOG.md` no longer reaches it (and no longer attracts a file-size complaint).
3. **Treat test-support paths as non-source** — anything under `test/` / `tests/` / `__tests__/` / `__mocks__/` / `fixtures/`, `*-testkit.*`, `conftest.py` (matches the class fixed downstream in canary#565).

## Reproducing test

`packages/core/tests/review/agents/bug-agent.test.ts` — a new `describe('detectMissingTests … (issue #1501)')` block mirrors the issue's diff (three source files + five `*.test.ts`, two newly added). Verified **fail-before / pass-after**: 4 of the new assertions fail against the unfixed source and all 17 pass with the fix.

## Assumptions made

- Scope is limited to the primary defect that inverts the signal (defects 1-3). The issue's "abstain instead of assert absence" vocabulary change and the *separate* mismatched-title/rationale finding are **out of scope** — the reporter offered to split the latter into its own issue.
- Crediting a test file is path-based (the review-ci path lists diff files with reason `changed`, not `test`).

Closes #1501

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga