### PR TITLE
fix(cli): setup-mcp Cursor picker prompt count matches CURSOR_CURATED_TOOLS

### DIFF
--- a/.changeset/bugfleet-cli-cursor-tool-count.md
+++ b/.changeset/bugfleet-cli-cursor-tool-count.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): the Cursor tool-picker prompt now derives the recommended-tool count from `CURSOR_CURATED_TOOLS.length` instead of a hardcoded "25", so the message no longer under-reports the 26 pre-selected tools.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '40be579ee505290ef20c0b2a538cb7c99146263d822a390479dcb9fc2deaa284'
+sourceHash: '5f8bb71d0830892c10bb2459709a4f690ea5b6ebce8a3b8a6ebb6971d638820b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'd39621308277361d62c3f578cf02c9bbc45dbe47a9ad874637901aba33027452'
-compiledAt: '2026-08-28T01:22:10.098Z'
+sourceHash: 'c6262e1cb5ddcba925f3ddce2febe86e24cfb6f51d9baed7e0ddcc96bf1d28db'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'add-extra.test.ts',
@@ -87,6 +86,7 @@ members:
     'rollback.test.ts',
     'scan-config.test.ts',
     'search.test.ts',
+    'setup-mcp.picker-message.test.ts',
     'setup-mcp.test.ts',
     'setup.test.ts',
     'share.test.ts',
@@ -130,21 +130,6 @@ members:
     'validate.test.ts',
   ]
 ---
-
-## Summary
-
-The `packages/cli/tests/commands` module is a comprehensive test suite for ~70+ CLI command implementations. It validates command interfaces (creation, option parsing), file I/O (artifact creation/deletion), validation logic (rejects invalid inputs and duplicates), and output modes (JSON, Markdown, stdout/file). Tests are hermetic using isolated temp directories, mock external dependencies, and clean up after themselves. Each test file focuses on a command domain (add, adopt, audit, check-\*, graph, hooks, install, maintenance, skills, state, validate, etc.) and exercises both happy paths and error cases.
-
-## Invariants
-
-- All command runners return Result&lt;T, E&gt; with a nullable .ok boolean; callers must check .ok before accessing .value or .error
-- Each test creates a unique tempDir via mkdtempSync(path.join(os.tmpdir(), 'harness-\*-')) in beforeEach() and destroys it with rmSync(..., { recursive: true, force: true }) in afterEach()—no test pollution across runs
-- Component creation requires a valid harness.config.json in the working directory; missing or malformed config fails gracefully
-- Names are rejected for: special characters, empty string, leading digits, path-traversal attempts (../); accepted names use kebab-case or underscores for certain types
-- Adding an already-existing component (module, doc, skill, persona) fails with error message containing 'already exists'; this is not idempotent
-- External I/O (npm registry, adoption records, MCP servers) is mocked; only file-system I/O to tempDir is real
-- Commands support --json for machine parsing, --no-write to emit Markdown to stdout, and --out &lt;file&gt; to write Markdown; each mode is independently tested
-- Tests use if (!result.ok) return; after asserting .ok === true, relying on TypeScript narrowing to safely dereference .value
 
 ## Interface Contract
 

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -206,8 +206,7 @@ export const ALL_MCP_TOOLS: string[] = [
 export async function runCursorToolPicker(): Promise<string[]> {
   try {
     const selected = await clack.multiselect({
-      message:
-        'Select tools to register for Cursor (25 recommended; Cursor supports ~40 across all servers)',
+      message: `Select tools to register for Cursor (${CURSOR_CURATED_TOOLS.length} recommended; Cursor supports ~40 across all servers)`,
       options: ALL_MCP_TOOLS.map((tool) => {
         const opt: { value: string; label: string; hint?: string } = { value: tool, label: tool };
         if (CURSOR_CURATED_TOOLS.includes(tool)) opt.hint = 'recommended';

--- a/packages/cli/tests/commands/setup-mcp.picker-message.test.ts
+++ b/packages/cli/tests/commands/setup-mcp.picker-message.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, type MockedFunction } from 'vitest';
+import { vi } from 'vitest';
+import * as clack from '@clack/prompts';
+import { runCursorToolPicker, CURSOR_CURATED_TOOLS } from '../../src/commands/setup-mcp';
+
+/**
+ * bug-fleet HUNT candidate (cli-config-surface area).
+ *
+ * `runCursorToolPicker`'s multiselect prompt hardcodes the recommended-tool
+ * count in its message string ("25 recommended"), but `CURSOR_CURATED_TOOLS`
+ * — the array that message is describing, and that seeds `initialValues` —
+ * actually has 26 entries (already pinned by
+ * `tests/commands/setup-mcp.test.ts`'s `toHaveLength(26)` assertion). The
+ * copy has drifted from the data it documents: a user running
+ * `setup-mcp --client cursor --pick` is told 25 tools are pre-selected when
+ * 26 actually are.
+ */
+vi.mock('@clack/prompts', () => ({
+  multiselect: vi.fn(),
+  isCancel: vi.fn().mockReturnValue(false),
+}));
+
+describe('runCursorToolPicker — recommended-count copy', () => {
+  const mockMultiselect = clack.multiselect as MockedFunction<typeof clack.multiselect>;
+
+  beforeEach(() => {
+    mockMultiselect.mockReset();
+    mockMultiselect.mockResolvedValue(CURSOR_CURATED_TOOLS as never);
+  });
+
+  it('states the actual CURSOR_CURATED_TOOLS count in the prompt message', async () => {
+    await runCursorToolPicker();
+
+    const call = mockMultiselect.mock.calls[0]?.[0] as { message: string } | undefined;
+    expect(call).toBeDefined();
+    expect(call!.message).toContain(`${CURSOR_CURATED_TOOLS.length} recommended`);
+  });
+});


### PR DESCRIPTION
## Defect

`runCursorToolPicker` (packages/cli/src/commands/setup-mcp.ts) renders a `@clack/prompts` multiselect whose message hardcoded the recommended-tool count: `"25 recommended"`. But `CURSOR_CURATED_TOOLS` — the array that message describes and that seeds the pre-selected values — actually has **26** entries (already pinned by `tests/commands/setup-mcp.test.ts`'s `toHaveLength(26)`). The copy drifted from the data it documents: a user running `setup-mcp --client cursor --pick` is told 25 tools are pre-selected when 26 actually are.

## Fix

Interpolate `${CURSOR_CURATED_TOOLS.length}` into the message so the count can never drift from the array again.

## Repro test

`packages/cli/tests/commands/setup-mcp.picker-message.test.ts` — mocks `@clack/prompts`, invokes the picker, and asserts the message contains `${CURSOR_CURATED_TOOLS.length} recommended`. Independently verified: **FAILS on current `main` source, PASSES with the fix.**

## Assumptions / provenance

Proactive bug-fleet hunt finding (cli-config-surface area) — no pre-existing tracker issue, so no `Closes #`. The reproducing test is the artifact. Copy-only change; no behavioral change to which tools are pre-selected.
