### PR TITLE
fix(cli): findConfigFile now checks the filesystem root, not just above it

### DIFF
--- a/.changeset/bugfleet-cli-config-root-boundary.md
+++ b/.changeset/bugfleet-cli-config-root-boundary.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): findConfigFile now checks the filesystem root itself, so a harness.config.json placed directly at the filesystem root is found instead of skipped by the exclusive `while (currentDir !== root)` loop bound.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '40be579ee505290ef20c0b2a538cb7c99146263d822a390479dcb9fc2deaa284'
+sourceHash: '5f8bb71d0830892c10bb2459709a4f690ea5b6ebce8a3b8a6ebb6971d638820b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/config/_module.md
+++ b/.harness/comprehension/packages/cli/src/config/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/config'
-sourceHash: 'dc863539f98db1404b07f9d33ab8c065b28e872ba6ed534ac0727e43f7bbc41f'
+sourceHash: 'f31d78aa6652d8c487ec30a46ad6cdb438c0a26210aa74e6742475058f718078'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'd39621308277361d62c3f578cf02c9bbc45dbe47a9ad874637901aba33027452'
-compiledAt: '2026-08-28T01:22:10.098Z'
+sourceHash: 'c6262e1cb5ddcba925f3ddce2febe86e24cfb6f51d9baed7e0ddcc96bf1d28db'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'add-extra.test.ts',
@@ -87,6 +86,7 @@ members:
     'rollback.test.ts',
     'scan-config.test.ts',
     'search.test.ts',
+    'setup-mcp.picker-message.test.ts',
     'setup-mcp.test.ts',
     'setup.test.ts',
     'share.test.ts',
@@ -130,21 +130,6 @@ members:
     'validate.test.ts',
   ]
 ---
-
-## Summary
-
-The `packages/cli/tests/commands` module is a comprehensive test suite for ~70+ CLI command implementations. It validates command interfaces (creation, option parsing), file I/O (artifact creation/deletion), validation logic (rejects invalid inputs and duplicates), and output modes (JSON, Markdown, stdout/file). Tests are hermetic using isolated temp directories, mock external dependencies, and clean up after themselves. Each test file focuses on a command domain (add, adopt, audit, check-\*, graph, hooks, install, maintenance, skills, state, validate, etc.) and exercises both happy paths and error cases.
-
-## Invariants
-
-- All command runners return Result&lt;T, E&gt; with a nullable .ok boolean; callers must check .ok before accessing .value or .error
-- Each test creates a unique tempDir via mkdtempSync(path.join(os.tmpdir(), 'harness-\*-')) in beforeEach() and destroys it with rmSync(..., { recursive: true, force: true }) in afterEach()—no test pollution across runs
-- Component creation requires a valid harness.config.json in the working directory; missing or malformed config fails gracefully
-- Names are rejected for: special characters, empty string, leading digits, path-traversal attempts (../); accepted names use kebab-case or underscores for certain types
-- Adding an already-existing component (module, doc, skill, persona) fails with error message containing 'already exists'; this is not idempotent
-- External I/O (npm registry, adoption records, MCP servers) is mocked; only file-system I/O to tempDir is real
-- Commands support --json for machine parsing, --no-write to emit Markdown to stdout, and --out &lt;file&gt; to write Markdown; each mode is independently tested
-- Tests use if (!result.ok) return; after asserting .ok === true, relying on TypeScript narrowing to safely dereference .value
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/tests/config/_module.md
+++ b/.harness/comprehension/packages/cli/tests/config/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/config'
-sourceHash: '9e623f328eb131a928f1b15304ab62b12ffa6cd218e23b476694248ce08724d6'
-compiledAt: '2026-08-28T01:22:09.672Z'
+sourceHash: '308cf17153bedf21b90b2749ff1740fa7c7e1a13cf281c635044d719821f1dd6'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'analysis-schema.test.ts',
@@ -15,6 +14,7 @@ members:
     'i18n-schema.test.ts',
     'integrations-schema.test.ts',
     'knowledge-schema.test.ts',
+    'loader.root-boundary.test.ts',
     'loader.test.ts',
     'local-models-harness-fit-schema.test.ts',
     'review-schema.test.ts',
@@ -27,20 +27,6 @@ members:
     'toolchain-schema.test.ts',
   ]
 ---
-
-## Summary
-
-The `packages/cli/tests/config` module validates Harness CLI configuration schemas through schema-first validation paired with graceful fallback loaders. It tests five configuration dimensions: analysis exclude patterns, dependency exclude patterns, constraint pack selection, deployment gates, and design system configuration. Each test file uses Zod for schema validation (`safeParse`/`parse`) and verifies both standalone schema behavior and integration into the top-level `HarnessConfigSchema`. The central pattern is: schemas enforce contracts (types, constraints, defaults); loaders handle filesystem reality (missing files, malformed JSON, absent blocks) by returning sensible defaults rather than throwing. All configuration blocks are optional at the top level; absence and validation failure both degrade gracefully.
-
-## Invariants
-
-- Exclude patterns reject empty strings and require arrays — AnalysisConfigSchema.safeParse({ exclude: [''] }).success === false; loaders return [] on validation failure
-- Loaders return [] for missing/malformed configs, not errors — loadAnalysisExclude() and loadDepsExclude() silently degrade when config file is absent, JSON malformed, block missing, or validation fails
-- Tri-state fields (enabled) distinguish undefined from false — DesignConfigSchema and DeploymentGateConfigSchema support enabled?: boolean; undefined, true, and false are three distinct states
-- Interdependent field validation enforced — if enabled: true, then platforms must be a non-empty array; conditional validation is schema-enforced, not loader-enforced
-- All config blocks integrate as optional into HarnessConfigSchema — top-level config without analysis, deps, deployment, design, or constraintPacks blocks must parse successfully
-- Constraint pack names are arbitrary strings — constraintPacks is an optional array of strings; no whitelist validation at config-parse time
-- Design strictness and platform enums are exhaustive — strictness ∈ {standard, strict, permissive}; platforms ⊆ {web, mobile}; reject values outside these sets
 
 ## Interface Contract
 
@@ -59,5 +45,5 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import * as os from 'os'
 import * as path from 'path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -19,13 +19,17 @@ export function findConfigFile(startDir: string = process.cwd()): Result<string,
   let currentDir = path.resolve(startDir);
   const root = path.parse(currentDir).root;
 
-  while (currentDir !== root) {
+  // Inclusive of the root itself: `currentDir === root` still runs one more
+  // check-then-break rather than exiting the loop before checking it, so a
+  // harness.config.json placed directly at the filesystem root is found.
+  for (;;) {
     for (const filename of CONFIG_FILENAMES) {
       const configPath = path.join(currentDir, filename);
       if (fs.existsSync(configPath)) {
         return Ok(configPath);
       }
     }
+    if (currentDir === root) break;
     currentDir = path.dirname(currentDir);
   }
 

--- a/packages/cli/tests/config/loader.root-boundary.test.ts
+++ b/packages/cli/tests/config/loader.root-boundary.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'path';
+
+let existsSyncOverride: ((p: string) => boolean) | undefined;
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      existsSync: (p: unknown) =>
+        existsSyncOverride ? existsSyncOverride(p as string) : actual.existsSync(p as never),
+    },
+    existsSync: (p: unknown) =>
+      existsSyncOverride ? existsSyncOverride(p as string) : actual.existsSync(p as never),
+  };
+});
+
+const { findConfigFile } = await import('../../src/config/loader');
+
+/**
+ * bug-fleet HUNT candidate (cli-config-surface area).
+ *
+ * `findConfigFile`'s docstring says it searches "moving up the directory
+ * tree until the root is reached" — implying the root directory itself is
+ * checked. The implementation's loop condition is `while (currentDir !==
+ * root)`, which stops the moment `currentDir` becomes the root WITHOUT ever
+ * running the existence check for that iteration. A `harness.config.json`
+ * placed directly at the filesystem root (e.g. a container `WORKDIR /`, or
+ * `C:\harness.config.json` on Windows) is therefore never found, even
+ * though every directory strictly between the start dir and the root was
+ * checked.
+ *
+ * `fs.existsSync` is mocked so the test never touches the real filesystem
+ * root — only the pure path-manipulation control flow of `findConfigFile`
+ * is under test.
+ */
+describe('findConfigFile — filesystem root boundary', () => {
+  it('finds a harness.config.json located exactly at the filesystem root', () => {
+    const root = path.parse(process.cwd()).root;
+    const rootConfigPath = path.join(root, 'harness.config.json');
+    // Start several directories below the root; none of the intermediate
+    // directories have a config file — only the root does.
+    const startDir = path.join(root, 'some', 'nested', 'start-dir');
+
+    existsSyncOverride = (p: string) => p === rootConfigPath;
+
+    const result = findConfigFile(startDir);
+
+    existsSyncOverride = undefined;
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(rootConfigPath);
+    }
+  });
+});


### PR DESCRIPTION
## Defect

`findConfigFile` (packages/cli/src/config/loader.ts) walks up the directory tree looking for `harness.config.json`, but its loop bound was exclusive of the filesystem root: `while (currentDir !== root)` exits the moment `currentDir` becomes the root **without ever running the existence check for that final iteration**. A `harness.config.json` placed directly at the filesystem root (e.g. a container `WORKDIR /`, or `C:\harness.config.json` on Windows) is therefore never found, even though every directory strictly between the start dir and the root is checked. The function's own docstring says it searches "until the root is reached", implying the root is inclusive — so behavior contradicts the contract.

## Fix

Convert the walk to an inclusive `for (;;)` loop that runs the check-then-`break` at the root rather than exiting before checking it.

## Repro test

`packages/cli/tests/config/loader.root-boundary.test.ts` — mocks `fs.existsSync` (never touches the real root), starts several dirs below root with a config only at the root, and asserts it is found. Independently verified: **FAILS on current `main` source, PASSES with the fix.**

## Assumptions / provenance

Proactive bug-fleet hunt finding (cli-config-surface area) — no pre-existing tracker issue, so no `Closes #`. The reproducing test is the artifact. Pure path-manipulation control-flow fix; no behavioral change for configs found below the root.
