### PR TITLE
feat(orchestrator): 1-hop blast-radius prewarm enrichment (#1690)

### DIFF
--- a/.changeset/comprehension-blast-radius-prewarm.md
+++ b/.changeset/comprehension-blast-radius-prewarm.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+comprehension: the orchestrator dispatch pre-warm now enriches a leaf with its 1-hop blast radius (#1690). When a dependency graph is present, `resolveLeafPrewarm` serves the committed comprehension units of the seed module's DIRECT importers (the code that depends on the leaf) in addition to the issue-referenced seed, bounded by a token budget cap (`DEFAULT_BLAST_RADIUS_TOKEN_BUDGET`, 4000). The seed is always served; only the importer/dep enrichment is capped, so a hub (high fan-in) leaf serves fewer importer units rather than ballooning the prompt. It is 1-hop only (never the transitive closure), best-effort (a missing/empty/stale graph degrades to the byte-identical seed-only pre-warm), and never calls an LLM.

--- a/.harness/comprehension/packages/orchestrator/src/workflow/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/workflow/_module.md
@@ -1,28 +1,48 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/workflow"
-sourceHash: "1e7638227307b0dd3d2a4428783f98d94f9f20558aeb542a8c8449d107331fdc"
-compiledAt: "2026-08-28T01:22:12.582Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["comprehension-prewarm.test.ts", "comprehension-prewarm.ts", "config.staged-routing.test.ts", "config.ts", "doc-coverage-gate.test.ts", "doc-coverage-gate.ts", "execute-workflow.4b.test.ts", "execute-workflow.staged-integration.test.ts", "execute-workflow.test.ts", "execute-workflow.ts", "gate-feedback.test.ts", "gate-feedback.ts", "loader.ts", "local-stage-prompt.test.ts", "local-stage-prompt.ts", "orchestrator-context.prewarm-seam.test.ts", "orchestrator-context.ts", "peer-unload.test.ts", "peer-unload.ts", "persist-stage-document.test.ts", "schema.acceptance.test.ts", "schema.amr-config.test.ts", "schema.expects.test.ts", "schema.roadmap-triage.test.ts", "schema.ts", "skill-catalog.ts", "stage-backend-routing.test.ts", "stage-prompt-template.ts", "unstick-advisory.test.ts", "unstick-advisory.ts", "workflow-for.ts"]
+module: 'packages/orchestrator/src/workflow'
+sourceHash: '21f855d976136fc1feda4ca8571cf2bdb4636d037422ec248de281134e478ed8'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'comprehension-blast-radius.test.ts',
+    'comprehension-blast-radius.ts',
+    'comprehension-prewarm.test.ts',
+    'comprehension-prewarm.ts',
+    'config.staged-routing.test.ts',
+    'config.ts',
+    'doc-coverage-gate.test.ts',
+    'doc-coverage-gate.ts',
+    'execute-workflow.4b.test.ts',
+    'execute-workflow.staged-integration.test.ts',
+    'execute-workflow.test.ts',
+    'execute-workflow.ts',
+    'gate-feedback.test.ts',
+    'gate-feedback.ts',
+    'loader.ts',
+    'local-stage-prompt.test.ts',
+    'local-stage-prompt.ts',
+    'orchestrator-context.blast-radius-seam.test.ts',
+    'orchestrator-context.prewarm-seam.test.ts',
+    'orchestrator-context.ts',
+    'peer-unload.test.ts',
+    'peer-unload.ts',
+    'persist-stage-document.test.ts',
+    'schema.acceptance.test.ts',
+    'schema.amr-config.test.ts',
+    'schema.expects.test.ts',
+    'schema.roadmap-triage.test.ts',
+    'schema.ts',
+    'skill-catalog.ts',
+    'stage-backend-routing.test.ts',
+    'stage-prompt-template.ts',
+    'unstick-advisory.test.ts',
+    'unstick-advisory.ts',
+    'workflow-for.ts',
+  ]
 ---
-
-## Summary
-
-The workflow module orchestrates multi-stage task execution with pluggable backends, pre-warmed comprehension context, and gate-based quality enforcement. It routes each stage to a backend (local coder, reasoning model, or adaptive choice) based on cognitive mode, validates configuration (especially backend routing and doc coverage), and handles retries with tier escalation when stages fail. Pre-warming injects issue-referenced module summaries into dispatch without calling an LLM—degrading gracefully when comprehension units are missing or stale. Documentation gates block merge until edited files are linked from docs. The module is the glue between task definition, LLM backends, and enforcement rules.
-
-## Invariants
-
-- Pre-warming is LLM-free and always safe — seed modules come from issue title/description/spec paths plus direct graph deps; only fresh units (source-hash verified) are served via serveGate; any store/read/serve failure silently returns an empty block; the stage prompt renders byte-identical to today.
-- Backend routing is per-stage, not per-workflow — each stage's cognitiveMode maps to routing.modes[X] in harness.config.json; design phases route to reasoning backends, execution phases to non-thinking coders; validation fails fast if a stage declares an unmapped mode.
-- Staged workflows retry with tier escalation, not replay — nextTier() moves from low→medium→high confidence on gate failure; each retry lives under a new attempt key; only the failed tier retries with stronger heuristics.
-- Comprehension units are source-hash verified — a unit is served only if its stored source hash matches the live source; stale or missing sources produce an empty block, never a mismatch hallucination.
-- Documentation gate is link-based and pre-push fresh — a file counts documented only if docs/ markdown links its basename (JSDoc doesn't count); pre-push blocks if reference docs are stale.
-- Gate feedback is distilled for reuse — distillGateFailure + truncateGateOutput extract actionable summaries; raw LLM output is capped and passed forward to the next retry, preventing context bloat.
-- Skill catalog is discovered at runtime, not hardcoded — enables portable features across adopters (one harness, many repos).
-- Peer unload coordination prevents cascade — resolvePeerUnloadTarget detects live peers on the same issue; avoids redundant dispatch and cross-run conflicts.
 
 ## Interface Contract
 
@@ -30,6 +50,7 @@ The workflow module orchestrates multi-stage task execution with pluggable backe
 export AgentBudgetSchema
 export BackendCapabilitiesSchema
 export BackendDefSchema
+export DEFAULT_BLAST_RADIUS_TOKEN_BUDGET
 export DEFAULT_REASONER_ASSIST_AFTER
 export DEFAULT_STAGE_DEADLINE_MS
 export LOCAL_DOCUMENT_STAGE_DEADLINE_MS
@@ -50,6 +71,7 @@ export WorkflowStepSchema
 export buildStageRequest
 export buildUnstickPrompt
 export buildWorkflowContext
+export createGraphBlastRadiusResolver
 export crossFieldRoutingIssues
 export deriveSeedModules
 export deriveVerifyCommands
@@ -104,6 +126,8 @@ import { StructuredLogger } from '../logging/logger.js'
 import { PromptRenderer } from '../prompt/renderer'
 import { PromptRenderer } from '../prompt/renderer.js'
 import { detectEcosystem } from '../workspace/ecosystem.js'
+import { createGraphBlastRadiusResolver } from './comprehension-blast-radius'
+import { createGraphBlastRadiusResolver } from './comprehension-blast-radius.js'
 import { LeafPrewarmDeps, deriveSeedModules, resolveLeafPrewarm } from './comprehension-prewarm'
 import { LeafPrewarmResult, resolveLeafPrewarm } from './comprehension-prewarm.js'
 import { getDefaultConfig, validateWorkflowConfig } from './config'
@@ -121,6 +145,7 @@ import { discoverSkillCatalogNames } from './skill-catalog'
 import { STAGE_PROMPT_TEMPLATE } from './stage-prompt-template.js'
 import { DEFAULT_REASONER_ASSIST_AFTER, REASONER_UNSTICK_TIMEOUT_MS, UNSTICK_SCHEMA, buildUnstickPrompt, formatUnstickAdvisory, shouldRequestUnstickAdvice } from './unstick-advisory'
 import { CHARS_PER_TOKEN, COMPREHENSION_ROOT, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, Err, Ok, Result, SourceFile, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, renderServedUnit, serveGate } from '@harness-engineering/core'
+import { GraphEdge, GraphNode, GraphStore } from '@harness-engineering/graph'
 import { RANK_TIER, TIER_RANK } from '@harness-engineering/intelligence'
 import { AgentBackend, AgentBudgetConfig, AgentEvent, BackendCapabilities, BackendDef, CapabilityTier, ComplexityVerdict, DEFAULT_RETRIEVAL_MODE, Err, Issue, LeafContextSource, McpServerSpec, Ok, Result, RetrievalMode, RoadmapAutoTriageConfig, RoadmapConfig, RoutingConfig, RoutingDecision, RoutingPolicy, RoutingRequest, RoutingUseCase, RoutingValue, STANDARD_COGNITIVE_MODES, StageRun, StagedWorkflowDecl, TurnResult, WorkflowConfig, WorkflowDefinition, WorkflowExecutionPlan, WorkflowStep } from '@harness-engineering/types'
 import * as fs, { existsSync } from 'node:fs'

--- a/docs/changes/comprehension-blast-radius-prewarm/plans/plan.md
+++ b/docs/changes/comprehension-blast-radius-prewarm/plans/plan.md
@@ -1,0 +1,56 @@
+# Plan — blast-radius prewarm enrichment (#1690)
+
+Autopilot trace: plan → execute → verify → review. Route: feature. Fork F3=a
+(1-hop importers, capped token budget).
+
+## Task 1 — Core enrichment seam + token cap (TDD)
+
+File: `packages/orchestrator/src/workflow/comprehension-prewarm.ts`
+Tests: `packages/orchestrator/src/workflow/comprehension-prewarm.test.ts`
+
+- Add `resolveBlastRadius?: (module: string) => string[]` and
+  `enrichmentTokenBudget?: number` to `LeafPrewarmDeps`.
+- Refactor `resolveLeafPrewarm` into seed-phase (always served) +
+  enrichment-phase (deps ∪ blastRadius, minus seed, bounded by the token cap,
+  deterministic order).
+- Factor the serve+attribute step so both phases share one code path.
+- New tests: SC1 (blast-radius importers served), SC2 (cap excludes over-budget
+  importer units; seed always served), SC4-adjacent (dedup vs seed), plus keep
+  all existing (a)-(f) tests green.
+
+## Task 2 — Graph-backed 1-hop importer resolver (TDD)
+
+File (new): `packages/orchestrator/src/workflow/comprehension-blast-radius.ts`
+Tests (new): `packages/orchestrator/src/workflow/comprehension-blast-radius.test.ts`
+
+- `createGraphBlastRadiusResolver(store: GraphStore, opts?)` → `(module) =>
+string[]`.
+- Resolve seed-module file nodes → inbound `imports` edges → importer file paths
+  → owning module dirs (posix dirname), exclude seed, dedup, sort.
+- Tests: 1-hop importer resolution (SC4), excludes the module itself, empty on
+  no importers / unknown module, never throws on a hostile store.
+
+## Task 3 — Wire at dispatch
+
+File: `packages/orchestrator/src/workflow/orchestrator-context.ts`
+
+- Add `DEFAULT_BLAST_RADIUS_TOKEN_BUDGET` constant.
+- In `resolveLeafPrewarmBestEffort`: best-effort load the graph store
+  (`resolveGraphDir` + `GraphStore.load`); when present build the resolver and
+  pass `resolveBlastRadius` + `enrichmentTokenBudget` into `resolveLeafPrewarm`.
+- No graph ⇒ omit resolver ⇒ byte-identical (SC3). Wrapped so a graph load
+  failure degrades to the prior result (SC5).
+
+## Task 4 — Verify + review
+
+- `pnpm --filter @harness-engineering/orchestrator test` (targeted files green).
+- `pnpm --filter @harness-engineering/orchestrator typecheck` + repo build.
+- Self-review for byte-identical degradation and best-effort guarantees.
+- Provenance committed; unmerged PR `Closes #1690`.
+
+## Risk / mitigation
+
+- Hub leaf blowup → token budget cap (F3=a).
+- Graph absence / stale graph → best-effort load, resolver omitted, graceful.
+- Dependency direction confusion → blast radius = INBOUND imports (dependents),
+  distinct from `resolveDirectDeps` (outbound).

--- a/docs/changes/comprehension-blast-radius-prewarm/proposal.md
+++ b/docs/changes/comprehension-blast-radius-prewarm/proposal.md
@@ -1,0 +1,113 @@
+# Comprehension: blast-radius prewarm enrichment (orchestrator)
+
+- Issue: #1690 (label: enhancement)
+- Route: feature (brainstorming → autopilot)
+- Slug: `comprehension-blast-radius-prewarm`
+- Confirmed fork: **F3 = (a)** — prewarm the leaf's **DIRECT (1-hop) importers** under a **capped token budget**, NOT the full transitive closure.
+
+## Problem
+
+When the orchestrator dispatches a leaf, `resolveLeafPrewarm`
+(`packages/orchestrator/src/workflow/comprehension-prewarm.ts`) seeds the
+pre-warmed comprehension block from a MINIMAL set: the modules referenced by the
+issue (paths named in title/description/spec/plans) plus, when a graph resolver
+is supplied, their direct dependencies (`resolveDirectDeps`). It degrades
+gracefully to an empty block.
+
+Today the wired dispatch path (`resolveLeafPrewarmBestEffort` in
+`orchestrator-context.ts`) never supplies any graph resolver, so the served
+pre-warm is the issue-referenced seed alone. The builder therefore lacks the
+comprehension of the code that **depends on** the leaf — its blast radius — even
+though the compiled-comprehension substrate (#1558/#1686) already has those
+units committed and servable LLM-free.
+
+## Goal
+
+Enrich the dispatch pre-warm with the leaf's **1-hop blast radius** — the direct
+importers (dependents) of the seed modules — so the builder sees the interface
+contracts of the code that will break if the leaf changes. Bound the enrichment
+by a **token budget cap** so a hub (high fan-in) leaf cannot balloon the prompt.
+
+## Non-goals
+
+- Full transitive closure / N-hop cascade (explicitly rejected by F3=a).
+- Any LLM call, network call, or new credential at dispatch (pre-warm is
+  LLM-free and best-effort by contract).
+- Changing the served-unit rendering or the serve-gate freshness contract.
+
+## Design
+
+Three additive layers, all best-effort (never throw, never call an LLM):
+
+### 1. Core enrichment seam + token cap (`comprehension-prewarm.ts`)
+
+Extend `LeafPrewarmDeps` with:
+
+- `resolveBlastRadius?: (module: string) => string[]` — returns the **1-hop
+  importer** module directories of `module` (the code that imports it). Distinct
+  from `resolveDirectDeps` (what the module imports). Absent ⇒ no blast-radius
+  enrichment (graceful degradation, byte-identical to today).
+- `enrichmentTokenBudget?: number` — cap (in tokens) on the CUMULATIVE served
+  size of the ENRICHMENT (non-seed) units. Absent ⇒ unbounded (preserves the
+  existing `resolveDirectDeps` back-compat behavior).
+
+`resolveLeafPrewarm` becomes two phases:
+
+1. **Seed (primary, always served):** serve every fresh issue-referenced seed
+   module. These are never dropped by the cap — the issue's own modules are the
+   point of the pre-warm.
+2. **Enrichment (bounded):** collect the union of `resolveDirectDeps(seed)` and
+   `resolveBlastRadius(seed)` minus the seed, deterministically ordered; serve
+   each fresh unit only while the running enrichment-token total stays within
+   `enrichmentTokenBudget`. Once a unit would exceed the cap it is skipped and
+   traversal stops (deterministic, order-stable).
+
+The block and `sources` breakdown are produced exactly as today, so the
+context-budget consult (`buildLeafContextEstimate`) attributes the enrichment
+tokens correctly.
+
+### 2. Graph-backed 1-hop importer resolver (new `comprehension-blast-radius.ts`)
+
+A pure factory `createGraphBlastRadiusResolver(store, opts?)` over a
+`@harness-engineering/graph` `GraphStore`:
+
+- For a module directory, find its `file` nodes (path under the dir).
+- For each, read inbound import edges `store.getEdges({ to: nodeId, type:
+'imports' })`; each edge's `from` node is a direct importer.
+- Map each importer file path → its owning module directory (posix dirname),
+  exclude the seed module itself, de-dup, sort.
+
+Never throws; an empty/absent graph yields `[]`.
+
+### 3. Wire it at dispatch (`orchestrator-context.ts`)
+
+`resolveLeafPrewarmBestEffort` loads the graph store best-effort (same
+`resolveGraphDir` path the rest of the orchestrator uses). When a graph is
+present it builds the blast-radius resolver and passes it plus the token budget
+into `resolveLeafPrewarm`. No graph ⇒ resolver omitted ⇒ behavior byte-identical
+to today. The token budget default is a named constant
+(`DEFAULT_BLAST_RADIUS_TOKEN_BUDGET`).
+
+## Success criteria
+
+- SC1: With a blast-radius resolver supplied, `resolveLeafPrewarm` includes the
+  1-hop importers' fresh units in the block/sources, in addition to the seed.
+- SC2: The enrichment respects `enrichmentTokenBudget` — importer units that
+  would push the cumulative enrichment tokens over the cap are excluded, while
+  every seed unit is always served regardless of the cap.
+- SC3: No resolver / no graph / empty graph ⇒ byte-identical empty-or-seed-only
+  behavior (graceful degradation preserved).
+- SC4: The graph resolver returns the correct 1-hop importer module dirs for a
+  module and never the transitive closure.
+- SC5: Best-effort throughout — a throwing store/reader/graph degrades to the
+  prior result, never breaks dispatch, never calls an LLM.
+
+## Assumptions
+
+- F3=a: 1-hop importers under a capped token budget (NOT transitive closure).
+- Seed modules are primary and exempt from the enrichment cap; only importer/dep
+  enrichment is bounded.
+- Graph file-node paths are project-root-relative posix paths; module identity is
+  the posix dirname (matches `deriveSeedModules` / committed comprehension keys).
+- Default enrichment budget is a conservative constant; an over-budget hub leaf
+  simply serves fewer importer units rather than failing.

--- a/docs/changes/comprehension-blast-radius-prewarm/provenance.json
+++ b/docs/changes/comprehension-blast-radius-prewarm/provenance.json
@@ -1,0 +1,24 @@
+{
+  "issues": [1690],
+  "route": "feature",
+  "stages": ["brainstorming", "autopilot"],
+  "assumptions": ["F3=a 1-hop importers under a capped token budget"],
+  "planArtifact": "docs/changes/comprehension-blast-radius-prewarm/plans/plan.md",
+  "slug": "comprehension-blast-radius-prewarm",
+  "title": "Comprehension: full blast-radius prewarm enrichment (orchestrator)",
+  "branch": "roadmap-fleet/1690-comprehension-blast-radius-prewarm",
+  "mechanisms": {
+    "coreEnrichmentSeam": "packages/orchestrator/src/workflow/comprehension-prewarm.ts — LeafPrewarmDeps gains resolveBlastRadius + enrichmentTokenBudget; resolveLeafPrewarm serves seed (always) then a token-budget-bounded enrichment (deps ∪ 1-hop importers).",
+    "graphResolver": "packages/orchestrator/src/workflow/comprehension-blast-radius.ts — createGraphBlastRadiusResolver(store) maps a module dir → its 1-hop importer module dirs via inbound `imports` edges (never transitive, never throws).",
+    "dispatchWiring": "packages/orchestrator/src/workflow/orchestrator-context.ts — resolveLeafPrewarmBestEffort best-effort loads the GraphStore (resolveGraphDir) and passes resolveBlastRadius + DEFAULT_BLAST_RADIUS_TOKEN_BUDGET (4000) into resolveLeafPrewarm; no graph ⇒ omitted ⇒ byte-identical seed-only pre-warm."
+  },
+  "forkF3": {
+    "decision": "(a) prewarm DIRECT (1-hop) importers under a capped token budget — NOT the full transitive closure.",
+    "proof": "createGraphBlastRadiusResolver reads only inbound 1-hop `imports` edges; comprehension-blast-radius.test.ts asserts a 2-hop importer is excluded; enrichmentTokenBudget caps cumulative enrichment tokens while the seed is always served."
+  },
+  "tests": [
+    "packages/orchestrator/src/workflow/comprehension-prewarm.test.ts — SC1 (blast-radius importers served), SC2 (token-budget cap; seed always served; unbounded back-compat), dedup vs seed.",
+    "packages/orchestrator/src/workflow/comprehension-blast-radius.test.ts — SC4 (1-hop importer resolution; excludes transitive), empty/unknown/hostile-store degrade to [].",
+    "packages/orchestrator/src/workflow/orchestrator-context.blast-radius-seam.test.ts — WIRED: real on-disk graph enriches resolveStagePrewarmBlock; no graph ⇒ seed-only (SC3)."
+  ]
+}

--- a/packages/orchestrator/src/workflow/comprehension-blast-radius.test.ts
+++ b/packages/orchestrator/src/workflow/comprehension-blast-radius.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { GraphStore, type GraphNode, type GraphEdge } from '@harness-engineering/graph';
+import { createGraphBlastRadiusResolver } from './comprehension-blast-radius';
+
+function fileNode(path: string): GraphNode {
+  return { id: `file:${path}`, type: 'file', name: path, path, metadata: {} };
+}
+
+function importsEdge(fromPath: string, toPath: string): GraphEdge {
+  return { from: `file:${fromPath}`, to: `file:${toPath}`, type: 'imports' };
+}
+
+/**
+ * Graph shape (arrows = "imports"):
+ *   packages/cli/src/bar.ts    ─▶ packages/core/src/foo.ts
+ *   packages/api/src/baz.ts    ─▶ packages/core/src/foo.ts
+ *   packages/web/src/deep.ts   ─▶ packages/cli/src/bar.ts     (2-hop from core)
+ * So the 1-hop importers of module `packages/core/src` are the module dirs
+ * `packages/cli/src` and `packages/api/src` — NOT `packages/web/src` (transitive).
+ */
+function buildStore(): GraphStore {
+  const store = new GraphStore();
+  for (const p of [
+    'packages/core/src/foo.ts',
+    'packages/cli/src/bar.ts',
+    'packages/api/src/baz.ts',
+    'packages/web/src/deep.ts',
+  ]) {
+    store.addNode(fileNode(p));
+  }
+  store.addEdge(importsEdge('packages/cli/src/bar.ts', 'packages/core/src/foo.ts'));
+  store.addEdge(importsEdge('packages/api/src/baz.ts', 'packages/core/src/foo.ts'));
+  store.addEdge(importsEdge('packages/web/src/deep.ts', 'packages/cli/src/bar.ts'));
+  return store;
+}
+
+describe('createGraphBlastRadiusResolver — #1690 1-hop blast radius', () => {
+  it('(SC4) returns the DIRECT (1-hop) importer module dirs of a module', () => {
+    const resolve = createGraphBlastRadiusResolver(buildStore());
+    expect(resolve('packages/core/src').sort()).toEqual(['packages/api/src', 'packages/cli/src']);
+  });
+
+  it('(SC4) does NOT include transitive (2-hop) importers', () => {
+    const resolve = createGraphBlastRadiusResolver(buildStore());
+    expect(resolve('packages/core/src')).not.toContain('packages/web/src');
+  });
+
+  it('reports the 1-hop importer of an intermediate module (cli imported by web)', () => {
+    const resolve = createGraphBlastRadiusResolver(buildStore());
+    expect(resolve('packages/cli/src')).toEqual(['packages/web/src']);
+  });
+
+  it('excludes the module itself when a file inside it imports a sibling in it', () => {
+    const store = new GraphStore();
+    store.addNode(fileNode('packages/core/src/a.ts'));
+    store.addNode(fileNode('packages/core/src/b.ts'));
+    store.addEdge(importsEdge('packages/core/src/a.ts', 'packages/core/src/b.ts'));
+    const resolve = createGraphBlastRadiusResolver(store);
+    expect(resolve('packages/core/src')).toEqual([]);
+  });
+
+  it('returns [] for a module with no importers and for an unknown module', () => {
+    const resolve = createGraphBlastRadiusResolver(buildStore());
+    expect(resolve('packages/web/src')).toEqual([]); // leaf importer, nobody imports it
+    expect(resolve('packages/nope/src')).toEqual([]); // not in the graph
+  });
+
+  it('returns [] for an empty graph and never throws', () => {
+    const resolve = createGraphBlastRadiusResolver(new GraphStore());
+    expect(resolve('packages/core/src')).toEqual([]);
+  });
+
+  it('degrades to [] on a hostile store (never throws)', () => {
+    const hostile = {
+      findNodes: () => {
+        throw new Error('boom');
+      },
+      getEdges: () => {
+        throw new Error('boom');
+      },
+      getNode: () => {
+        throw new Error('boom');
+      },
+    } as unknown as GraphStore;
+    const resolve = createGraphBlastRadiusResolver(hostile);
+    expect(resolve('packages/core/src')).toEqual([]);
+  });
+});

--- a/packages/orchestrator/src/workflow/comprehension-blast-radius.ts
+++ b/packages/orchestrator/src/workflow/comprehension-blast-radius.ts
@@ -1,0 +1,85 @@
+/**
+ * #1690 — graph-backed 1-hop blast-radius resolver for the dispatch pre-warm.
+ *
+ * The compiled-comprehension pre-warm (`resolveLeafPrewarm`) can enrich a leaf's
+ * seed modules with their DIRECT importers — the code that depends on the leaf,
+ * i.e. its 1-hop blast radius (F3=a: 1-hop, NOT the transitive closure). This
+ * module builds that `resolveBlastRadius` seam over a `@harness-engineering/graph`
+ * `GraphStore`.
+ *
+ * Given a module DIRECTORY it: (1) finds the file nodes under that directory,
+ * (2) reads their inbound `imports` edges (each edge's `from` node is a direct
+ * importer), (3) maps each importer file path to its owning module directory,
+ * and returns those directories (excluding the seed module itself), de-duped and
+ * sorted. It NEVER throws — a hostile/empty graph yields `[]` — so it can be
+ * wired into the best-effort dispatch pre-warm.
+ */
+
+import type { GraphStore, GraphNode } from '@harness-engineering/graph';
+
+/** Posix-normalize a path and strip a trailing slash. */
+function toPosix(p: string): string {
+  return p.replaceAll('\\', '/').replace(/\/+$/, '');
+}
+
+/**
+ * Owning module DIRECTORY of a file path: the dirname when the last segment is a
+ * `name.ext` file, else the path itself (already a directory). Mirrors the
+ * seed-derivation contract in `comprehension-prewarm.ts` so importer modules key
+ * the same committed comprehension units.
+ */
+function moduleDirOfFile(filePath: string): string | null {
+  const posix = toPosix(filePath);
+  const slash = posix.lastIndexOf('/');
+  if (slash === -1) return null;
+  const last = posix.slice(slash + 1);
+  return last.lastIndexOf('.') > 0 ? posix.slice(0, slash) : posix;
+}
+
+/** Whether `filePath` lives under module directory `dir` (or is that dir). */
+function isUnderModuleDir(filePath: string, dir: string): boolean {
+  const posix = toPosix(filePath);
+  return posix === dir || posix.startsWith(`${dir}/`);
+}
+
+export interface GraphBlastRadiusResolver {
+  (module: string): string[];
+}
+
+/**
+ * Build a `resolveBlastRadius(module) => string[]` over a loaded `GraphStore`.
+ * Returns the 1-hop importer module directories of the given module directory.
+ * Best-effort: any failure (or an empty graph) degrades to `[]`.
+ */
+export function createGraphBlastRadiusResolver(store: GraphStore): GraphBlastRadiusResolver {
+  // Snapshot the file nodes once; a dispatch pre-warm resolves only a handful of
+  // seed modules, and the graph is immutable for the life of the resolver.
+  let fileNodes: GraphNode[] = [];
+  try {
+    fileNodes = store.findNodes({ type: 'file' });
+  } catch {
+    fileNodes = [];
+  }
+
+  return (module: string): string[] => {
+    try {
+      const dir = toPosix(module);
+      if (!dir) return [];
+      const importerDirs = new Set<string>();
+      for (const node of fileNodes) {
+        if (!node.path || !isUnderModuleDir(node.path, dir)) continue;
+        // Inbound `imports` edges: each `from` node imports this file.
+        for (const edge of store.getEdges({ to: node.id, type: 'imports' })) {
+          const importer = store.getNode(edge.from);
+          if (!importer?.path) continue;
+          const importerDir = moduleDirOfFile(importer.path);
+          // 1-hop only, and never the seed module itself.
+          if (importerDir && importerDir !== dir) importerDirs.add(importerDir);
+        }
+      }
+      return [...importerDirs].sort();
+    } catch {
+      return [];
+    }
+  };
+}

--- a/packages/orchestrator/src/workflow/comprehension-prewarm.test.ts
+++ b/packages/orchestrator/src/workflow/comprehension-prewarm.test.ts
@@ -190,4 +190,89 @@ describe('resolveLeafPrewarm — SF4.1', () => {
     expect(res.sources.map((s) => s.label).sort()).toEqual([dep, module].sort());
     expect(resolveDirectDeps).toHaveBeenCalled();
   });
+
+  // #1690 — 1-hop blast-radius enrichment (F3=a), bounded by a token budget.
+  it('(SC1) enriches with 1-hop importers (blast radius) alongside the seed', async () => {
+    const importer = 'packages/cli/src';
+    const resolveBlastRadius = vi.fn((m: string) => (m === module ? [importer] : []));
+    const res = await resolveLeafPrewarm(
+      issue({ title: `edit ${module}/a.ts` }),
+      deps({
+        store: fakeStore({
+          [module]: freshUnit(module, source),
+          [importer]: freshUnit(importer, source),
+        }),
+        reader: fakeReader({ [module]: source, [importer]: source }),
+        resolveBlastRadius,
+      })
+    );
+    expect(res.sources.map((s) => s.label).sort()).toEqual([importer, module].sort());
+    expect(res.block).toContain(`contract for ${importer}`);
+    expect(resolveBlastRadius).toHaveBeenCalledWith(module);
+  });
+
+  it('(SC1) unions direct deps AND blast-radius importers, de-duping the seed', async () => {
+    const dep = 'packages/types/src';
+    const importer = 'packages/cli/src';
+    const res = await resolveLeafPrewarm(
+      issue({ title: `edit ${module}/a.ts` }),
+      deps({
+        store: fakeStore({
+          [module]: freshUnit(module, source),
+          [dep]: freshUnit(dep, source),
+          [importer]: freshUnit(importer, source),
+        }),
+        reader: fakeReader({ [module]: source, [dep]: source, [importer]: source }),
+        // A resolver that also echoes the seed must NOT duplicate it.
+        resolveDirectDeps: (m) => (m === module ? [dep, module] : []),
+        resolveBlastRadius: (m) => (m === module ? [importer] : []),
+      })
+    );
+    expect(res.sources.map((s) => s.label).sort()).toEqual([dep, importer, module].sort());
+    // Seed served exactly once even though a resolver echoed it.
+    expect(res.sources.filter((s) => s.label === module)).toHaveLength(1);
+  });
+
+  it('(SC2) caps enrichment by token budget while ALWAYS serving the seed', async () => {
+    // Two importers; the budget only admits the first (alphabetically ordered).
+    const impA = 'aaa/importer';
+    const impB = 'zzz/importer';
+    const oneUnitTokens = Math.ceil(renderServedUnit(freshUnit(impA, source)).length / 4);
+    const res = await resolveLeafPrewarm(
+      issue({ title: `edit ${module}/a.ts` }),
+      deps({
+        store: fakeStore({
+          [module]: freshUnit(module, source),
+          [impA]: freshUnit(impA, source),
+          [impB]: freshUnit(impB, source),
+        }),
+        reader: fakeReader({ [module]: source, [impA]: source, [impB]: source }),
+        resolveBlastRadius: (m) => (m === module ? [impA, impB] : []),
+        // Budget fits exactly ONE enrichment unit.
+        enrichmentTokenBudget: oneUnitTokens,
+      })
+    );
+    const labels = res.sources.map((s) => s.label);
+    expect(labels).toContain(module); // seed always served
+    expect(labels).toContain(impA); // first enrichment unit admitted
+    expect(labels).not.toContain(impB); // second exceeds the cap → excluded
+  });
+
+  it('(SC2) an unset budget leaves enrichment unbounded (back-compat)', async () => {
+    const impA = 'aaa/importer';
+    const impB = 'zzz/importer';
+    const res = await resolveLeafPrewarm(
+      issue({ title: `edit ${module}/a.ts` }),
+      deps({
+        store: fakeStore({
+          [module]: freshUnit(module, source),
+          [impA]: freshUnit(impA, source),
+          [impB]: freshUnit(impB, source),
+        }),
+        reader: fakeReader({ [module]: source, [impA]: source, [impB]: source }),
+        resolveBlastRadius: (m) => (m === module ? [impA, impB] : []),
+      })
+    );
+    expect(res.sources.map((s) => s.label).sort()).toEqual([impA, impB, module].sort());
+  });
 });

--- a/packages/orchestrator/src/workflow/comprehension-prewarm.ts
+++ b/packages/orchestrator/src/workflow/comprehension-prewarm.ts
@@ -32,9 +32,25 @@ export interface LeafPrewarmDeps {
   /**
    * Optional direct-dep enrichment. Present only when a graph is available at
    * dispatch; absent ⇒ the seed is the issue-referenced modules alone (SC3
-   * graceful degradation).
+   * graceful degradation). Returns the modules a seed module DEPENDS ON.
    */
   resolveDirectDeps?: (module: string) => string[];
+  /**
+   * #1690 — optional 1-hop BLAST-RADIUS enrichment. Returns the DIRECT importers
+   * (dependents) of a seed module — the code that would break if the leaf
+   * changes — the mirror of `resolveDirectDeps`. Present only when a graph is
+   * available at dispatch; absent ⇒ no blast-radius enrichment (SC3 graceful
+   * degradation). Bounded by `enrichmentTokenBudget` (F3=a: 1-hop, capped).
+   */
+  resolveBlastRadius?: (module: string) => string[];
+  /**
+   * #1690 — cap (in tokens) on the CUMULATIVE served size of the ENRICHMENT
+   * (non-seed) units. Seed modules are always served regardless of this cap;
+   * only dep/blast-radius enrichment is bounded, so a hub (high fan-in) leaf
+   * cannot balloon the prompt. Absent (or non-positive) ⇒ unbounded, which
+   * preserves the pre-#1690 `resolveDirectDeps` back-compat behavior.
+   */
+  enrichmentTokenBudget?: number;
 }
 
 /** The rendered pre-warm block + its per-source token breakdown. */
@@ -96,30 +112,75 @@ async function serveFresh(
   }
 }
 
+/** Served-token estimate for a rendered unit (same basis as `sources`). */
+function unitTokens(rendered: string): number {
+  return Math.ceil(rendered.length / CHARS_PER_TOKEN);
+}
+
 /**
- * Resolve a leaf's pre-warm block from its issue-referenced (and optionally
- * dep-enriched) modules. Serves only fresh units; returns an empty block when
- * none are available. Best-effort — never throws, never calls an LLM.
+ * Derive the ENRICHMENT module set for a seed: the union of each seed module's
+ * direct dependencies (`resolveDirectDeps`) and its 1-hop importers /
+ * blast radius (`resolveBlastRadius`), with the seed modules themselves removed
+ * (they are served as the primary phase). Deterministically de-duplicated and
+ * sorted so the token-budget cap admits a stable prefix. Empty when neither
+ * resolver is supplied (SC3 graceful degradation).
+ */
+function deriveEnrichmentModules(seed: string[], deps: LeafPrewarmDeps): string[] {
+  if (!deps.resolveDirectDeps && !deps.resolveBlastRadius) return [];
+  const seedSet = new Set(seed);
+  const enrichment = new Set<string>();
+  for (const module of seed) {
+    for (const dep of deps.resolveDirectDeps?.(module) ?? []) {
+      if (!seedSet.has(dep)) enrichment.add(dep);
+    }
+    for (const importer of deps.resolveBlastRadius?.(module) ?? []) {
+      if (!seedSet.has(importer)) enrichment.add(importer);
+    }
+  }
+  return [...enrichment].sort();
+}
+
+/**
+ * Resolve a leaf's pre-warm block from its issue-referenced seed modules, plus
+ * an optional 1-hop enrichment (direct deps and/or blast-radius importers). The
+ * seed is always served (primary); the enrichment is served in a deterministic
+ * order and BOUNDED by `enrichmentTokenBudget` (#1690, F3=a — 1-hop, capped) so
+ * a hub leaf cannot balloon the prompt. Serves only fresh units; returns an
+ * empty block when none are available. Best-effort — never throws, never calls
+ * an LLM.
  */
 export async function resolveLeafPrewarm(
   issue: Issue,
   deps: LeafPrewarmDeps
 ): Promise<LeafPrewarmResult> {
   const seed = deriveSeedModules(issue);
-  const modules = deps.resolveDirectDeps
-    ? [...new Set(seed.flatMap((m) => [m, ...deps.resolveDirectDeps!(m)]))]
-    : seed;
 
   const rendered: string[] = [];
   const sources: LeafContextSource[] = [];
-  for (const module of modules) {
+
+  // Phase 1 — seed (primary): always served, never subject to the cap.
+  for (const module of seed) {
     const served = await serveFresh(module, deps);
     if (!served) continue;
     rendered.push(served.rendered);
-    sources.push({
-      label: served.module,
-      tokens: Math.ceil(served.rendered.length / CHARS_PER_TOKEN),
-    });
+    sources.push({ label: served.module, tokens: unitTokens(served.rendered) });
+  }
+
+  // Phase 2 — enrichment (deps ∪ blast radius): bounded by the token budget.
+  // A non-positive/absent budget means unbounded (back-compat). Once a fresh
+  // unit would push the cumulative enrichment tokens over the cap it is skipped
+  // and traversal stops, so the admitted set is a stable, deterministic prefix.
+  const budget = deps.enrichmentTokenBudget;
+  const capped = typeof budget === 'number' && budget > 0;
+  let enrichmentTokens = 0;
+  for (const module of deriveEnrichmentModules(seed, deps)) {
+    const served = await serveFresh(module, deps);
+    if (!served) continue;
+    const tokens = unitTokens(served.rendered);
+    if (capped && enrichmentTokens + tokens > budget) break;
+    enrichmentTokens += tokens;
+    rendered.push(served.rendered);
+    sources.push({ label: served.module, tokens });
   }
 
   if (rendered.length === 0) return { block: '', sources: [] };

--- a/packages/orchestrator/src/workflow/orchestrator-context.blast-radius-seam.test.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.blast-radius-seam.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as nodePath from 'node:path';
+import {
+  computeSourceHash,
+  ComprehensionStore,
+  createNodeComprehensionIO,
+  createNodeModuleSourceReader,
+  type ComprehensionUnit,
+} from '@harness-engineering/core';
+import { GraphStore } from '@harness-engineering/graph';
+import type { Issue } from '@harness-engineering/types';
+import { resolveStagePrewarmBlock, resolveLeafPrewarmSources } from './orchestrator-context';
+
+function issue(over: Partial<Issue> = {}): Issue {
+  return {
+    id: 'iss-1',
+    identifier: 'ISS-1',
+    title: 'Do the thing',
+    description: null,
+    priority: null,
+    state: 'planned',
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: null,
+    updatedAt: null,
+    externalId: null,
+    ...over,
+  };
+}
+
+/**
+ * #1690 WIRED seam — proves the dispatch pre-warm enriches a leaf with its 1-hop
+ * blast-radius (importer) comprehension when a graph is present on disk, and
+ * degrades to a seed-only block when it is not.
+ */
+describe('resolveStagePrewarmBlock — 1-hop blast-radius enrichment (#1690)', () => {
+  const originalCwd = process.cwd();
+  afterEach(() => process.chdir(originalCwd));
+
+  function writeModule(root: string, module: string, file: string, content: string): void {
+    fs.mkdirSync(nodePath.join(root, module), { recursive: true });
+    fs.writeFileSync(nodePath.join(root, module, file), content, 'utf-8');
+  }
+
+  async function commitUnit(
+    root: string,
+    module: string,
+    contract: string,
+    summary: string
+  ): Promise<void> {
+    const reader = createNodeModuleSourceReader(root);
+    const src = (await reader.readModuleSource(module))!;
+    const store = new ComprehensionStore({
+      root: `${root.replaceAll('\\', '/')}/.harness/comprehension`,
+      io: createNodeComprehensionIO(),
+    });
+    const unit: ComprehensionUnit = {
+      provenance: {
+        schemaVersion: 1,
+        module,
+        sourceHash: computeSourceHash(src),
+        compiledAt: '2026-08-27T00:00:00.000Z',
+        compiler: { static: '1.0.0', semantic: '1.0.0' },
+        model: null,
+        semantic: 'absent',
+        members: src.map((f) => f.path),
+      },
+      summary,
+      invariants: [],
+      interfaceContract: contract,
+      dependencySlice: 'imports: none',
+    };
+    expect((await store.write(unit)).ok).toBe(true);
+  }
+
+  /** Build a project: seed module `src/core` imported by `src/cli`, both with units. */
+  async function buildProject(): Promise<{ root: string; seed: string; importer: string }> {
+    const root = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'blast-radius-seam-'));
+    const seed = 'src/core';
+    const importer = 'src/cli';
+    writeModule(root, seed, 'core.ts', 'export const core = () => 1;\n');
+    writeModule(
+      root,
+      importer,
+      'cli.ts',
+      "import { core } from '../core/core';\nexport const cli = () => core();\n"
+    );
+    await commitUnit(root, seed, 'export const core: () => number', 'the core summary');
+    await commitUnit(root, importer, 'export const cli: () => number', 'the cli summary');
+    return { root, seed, importer };
+  }
+
+  async function writeGraph(root: string, seed: string, importer: string): Promise<void> {
+    const store = new GraphStore();
+    const seedFile = `${seed}/core.ts`;
+    const importerFile = `${importer}/cli.ts`;
+    store.addNode({
+      id: `file:${seedFile}`,
+      type: 'file',
+      name: seedFile,
+      path: seedFile,
+      metadata: {},
+    });
+    store.addNode({
+      id: `file:${importerFile}`,
+      type: 'file',
+      name: importerFile,
+      path: importerFile,
+      metadata: {},
+    });
+    // importer imports seed ⇒ seed's 1-hop blast radius is the importer module.
+    store.addEdge({ from: `file:${importerFile}`, to: `file:${seedFile}`, type: 'imports' });
+    await store.save(nodePath.join(root, '.harness', 'graph'));
+  }
+
+  it('enriches the pre-warm with the seed module 1-hop importer when a graph exists', async () => {
+    const { root, seed, importer } = await buildProject();
+    await writeGraph(root, seed, importer);
+    const cwdElsewhere = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'blast-cwd-'));
+    process.chdir(cwdElsewhere);
+
+    const block = await resolveStagePrewarmBlock(
+      issue({ description: `Touches ${seed}/core.ts for the change.` }),
+      root
+    );
+    // Seed contract present…
+    expect(block).toContain('export const core: () => number');
+    // …AND the 1-hop importer contract (the blast-radius enrichment).
+    expect(block).toContain('export const cli: () => number');
+
+    const sources = await resolveLeafPrewarmSources(
+      issue({ description: `Touches ${seed}/core.ts for the change.` }),
+      root
+    );
+    expect(sources.map((s) => s.label).sort()).toEqual([importer, seed].sort());
+  });
+
+  it('degrades to a seed-only block when no graph is present (byte-identical, SC3)', async () => {
+    const { root, seed } = await buildProject();
+    // No graph written.
+    const block = await resolveStagePrewarmBlock(
+      issue({ description: `Touches ${seed}/core.ts for the change.` }),
+      root
+    );
+    expect(block).toContain('export const core: () => number');
+    expect(block).not.toContain('export const cli: () => number');
+  });
+});

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -21,12 +21,21 @@ import { isLocalExecutionBackend } from '../agent/backend-factory.js';
 import type { OrchestratorBackendFactory } from '../agent/orchestrator-backend-factory.js';
 import { selectStagePromptTemplate } from './local-stage-prompt.js';
 import { resolveLeafPrewarm, type LeafPrewarmResult } from './comprehension-prewarm.js';
+import { createGraphBlastRadiusResolver } from './comprehension-blast-radius.js';
 import {
   ComprehensionStore,
   COMPREHENSION_ROOT,
   createNodeComprehensionIO,
   createNodeModuleSourceReader,
 } from '@harness-engineering/core';
+
+/**
+ * #1690 — default token cap on the dispatch pre-warm's 1-hop blast-radius
+ * enrichment (F3=a). Seed (issue-referenced) units are always served; only the
+ * importer/dep enrichment is bounded by this budget, so a hub (high fan-in) leaf
+ * serves fewer importer units rather than ballooning the prompt.
+ */
+export const DEFAULT_BLAST_RADIUS_TOKEN_BUDGET = 4000;
 import { detectEcosystem } from '../workspace/ecosystem.js';
 import type { StreamRecorder } from '../core/stream-recorder.js';
 import type { StructuredLogger } from '../logging/logger.js';
@@ -368,9 +377,41 @@ async function resolveLeafPrewarmBestEffort(
       io: createNodeComprehensionIO(),
     });
     const reader = createNodeModuleSourceReader(root);
-    return await resolveLeafPrewarm(issue, { projectRoot: root, store, reader });
+    // #1690 — best-effort 1-hop blast-radius enrichment. When a dependency graph
+    // is present, enrich the seed with its DIRECT importers (dependents) under a
+    // token budget cap (F3=a). No graph ⇒ resolver omitted ⇒ seed-only pre-warm
+    // (byte-identical to the pre-#1690 behavior, SC3).
+    const resolveBlastRadius = await loadBlastRadiusResolver(root);
+    return await resolveLeafPrewarm(issue, {
+      projectRoot: root,
+      store,
+      reader,
+      ...(resolveBlastRadius && {
+        resolveBlastRadius,
+        enrichmentTokenBudget: DEFAULT_BLAST_RADIUS_TOKEN_BUDGET,
+      }),
+    });
   } catch {
     return { block: '', sources: [] };
+  }
+}
+
+/**
+ * #1690 — best-effort load the dependency graph and build the 1-hop blast-radius
+ * resolver rooted at `root`. Returns `undefined` when no graph is persisted or
+ * the load fails, so the pre-warm degrades to the seed-only block. Never throws.
+ */
+async function loadBlastRadiusResolver(
+  root: string
+): Promise<((module: string) => string[]) | undefined> {
+  try {
+    const { GraphStore, resolveGraphDir } = await import('@harness-engineering/graph');
+    const store = new GraphStore();
+    const loaded = await store.load(resolveGraphDir(root));
+    if (!loaded) return undefined;
+    return createGraphBlastRadiusResolver(store);
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

Enriches the orchestrator dispatch comprehension pre-warm with the leaf's **1-hop blast radius** — the DIRECT importers (dependents) of the issue-referenced seed modules — so the builder sees the interface contracts of the code that will break if the leaf changes. Bounded by a token budget cap so a hub (high fan-in) leaf cannot balloon the prompt.

Route: **feature** (harness-brainstorming spec → harness-autopilot plan/execute/review).

## What changed

- **`comprehension-prewarm.ts`** — `LeafPrewarmDeps` gains `resolveBlastRadius?` (1-hop importers) and `enrichmentTokenBudget?`. `resolveLeafPrewarm` is now two-phase: the issue-referenced **seed is always served** (primary), then the **enrichment** (deps ∪ 1-hop importers, seed removed, deterministic order) is served bounded by the token budget.
- **`comprehension-blast-radius.ts`** (new) — `createGraphBlastRadiusResolver(store)` maps a module dir → its 1-hop importer module dirs via inbound `imports` edges. 1-hop only (never transitive), never throws.
- **`orchestrator-context.ts`** — `resolveLeafPrewarmBestEffort` best-effort loads the `GraphStore` (`resolveGraphDir`) and wires the resolver + `DEFAULT_BLAST_RADIUS_TOKEN_BUDGET` (4000) into the pre-warm. No graph ⇒ resolver omitted ⇒ **byte-identical** seed-only behavior.

## Tests

- `comprehension-prewarm.test.ts` — SC1 (importers served alongside seed; deps∪importers union with seed dedup), SC2 (token-budget cap excludes over-budget importer units while the seed is always served; unbounded back-compat).
- `comprehension-blast-radius.test.ts` — SC4 (1-hop importer resolution; **excludes 2-hop transitive**), empty/unknown/hostile-store degrade to `[]`.
- `orchestrator-context.blast-radius-seam.test.ts` — **WIRED**: a real on-disk graph enriches `resolveStagePrewarmBlock` end-to-end; no graph ⇒ seed-only (SC3).

All 382 orchestrator workflow tests pass; typecheck + lint clean.

## Assumptions made

- **F3 = (a)**: prewarm DIRECT (1-hop) importers under a capped token budget — **NOT** the full transitive closure (per the CONFIRM-gate fork answer).
- Seed modules are primary and exempt from the enrichment cap; only importer/dep enrichment is bounded.
- Graph file-node paths are project-root-relative posix paths; module identity is the posix dirname (matches `deriveSeedModules` / committed comprehension keys).
- Default enrichment budget is a conservative constant (4000 tokens); an over-budget hub leaf serves fewer importer units rather than failing.

Artifacts: `docs/changes/comprehension-blast-radius-prewarm/{proposal.md,plans/plan.md,provenance.json}`.

Closes #1690

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga