### PR TITLE
fix(mcp): make manage_adr git-worktree-aware (#1507)

### DIFF
--- a/.changeset/manage-adr-worktree-aware.md
+++ b/.changeset/manage-adr-worktree-aware.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+`manage_adr` is now git-worktree-aware (#1507). It resolves the ADR root from
+the caller's working directory via `git rev-parse --show-toplevel` instead of
+writing to the MCP server's launch root, so ADRs authored inside a `git
+worktree` land in that worktree (and mint collision-free numbers against its
+store) rather than polluting the wrong checkout. Falls back to the supplied
+project path when the cwd is not inside a git repository.

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,31 +1,111 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/mcp/tools"
-sourceHash: "8bf328a2311348a36dfe4c755cb3ea5c83d7361b1675dd39c14ac60d11b6c487"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["acceptance-eval.ts", "adr-store.ts", "adr.ts", "advise-skills.test.ts", "advise-skills.ts", "agent-definitions.ts", "agent.ts", "align-design-system.ts", "api-craft.ts", "architecture.ts", "assess-project.ts", "audit-anatomy.ts", "audit-brand.ts", "blueprint.test.ts", "blueprint.ts", "canary.test.ts", "canary.ts", "ci.ts", "cli-ergonomics-craft.ts", "code-craft.ts", "code-nav.ts", "compact.ts", "compound.test.ts", "compound.ts", "conflict-prediction.ts", "constraint-emergence.ts", "copy-craft.ts", "cross-check.test.ts", "cross-check.ts", "decay-trends.ts", "design-craft.ts", "design-pipeline.ts", "detect-drift.ts", "dispatch-skills.ts", "docs-craft.ts", "docs-publish.ts", "docs.ts", "edit-file.test.ts", "edit-file.ts", "entropy.ts", "event-emitter.ts", "feedback.ts", "gateway-tools.test.ts", "gateway-tools.ts", "gather-context.ts", "generate-slash-commands.ts", "get-comprehension.test.ts", "get-comprehension.ts", "hermes-tools.test.ts", "init.ts", "insights-summary.ts", "instruction-density.test.ts", "instruction-density.ts", "interaction-renderer.test.ts", "interaction-renderer.ts", "interaction-schemas.ts", "interaction.ts", "knowledge-craft.ts", "linter.ts", "naming-craft.ts", "outcome-eval.ts", "parallelization.test.ts", "parallelization.ts", "performance.ts", "persona.ts", "phase-gate.ts", "predict-failures.ts", "pulse.test.ts", "pulse.ts", "put-comprehension.ts", "recommend-skills.ts", "review-changes.ts", "review-pipeline.ts", "roadmap-auto-sync.ts", "roadmap-file-less.ts", "roadmap.ts", "search-sessions.ts", "search-skills.ts", "security-craft.ts", "security.ts", "skill-proposal.ts", "skill-telemetry.ts", "skill.ts", "spec-craft.ts", "stale-constraints.ts", "state.ts", "strategy.test.ts", "strategy.ts", "summarize-session.ts", "task-independence.ts", "test-craft.ts", "traceability.ts", "uat-signoff.test.ts", "uat-signoff.ts", "validate.ts", "webhook-tools.test.ts", "webhook-tools.ts"]
+module: 'packages/cli/src/mcp/tools'
+sourceHash: '54a94145e1c813d3ca8073864fda3c44e23ee35de4dfb6a65f178cd6dd0ff76a'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'acceptance-eval.ts',
+    'adr-store.ts',
+    'adr.ts',
+    'advise-skills.test.ts',
+    'advise-skills.ts',
+    'agent-definitions.ts',
+    'agent.ts',
+    'align-design-system.ts',
+    'api-craft.ts',
+    'architecture.ts',
+    'assess-project.ts',
+    'audit-anatomy.ts',
+    'audit-brand.ts',
+    'blueprint.test.ts',
+    'blueprint.ts',
+    'canary.test.ts',
+    'canary.ts',
+    'ci.ts',
+    'cli-ergonomics-craft.ts',
+    'code-craft.ts',
+    'code-nav.ts',
+    'compact.ts',
+    'compound.test.ts',
+    'compound.ts',
+    'conflict-prediction.ts',
+    'constraint-emergence.ts',
+    'copy-craft.ts',
+    'cross-check.test.ts',
+    'cross-check.ts',
+    'decay-trends.ts',
+    'design-craft.ts',
+    'design-pipeline.ts',
+    'detect-drift.ts',
+    'dispatch-skills.ts',
+    'docs-craft.ts',
+    'docs-publish.ts',
+    'docs.ts',
+    'edit-file.test.ts',
+    'edit-file.ts',
+    'entropy.ts',
+    'event-emitter.ts',
+    'feedback.ts',
+    'gateway-tools.test.ts',
+    'gateway-tools.ts',
+    'gather-context.ts',
+    'generate-slash-commands.ts',
+    'get-comprehension.test.ts',
+    'get-comprehension.ts',
+    'hermes-tools.test.ts',
+    'init.ts',
+    'insights-summary.ts',
+    'instruction-density.test.ts',
+    'instruction-density.ts',
+    'interaction-renderer.test.ts',
+    'interaction-renderer.ts',
+    'interaction-schemas.ts',
+    'interaction.ts',
+    'knowledge-craft.ts',
+    'linter.ts',
+    'naming-craft.ts',
+    'outcome-eval.ts',
+    'parallelization.test.ts',
+    'parallelization.ts',
+    'performance.ts',
+    'persona.ts',
+    'phase-gate.ts',
+    'predict-failures.ts',
+    'pulse.test.ts',
+    'pulse.ts',
+    'put-comprehension.ts',
+    'recommend-skills.ts',
+    'review-changes.ts',
+    'review-pipeline.ts',
+    'roadmap-auto-sync.ts',
+    'roadmap-file-less.ts',
+    'roadmap.ts',
+    'search-sessions.ts',
+    'search-skills.ts',
+    'security-craft.ts',
+    'security.ts',
+    'skill-proposal.ts',
+    'skill-telemetry.ts',
+    'skill.ts',
+    'spec-craft.ts',
+    'stale-constraints.ts',
+    'state.ts',
+    'strategy.test.ts',
+    'strategy.ts',
+    'summarize-session.ts',
+    'task-independence.ts',
+    'test-craft.ts',
+    'traceability.ts',
+    'uat-signoff.test.ts',
+    'uat-signoff.ts',
+    'validate.ts',
+    'webhook-tools.test.ts',
+    'webhook-tools.ts',
+  ]
 ---
-
-## Summary
-
-packages/cli/src/mcp/tools is a ~100-file comprehensive MCP tool implementation layer for the harness engineering platform. Each file exports a tool definition (with inputSchema), a handler function, and supporting types. Tools are grouped by domain (design-craft, spec-craft, code-craft, comprehension, roadmap management, graph queries, etc.) and registered in server.ts with middleware (injection guard → compaction → context budget). Recent additions include ADR 0109 tools (get/put_comprehension) for provider-neutral, agent-authored semantic understanding write-back. All tools return internal project content, validate inputs before computing, and never throw—every failure wraps in `{ content: [...], isError: true }` envelopes. Capability declarations (tool-capability-declarations.js) tie each tool to declared scopes; missing declarations fall back to name heuristics. The put_comprehension tool enforces source-fresh static units via serveGate, validates semantic payloads against zod schema before disk writes, and rejects owned heading markers to prevent serialization corruption.
-
-## Invariants
-
-- Handler registry match: every tool definition in TOOL_DEFINITIONS must have a corresponding handler in TOOL_HANDLERS with exact snake_case name key; definition names must be tool-unique and map precisely.
-- Middleware order is strict: injection-guard → compaction → context-budget. Output must pass all layers in order for consistency.
-- No-throw contract: tool handlers never throw. All errors wrap in `{ content: [...], isError: true }` envelopes matching get_comprehension/put_comprehension pattern.
-- Capability declaration binding: TOOL_CAPABILITY_DECLARATIONS keys must match definition.name exactly for capability to merge; missing declarations fall back to name heuristic in tool-capabilities.ts.
-- Semantic schema authority: put_comprehension validates `semanticResponseSchema` before any disk write; agent-supplied payloads must pass zod validation or return invalid status—never written malformed.
-- Source-fresh gate: put_comprehension refuses stale units (serveGate verdict); semantic attaches only to source-fresh static units, forcing recompile via get_comprehension for stale units.
-- Owned heading prohibition: put_comprehension rejects payloads with top-level section headings (##) to prevent serialization corruption on round-trip; agents must not supply these in summary/invariants.
-- Provider-neutral comprehension: get_comprehension defers semantic provider resolution lazily (only on recompile branch), so fresh serves never load config; put_comprehension never resolves a provider (write-back only).
-- Reentrancy guard: get_comprehension respects `withComprehensionActive` guard from canonical driver; reentrant calls return `{ status: 'reentrant' }` not errors.
-- Definition completeness: every exported tool symbol (XXXDefinition, handleXXX, XXXInput/Output) must appear in both its file AND server.ts registry; missing registrations cause silent tool omission from MCP listing.
-- trustedOutput marking: all harness MCP tools return internal project content marked `trustedOutput: true`; external-proxying tools must omit this flag (defaults to untrusted). Injection guard skips scanning trusted output.
-- Handler input validation: tool handlers must validate input shape before any computation (typeof checks, Array.isArray); malformed inputs return `isError: true`, never throw.
 
 ## Interface Contract
 
@@ -308,6 +388,7 @@ export renderTransition
 export requestPeerReviewDefinition
 export resolveLintCommand
 export resolveTestContent
+export resolveWorktreeRoot
 export reviewChangesDefinition
 export runAgentTaskDefinition
 export runAlignDesignSystem
@@ -445,7 +526,7 @@ import { loadGraphStore } from '../utils/graph-loader.js'
 import { McpToolResponse, bigIntSafeReplacer, resultToMcpResponse } from '../utils/result-adapter.js'
 import { sanitizePath } from '../utils/sanitize-path.js'
 import { sortFindingsBySeverity } from '../utils/severity.js'
-import { AdrStoreError, CreateAdrInput, UpdateAdrInput, createAdr, listAdrs, readAdr, updateAdr } from './adr-store.js'
+import { AdrStoreError, CreateAdrInput, UpdateAdrInput, createAdr, listAdrs, readAdr, resolveWorktreeRoot, updateAdr } from './adr-store.js'
 import { adviseSkillsDefinition, handleAdviseSkills } from './advise-skills.js'
 import from './architecture.js'
 import { generateBlueprintDefinition, handleGenerateBlueprint } from './blueprint.js'

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,29 +1,92 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/mcp/tools"
-sourceHash: "ebc8c4ae0e5408f9bdad2db0dc7fbf806269da79600dd4bdcc36740eb24e58d7"
-compiledAt: "2026-08-29T15:51:34.908Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["acceptance-eval.test.ts", "adr.test.ts", "agent.test.ts", "api-craft.test.ts", "architecture.test.ts", "assess-project-error-handling.test.ts", "assess-project.test.ts", "brainstorming-file-less-smoke.test.ts", "cli-ergonomics-craft.test.ts", "code-craft.test.ts", "code-nav-handlers.test.ts", "code-nav.test.ts", "compact.test.ts", "conflict-prediction.test.ts", "constraint-emergence.test.ts", "copy-craft.test.ts", "cross-check.test.ts", "decay-trends.test.ts", "docs-craft.test.ts", "docs.test.ts", "entropy-config-threading.test.ts", "entropy.test.ts", "event-emitter.test.ts", "events-jsonl-retired.guard.test.ts", "feedback.test.ts", "gather-context-comprehension.test.ts", "gather-context-extra.test.ts", "gather-context-session.test.ts", "gather-context.test.ts", "generate-slash-commands.test.ts", "graph-anomaly.test.ts", "graph-ask.test.ts", "graph-blast-radius.test.ts", "graph.test.ts", "init.test.ts", "interaction.test.ts", "knowledge-craft.test.ts", "linter.test.ts", "naming-craft.test.ts", "outcome-eval.test.ts", "pagination-integration.test.ts", "persona-handlers.test.ts", "persona.security.test.ts", "persona.test.ts", "phase-gate.test.ts", "predict-failures.test.ts", "put-comprehension.test.ts", "recommend-skills.test.ts", "review-changes.test.ts", "review-pipeline.test.ts", "roadmap-auto-sync.test.ts", "roadmap-groom-sharded.test.ts", "roadmap-groom.test.ts", "roadmap-scoped-sync.test.ts", "roadmap.file-backed-regression.test.ts", "roadmap.file-less-stub.test.ts", "roadmap.file-less.test.ts", "roadmap.sharded.test.ts", "roadmap.test.ts", "search-skills.test.ts", "security-craft.test.ts", "skill-progressive-loading.test.ts", "skill-proposal.test.ts", "skill-telemetry.test.ts", "skill.security.test.ts", "skill.test.ts", "spec-craft.test.ts", "stale-constraints.test.ts", "state-events.test.ts", "state-extra.test.ts", "state-sc1-guard.test.ts", "state.test.ts", "task-independence.test.ts", "test-craft.test.ts", "traceability.test.ts", "validate.test.ts", "workflow-e2e.test.ts"]
+module: 'packages/cli/tests/mcp/tools'
+sourceHash: 'e61eeb5db91961c3d7b91d994a3fa1bff59856f32fbb4c5571abb3d515a7474b'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'acceptance-eval.test.ts',
+    'adr-worktree.test.ts',
+    'adr.test.ts',
+    'agent.test.ts',
+    'api-craft.test.ts',
+    'architecture.test.ts',
+    'assess-project-error-handling.test.ts',
+    'assess-project.test.ts',
+    'brainstorming-file-less-smoke.test.ts',
+    'cli-ergonomics-craft.test.ts',
+    'code-craft.test.ts',
+    'code-nav-handlers.test.ts',
+    'code-nav.test.ts',
+    'compact.test.ts',
+    'conflict-prediction.test.ts',
+    'constraint-emergence.test.ts',
+    'copy-craft.test.ts',
+    'cross-check.test.ts',
+    'decay-trends.test.ts',
+    'docs-craft.test.ts',
+    'docs.test.ts',
+    'entropy-config-threading.test.ts',
+    'entropy.test.ts',
+    'event-emitter.test.ts',
+    'events-jsonl-retired.guard.test.ts',
+    'feedback.test.ts',
+    'gather-context-comprehension.test.ts',
+    'gather-context-extra.test.ts',
+    'gather-context-session.test.ts',
+    'gather-context.test.ts',
+    'generate-slash-commands.test.ts',
+    'graph-anomaly.test.ts',
+    'graph-ask.test.ts',
+    'graph-blast-radius.test.ts',
+    'graph.test.ts',
+    'init.test.ts',
+    'interaction.test.ts',
+    'knowledge-craft.test.ts',
+    'linter.test.ts',
+    'naming-craft.test.ts',
+    'outcome-eval.test.ts',
+    'pagination-integration.test.ts',
+    'persona-handlers.test.ts',
+    'persona.security.test.ts',
+    'persona.test.ts',
+    'phase-gate.test.ts',
+    'predict-failures.test.ts',
+    'put-comprehension.test.ts',
+    'recommend-skills.test.ts',
+    'review-changes.test.ts',
+    'review-pipeline.test.ts',
+    'roadmap-auto-sync.test.ts',
+    'roadmap-groom-sharded.test.ts',
+    'roadmap-groom.test.ts',
+    'roadmap-scoped-sync.test.ts',
+    'roadmap.file-backed-regression.test.ts',
+    'roadmap.file-less-stub.test.ts',
+    'roadmap.file-less.test.ts',
+    'roadmap.sharded.test.ts',
+    'roadmap.test.ts',
+    'search-skills.test.ts',
+    'security-craft.test.ts',
+    'skill-progressive-loading.test.ts',
+    'skill-proposal.test.ts',
+    'skill-telemetry.test.ts',
+    'skill.security.test.ts',
+    'skill.test.ts',
+    'spec-craft.test.ts',
+    'stale-constraints.test.ts',
+    'state-events.test.ts',
+    'state-extra.test.ts',
+    'state-sc1-guard.test.ts',
+    'state.test.ts',
+    'task-independence.test.ts',
+    'test-craft.test.ts',
+    'traceability.test.ts',
+    'validate.test.ts',
+    'workflow-e2e.test.ts',
+  ]
 ---
-
-## Summary
-
-This module is a comprehensive integration test suite for all MCP (Model Context Protocol) tools exposed by the harness CLI. It contains 77 test files validating tool definitions, input contracts, error handling, file I/O operations, and state mutation guarantees across features like acceptance evaluation, ADR management, roadmap (sharded and file-backed), roadmap syncing, personas, skills, and semantic analysis.
-
-Common test patterns verify (1) tool schemas and required parameters, (2) input validation with clear error messages, (3) graceful degradation when external services (LLM, graph) are unavailable, (4) transactional correctness—mutations touch only the claimed shard or feature, not collateral files, and (5) state fidelity by comparing disk snapshots before/after operations. Tests use isolated temp directories per test and clean up rigorously. The three exported utilities (`writeShardedProject`, `snapshotShardDir`, `changedShards`) are test helpers for roadmap sharding that verify the single-shard write guarantee: a feature mutation rewrites exactly its own shard, never another.
-
-## Invariants
-
-- Single-shard write guarantee: A feature mutation (add/update/remove/promote) writes exactly one shard file; unrelated shards remain untouched. Violations break incremental sync and conflict detection.
-- Tool definition contract immutable: Each tool's MCP definition (name, required fields, schema) is hardcoded and must not drift from implementation; tests assert exact match to catch breaking renames or field-requirement changes.
-- No collateral state mutation: Roadmap operations that fail (e.g., blocked claim refusal, duplicate ADR number) commit zero disk writes; test snapshots verify no shard/file changed before vs. after.
-- Degrade-safe fallback: When no LLM provider is configured, tools must return low-confidence advisory verdicts (e.g., INCONCLUSIVE), never crash or hang; acceptance_eval sets authority via TypeScript logic, not LLM, so it's computable offline.
-- Collision-safe ADR numbering: Next number = max(existing)+1, not count+1, tolerating gaps and duplicates; sequential creates never collide even under concurrent allocation.
-- Cascade unblock-only: Marking a blocker done flips a blocked dependent to planned; re-blocking requires an explicit action, never automatic (issue #610).
-- Store parity: Sharded reads (show/query) load from docs/roadmap.d/*.md and reconstruct the same logical state as the monolithic docs/roadmap.md; aggregate is regenerated on every write.
 
 ## Interface Contract
 
@@ -40,7 +103,7 @@ import { computeLoadPlan } from '../../../../core/src/context/progressive-loader
 import { extractLevel } from '../../../../core/src/context/section-parser'
 import { acceptanceEvalDefinition, handleAcceptanceEval, resolveTestContent } from '../../../src/mcp/tools/acceptance-eval.js'
 import { handleManageAdr, manageAdrDefinition } from '../../../src/mcp/tools/adr'
-import { allocateNextNumber, listAdrs } from '../../../src/mcp/tools/adr-store'
+import { allocateNextNumber, listAdrs, resolveWorktreeRoot } from '../../../src/mcp/tools/adr-store'
 import { addComponentDefinition, handleAddComponent, handleRunAgentTask, runAgentTaskDefinition } from '../../../src/mcp/tools/agent'
 import { apiCraftDefinition, apiCraftFinalizeDefinition, handleApiCraft, handleApiCraftFinalize } from '../../../src/mcp/tools/api-craft'
 import { checkDependenciesDefinition } from '../../../src/mcp/tools/architecture'
@@ -116,6 +179,7 @@ import { deriveAcceptanceAuthority } from '@harness-engineering/intelligence'
 import { Err, Ok, Result } from '@harness-engineering/types'
 import * as fs from 'fs'
 import * as fs from 'fs/promises'
+import { execFileSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as fsp from 'node:fs/promises'
 import * as os from 'node:os'

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/mcp/tools'
-sourceHash: 'e61eeb5db91961c3d7b91d994a3fa1bff59856f32fbb4c5571abb3d515a7474b'
+sourceHash: 'cb12347bd3b1558999bc6c9fab99af54bfaf0cf376cde7538c4a7ef66f98791e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/docs/changes/manage-adr-worktree-aware/provenance.json
+++ b/docs/changes/manage-adr-worktree-aware/provenance.json
@@ -1,0 +1,7 @@
+{
+  "issues": [1507],
+  "route": "bug",
+  "stages": ["debugging"],
+  "assumptions": ["F2=a resolve worktree via git rev-parse --show-toplevel from cwd"],
+  "reproducingTest": "packages/cli/tests/mcp/tools/adr-worktree.test.ts"
+}

--- a/packages/cli/src/mcp/tools/adr-store.ts
+++ b/packages/cli/src/mcp/tools/adr-store.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -62,6 +63,34 @@ export class AdrStoreError extends Error {
 /** Absolute path to the decisions directory under `projectRoot`. */
 export function decisionsDirFor(projectRoot: string): string {
   return path.join(projectRoot, DECISIONS_DIR);
+}
+
+/**
+ * Resolve the ADR root to the active git worktree.
+ *
+ * `manage_adr` is invoked from whatever checkout the caller is working in, which
+ * — under `git worktree` — is NOT necessarily the MCP server's launch root
+ * (`fallbackRoot`, threaded in as the `path` argument). Writing ADRs to the
+ * server root pollutes the wrong checkout and mints collision-free numbers
+ * against a store the worktree branch can't see (#1507).
+ *
+ * We resolve the enclosing worktree top-level via `git rev-parse
+ * --show-toplevel` from the caller's `cwd`. When `cwd` is inside a git worktree
+ * we target that worktree; otherwise (not a git repo, or git unavailable) we
+ * fall back to the caller-supplied root, so non-git usage is unaffected.
+ */
+export function resolveWorktreeRoot(cwd: string, fallbackRoot: string): string {
+  try {
+    const top = execSync('git rev-parse --show-toplevel', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (top.length > 0) return path.resolve(top);
+  } catch {
+    // Not inside a git worktree (or git unavailable) — keep the supplied root.
+  }
+  return fallbackRoot;
 }
 
 /**

--- a/packages/cli/src/mcp/tools/adr.ts
+++ b/packages/cli/src/mcp/tools/adr.ts
@@ -7,6 +7,7 @@ import {
   createAdr,
   listAdrs,
   readAdr,
+  resolveWorktreeRoot,
   updateAdr,
   type CreateAdrInput,
   type UpdateAdrInput,
@@ -181,8 +182,14 @@ function handleUpdate(projectPath: string, input: ManageAdrInput): McpResponse {
   return resultToMcpResponse(Ok(updateAdr(projectPath, input.ref, patch)));
 }
 
-export async function handleManageAdr(input: ManageAdrInput): Promise<McpResponse> {
-  const projectPath = sanitizePath(input.path);
+export async function handleManageAdr(
+  input: ManageAdrInput,
+  cwd: string = process.cwd()
+): Promise<McpResponse> {
+  // Prefer the active git worktree resolved from the caller's cwd over the
+  // server-threaded `path` (the launch root), so ADRs authored inside a
+  // `git worktree` land in that worktree rather than the wrong checkout (#1507).
+  const projectPath = resolveWorktreeRoot(cwd, sanitizePath(input.path));
   try {
     switch (input.action) {
       case 'create':

--- a/packages/cli/tests/mcp/tools/adr-worktree.test.ts
+++ b/packages/cli/tests/mcp/tools/adr-worktree.test.ts
@@ -56,10 +56,13 @@ afterEach(() => {
 
 describe('manage_adr git-worktree awareness (#1507)', () => {
   it('resolveWorktreeRoot resolves the worktree top-level from its cwd, not the server root', () => {
-    // realpathSync normalizes macOS /var -> /private/var symlinks.
+    // realpathSync.native canonicalizes both macOS /var -> /private/var symlinks
+    // AND Windows 8.3 short names (RUNNER~1) -> long names (runneradmin), which
+    // `git rev-parse --show-toplevel` emits but os.tmpdir()/mkdtemp does not.
+    const canon = (p: string): string => fs.realpathSync.native(p);
     const resolved = resolveWorktreeRoot(worktree, mainRepo);
-    expect(fs.realpathSync(resolved)).toBe(fs.realpathSync(worktree));
-    expect(fs.realpathSync(resolved)).not.toBe(fs.realpathSync(mainRepo));
+    expect(canon(resolved)).toBe(canon(worktree));
+    expect(canon(resolved)).not.toBe(canon(mainRepo));
   });
 
   it('writes a created ADR into the active worktree, not the server projectRoot', async () => {

--- a/packages/cli/tests/mcp/tools/adr-worktree.test.ts
+++ b/packages/cli/tests/mcp/tools/adr-worktree.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { handleManageAdr } from '../../../src/mcp/tools/adr';
+import { resolveWorktreeRoot } from '../../../src/mcp/tools/adr-store';
+
+/**
+ * Regression test for #1507: `manage_adr` must be git-worktree-aware.
+ *
+ * Before the fix the handler wrote ADRs to `input.path` (the MCP server's launch
+ * root), so an ADR authored while working inside a `git worktree` landed in the
+ * WRONG checkout. The fix (F2) resolves the active worktree via
+ * `git rev-parse --show-toplevel` from the caller's cwd and writes there.
+ */
+
+let mainRepo: string;
+let worktree: string;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+const decisionsRel = path.join('docs', 'knowledge', 'decisions');
+
+function decisionFiles(root: string): string[] {
+  const dir = path.join(root, decisionsRel);
+  try {
+    return fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
+  } catch {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-wt-'));
+  mainRepo = path.join(base, 'main');
+  fs.mkdirSync(mainRepo, { recursive: true });
+  git(mainRepo, 'init', '-b', 'main');
+  git(mainRepo, 'config', 'user.email', 'test@example.com');
+  git(mainRepo, 'config', 'user.name', 'Test');
+  fs.writeFileSync(path.join(mainRepo, 'README.md'), '# main\n');
+  git(mainRepo, 'add', '.');
+  git(mainRepo, 'commit', '-m', 'init');
+
+  // A sibling worktree on its own branch — the checkout the caller works in.
+  worktree = path.join(base, 'wt');
+  git(mainRepo, 'worktree', 'add', '-b', 'feature', worktree, 'HEAD');
+});
+
+afterEach(() => {
+  // Remove the whole temp base (parent of both mainRepo and worktree).
+  fs.rmSync(path.dirname(mainRepo), { recursive: true, force: true });
+});
+
+describe('manage_adr git-worktree awareness (#1507)', () => {
+  it('resolveWorktreeRoot resolves the worktree top-level from its cwd, not the server root', () => {
+    // realpathSync normalizes macOS /var -> /private/var symlinks.
+    const resolved = resolveWorktreeRoot(worktree, mainRepo);
+    expect(fs.realpathSync(resolved)).toBe(fs.realpathSync(worktree));
+    expect(fs.realpathSync(resolved)).not.toBe(fs.realpathSync(mainRepo));
+  });
+
+  it('writes a created ADR into the active worktree, not the server projectRoot', async () => {
+    // `path` is the server launch root (main repo); cwd is the active worktree.
+    const resp = await handleManageAdr(
+      {
+        path: mainRepo,
+        action: 'create',
+        title: 'Worktree Aware ADR',
+        context: 'Authored from a git worktree.',
+        decision: 'ADRs must land in the active worktree.',
+        consequences: 'No more polluting the main checkout.',
+      },
+      worktree
+    );
+
+    expect(resp.isError).toBeFalsy();
+    // The ADR lands in the worktree...
+    expect(decisionFiles(worktree)).toHaveLength(1);
+    expect(decisionFiles(worktree)[0]).toMatch(/^0001-worktree-aware-adr\.md$/);
+    // ...and NOT in the server's projectRoot.
+    expect(decisionFiles(mainRepo)).toHaveLength(0);
+  });
+
+  it('falls back to the supplied projectRoot when cwd is not inside a git repo', async () => {
+    const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-nogit-'));
+    try {
+      const resp = await handleManageAdr(
+        {
+          path: mainRepo,
+          action: 'create',
+          title: 'Fallback ADR',
+          context: 'ctx',
+          decision: 'dec',
+          consequences: 'cons',
+        },
+        nonGit
+      );
+      expect(resp.isError).toBeFalsy();
+      // cwd is not a git repo -> fall back to the supplied root (main repo).
+      expect(decisionFiles(mainRepo)).toHaveLength(1);
+      expect(decisionFiles(nonGit)).toHaveLength(0);
+    } finally {
+      fs.rmSync(nonGit, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/mcp/tools/adr.test.ts
+++ b/packages/cli/tests/mcp/tools/adr.test.ts
@@ -7,6 +7,7 @@ import { allocateNextNumber, listAdrs } from '../../../src/mcp/tools/adr-store';
 
 let tmpDir: string;
 let decisionsDir: string;
+let originalCwd: string;
 
 function writeAdr(number: string, slug: string, extra: string = ''): void {
   const content = `---
@@ -43,9 +44,16 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-test-'));
   decisionsDir = path.join(tmpDir, 'docs', 'knowledge', 'decisions');
   fs.mkdirSync(decisionsDir, { recursive: true });
+  // `handleManageAdr` is git-worktree-aware (#1507): it resolves the ADR root
+  // from the caller's cwd. Run these store-behavior tests from inside tmpDir so
+  // the fallback (tmpDir is not a git repo) targets the intended project root
+  // rather than the real repo the test runner is launched in.
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
 });
 
 afterEach(() => {
+  process.chdir(originalCwd);
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

`manage_adr` (and its backing `adr-store.ts`) was not git-worktree-aware: it wrote ADRs to — and minted collision-free numbers against — the MCP server's launch root (`input.path`), not the git worktree the caller was actually operating in. ADRs authored inside a `git worktree` landed in the wrong checkout, and the number-collision check silently ignored ADRs on other worktree branches.

## Fix (F2)

`handleManageAdr` now resolves the ADR root from the caller's cwd via `git rev-parse --show-toplevel` (new `resolveWorktreeRoot` helper in `adr-store.ts`), preferring the active worktree top-level over the threaded `path`. When the cwd is not inside a git repository (or git is unavailable) it falls back to the supplied project path, so non-git usage is unaffected.

## Reproducing test

`packages/cli/tests/mcp/tools/adr-worktree.test.ts` — creates a real repo + sibling `git worktree`, invokes `manage_adr create` with `path` = main repo but cwd = worktree, and asserts the ADR lands in the worktree and NOT in the server root. **Fails before / passes after** the fix (verified: before the fix the assertion `expected [] to have length 1` fails because the ADR was written to the main repo). Also covers the non-git fallback path.

The existing `adr.test.ts` suite now chdir's into its tmpDir in setup so store-behavior tests target the intended root under the new cwd-aware contract (and no longer risk polluting the real repo).

## Assumptions made

- **F2 = (a)**: resolve the active worktree via `git rev-parse --show-toplevel` from the caller's cwd, rather than threading an explicit path argument. ADRs are written into the active worktree's root resolved from cwd.

## Verification

- `pnpm turbo build` (CLI), `tsc --noEmit` clean
- `adr.test.ts` + `adr-worktree.test.ts` (19) green; `server.test.ts` + `tool-tiers.test.ts` (36) green
- Changeset added; reference-docs + tool-catalog pre-push gates fresh

Closes #1507

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga