### PR TITLE
fix(cli): keep manage_roadmap's error-response contract on a missing path

### DIFF
--- a/.changeset/bugfleet-cli-mcp-roadmap-missing-path.md
+++ b/.changeset/bugfleet-cli-mcp-roadmap-missing-path.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): `manage_roadmap` (handleManageRoadmap) now returns its graceful `{ isError: true }` McpResponse when `path` is missing/non-string, instead of letting `sanitizePath` throw synchronously and reject the returned promise with an unhandled rejection.

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: '7f4c8cb711a2c3b3cb29409305f14b213d8f2e7762c99d0c04891d7b4b7e45b8'
+sourceHash: 'a0065595035f830e59b66e0522f6c9cd14baf4421533556791aa13a65378f7e8'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/mcp/tools'
-sourceHash: '61767a78a75882f0b893698f56ad25dff4aceefbddef1b3cfbb8878a27b67710'
+sourceHash: 'f4effe056631f1c5879430fe383f824e2bf7f8a86c37e4a0a53fba88081d26d3'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -62,6 +62,7 @@ members:
     'roadmap-auto-sync.test.ts',
     'roadmap-groom-sharded.test.ts',
     'roadmap-groom.test.ts',
+    'roadmap-missing-path.test.ts',
     'roadmap-scoped-sync.test.ts',
     'roadmap.file-backed-regression.test.ts',
     'roadmap.file-less-stub.test.ts',

--- a/packages/cli/src/mcp/tools/roadmap.ts
+++ b/packages/cli/src/mcp/tools/roadmap.ts
@@ -825,7 +825,25 @@ function shouldTriggerExternalSync(input: ManageRoadmapInput, response: McpRespo
 }
 
 export async function handleManageRoadmap(input: ManageRoadmapInput): Promise<McpResponse> {
-  const projectPathPre = sanitizePath(input.path);
+  // `sanitizePath` throws synchronously on a missing/non-string `path` (e.g.
+  // `path.resolve(undefined)`). Every other validation failure in this file
+  // resolves to a graceful `{ isError: true }` McpResponse rather than
+  // rejecting the returned promise — this guard keeps that contract for a
+  // bad `path` too, instead of leaking an unhandled rejection to the caller.
+  let projectPathPre: string;
+  try {
+    projectPathPre = sanitizePath(input.path);
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
 
   // Phase 4 / S1: dispatch on roadmap mode.
   // Note: `sanitizePath(input.path)` runs upstream of the file-less guard,

--- a/packages/cli/tests/mcp/tools/roadmap-missing-path.test.ts
+++ b/packages/cli/tests/mcp/tools/roadmap-missing-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { handleManageRoadmap } from '../../../src/mcp/tools/roadmap';
+
+// Bug repro (bugfleet/cli-mcp-core hunt): `handleManageRoadmap` calls
+// `sanitizePath(input.path)` OUTSIDE its own try/catch (see roadmap.ts, the
+// line immediately after the function signature, before `loadProjectRoadmapMode`
+// and before the `try {` block that wraps every other failure path in this
+// file). Every other validation failure in this file — missing `feature`,
+// missing `filter`, milestone not found, roadmap not found, etc. — resolves
+// to a graceful `{ content: [...], isError: true }` McpResponse. A missing or
+// non-string `path` instead makes `sanitizePath` call `path.resolve(undefined)`,
+// which throws synchronously, so the returned Promise REJECTS instead of
+// resolving to the same graceful error shape.
+//
+// The tool's own `inputSchema` marks `path` as `required`, but nothing in the
+// dispatch chain (`dispatchTool` in server.ts, nor any of the injection-guard /
+// compaction / context-budget middleware) validates arguments against that
+// schema before calling the handler — confirmed by grepping those files for
+// `inputSchema`/`validate` (none found). So a caller (any MCP client, or a
+// bug in an upstream agent that composes tool args) that omits `path` reaches
+// this handler directly and gets an unhandled rejection instead of the
+// documented, consistent error-response contract.
+describe('manage_roadmap handles a missing path without throwing (regression)', () => {
+  it('resolves a graceful isError response instead of rejecting when path is omitted', async () => {
+    await expect(
+      handleManageRoadmap({ action: 'show' } as unknown as Parameters<
+        typeof handleManageRoadmap
+      >[0])
+    ).resolves.toEqual(expect.objectContaining({ isError: true }));
+  });
+});


### PR DESCRIPTION
## Defect

`handleManageRoadmap` (packages/cli/src/mcp/tools/roadmap.ts) calls `sanitizePath(input.path)` **outside** its own try/catch, on the line right after the function signature. Every other validation failure in this file — missing `feature`, missing `filter`, milestone not found, roadmap not found — resolves to a graceful `{ content: [...], isError: true }` McpResponse. But a missing or non-string `path` makes `sanitizePath` call `path.resolve(undefined)`, which throws synchronously, so the returned Promise **rejects** instead of resolving to the documented error shape.

Although the tool's `inputSchema` marks `path` as required, nothing in the dispatch chain (`dispatchTool` in server.ts, nor the injection-guard / compaction / context-budget middleware) validates arguments against the schema before calling the handler. So any MCP client — or an upstream agent that composes tool args and omits `path` — reaches this handler directly and gets an unhandled rejection instead of the consistent error-response contract.

## Fix

Wrap the initial `sanitizePath(input.path)` in a try/catch that returns the same `{ isError: true }` McpResponse shape as every other failure path.

## Repro test

`packages/cli/tests/mcp/tools/roadmap-missing-path.test.ts` — calls `handleManageRoadmap({ action: 'show' })` (no `path`) and asserts the promise **resolves** to `{ isError: true }` rather than rejecting. Independently verified: **FAILS on current `main` source, PASSES with the fix.**

## Assumptions / provenance

Proactive bug-fleet hunt finding (cli-mcp-core area) — no pre-existing tracker issue, so no `Closes #`. The reproducing test is the artifact. Contract-preserving change; no effect on valid-path calls.
