### PR TITLE
adr-fleet Wave 3 (DECIDE): CI-trust fork scope (0117), pr-fleet depth tiebreak (0118), accept 0093 folding #1313

### DIFF
--- a/docs/knowledge/decisions/.provenance/adr-fleet-wave3-2026-08-31.md
+++ b/docs/knowledge/decisions/.provenance/adr-fleet-wave3-2026-08-31.md
@@ -1,0 +1,53 @@
+# adr-fleet run provenance — fleet-command Wave 3 (DECIDE), 2026-08-31
+
+Conductor lane: `adr-fleet`, concurrency 1, worktree-isolated off `origin/main`
+@ `767f073b7`. Ran the real five-phase SELECT → CONFIRM → DISPATCH → VERIFY → REPORT.
+
+## Queue (6 routed by issue-fleet intake) + #1441
+
+| Issue | SELECT verdict                                                                                                                             | Action                                                 |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| #1320 | novel architectural decision                                                                                                               | **DRAFT ADR 0117** (proposed)                          |
+| #1316 | novel architectural decision                                                                                                               | **DRAFT ADR 0118** (proposed)                          |
+| #1313 | genuine but coupled to proposed ADR 0093                                                                                                   | **FOLD into 0093** (fidelity:sampled) + accept 0093    |
+| #1322 | already-decided (ADR 0112, accepted, source cites #1322)                                                                                   | **CLOSE** with citation                                |
+| #1268 | already-decided (ADR 0114, accepted, source cites #1268)                                                                                   | **CLOSE** with citation                                |
+| #1269 | already-decided (ADR 0115, accepted, source cites #1269)                                                                                   | **CLOSE** with citation                                |
+| #1441 | NOT architectural — mechanical data cleanup under existing policy (ADR 0022 + #1323 validator + `.harness/decisions/number-baseline.json`) | **RE-ROUTE to build (roadmap-fleet)** — no ADR drafted |
+
+## CONFIRM (Phase 2) — human-approved
+
+Human approved the batch; fork **F1** answered = FOLD #1313 into ADR 0093 (add the
+fidelity/sampled third member class), then set 0093 `status: accepted`. Concurrency 1
+(fixed by conductor global-pool allocation).
+
+## Number pre-allocation & collision guard
+
+`origin/main` max ADR = 0116 (fetched fresh; verified no local lag). Next free = 0117,
+0118 — assigned to #1320, #1316. No collision on origin/main (guard against the PR #1737
+0110-collision trap). ADRs authored **directly** in canonical format (frontmatter +
+Context/Decision/Consequences) — NOT via `manage_adr action:create`, which silently drops
+the `decision` field this session.
+
+## Artifacts carried by this branch
+
+- `docs/knowledge/decisions/0117-ci-trust-fork-scoped-to-verify-dependency-set.md` — `status: proposed`
+- `docs/knowledge/decisions/0118-pr-fleet-depth-tiebreak-never-shed-lander.md` — `status: proposed`
+- `docs/knowledge/decisions/0093-fleet-scheduling-depth-lossy-key.md` — amended (`proposed` → `accepted`, folds #1313)
+
+## Never-auto-accept posture
+
+- 0117 and 0118 are **proposed** — they await the human's terminal sign-off pass; the fleet
+  did NOT flip them to accepted.
+- 0093 is flipped to **accepted** ONLY because the human's F1 answer at CONFIRM explicitly
+  authorized it (fold + accept). The fleet is the executor of that authorization, not its
+  originator.
+
+## Assumptions made (recommended-option defaults)
+
+- 0117: ambiguous-check fallback = keep firing the trust fork but **label** it (#1320 middle
+  option); VERIFY dependency set = per-OS build/test + enforce/harness gates.
+- 0118: `mergeStateStatus`/`reviewDecision` SELECT read scoped OUT of the ADR as a build
+  follow-up (SELECT enhancement, not a scheduling-rule decision).
+- 0093 fold: adopted #1313's "sampled probe" option; rejected its participation / opt-in-only
+  alternatives (documented in Alternatives Considered).

--- a/docs/knowledge/decisions/0093-fleet-scheduling-depth-lossy-key.md
+++ b/docs/knowledge/decisions/0093-fleet-scheduling-depth-lossy-key.md
@@ -2,10 +2,17 @@
 number: 0093
 title: Fleet scheduling depth is a lossy key
 date: 2026-08-18
-status: proposed
+status: accepted
 tier: medium
 source: 'design routing of bug-backlog issues #1305, #1319, #1312'
 ---
+
+> **Amended 2026-08-31 (decision-blocked issue #1313, folded per `fleet-command` Wave 3 CONFIRM fork F1).**
+> Decision item 4 and the accompanying Context/Consequences notes were added to model
+> the third member class — depth **knowable only by paying for the work** (e.g.
+> `craft-fleet`) — by extending the probe contract's `fidelity` dimension with a
+> `sampled` value. The ADR is accepted at the same time (`proposed` → `accepted`) on the
+> human's explicit F1 answer.
 
 ## Context
 
@@ -43,6 +50,15 @@ unknown is protected from shedding (#1305), and any member whose findings replic
 its way to the front of the honest queue (#1319). Left alone, the scheduler selects hardest for
 exactly the members it should scrutinize most: the expensive, the dark, and the duplicative.
 
+**A third member class exists between "cheaply exact" and "legitimately unknown" (#1313).**
+`craft-fleet`'s queue **is** the expensive work — eleven LLM critique sweeps over ~5,000 files —
+and its human gate needs verbatim findings that cannot exist until SELECT has already run. So its
+depth is neither cheaply probeable **nor** genuinely unknowable: it is **knowable only by paying
+for (a slice of) the work**. Under the plain contract below it has only two bad options — report
+`unknown` (and, pre-amendment, be protected; post-amendment, be shed-first despite having real,
+estimable work) or run the entire sweep just to answer the probe. Neither is right: a member whose
+depth is measurable by sampling should neither hide as dark nor pay full price to be counted.
+
 ## Decision
 
 The fleet family adopts a **depth-reporting contract** that makes depth a comparable key and
@@ -67,6 +83,23 @@ removes the incentives above. Depth stops being "whatever a member happens to co
    runs only on an **explicit human call** at CONFIRM, never by silently surviving the shed. Dark
    is the weakest position, not the safest.
 
+4. **The probe contract carries a `fidelity` dimension; a pay-to-know member reports
+   `fidelity: sampled` (#1313).** The gate-free probe returns `{ceiling, plannedBatchSize,
+fidelity}`, where `fidelity` is `exact` for a member that can enumerate its distinct fixes
+   cheaply and **`sampled`** for the third class — a member whose depth is knowable only by paying
+   for the work (e.g. `craft-fleet`). A `sampled` member probes a **bounded slice**, extrapolates a
+   `plannedBatchSize` (still collapsed by fix-identity per item 2), and marks the estimate
+   `sampled`. Crucially, **a `sampled` report is a conforming report, not `unknown`**: it
+   participates in scheduling and is **sheddable by its extrapolated depth** like any honest number,
+   so the expensive member is neither protected-by-darkness (#1305) nor forced to run its whole
+   sweep to be counted — it pays for a slice, not the batch. The `sampled` label travels with the
+   number so the conductor and the human can see that the depth is an extrapolation rather than an
+   exact count and weigh a shed/keep decision accordingly. Reporting `unknown` when a member could
+   have sampled is itself non-conforming and is treated as shed-first per item 3; sampling is the
+   honest floor for a measurable-by-sampling member. (This subsumes #1313's "sampled probe" option;
+   its "authorize by participation" and "opt-in only" alternatives are considered and rejected
+   below.)
+
 The contract is enforced where it is cheap to check: `--report-only` conformance is a member-level
 test, and the conductor treats a missing or non-conforming report as unknown → shed-first rather
 than as an unprobeable exception to route around.
@@ -84,6 +117,13 @@ than as an unprobeable exception to route around.
   understates genuine work, so the (items / distinct-fixes) pair is retained where the raw count
   still informs. Shed-first-on-unknown means a member whose probe regresses to non-conforming is
   dropped rather than run — loud and safe, but it can shed a member that would have had real work.
+- **On the `sampled` fidelity class (#1313):** the third class costs a bounded slice of its own
+  expensive work to answer the probe (real, but far below running the full sweep), and its
+  `plannedBatchSize` is an extrapolation — an over- or under-estimate can misorder a shed/keep
+  decision at the margin. The `sampled` label is what keeps that honest: the conductor and human
+  treat a sampled depth as an estimate, not a census, and the member is still fully sheddable, so
+  the failure mode is a bounded mis-ranking rather than the permanent protection the plain contract
+  produced.
 - **Reversibility:** high — the shed order, the collapse rule, and the report shape are
   scheduling policy expressed in skill prose plus a per-member flag and test. Tightening the
   collapse, changing the pair format, or re-tuning the shed threshold is a prose-and-test change,
@@ -106,11 +146,21 @@ than as an unprobeable exception to route around.
   it re-centralizes knowledge each member holds best (its own fix-identity), and drifts silently
   the moment a member changes. The contract lives with the member and is enforced by the member's
   own test.
+- **Authorize the pay-to-know member by participation, not magnitude (#1313 option 2).** Rejected —
+  authorizing `craft-fleet` at CONFIRM purely because it opted in, without any depth number, re-creates
+  a member the scheduler cannot compare or shed against honest numbers — the same darkness this ADR
+  removes, merely relabelled "participating."
+- **Make the pay-to-know member opt-in only and never auto-schedule it (#1313 option 3).** Rejected —
+  it permanently exempts the single most expensive member from the scheduling discipline the rest of
+  the family lives under; a bounded `sampled` probe gives the conductor a comparable number at a
+  bounded cost, which is strictly better than exempting the member from measurement.
 
 ## References
 
 - Resolves: #1305 (unknown is a protected status), #1319 (replicated findings inflate depth),
-  #1312 (`--report-only` gate-free probe contract unspecified; ideate-fleet unprobeable).
+  #1312 (`--report-only` gate-free probe contract unspecified; ideate-fleet unprobeable),
+  #1313 (craft-fleet is an unmodeled member class — depth knowable only by paying for the work;
+  folded via the `fidelity: sampled` extension in Decision item 4).
 - Refines: [`0091-fleet-command-conductor-tier-authority-model.md`](0091-fleet-command-conductor-tier-authority-model.md) — the global leaf-slot budget, the shed order, and the gate-free probing rule (property 4) this contract makes honest.
 - Companion: [`0088-front-load-park-unforeseen-interaction-model.md`](0088-front-load-park-unforeseen-interaction-model.md) — the CONFIRM round where an unmeasured member is scheduled only on an explicit human call.
 - Family overview: `docs/reference/fleet-family.md` (the `-fleet` spine, gate-free probing, and the conductor tier).

--- a/docs/knowledge/decisions/0117-ci-trust-fork-scoped-to-verify-dependency-set.md
+++ b/docs/knowledge/decisions/0117-ci-trust-fork-scoped-to-verify-dependency-set.md
@@ -1,0 +1,113 @@
+---
+number: 0117
+title: The CI-trust fork is scoped to VERIFY's actual dependency set, not any non-empty CI queue
+date: 2026-08-31
+status: proposed
+tier: medium
+source: 'decision-blocked issue #1320'
+---
+
+## Context
+
+The `fleet-command` conductor opens each run with a **CI trust gate** (ADR 0091,
+property "run order is derived — and wave 0 is a trust gate, not a repair"). The rule
+as written is purely mechanical: **any non-empty `cicd-fleet` queue** implies the
+conductor recommends running `cicd-fleet` alone this session and defers everything else,
+surfaced at CONFIRM as a **fork with a recommended default** (run the CI member alone /
+proceed with every downstream verdict labelled `degraded` / trim the fleets that lean
+hardest on CI).
+
+But the downstream thing that actually depends on CI trustworthiness is **VERIFY's
+all-OS-green check** — the per-item verification every member performs before a result is
+`verified` rather than `degraded`/`failed` (`docs/reference/fleet-family.md`, the
+artifact + all-OS-CI discipline; ADR 0091 property 5, "verification reads the children's
+artifacts"). A red that **cannot affect that check** should not gate the run.
+
+The first `fleet-command` run (issue #1259) showed the mismatch concretely: the single
+red in the CI queue was a **release-permissions** issue (protected-`main` / PR-create) —
+all-OS `build-and-test` was fully green. VERIFY's dependency set was entirely healthy.
+The mechanical rule nonetheless recommended deferring the **entire run** behind a CI
+repair that had no bearing on whether any lane's verification could be trusted.
+
+That cost is not free. Because the fork carries a recommended default and CONFIRM is a
+**once-only** human round (ADR 0088, the front-load-park-unforeseen interaction model), a
+mechanically-fired fork **spends a human decision slot** and can **defer a whole run** on
+a signal that is irrelevant to trust. The trust gate exists to protect verification
+integrity; firing it on reds outside verification's dependency set inverts its purpose —
+it adds friction without adding safety.
+
+## Decision
+
+**Scope the CI-trust read to the signal VERIFY actually consumes: the per-OS
+`build`/`test` checks and the `enforce`/`harness` gates. A red outside that dependency
+set is reported as a finding (routed to `cicd-fleet`'s own queue), not raised as a
+run-level trust fork.**
+
+Concretely:
+
+1. **Define VERIFY's dependency set explicitly.** It is the set of checks a member's
+   VERIFY phase reads to reach a `verified` verdict: the per-target-OS `build-and-test`
+   checks plus the project's required `enforce` / `harness` gates. This set is what "an
+   untrustworthy CI signal" must be measured against — not the raw queue length.
+
+2. **Intersect the CI queue's reds with that set.** If one or more reds **intersect**
+   VERIFY's dependency set, fire the trust fork as today — verification genuinely cannot
+   be trusted, and the human must choose (run CI alone / proceed degraded / trim). If the
+   reds are **disjoint** from the set (release-permissions, publish/OIDC, docs-site
+   deploy, and similar out-of-band checks), do **not** fire a run-level fork; record them
+   as findings for `cicd-fleet` and proceed.
+
+3. **Label the fork with the intersection when it does fire.** Even when firing, annotate
+   the fork with **which checks are red** and **whether they intersect VERIFY's
+   dependency set**, so the human answering the once-only round can see the difference
+   between "your test signal is untrustworthy" and "an adjacent pipeline is red."
+
+4. **Fail safe toward surfacing when the distinction is hard to draw mechanically.** If a
+   given check cannot be classified in or out of the dependency set with confidence,
+   treat it as **intersecting** and fire the labelled fork. Surfacing an ambiguous red to
+   the human is the safe error; silently swallowing a possibly-trust-relevant red is not.
+
+**Assumptions made (recommended-option defaults, per the fleet's park-vs-default model):**
+the middle option from #1320 — keep firing but **label** — is adopted as the fallback for
+ambiguous checks rather than attempting a perfect mechanical partition on day one; the
+dependency set is defined as the per-OS build/test plus enforce/harness gates (not a
+broader "all required checks") because that is exactly what VERIFY reads today.
+
+## Consequences
+
+- **Positive:** the once-only CONFIRM decision slot is no longer spent on reds that cannot
+  affect any lane's verification, and a whole run is no longer deferred behind a CI repair
+  irrelevant to trust. The trust gate reclaims its actual purpose — protecting
+  verification integrity — and its false-positive rate drops to the reds that genuinely
+  threaten a `verified` verdict.
+- **Negative / tradeoffs:** the conductor must now know VERIFY's dependency set and
+  classify each red check against it, which is more logic than counting a queue. A
+  misclassification that files a **trust-relevant** red as a mere finding would let a
+  degraded signal through unflagged — which is why the classification errs toward firing
+  the labelled fork whenever a check cannot be confidently placed outside the set.
+- **Reversibility:** high. The dependency set and the intersection rule are conductor
+  scheduling policy expressed in prose plus the fork-labelling; widening or narrowing the
+  set, or reverting to the mechanical "any non-empty queue" rule, is a prose-and-test
+  change, not an architecture change.
+
+## Alternatives Considered
+
+- **Keep the mechanical "any non-empty `cicd-fleet` queue fires the fork" rule.** Rejected
+  — it defers whole runs on reds (release-permissions, docs deploy) that provably cannot
+  change any VERIFY verdict, spending the scarce once-only decision slot on noise.
+- **Drop the CI trust fork entirely and always proceed `degraded`.** Rejected — a red that
+  **does** intersect VERIFY's dependency set means the all-OS-green check itself is
+  untrustworthy; suppressing the fork there would ship `verified` verdicts built on a
+  signal that cannot be trusted. The gate must still fire on real intersections.
+- **Fire the fork always but only ever label it (never suppress).** Rejected as the
+  primary rule (kept only as the ambiguous-check fallback) — labelling helps the human but
+  still burns a decision slot on every disjoint red; the point of the scoping is that a
+  provably-disjoint red should not reach CONFIRM at all.
+
+## References
+
+- Refines: [`0091-fleet-command-conductor-tier-authority-model.md`](0091-fleet-command-conductor-tier-authority-model.md) — the CI trust gate (wave 0) and the degraded-verdict labelling this ADR scopes to VERIFY's dependency set.
+- Companion: [`0088-front-load-park-unforeseen-interaction-model.md`](0088-front-load-park-unforeseen-interaction-model.md) — the once-only CONFIRM round whose decision slot a mechanically-fired fork spends.
+- Resolves: #1320 (the CI trust fork fires on any non-empty CI queue, a signal unrelated to whether test results are trustworthy).
+- Related: #1294 (base-freshness) and #1295 (pr-fleet first-run report), which bear on what VERIFY and pr-fleet SELECT read.
+- Family overview: `docs/reference/fleet-family.md` (the `-fleet` spine, the artifact + all-OS-CI verification discipline).

--- a/docs/knowledge/decisions/0118-pr-fleet-depth-tiebreak-never-shed-lander.md
+++ b/docs/knowledge/decisions/0118-pr-fleet-depth-tiebreak-never-shed-lander.md
@@ -1,0 +1,101 @@
+---
+number: 0118
+title: At queue depth <=1 the "never shed the lander" rule wins; pr-fleet's single-PR guidance is advisory under the conductor
+date: 2026-08-31
+status: proposed
+tier: medium
+source: 'decision-blocked issue #1316'
+---
+
+## Context
+
+Two rules in the `-fleet` family contradict each other at queue depth 1:
+
+- **`fleet-command`'s wave shape says the lander is never shed.** The land stage is
+  terminal and always scheduled so that whatever the run built actually gets landed
+  (ADR 0091; `docs/reference/fleet-family.md`, the conveyor's terminal land wave).
+- **`pr-fleet`'s own "When to Use" says NOT for a single PR** — its overhead (worktree
+  fan-out, review-assist subagents) only pays off across a batch; for one PR you review
+  and land it directly.
+
+There is **no tiebreak**. A run with exactly one open PR satisfies one rule only by
+violating the other: schedule the lander (violating pr-fleet's single-PR guidance) or
+honor the single-PR guidance (violating never-shed-the-lander).
+
+The first `fleet-command` run avoided noticing this **by luck**. The PR queue emptied
+mid-SELECT — PR #1256 merged while sibling probes were still running — so the lane was
+recorded as _unscheduled for empty queue_ rather than _shed_, which happens to satisfy
+both rules at once. A depth of **exactly 1 at authorization time** would have hit the
+contradiction squarely, and the conductor would have had no stated rule to resolve it.
+
+The two rules are not actually in conflict once their **motivations** are separated.
+`pr-fleet`'s single-PR guidance is an **efficiency** rule — don't stand up a fleet's
+machinery for one item. The conductor's never-shed-the-lander is a **completeness** rule —
+the run must land whatever it built, terminally, regardless of batch size. When a member's
+efficiency guidance is read as binding on the conductor, a completeness guarantee gets
+sacrificed to an efficiency heuristic. The fix is to state which motivation governs when
+the conductor is the caller.
+
+## Decision
+
+**At queue depth <=1, "never shed the lander" wins: the conductor always schedules
+`pr-fleet` in the terminal land wave regardless of depth, and `pr-fleet`'s own
+"NOT for a single PR" guidance is advisory — it applies to direct human invocation, not
+to invocation by the conductor.**
+
+Rationale: the conductor's reason for scheduling the lander last is **completeness**
+(land whatever the upstream waves built), not per-invocation efficiency. A member's
+efficiency-motivated guidance does not bind the caller whose contract is completeness. For
+a **direct human** `pr-fleet` invocation the single-PR guidance still holds — a human with
+one PR should just review and land it rather than spin up the fleet.
+
+Separately, and as a **mechanical follow-up routed to build (not the architectural core of
+this ADR)**: `pr-fleet` SELECT should read each PR's `mergeStateStatus` and
+`reviewDecision` so an **unlandable** single-PR queue surfaces at CONFIRM rather than at
+the terminal wave. Depth alone does not distinguish "one PR ready to land" from "one PR
+that cannot land" (blocked, behind base, awaiting required review); reading merge/review
+state at SELECT lets the conductor present that distinction in the once-only round instead
+of discovering it after every upstream wave has run.
+
+**Assumptions made (recommended-option defaults):** the recommended default from #1316 —
+"never shed" wins and the member's single-PR guidance is advisory under the conductor — is
+adopted as decided; the `mergeStateStatus`/`reviewDecision` SELECT read is scoped **out**
+of this ADR's decision and recorded as a build follow-up (it is a SELECT enhancement, not
+a scheduling-rule decision), so this ADR does not block on it.
+
+## Consequences
+
+- **Positive:** the latent contradiction is removed; the conductor has a stated rule and
+  always honors the completeness guarantee — a single built-and-ready PR is never stranded
+  because a member's efficiency heuristic shed the lander. The member's standalone guidance
+  stays valid for the human-invocation case it was written for.
+- **Negative / tradeoffs:** the conductor may spin up `pr-fleet`'s machinery for a single
+  PR that then turns out to be **unlandable**, paying fan-out cost for no landing. That
+  waste is exactly what the separate `mergeStateStatus`/`reviewDecision` SELECT read
+  mitigates by surfacing unlandability at CONFIRM — so this ADR names that follow-up even
+  though it does not decide it.
+- **Reversibility:** high. The tiebreak is a one-line scheduling rule plus the
+  advisory-scoping of the member's guidance; re-tuning it (e.g. shedding the lander at
+  depth 0 only, or making the guidance bind under some conductor mode) is a prose-and-test
+  change, not an architecture change.
+
+## Alternatives Considered
+
+- **Let merge order / luck decide (the status quo).** Rejected — the first run passed only
+  because the queue emptied mid-SELECT; a depth-exactly-1 run has no rule and would resolve
+  the contradiction arbitrarily, differently across runs.
+- **Honor `pr-fleet`'s single-PR guidance and shed the lander at depth 1.** Rejected — it
+  sacrifices the conductor's completeness guarantee (land whatever was built) to a member's
+  efficiency heuristic; a single ready PR would be left unlanded at the end of a run.
+- **Fold the merge/review-state read into this decision as a hard prerequisite.** Rejected
+  — it couples a clean scheduling-rule decision to a SELECT-enhancement build task. The
+  tiebreak stands on its own; the state read is a separately-routed improvement to _what
+  SELECT reads_, not to _whether the lander is scheduled_.
+
+## References
+
+- Refines: [`0091-fleet-command-conductor-tier-authority-model.md`](0091-fleet-command-conductor-tier-authority-model.md) — the wave shape and the never-shed-the-lander terminal land wave this ADR gives a depth-<=1 tiebreak.
+- Related: [`0089-pr-fleet-land-stage-human-merge-gate.md`](0089-pr-fleet-land-stage-human-merge-gate.md) — the pr-fleet land stage whose single-PR guidance this ADR scopes to direct human invocation; [`0093-fleet-scheduling-depth-lossy-key.md`](0093-fleet-scheduling-depth-lossy-key.md) — depth as a scheduling key.
+- Resolves: #1316 (pr-fleet's scheduling rules conflict at queue depth <=1 with no tiebreak).
+- Related: #1294 (base-freshness) and #1295 (pr-fleet first-run report), which bear on what pr-fleet SELECT should read.
+- Family overview: `docs/reference/fleet-family.md` (the `-fleet` spine and the terminal land wave).

--- a/docs/reference/tool-catalog.md
+++ b/docs/reference/tool-catalog.md
@@ -5378,7 +5378,7 @@ Write a StrategyDoc to STRATEGY.md at the project root. Validates against Strate
 }
 ```
 
-## Skills (790)
+## Skills (791)
 
 Every shipped skill contract, read live from its `skill.yaml`. A drift between a skill’s real declared contract and this catalog fails the build.
 


### PR DESCRIPTION
## adr-fleet — fleet-command Wave 3 (DECIDE)

Batch-decide run over 6 design-shaped issues routed by intake, plus #1441. Ran the real five-phase SELECT → CONFIRM → DISPATCH → VERIFY. **Never auto-accepts:** the two new ADRs are `proposed` and await the human terminal sign-off pass; 0093 is flipped to `accepted` only on the human's explicit CONFIRM fork-F1 answer.

### ADRs carried
- **0117** (`proposed`) — *The CI-trust fork is scoped to VERIFY's actual dependency set.* Reds disjoint from the per-OS build/test + enforce/harness set are findings, not a run-level trust gate. **Resolves #1320.**
- **0118** (`proposed`) — *At queue depth ≤1 "never shed the lander" wins; pr-fleet's single-PR guidance is advisory under the conductor.* **Resolves #1316.**
- **0093** (`proposed` → `accepted`) — folds **#1313**: adds the `fidelity: sampled` third member class (depth knowable only by paying for the work, e.g. `craft-fleet`), so the expensive member is neither protected-by-darkness nor forced to run its whole sweep to be counted.

### SELECT verdicts on the rest of the queue (not drafted here)
- **#1322 → already-decided by ADR 0112** (accepted; its `source` cites #1322) — close with citation.
- **#1268 → already-decided by ADR 0114** (accepted; `source` cites #1268) — close with citation.
- **#1269 → already-decided by ADR 0115** (accepted; `source` cites #1269) — close with citation.
- **#1441 → not architectural** — mechanical data cleanup under existing policy (ADR 0022 + the #1323 duplicate-number validator + `.harness/decisions/number-baseline.json`). Re-routed to build (roadmap-fleet); no ADR drafted.

### Provenance
`docs/knowledge/decisions/.provenance/adr-fleet-wave3-2026-08-31.md`.

### Notes
- Numbers pre-allocated off `origin/main` (max 0116 → 0117/0118); no collision (guards the PR #1737 0110-collision trap).
- ADRs authored directly in canonical format (not via `manage_adr action:create`, which silently drops the `decision` field this session).
- The second commit refreshes `docs/reference/tool-catalog.md` (skill count 790→791) — **pre-existing main drift** unrelated to the ADRs, folded in only to pass the fail-closed pre-push freshness gate.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga