### PR TITLE
feat(comprehension): opt-in token-gated CI semantic refresh (ADR 0110 §3, #1689)

### DIFF
--- a/.changeset/comprehension-0110-ci-refresh.md
+++ b/.changeset/comprehension-0110-ci-refresh.md
@@ -1,0 +1,27 @@
+---
+'@harness-engineering/cli': minor
+---
+
+feat(comprehension): opt-in token-gated CI semantic refresh — the automated
+alternative provider (ADR 0110 §3, `Closes #1689`). Stacks on the single-writer
+core (#1713): where the default is a maintainer running `harness comprehend --all`
+locally, this adds the automated equivalent for teams that want CI to keep the
+committed semantic substrate fresh on a keyed runner.
+
+- **`comprehend --refresh`** — a new run mode and the authoritative in-CLI gate. It
+  performs the single-writer main-pass (regenerate + stage committed semantic) ONLY
+  when all three signals hold: `comprehension.ci: refresh` is configured, this is
+  the `main` main-pass, and a provider credential resolves. A new pure
+  `comprehension/refresh-gate.ts` (`resolveRefreshJobGate`) makes the decision and
+  reports the first missing prerequisite. Provider-neutral — the credential is
+  whatever `resolveAnalysisProvider` resolves (Anthropic key, a config-declared
+  OpenAI-compatible endpoint, or the claude CLI), never a forced Claude model.
+- **Off by default.** Every inactive branch is a clean no-op (exit 0) — a default
+  adopter (`ci: verify`, no secret) sees zero new behavior and CI stays token-free
+  (the ADR-0109 invariant). `ci: refresh` set but no credential degrades to a
+  token-free no-op with an actionable `::warning::`, never a red merge.
+- **New CI job `comprehension-refresh`** — runs POST-MERGE on `main` only (never in
+  a PR context), gated behind a repo variable `HARNESS_COMPREHENSION_CI_REFRESH`
+  plus the in-CLI gate, and commits the refreshed `.harness/comprehension/**` shards
+  via the github-actions[bot] with `[skip ci]`. Loop-safe by construction (skip-ci
+  and idempotent regeneration).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,3 +358,122 @@ jobs:
           HUSKY: '0'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTOAPPROVE_PAT: ${{ secrets.BASELINE_AUTOAPPROVE_PAT }}
+
+  # ADR 0110 §3 / #1689 — OPT-IN, token-gated CI semantic refresh (the automated
+  # ALTERNATIVE to the default maintainer-local provider). `main` is the single
+  # writer of the semantic half, so this runs POST-MERGE on `main` ONLY (never in a
+  # PR context — a PR must stay static-only, or it re-creates the very conflict the
+  # single-writer design eliminates). It performs the provider-backed main-pass and
+  # commits the refreshed semantic units via the github-actions[bot].
+  #
+  # OFF BY DEFAULT — TWO switches must both be set, so a default adopter sees ZERO
+  # new behavior and CI stays token-free (the ADR-0109 invariant):
+  #   1. the repo VARIABLE `HARNESS_COMPREHENSION_CI_REFRESH == 'true'` — the
+  #      workflow-level opt-in. GitHub `if:` cannot read the repo's harness.config or
+  #      a secret, so a cheap variable is the only way to keep the whole job INERT
+  #      (never scheduled, zero CI minutes) for the default adopter.
+  #   2. `comprehension.ci: refresh` in harness.config + an LLM credential SECRET —
+  #      the AUTHORITATIVE in-CLI gate (`comprehend --refresh`). Even if the variable
+  #      is set, a missing config value / credential degrades to a token-free no-op
+  #      (an actionable ::warning::) — it never reds the merge. Provider-neutral: the
+  #      credential is any of ANTHROPIC_API_KEY, or HARNESS_ANALYSIS_BASE_URL (+
+  #      optional HARNESS_ANALYSIS_API_KEY) for any OpenAI-compatible vendor.
+  comprehension-refresh:
+    if: >-
+      github.ref == 'refs/heads/main' && github.event_name == 'push' &&
+      vars.HARNESS_COMPREHENSION_CI_REFRESH == 'true'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      # `contents: write` for the direct bot push of the refreshed shards;
+      # `pull-requests: write` for the PR fallback when branch protection blocks
+      # a direct push to main (same posture as refresh-baselines).
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the bot push / PR fallback has a usable main base.
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - run: pnpm build
+
+      # The single-writer main-pass. `--refresh` is the authoritative gate: it acts
+      # ONLY when `comprehension.ci: refresh` is configured AND a provider credential
+      # resolves; otherwise it is a clean no-op (exit 0). HARNESS_COMPREHENSION_MAIN_PASS
+      # asserts the main-pass context (the checkout is a detached HEAD at the merged
+      # SHA, where branch resolution is unreliable). All credential envs are passed
+      # through empty-when-unset — the CLI picks whichever vendor resolves.
+      - name: Comprehension semantic refresh (opt-in, token-gated)
+        env:
+          HARNESS_COMPREHENSION_MAIN_PASS: '1'
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HARNESS_ANALYSIS_BASE_URL: ${{ secrets.HARNESS_ANALYSIS_BASE_URL }}
+          HARNESS_ANALYSIS_API_KEY: ${{ secrets.HARNESS_ANALYSIS_API_KEY }}
+          HARNESS_ANALYSIS_MODEL: ${{ secrets.HARNESS_ANALYSIS_MODEL }}
+        run: node packages/cli/dist/bin/harness.js comprehend --refresh
+
+      # Commit the refreshed semantic shards via the bot. Loop-safe by construction:
+      #   - `[skip ci]` on the commit prevents this push from starting a new CI run;
+      #   - regeneration is IDEMPOTENT — once semantic is fresh, the next run finds
+      #     nothing stale and stages nothing, so `git diff --cached --quiet` short-
+      #     circuits to a no-op even if [skip ci] were ever missed. Both guards hold.
+      # Scoped strictly to `.harness/comprehension/**` so the bot can only ever touch
+      # the substrate it regenerated. Direct push first; PR fallback (for review by a
+      # human — no auto-approve) when branch protection blocks the direct push.
+      - name: Commit refreshed semantic shards
+        env:
+          HUSKY: '0'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          SUBSTRATE=".harness/comprehension"
+          git add "$SUBSTRATE"
+          if git diff --cached --quiet; then
+            echo "No semantic refresh to commit (all units already source-fresh)."
+            exit 0
+          fi
+          git commit -m "chore(comprehension): CI semantic refresh [skip ci]"
+          OURS=$(git rev-parse HEAD)
+          if git push 2>&1; then
+            exit 0
+          fi
+          echo "Direct push blocked by branch protection. Opening a PR instead."
+          git fetch origin main
+          BRANCH="chore/comprehension-refresh-$(date +%s)"
+          git checkout -B "$BRANCH" origin/main
+          # Re-apply the freshly regenerated shards on top of the latest main. The
+          # substrate is regenerated wholesale, so "ours" is always the correct
+          # resolution and this re-apply cannot conflict.
+          git checkout "$OURS" -- "$SUBSTRATE"
+          git add "$SUBSTRATE"
+          if git diff --cached --quiet; then
+            echo "Latest main already carries this refresh; nothing to PR."
+            exit 0
+          fi
+          git commit -m "chore(comprehension): CI semantic refresh [skip ci]"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore(comprehension): CI semantic refresh" \
+            --body "Automated single-writer semantic refresh (ADR 0110 §3 / #1689). Opened because a direct push to main is blocked by branch protection. Review and merge to land the refreshed comprehension substrate." \
+            --base main \
+            --head "$BRANCH"

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '931d4598bfdd7d2608971a440a1680e47f42ad694de730c8d381712b0c81e848'
+sourceHash: '24d13397fb338f8542cd526c4c240a4c16ba8a1ac88c99604dcb653f67a4d2cb'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -392,6 +392,7 @@ import { maybeCreateGenerateSemantic } from '../comprehension/generate-semantic'
 import { shouldRunComprehendHook } from '../comprehension/hook'
 import { enumerateModules, filesToModules } from '../comprehension/invalidation'
 import { committedSemanticAllowed } from '../comprehension/policy'
+import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../comprehension/refresh-gate'
 import { RegressionContext, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
 import { createStaticExtractor } from '../comprehension/static-extractor'
 import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js'

--- a/.harness/comprehension/packages/cli/src/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/src/comprehension/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/comprehension'
-sourceHash: '582fb72701bef0ef59297c8d9c6b26b48fd1d97abacbafe9d723ff7a1b8ff989'
+sourceHash: '8f6c66e0b7ca936151d3e6ef555f60d5ef43f05a07c2810228e0ba9ece952c82'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -13,6 +13,7 @@ members:
     'hook.ts',
     'invalidation.ts',
     'policy.ts',
+    'refresh-gate.ts',
     'regression.ts',
     'static-extractor.ts',
   ]
@@ -38,6 +39,7 @@ export defaultSemanticModel
 export detectCommittedSemanticOnBranch
 export detectSemanticRegressions
 export enumerateModules
+export explainInactiveRefreshGate
 export filesToModules
 export isComprehensionReentrant
 export isMainPassContext
@@ -51,6 +53,7 @@ export renderDependencySlice
 export renderInterfaceContract
 export resolveComprehensionBranch
 export resolveComprehensionCiMode
+export resolveRefreshJobGate
 export runComprehend
 export runComprehendCheck
 export runComprehendStats

--- a/.harness/comprehension/packages/cli/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/tests/comprehension/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/comprehension'
-sourceHash: '36a5d7b391ead300120d30474be167cabbacc6d02b1023e87b1c7456f330e5fc'
+sourceHash: '47c1d239bd50f7fe4ffe0cc57f80775d64d8350811496303dbdd7bc15ff02ebf'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -16,6 +16,7 @@ members:
     'hook.test.ts',
     'invalidation.test.ts',
     'policy.test.ts',
+    'refresh-gate.test.ts',
     'regression.test.ts',
     'static-extractor.test.ts',
   ]
@@ -39,6 +40,7 @@ import { DEFAULT_DIGEST_CHAR_BUDGET, DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_SEMANTIC
 import { shouldRunComprehendHook } from '../../src/comprehension/hook'
 import { enumerateModules, filesToModules } from '../../src/comprehension/invalidation'
 import { MAIN_BRANCH, committedSemanticAllowed, isMainPassContext, resolveComprehensionBranch } from '../../src/comprehension/policy'
+import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../../src/comprehension/refresh-gate'
 import { RefReadDeps, SemanticState, detectCommittedSemanticOnBranch, detectSemanticRegressions, parseModuleSemantic, readSemanticMapAtRef } from '../../src/comprehension/regression'
 import { createStaticExtractor, isStaticSupported, renderDependencySlice, renderInterfaceContract } from '../../src/comprehension/static-extractor'
 import { ComprehensionConfigSchema, HarnessConfig, HarnessConfigSchema } from '../../src/config/schema'

--- a/docs/changes/comprehension-0110-ci-refresh/plans/plan.md
+++ b/docs/changes/comprehension-0110-ci-refresh/plans/plan.md
@@ -1,0 +1,104 @@
+# Plan: opt-in token-gated CI semantic refresh (the automated alternative provider)
+
+Issue: Intense-Visions/harness-engineering#1689
+Slug: `comprehension-0110-ci-refresh`
+Route: **spec-ready** (design settled in ADR 0110 §3 + §Implementation-slices #2) →
+run harness-autopilot against the ADR.
+Spec: `docs/knowledge/decisions/0110-single-writer-semantic-comprehension.md`
+Stacks on: #1713 (`feat/comprehension-0110-single-writer-1713`) — the single-writer
+core. This PR's base is that branch (GitHub auto-retargets to `main` when #1713 lands).
+
+## Problem (ADR 0110 §3)
+
+ADR 0110 makes `main` the single writer of the SEMANTIC half and chooses the
+**maintainer-local** provider as the DEFAULT (§3): a human periodically runs
+`harness comprehend --all` and commits the semantic pass. §3 records the
+**alternative provider** — a scheduled/keyed CI runner — as the opt-in this issue
+(#1689) delivers, for teams that want automated CI freshness without relying on a
+maintainer's cadence. It must be **off by default** and require an LLM credential
+supplied as a CI secret, so a default adopter sees zero new behavior and CI stays
+token-free (the ADR-0109 invariant).
+
+#1713 already wired the code seam this plugs into: `policy.ts`
+(`committedSemanticAllowed` / `HARNESS_COMPREHENSION_MAIN_PASS`), the
+`comprehension.ci` config consumer, and `runRefreshMainPass` (provider-backed
+main-pass regeneration). #1689 adds the **CI job** that supplies a credential and
+commits the refreshed units on `main` post-merge, plus the authoritative in-CLI gate
+that keeps it off-by-default and provider-neutral.
+
+## Design — three coupled changes
+
+### 1. A pure, tested gate — `comprehension/refresh-gate.ts`
+
+`resolveRefreshJobGate({ ciMode, isMainPass, credentialPresent })` AND-s the three
+opt-in signals cheapest-first and returns `{active}` or `{active:false, reason}`
+where `reason` is the FIRST missing prerequisite (`not-enabled` → `not-main-pass` →
+`no-credential`). `explainInactiveRefreshGate(reason)` renders an actionable,
+single-line message. Off-by-default is structural: the only `active` branch requires
+`ciMode === 'refresh'`. Provider-neutral: `credentialPresent` is whatever
+`resolveAnalysisProvider` resolves (Anthropic key, a config-declared
+OpenAI-compatible endpoint, or the claude CLI) — never a forced Claude model.
+
+### 2. The CLI entrypoint — `comprehend --refresh`
+
+A new run mode (`resolveMode`: `refresh` > check > stats > all > changed).
+`runRefreshMode`:
+
+- resolves `ciMode` (config), `isMainPass` (`committedSemanticAllowed()`), and
+  probes a provider WITHOUT forcing a model (the token gate);
+- calls `resolveRefreshJobGate`. **Every inactive branch is a clean no-op (exit 0)**
+  — the refresh is remediation, never a pass/fail signal, so a default adopter (or
+  one who forgot the secret) never reds a merge. The `no-credential` case is
+  surfaced as an ACTIONABLE `::warning::` GitHub annotation;
+- when active, runs the single-writer main-pass (`compileComprehension('all', …,
+{stage:true, isMainPass:true})`, reusing the already-probed provider) and STAGES
+  the shards for the workflow to commit. Reports the count via a `::notice::`.
+
+`--all` (full stale sweep) is used rather than `--changed`: a post-merge `main`
+checkout has no meaningful merge-base diff, and `runComprehend` skips already-fresh
+modules, so only genuinely stale units cost tokens (bounded by
+`comprehension.maxTokensPerRun`).
+
+### 3. The CI job — `.github/workflows/ci.yml` → `comprehension-refresh`
+
+Post-merge on `main` ONLY (`push` to `main`) — never in a PR context, or it
+re-creates the very conflict single-writer eliminates. `needs: build-and-test` (only
+refresh a green `main`). **Two switches, both required** (off by default):
+
+- repo VARIABLE `HARNESS_COMPREHENSION_CI_REFRESH == 'true'` — the workflow-level
+  opt-in. GitHub `if:` cannot read the repo's harness.config or a secret, so a cheap
+  variable is the only way to keep the whole job INERT (never scheduled, zero CI
+  minutes) for the default adopter.
+- `comprehension.ci: refresh` in config + an LLM credential SECRET — the
+  AUTHORITATIVE in-CLI gate. Even with the variable set, a missing config/credential
+  degrades to a token-free no-op (never reds the merge).
+
+The job sets `HARNESS_COMPREHENSION_MAIN_PASS=1` (detached HEAD at the merged SHA),
+passes all credential envs through (empty-when-unset; provider-neutral), runs
+`comprehend --refresh`, then commits any staged `.harness/comprehension/**` shards
+via the github-actions[bot] with `[skip ci]` (direct push first; PR fallback for
+human review when branch protection blocks the push). **Loop-safe by construction:**
+`[skip ci]` on the commit AND idempotent regeneration (once fresh, the next run
+stages nothing → `git diff --cached --quiet` short-circuits).
+
+## Tasks
+
+1. `refresh-gate.ts` (pure gate) + `refresh-gate.test.ts`.
+2. `comprehend.ts` — `--refresh` flag/mode, `runRefreshMode`, GitHub-annotation
+   helper, `compileComprehension` provider-reuse seam.
+3. Extend `comprehend-flags.test.ts` (flag + `resolveMode` precedence) and
+   `comprehend-smoke.e2e.test.ts` (off-by-default no-op, no-credential actionable
+   no-op, off-main-pass no-op, active regenerate, idempotent loop-safety).
+4. `ci.yml` — the `comprehension-refresh` job.
+5. Regenerate `docs/reference/cli-commands.md`; changeset; plan + provenance.
+
+## Verification
+
+- Unit: gate (all reasons + first-missing precedence), `resolveMode` precedence.
+- E2E over the built binary: ci:verify / no-config ⇒ clean no-op writing NO shard;
+  ci:refresh + main-pass + no credential ⇒ actionable no-op, token-free; ci:refresh
+  off the main-pass ⇒ no-op; ci:refresh + faked provider + main-pass ⇒ regenerates a
+  `semantic: present` unit that serves fresh; a second run is idempotent (stages
+  nothing).
+- Full comprehension suite green (174 passed); cli typecheck + lint clean; workflow
+  YAML parses; token-free CI invariant preserved for the default adopter.

--- a/docs/changes/comprehension-0110-ci-refresh/provenance.json
+++ b/docs/changes/comprehension-0110-ci-refresh/provenance.json
@@ -1,0 +1,23 @@
+{
+  "issue": 1689,
+  "issues": [1689],
+  "route": "spec-ready",
+  "spec": "docs/knowledge/decisions/0110-single-writer-semantic-comprehension.md",
+  "stacksOn": 1713,
+  "baseBranch": "feat/comprehension-0110-single-writer-1713",
+  "stages": ["autopilot", "planning", "execution", "verification"],
+  "planArtifact": "docs/changes/comprehension-0110-ci-refresh/plans/plan.md",
+  "assumptions": [
+    "SCOPE: #1713 already built the CODE seam (policy.ts committedSemanticAllowed / HARNESS_COMPREHENSION_MAIN_PASS, the comprehension.ci consumer, and runRefreshMainPass provider-backed regeneration). #1689 adds (a) an authoritative in-CLI gate + dedicated entrypoint `comprehend --refresh`, and (b) the post-merge CI job that supplies a credential and bot-commits the refreshed units. It builds ON #1713's seam, does not fork or duplicate it.",
+    "GATE = a new pure module comprehension/refresh-gate.ts: resolveRefreshJobGate({ciMode,isMainPass,credentialPresent}) AND-s the three opt-in signals cheapest-first; reason is the FIRST missing prerequisite (not-enabled > not-main-pass > no-credential). Off-by-default is STRUCTURAL — the only active branch requires ciMode==='refresh'.",
+    "ENTRYPOINT = a new `comprehend --refresh` mode (resolveMode precedence refresh > check > stats > all > changed). runRefreshMode probes a provider WITHOUT forcing a model (provider-neutral token gate), calls the gate, and on active runs compileComprehension('all',{stage:true,isMainPass:true}) reusing the probed provider. Added an optional `provider` param to compileComprehension to avoid a double resolve; it is honoured only when NOT static-only (an explicit --static/semantic:false always wins and stays provider-free).",
+    "CREDENTIAL-ABSENT DECISION (the ADR's open question): `ci: refresh` set but no secret => DEGRADE to a token-free NO-OP (exit 0) with an ACTIONABLE ::warning:: GitHub annotation naming the provider-neutral secrets (ANTHROPIC_API_KEY, or HARNESS_ANALYSIS_BASE_URL/_API_KEY for any OpenAI-compatible vendor). NOT a hard error — a hard error would red EVERY merge for a misconfigured adopter; off-by-default safety and the ADR-0109 token-free invariant both demand a clean no-op.",
+    "OFF-BY-DEFAULT MECHANISM = TWO switches. (1) repo VARIABLE HARNESS_COMPREHENSION_CI_REFRESH=='true' gates the WHOLE job in `if:` so the job is INERT (never scheduled, zero CI minutes) for the default adopter — GitHub `if:` cannot read harness.config or a secret, so a cheap variable is the only zero-cost workflow-level switch. (2) comprehension.ci: refresh in config + credential secret = the AUTHORITATIVE in-CLI gate (belt-and-suspenders: variable set but config/secret missing => token-free no-op). Recorded as a deliberate, necessary dual-signal, not a dual-source-of-truth bug.",
+    "RUNS ON main POST-MERGE ONLY: job `if: github.ref=='refs/heads/main' && github.event_name=='push'`, needs: build-and-test (only refresh a green main). HARNESS_COMPREHENSION_MAIN_PASS=1 asserts the main-pass context under the detached-HEAD merged-SHA checkout. NEVER runs in a PR context (guarded by the push+ref condition) — a PR must stay static-only per ADR 0110 §1.",
+    "BOT IDENTITY = github-actions[bot] (github-actions[bot]@users.noreply.github.com), mirroring the existing refresh-baselines job. Commits scoped strictly to .harness/comprehension/** with message 'chore(comprehension): CI semantic refresh [skip ci]'. Direct push first; PR fallback for HUMAN review (no auto-approve, unlike refresh-baselines) when branch protection blocks the push — semantic prose refresh warrants a look, and adopter branch-protection varies.",
+    "LOOP-GUARD = belt-and-suspenders: (1) [skip ci] on the bot commit prevents the push from starting a new CI run; (2) idempotent regeneration — once semantic is source-fresh, the next --refresh stages nothing and `git diff --cached --quiet` short-circuits to a no-op even if [skip ci] were ever missed (e.g. a squash-merge of the PR-fallback branch). The e2e 'idempotent' test proves (2).",
+    "REFRESH USES --all NOT --changed: a post-merge main checkout has no meaningful merge-base diff (deriveChangedSurface would be empty). runComprehend skips already-fresh modules, so --all only regenerates genuinely stale units, bounded by comprehension.maxTokensPerRun.",
+    "STACKED PR: branched off origin/feat/comprehension-0110-single-writer-1713 (NOT main); PR base = that branch so the diff shows only #1689's addition. GitHub auto-retargets to main when #1713 merges."
+  ],
+  "closingKeyword": "Closes #1689"
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -223,6 +223,7 @@ Compile and maintain the per-module comprehension substrate
 - `--changed` — Recompile only modules owning changed files (default)
 - `--all` — Recompile every module (backfill)
 - `--check` — Token-free: report source-stale units, exit non-zero if any
+- `--refresh` — Opt-in token-gated CI refresh (#1689): on the single-writer main-pass with a provider credential and comprehension.ci:refresh, regenerate+stage committed semantic; a clean no-op otherwise
 - `--since` — With --check: also fail on any module that regressed semantic present→absent vs this git ref (token-free)
 - `--context` — With --check --since: which path to guard (ADR 0110 §4). "main" (default): present→absent is a regression. "pr": the static-only PR path, present→absent is expected and never flagged.
 - `--stats` — Report served-vs-raw token savings (token-free)

--- a/packages/cli/src/commands/comprehend.ts
+++ b/packages/cli/src/commands/comprehend.ts
@@ -18,6 +18,11 @@ import {
 import { shouldRunComprehendHook } from '../comprehension/hook';
 import { committedSemanticAllowed } from '../comprehension/policy';
 import {
+  resolveRefreshJobGate,
+  explainInactiveRefreshGate,
+  type RefreshJobGateReason,
+} from '../comprehension/refresh-gate';
+import {
   detectSemanticRegressions,
   detectCommittedSemanticOnBranch,
   readSemanticMapAtRef,
@@ -39,13 +44,21 @@ import { deriveChangedSurface, type ChangedSurface } from './validate-scope';
 import { logger } from '../output/logger';
 import { ExitCode } from '../utils/errors';
 
-export type ComprehendMode = 'changed' | 'all' | 'check' | 'stats';
+export type ComprehendMode = 'changed' | 'all' | 'check' | 'stats' | 'refresh';
 
 interface ComprehendFlags {
   changed?: boolean;
   all?: boolean;
   check?: boolean;
   stats?: boolean;
+  /**
+   * #1689 / ADR 0110 §3 — the opt-in token-gated CI **refresh** entrypoint. On the
+   * single-writer main-pass with a provider credential AND `comprehension.ci:
+   * refresh` configured, regenerate + stage committed semantic (the automated
+   * equivalent of the maintainer-local `comprehend --all`). A clean no-op (exit 0)
+   * on every other configuration — off by default, never reds a merge.
+   */
+  refresh?: boolean;
   /**
    * With `--check`: also fail when any module regressed `semantic: present →
    * absent` versus this git ref (ADR 0109 slice 4). Token-free — frontmatter reads
@@ -69,8 +82,9 @@ interface ComprehendFlags {
   hook?: boolean;
 }
 
-/** Resolve the run mode from the boolean flags: check > stats > all > changed. */
+/** Resolve the run mode from the boolean flags: refresh > check > stats > all > changed. */
 export function resolveMode(flags: ComprehendFlags): ComprehendMode {
+  if (flags.refresh) return 'refresh';
   if (flags.check) return 'check';
   if (flags.stats) return 'stats';
   if (flags.all) return 'all';
@@ -372,7 +386,19 @@ async function compileComprehension(
   store: ComprehensionStore,
   reader: ReturnType<typeof createNodeModuleSourceReader>,
   cconf: ComprehensionConfig,
-  opts: { staticOnly?: boolean; stage?: boolean; hook?: boolean; isMainPass?: boolean } = {}
+  opts: {
+    staticOnly?: boolean;
+    stage?: boolean;
+    hook?: boolean;
+    isMainPass?: boolean;
+    /**
+     * A pre-resolved provider to REUSE (the `--refresh` seam already probed one to
+     * gate on credential presence). Honoured only when the run is NOT static-only —
+     * an explicit `--static` / `semantic:false` posture always wins and stays
+     * provider-free. Omit to resolve lazily via `resolveCompileProvider`.
+     */
+    provider?: AnalysisProvider | null;
+  } = {}
 ): Promise<ComprehendRunResult | null> {
   const scope =
     mode === 'changed'
@@ -399,8 +425,14 @@ async function compileComprehension(
   }
 
   // SC4: static-only (`--static`), semantic-disabled, or off the main-pass ⇒ no
-  // provider is resolved — no credential, no LLM on the push/CI/PR path.
-  const provider = await resolveCompileProvider(cconf, posture.staticOnly);
+  // provider is resolved — no credential, no LLM on the push/CI/PR path. When the
+  // caller already probed a provider (the `--refresh` gate) reuse it rather than
+  // resolve twice, but never when the posture is static-only (that must stay
+  // provider-free regardless of what was passed).
+  const provider =
+    opts.provider !== undefined && !posture.staticOnly
+      ? opts.provider
+      : await resolveCompileProvider(cconf, posture.staticOnly);
   // Provider-aware model via the shared helper — resolved from the SAME config
   // endpoint the provider was constructed with, so the model and provider decisions
   // cannot diverge (ADR 0109 slice 3 fix).
@@ -518,6 +550,97 @@ async function runRefreshMainPass(
   return result.compiled.length;
 }
 
+/**
+ * Emit a GitHub Actions workflow annotation (`::warning::` / `::notice::`) so an
+ * operator sees the refresh outcome on the run summary, not just buried in the log.
+ * A NO-OP outside Actions (guarded by `GITHUB_ACTIONS`) so local `comprehend
+ * --refresh` output stays clean. Best-effort formatting only — never throws.
+ */
+function emitGithubAnnotation(level: 'warning' | 'notice', message: string): void {
+  if (process.env.GITHUB_ACTIONS !== 'true') return;
+  // Newlines break the single-line annotation grammar; collapse to spaces.
+  process.stdout.write(`::${level}::${message.replace(/\s*\n\s*/g, ' ')}\n`);
+}
+
+/**
+ * #1689 / ADR 0110 §3 — the opt-in token-gated CI **refresh** entrypoint
+ * (`comprehend --refresh`). This is the automated ALTERNATIVE to the default
+ * maintainer-local provider: the post-merge `main` CI job invokes it to perform
+ * the single-writer main-pass and commit the refreshed semantic units via a bot.
+ *
+ * OFF BY DEFAULT and provider-neutral. It runs only when ALL THREE gate signals
+ * hold (see {@link ../comprehension/refresh-gate!resolveRefreshJobGate}):
+ *  - `comprehension.ci: refresh` is configured (the opt-in switch),
+ *  - this is the single-writer main-pass (committed semantic belongs to `main`),
+ *  - a provider credential resolves (Anthropic key / config endpoint / claude CLI).
+ *
+ * Every inactive branch is a CLEAN no-op (exit 0) — the refresh is remediation,
+ * never a pass/fail signal, so a default adopter (or one who forgot the secret)
+ * never reds a merge. The credential-absent case is surfaced as an ACTIONABLE
+ * `::warning::` so the misconfiguration is visible without failing the build. When
+ * active, it recompiles the STALE surface with `--all` (a full sweep — post-merge
+ * `main` has no meaningful merge-base diff; `runComprehend` skips already-fresh
+ * modules, so only genuinely stale units cost tokens, bounded by
+ * `comprehension.maxTokensPerRun`) and STAGES the shards for the workflow to commit.
+ */
+async function runRefreshMode(
+  projectRoot: string,
+  store: ComprehensionStore,
+  reader: ReturnType<typeof createNodeModuleSourceReader>,
+  config: HarnessConfig | undefined
+): Promise<void> {
+  const cconf = readComprehensionConfig(config);
+  const ciMode = resolveComprehensionCiMode(config);
+  const isMainPass = committedSemanticAllowed();
+
+  // The token gate: probe for a provider WITHOUT forcing a model (provider-neutral).
+  // A null provider ⇒ no credential in this context ⇒ the gate degrades to a no-op.
+  const provider = await resolveCompileProvider(cconf, false);
+
+  const gate = resolveRefreshJobGate({
+    ciMode,
+    isMainPass,
+    credentialPresent: provider !== null,
+  });
+
+  if (!gate.active) {
+    const reason: RefreshJobGateReason = gate.reason;
+    const explanation = explainInactiveRefreshGate(reason);
+    logger.info(explanation);
+    // Only the misconfiguration (opted in but no secret) is worth a loud, actionable
+    // annotation; `not-enabled` (default adopter) and `not-main-pass` (a branch)
+    // are expected quiet no-ops.
+    if (reason === 'no-credential') emitGithubAnnotation('warning', explanation);
+    process.exit(ExitCode.SUCCESS);
+  }
+
+  // Active: run the single-writer main-pass and stage the refreshed shards. Reuse
+  // the SAME provider already resolved above (isMainPass:true is authoritative here
+  // — the gate proved it — so compileComprehension will not re-derive it).
+  const result = await compileComprehension('all', projectRoot, store, reader, cconf, {
+    stage: true,
+    isMainPass: true,
+    provider,
+  });
+
+  if (result === null || result.compiled.length === 0) {
+    const msg =
+      'comprehension.ci: refresh ran on the main-pass — all committed semantic is already ' +
+      'source-fresh, nothing to regenerate. No shards staged.';
+    logger.success(msg);
+    emitGithubAnnotation('notice', msg);
+    process.exit(ExitCode.SUCCESS);
+  }
+
+  const msg =
+    `comprehension.ci: refresh regenerated ${result.compiled.length} module(s) ` +
+    `(${result.semanticPresent} semantic) on the main-pass — the staged shards are ready ` +
+    'for the bot commit.';
+  logger.success(msg);
+  emitGithubAnnotation('notice', msg);
+  process.exit(ExitCode.SUCCESS);
+}
+
 async function runComprehendAction(
   mode: ComprehendMode,
   globalConfig?: string,
@@ -555,6 +678,7 @@ async function runComprehendAction(
       ...(opts.context ? { context: opts.context } : {}),
     });
   if (mode === 'stats') return runStatsMode(store, reader);
+  if (mode === 'refresh') return runRefreshMode(projectRoot, store, reader, config);
   return runCompileMode(mode, projectRoot, store, reader, config, opts);
 }
 
@@ -573,6 +697,10 @@ export function createComprehendCommand(): Command {
     .option('--changed', 'Recompile only modules owning changed files (default)')
     .option('--all', 'Recompile every module (backfill)')
     .option('--check', 'Token-free: report source-stale units, exit non-zero if any')
+    .option(
+      '--refresh',
+      'Opt-in token-gated CI refresh (#1689): on the single-writer main-pass with a provider credential and comprehension.ci:refresh, regenerate+stage committed semantic; a clean no-op otherwise'
+    )
     .option(
       '--since <ref>',
       'With --check: also fail on any module that regressed semantic present→absent vs this git ref (token-free)'

--- a/packages/cli/src/comprehension/refresh-gate.ts
+++ b/packages/cli/src/comprehension/refresh-gate.ts
@@ -1,0 +1,105 @@
+/**
+ * ADR 0110 §3 (alternative provider) / #1689 — the opt-in, token-gated CI
+ * **refresh** gate.
+ *
+ * ADR 0110 makes `main` the single writer of the SEMANTIC half and chooses the
+ * MAINTAINER-LOCAL provider as the default (§3): a human periodically runs
+ * `harness comprehend --all` and commits the semantic pass. #1689 is the recorded
+ * ALTERNATIVE provider — an automated, keyed CI runner that performs the same
+ * single-writer main-pass on `main` post-merge and commits the refreshed units via
+ * a bot. It is **off by default** and only acts when a team has opted in AND
+ * supplied an LLM credential as a CI secret, so a default adopter (no secret,
+ * `ci: verify`) sees zero new behavior and CI stays token-free (the ADR-0109
+ * invariant).
+ *
+ * This module is the pure, injectable decision seam that answers a single
+ * question — "may THIS invocation perform the automated CI refresh?" — from three
+ * orthogonal signals, so the CLI surface (`comprehend --refresh`) and the CI
+ * workflow stay thin and the policy is unit-tested disk/git/network-free. The
+ * three signals are AND-ed in order of cheapness so the reported reason is the
+ * first missing prerequisite an operator must fix:
+ *
+ *  1. `ci: refresh` is configured (`ciMode`) — the opt-in switch. Anything else
+ *     (`verify` default / `off`) means the automated refresh is not enabled.
+ *  2. this is the single-writer main-pass (`isMainPass`, from
+ *     {@link ../comprehension/policy!committedSemanticAllowed}) — committed
+ *     semantic belongs to `main` only; a PR/branch context must never refresh.
+ *  3. a provider credential actually resolves (`credentialPresent`) — the
+ *     token gate. Provider-NEUTRAL: `credentialPresent` is whatever
+ *     `resolveAnalysisProvider` resolves (Anthropic key, a config-declared
+ *     OpenAI-compatible endpoint, or the claude CLI), never a forced Claude model.
+ *
+ * The gate NEVER decides pass/fail of a build — an inactive gate is always a
+ * clean no-op (the refresh is remediation, not a correctness signal). The
+ * credential-absent case (`ci: refresh` set but no secret) degrades to a
+ * token-free no-op with an ACTIONABLE explanation rather than an error, so a
+ * misconfigured adopter never reds `main` on merge.
+ */
+
+import type { ComprehensionConfig } from '../config/schema';
+
+/** The resolved `comprehension.ci` mode (`'verify' | 'refresh' | 'off'`). */
+export type ComprehensionCiMode = ComprehensionConfig['ci'];
+
+/** The three orthogonal inputs the refresh gate AND-s together. */
+export interface RefreshJobGateDeps {
+  /** The configured `comprehension.ci` mode — only `'refresh'` opts in. */
+  ciMode: ComprehensionCiMode;
+  /** Whether this is the single-writer main-pass (committed semantic allowed). */
+  isMainPass: boolean;
+  /** Whether an analysis provider (any vendor) actually resolved — the token gate. */
+  credentialPresent: boolean;
+}
+
+/**
+ * Why the automated refresh did NOT run — the FIRST missing prerequisite, so the
+ * message names exactly what an operator must set to activate it.
+ */
+export type RefreshJobGateReason = 'not-enabled' | 'not-main-pass' | 'no-credential';
+
+/** The gate verdict: active (run the refresh) or inactive (clean no-op + reason). */
+export type RefreshJobGate = { active: true } | { active: false; reason: RefreshJobGateReason };
+
+/**
+ * Resolve whether the opt-in token-gated CI refresh should run. Pure — all three
+ * signals are supplied by the caller. AND-ed cheapest-first so the reason is the
+ * first prerequisite to fix. Off-by-default is structural: the only `active`
+ * branch requires `ciMode === 'refresh'`, so an unconfigured adopter can never
+ * activate it.
+ */
+export function resolveRefreshJobGate(deps: RefreshJobGateDeps): RefreshJobGate {
+  if (deps.ciMode !== 'refresh') return { active: false, reason: 'not-enabled' };
+  if (!deps.isMainPass) return { active: false, reason: 'not-main-pass' };
+  if (!deps.credentialPresent) return { active: false, reason: 'no-credential' };
+  return { active: true };
+}
+
+/**
+ * An actionable, single-line explanation for an inactive gate — what the operator
+ * would change to activate the automated refresh. Used for the job-log message and
+ * (for `no-credential`, the only misconfiguration worth surfacing loudly) a GitHub
+ * `::warning::` annotation. Never an error: an inactive gate is a clean no-op.
+ */
+export function explainInactiveRefreshGate(reason: RefreshJobGateReason): string {
+  switch (reason) {
+    case 'not-enabled':
+      return (
+        "comprehension.ci is not 'refresh' — the opt-in automated CI refresh is OFF " +
+        '(default). Set `comprehension.ci: refresh` to enable it (ADR 0110 §3 / #1689). No-op.'
+      );
+    case 'not-main-pass':
+      return (
+        'comprehension.ci: refresh requested off the main-pass — committed semantic is ' +
+        'written only on `main` (single writer, ADR 0110). This runner must be the ' +
+        'post-merge `main` job (HARNESS_COMPREHENSION_MAIN_PASS=1). No-op.'
+      );
+    case 'no-credential':
+      return (
+        'comprehension.ci: refresh is enabled but NO analysis provider credential resolved. ' +
+        'Supply an LLM credential as a CI secret — either ANTHROPIC_API_KEY, or ' +
+        'HARNESS_ANALYSIS_BASE_URL (+ optional HARNESS_ANALYSIS_API_KEY / ' +
+        '`comprehension.analysisBaseUrl`) for any OpenAI-compatible vendor. CI stays ' +
+        'token-free without it; semantic is left to the maintainer-local pass. No-op.'
+      );
+  }
+}

--- a/packages/cli/tests/comprehension/comprehend-flags.test.ts
+++ b/packages/cli/tests/comprehension/comprehend-flags.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { AnalysisProvider } from '@harness-engineering/intelligence';
 import {
   createComprehendCommand,
+  resolveMode,
   resolveCompileProvider,
   resolveChangedScope,
   resolveStaticOnlyPosture,
@@ -91,6 +92,30 @@ describe('createComprehendCommand — SF1 flags present', () => {
   it('exposes the --context flag', () => {
     const flags = createComprehendCommand().options.map((o) => o.long);
     expect(flags).toContain('--context');
+  });
+
+  // #1689 / ADR 0110 §3 — the opt-in token-gated CI refresh entrypoint.
+  it('exposes the --refresh flag', () => {
+    const flags = createComprehendCommand().options.map((o) => o.long);
+    expect(flags).toContain('--refresh');
+  });
+});
+
+// #1689 — resolveMode routes --refresh (highest precedence, a distinct CI op).
+describe('resolveMode — #1689 refresh precedence', () => {
+  it('maps --refresh to the refresh mode', () => {
+    expect(resolveMode({ refresh: true })).toBe('refresh');
+  });
+
+  it('refresh wins over check/stats/all when several flags are set', () => {
+    expect(resolveMode({ refresh: true, check: true, stats: true, all: true })).toBe('refresh');
+  });
+
+  it('the existing precedence is unchanged when --refresh is absent (check > stats > all > changed)', () => {
+    expect(resolveMode({ check: true, stats: true, all: true })).toBe('check');
+    expect(resolveMode({ stats: true, all: true })).toBe('stats');
+    expect(resolveMode({ all: true })).toBe('all');
+    expect(resolveMode({})).toBe('changed');
   });
 });
 

--- a/packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts
+++ b/packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts
@@ -330,3 +330,197 @@ describe.skipIf(!HAS_BIN || !process.env.HARNESS_E2E_LIVE)(
     });
   }
 );
+
+// --- #1689 / ADR 0110 §3 — the opt-in token-gated CI `--refresh` entrypoint -----
+// End-to-end over the REAL built binary: the automated alternative provider that
+// the post-merge `main` CI job invokes. It must be OFF by default (no config / no
+// credential ⇒ clean no-op, exit 0, never reds a merge) and only regenerate on the
+// single-writer main-pass with a credential AND `comprehension.ci: refresh`.
+// POSIX-only for the with-provider leg (a fake `claude` on PATH), matching the
+// faked-LLM block above.
+const POSIX_REFRESH = process.platform !== 'win32';
+
+describe.skipIf(!HAS_BIN)('harness comprehend --refresh — E2E opt-in gate (#1689)', () => {
+  function scaffoldRefresh(ci?: 'verify' | 'refresh' | 'off'): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'comprehend-refresh-'));
+    mkdirSync(path.join(dir, 'math'), { recursive: true });
+    writeFileSync(
+      path.join(dir, 'math', 'add.ts'),
+      `/** Adds two numbers. */\nexport function add(a: number, b: number): number {\n  return a + b;\n}\n`
+    );
+    writeFileSync(path.join(dir, 'math', 'index.ts'), `export { add } from './add';\n`);
+    if (ci) {
+      writeFileSync(
+        path.join(dir, 'harness.config.json'),
+        JSON.stringify({ version: 1, comprehension: { ci } }, null, 2)
+      );
+    }
+    return dir;
+  }
+
+  // An env with NO provider resolvable: strip every credential signal AND point PATH
+  // at an empty dir so `claude` is not discoverable. process.execPath is absolute,
+  // so the spawned CLI still runs; the inactive-gate path never shells out to git.
+  function noProviderEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    const empty = mkdtempSync(path.join(tmpdir(), 'empty-path-'));
+    const e = { ...process.env, ...extra };
+    delete e.ANTHROPIC_API_KEY;
+    delete e.HARNESS_ANALYSIS_BASE_URL;
+    delete e.HARNESS_ANALYSIS_API_KEY;
+    e.PATH = empty;
+    e.Path = empty;
+    return e;
+  }
+
+  it('OFF by default: ci:verify ⇒ --refresh is a clean no-op that writes no semantic (exit 0)', () => {
+    const proj = scaffoldRefresh('verify');
+    try {
+      const r = comprehend(
+        proj,
+        ['--refresh'],
+        noProviderEnv({ HARNESS_COMPREHENSION_MAIN_PASS: '1' })
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout + r.stderr).toMatch(/not 'refresh'|OFF \(default\)/);
+      // No shard written at all — the gate short-circuited before any compile.
+      expect(existsSync(path.join(proj, UNIT))).toBe(false);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
+  });
+
+  it('no config block ⇒ still OFF by default (defaults to verify)', () => {
+    const proj = scaffoldRefresh(undefined);
+    try {
+      const r = comprehend(
+        proj,
+        ['--refresh'],
+        noProviderEnv({ HARNESS_COMPREHENSION_MAIN_PASS: '1' })
+      );
+      expect(r.status).toBe(0);
+      expect(existsSync(path.join(proj, UNIT))).toBe(false);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
+  });
+
+  it('ci:refresh + main-pass but NO credential ⇒ actionable no-op, exit 0, token-free', () => {
+    const proj = scaffoldRefresh('refresh');
+    try {
+      const r = comprehend(
+        proj,
+        ['--refresh'],
+        noProviderEnv({ HARNESS_COMPREHENSION_MAIN_PASS: '1' })
+      );
+      expect(r.status).toBe(0);
+      // The actionable message names the provider-neutral secrets to set.
+      expect(r.stdout + r.stderr).toMatch(/no analysis provider credential/i);
+      expect(r.stdout + r.stderr).toMatch(/ANTHROPIC_API_KEY|HARNESS_ANALYSIS_BASE_URL/);
+      // Nothing regenerated: CI stayed token-free.
+      expect(existsSync(path.join(proj, UNIT))).toBe(false);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
+  });
+
+  it('ci:refresh but OFF the main-pass ⇒ no-op (semantic belongs to main)', () => {
+    const proj = scaffoldRefresh('refresh');
+    try {
+      // No main-pass signal at all ⇒ branch/PR context ⇒ inactive.
+      const e = noProviderEnv();
+      delete e.HARNESS_COMPREHENSION_MAIN_PASS;
+      delete e.GITHUB_REF;
+      delete e.GITHUB_HEAD_REF;
+      delete e.HARNESS_BRANCH;
+      delete e.CI_COMMIT_REF_NAME;
+      delete e.BUILDKITE_BRANCH;
+      const r = comprehend(proj, ['--refresh'], e);
+      expect(r.status).toBe(0);
+      expect(r.stdout + r.stderr).toMatch(/off the main-pass|belongs to|single writer/i);
+      expect(existsSync(path.join(proj, UNIT))).toBe(false);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
+  });
+});
+
+describe.skipIf(!HAS_BIN || !POSIX_REFRESH)(
+  'harness comprehend --refresh — active path with a faked provider (#1689)',
+  () => {
+    let binDir: string;
+
+    function writeFakeClaude(dir: string): void {
+      const script = `#!/usr/bin/env node
+const good = { type: 'result', result: 'done', structured_output: { summary: 'FAKE_SUMMARY: adds two numbers; pure and total.', invariants: ['add(a,b) returns a+b'] }, usage: { input_tokens: 10, output_tokens: 5 }, model: 'fake-claude' };
+process.stdout.write(JSON.stringify(good));
+`;
+      writeFileSync(path.join(dir, 'claude'), script, { mode: 0o755 });
+    }
+
+    beforeAll(() => {
+      binDir = mkdtempSync(path.join(tmpdir(), 'fake-bin-refresh-'));
+      writeFakeClaude(binDir);
+    });
+
+    afterAll(() => {
+      if (binDir) rmSync(binDir, { recursive: true, force: true });
+    });
+
+    function scaffoldRefresh(): string {
+      const dir = mkdtempSync(path.join(tmpdir(), 'comprehend-refresh-live-'));
+      mkdirSync(path.join(dir, 'math'), { recursive: true });
+      writeFileSync(
+        path.join(dir, 'math', 'add.ts'),
+        `/** Adds two numbers. */\nexport function add(a: number, b: number): number {\n  return a + b;\n}\n`
+      );
+      writeFileSync(path.join(dir, 'math', 'index.ts'), `export { add } from './add';\n`);
+      writeFileSync(
+        path.join(dir, 'harness.config.json'),
+        JSON.stringify({ version: 1, comprehension: { ci: 'refresh' } }, null, 2)
+      );
+      return dir;
+    }
+
+    // Steer the resolver onto the claude-CLI path (no key, fake `claude` first on
+    // PATH) AND assert the single-writer main-pass context. This models the #1689
+    // CI job: HARNESS_COMPREHENSION_MAIN_PASS=1 + a credential + ci:refresh.
+    function activeEnv(): NodeJS.ProcessEnv {
+      const e = { ...process.env, HARNESS_COMPREHENSION_MAIN_PASS: '1' };
+      delete e.ANTHROPIC_API_KEY;
+      delete e.HARNESS_ANALYSIS_BASE_URL;
+      e.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ''}`;
+      return e;
+    }
+
+    it('ACTIVE: regenerates + reports the refreshed semantic units on the main-pass', () => {
+      const proj = scaffoldRefresh();
+      try {
+        const r = comprehend(proj, ['--refresh'], activeEnv());
+        expect(r.status).toBe(0);
+        expect(r.stdout).toMatch(/regenerated 1 module\(s\)/);
+        expect(r.stdout).toMatch(/1 semantic/);
+        const unit = readFileSync(path.join(proj, UNIT), 'utf8');
+        expect(unit).toContain('semantic: present');
+        expect(unit).toContain('FAKE_SUMMARY');
+        // The freshly written semantic unit serves (hash equality holds).
+        expect(comprehend(proj, ['--check'], activeEnv()).status).toBe(0);
+      } finally {
+        rmSync(proj, { recursive: true, force: true });
+      }
+    });
+
+    it('idempotent: a second --refresh finds everything fresh and stages nothing (loop-safe)', () => {
+      const proj = scaffoldRefresh();
+      try {
+        expect(comprehend(proj, ['--refresh'], activeEnv()).status).toBe(0);
+        const second = comprehend(proj, ['--refresh'], activeEnv());
+        expect(second.status).toBe(0);
+        // Nothing to regenerate ⇒ no shards staged ⇒ the bot commit is a no-op ⇒
+        // no CI loop even without [skip ci].
+        expect(second.stdout).toMatch(/already source-fresh|nothing to regenerate/i);
+      } finally {
+        rmSync(proj, { recursive: true, force: true });
+      }
+    });
+  }
+);

--- a/packages/cli/tests/comprehension/refresh-gate.test.ts
+++ b/packages/cli/tests/comprehension/refresh-gate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRefreshJobGate,
+  explainInactiveRefreshGate,
+  type RefreshJobGateReason,
+} from '../../src/comprehension/refresh-gate';
+
+// #1689 / ADR 0110 §3 — the opt-in token-gated CI refresh gate. Three orthogonal
+// signals AND-ed cheapest-first; the reported reason is the FIRST missing one.
+
+describe('resolveRefreshJobGate — #1689 opt-in token gate', () => {
+  const active = { ciMode: 'refresh' as const, isMainPass: true, credentialPresent: true };
+
+  it('is ACTIVE only when refresh + main-pass + credential all hold', () => {
+    expect(resolveRefreshJobGate(active)).toEqual({ active: true });
+  });
+
+  it("is OFF by default: ciMode 'verify' ⇒ inactive 'not-enabled' (before any other check)", () => {
+    // Even with a credential on a main-pass, a default adopter never activates.
+    expect(resolveRefreshJobGate({ ...active, ciMode: 'verify' })).toEqual({
+      active: false,
+      reason: 'not-enabled',
+    });
+  });
+
+  it("ciMode 'off' ⇒ inactive 'not-enabled'", () => {
+    expect(resolveRefreshJobGate({ ...active, ciMode: 'off' })).toEqual({
+      active: false,
+      reason: 'not-enabled',
+    });
+  });
+
+  it("refresh but OFF the main-pass ⇒ inactive 'not-main-pass' (semantic belongs to main)", () => {
+    expect(resolveRefreshJobGate({ ...active, isMainPass: false })).toEqual({
+      active: false,
+      reason: 'not-main-pass',
+    });
+  });
+
+  it("refresh + main-pass but NO credential ⇒ inactive 'no-credential' (stays token-free)", () => {
+    expect(resolveRefreshJobGate({ ...active, credentialPresent: false })).toEqual({
+      active: false,
+      reason: 'no-credential',
+    });
+  });
+
+  it('reports the FIRST missing prerequisite when several are absent (not-enabled wins)', () => {
+    expect(
+      resolveRefreshJobGate({ ciMode: 'verify', isMainPass: false, credentialPresent: false })
+    ).toEqual({ active: false, reason: 'not-enabled' });
+  });
+
+  it('reports not-main-pass before no-credential when enabled off the main-pass without a key', () => {
+    expect(
+      resolveRefreshJobGate({ ciMode: 'refresh', isMainPass: false, credentialPresent: false })
+    ).toEqual({ active: false, reason: 'not-main-pass' });
+  });
+});
+
+describe('explainInactiveRefreshGate — actionable, single-line reasons', () => {
+  const reasons: RefreshJobGateReason[] = ['not-enabled', 'not-main-pass', 'no-credential'];
+
+  it('returns a non-empty single-line message for every reason', () => {
+    for (const r of reasons) {
+      const msg = explainInactiveRefreshGate(r);
+      expect(msg.length).toBeGreaterThan(0);
+      expect(msg).not.toContain('\n');
+    }
+  });
+
+  it('the no-credential message names the provider-neutral secret options', () => {
+    const msg = explainInactiveRefreshGate('no-credential');
+    expect(msg).toContain('ANTHROPIC_API_KEY');
+    expect(msg).toContain('HARNESS_ANALYSIS_BASE_URL');
+    // Provider-neutral — never prescribes a single Claude model.
+    expect(msg).toMatch(/OpenAI-compatible/);
+  });
+
+  it('the not-enabled message points at the comprehension.ci: refresh switch', () => {
+    expect(explainInactiveRefreshGate('not-enabled')).toContain('comprehension.ci');
+  });
+});


### PR DESCRIPTION
## Opt-in token-gated CI semantic refresh (the automated alternative provider)

`Closes #1689`. Implements **ADR 0110 §3 + §Implementation-slices #2** — the opt-in automated ALTERNATIVE to the default maintainer-local provider.

**Stacked on #1713.** Base = `feat/comprehension-0110-single-writer-1713` (the single-writer core). This diff shows only #1689's addition; GitHub will auto-retarget to `main` when #1713 merges.

### What & why
ADR 0110 makes `main` the single writer of the semantic half; the DEFAULT provider is a maintainer running `harness comprehend --all` locally (§3). This PR adds the automated equivalent for teams that want CI to keep the committed semantic substrate fresh on a keyed runner — plugging into the exact single-writer main-pass seam #1713 wired (`policy.ts` / `HARNESS_COMPREHENSION_MAIN_PASS` / `compileComprehension`).

### Changes
- **`comprehension/refresh-gate.ts`** — pure `resolveRefreshJobGate({ciMode, isMainPass, credentialPresent})`, AND-ing the three opt-in signals cheapest-first; reports the first missing prerequisite. Provider-neutral (the credential is whatever `resolveAnalysisProvider` resolves — Anthropic key / config-declared OpenAI-compatible endpoint / claude CLI — never a forced Claude model).
- **`comprehend --refresh`** — the authoritative in-CLI entrypoint. Active only when `comprehension.ci: refresh` + main-pass + a resolvable credential all hold; every other case is a clean no-op (exit 0). `ci: refresh` set but no credential degrades to a token-free no-op with an actionable `::warning::` — never reds a merge.
- **CI job `comprehension-refresh`** — POST-MERGE on `main` only (never in a PR context), gated behind a repo variable `HARNESS_COMPREHENSION_CI_REFRESH` plus the in-CLI gate, committing the refreshed `.harness/comprehension/**` shards via the github-actions[bot] with `[skip ci]`. Loop-safe by construction (skip-ci + idempotent regeneration).

### Off by default
A default adopter (`ci: verify`, no repo variable, no secret) sees **zero new behavior** and CI stays **token-free** (the ADR-0109 invariant). The whole job is inert (never scheduled).

### Verification
- Pure gate unit tests (all reasons + first-missing precedence); `resolveMode` precedence.
- E2E over the built binary: default/no-config no-op writes no shard; ci:refresh + no credential → actionable token-free no-op; off the main-pass → no-op; ci:refresh + faked provider + main-pass → regenerates a `semantic: present` unit that serves fresh; second run idempotent (stages nothing).
- Full comprehension suite green (174 passed); cli typecheck + lint clean; format:check + generate-docs --check + tool-catalog:check green.

Plan: `docs/changes/comprehension-0110-ci-refresh/plans/plan.md` · Provenance: `docs/changes/comprehension-0110-ci-refresh/provenance.json`

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga