### PR TITLE
fix(orchestrator): guard runAgentInBackgroundTask against stale-abort cross-attempt contamination

### DIFF
--- a/.changeset/bugfleet-orch-runloop-a-stale-abort.md
+++ b/.changeset/bugfleet-orch-runloop-a-stale-abort.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): guard `runAgentInBackgroundTask` against stale-abort cross-attempt contamination. An aborted, superseded attempt for an `issue.id` no longer fires `emitWorkerExit('Stopped by reconciliation')` against — nor evicts the tracked controller/pid of — a newer attempt that has since re-taken the same `issue.id`. The post-loop and `finally` cleanups now gate on an `isCurrentAttempt()` identity check.

--- a/.harness/comprehension/packages/orchestrator/src/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/_module.md
@@ -1,28 +1,25 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src"
-sourceHash: "903aa6526bcb7d4c4d0c87303ec5a6dc7a02955615004017f26238cecb3b4e31"
-compiledAt: "2026-08-28T01:22:12.124Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["index.ts", "local-template-lint.test.ts", "orchestrator.default-verify-runner.test.ts", "orchestrator.dispatch-wiring.test.ts", "orchestrator.local-gate.test.ts", "orchestrator.quality-verdict.test.ts", "orchestrator.retrospective.test.ts", "orchestrator.routing-ingestion.test.ts", "orchestrator.template-resolution.test.ts", "orchestrator.ts"]
+module: 'packages/orchestrator/src'
+sourceHash: '4d45c181ed0b5db223a30e15e58d1e99907292d8d44de380af87ec0631e9906e'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'index.ts',
+    'local-template-lint.test.ts',
+    'orchestrator.default-verify-runner.test.ts',
+    'orchestrator.dispatch-wiring.test.ts',
+    'orchestrator.local-gate.test.ts',
+    'orchestrator.quality-verdict.test.ts',
+    'orchestrator.retrospective.test.ts',
+    'orchestrator.routing-ingestion.test.ts',
+    'orchestrator.stale-abort-race.test.ts',
+    'orchestrator.template-resolution.test.ts',
+    'orchestrator.ts',
+  ]
 ---
-
-## Summary
-
-**packages/orchestrator/src** is the core orchestration engine for dispatching AI agents to issues. It's structured around three primary flows: (1) Issue → Agent Dispatch: accepts issues from trackers (GitHub/Roadmap/Linear), optionally runs auto-triage and brainstorming, marks eligible items for dispatch, and routes to appropriate backends (Claude/local Ollama) via adaptive routing. (2) Maintenance Pipeline: cron-driven and on-demand task scheduling for checks and agent-fixable issues, with shared infrastructure (backend resolution, check execution, result classification) between cron and CLI so they never drift. (3) Session & State Lifecycle: tracks dispatch through workflow stages, records outcomes for precedent lookup, archives sessions with search indexing and optional LLM summarization, and manages proposals, webhooks, and notifications. The package re-exports carefully scoped surfaces so consumers (CLI, tests, dashboards) can compose orchestration logic without reaching into internals.
-
-## Invariants
-
-- Single source of truth for backend resolution: makeBackendResolver is THE implementation for both cron orchestrator and CLI; the two must never diverge.
-- Ecosystem detection is canonical: detectEcosystem / detectEcosystemFromFiles maps lockfiles → install/verify commands; consumed by enforcement gates and harness init scaffolding.
-- Workflow stages are composable predicates: workflowFor (>=2-stage predicate) + buildWorkflowContext (composition root) enable staged dispatch without internal path creep.
-- Maintenance dispatch is shared: createAgentDispatcher builds the identical real dispatcher for both cron and CLI --fix paths; graceful degradation when backends missing, not stubbing.
-- Check execution is deterministic across boundaries: runHarnessCheck + timeout/buffer constants used by both cron and CLI; a single spawn/parse/fail classification implementation.
-- Outcomes record precedent: Triage verdicts stored; precedentLookupFromStored aggregates base rates for gate cold-start → unknown before outcomes accrue.
-- Probe workspaces are throwaway: HarnessFitProbeRunner runs in isolated workspaces, judged by acceptance commands; no state leakage to the real workspace.
-- Webhook & token persistence is durable: SQLite-backed WebhookQueue and TokenStore; consumers can open them directly without orchestrator running (CLI deliveries, gateway token).
 
 ## Interface Contract
 

--- a/packages/orchestrator/src/orchestrator.stale-abort-race.test.ts
+++ b/packages/orchestrator/src/orchestrator.stale-abort-race.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execSync, type execFile } from 'node:child_process';
+import type { WorkflowConfig, IssueTrackerClient, Issue } from '@harness-engineering/types';
+import { Ok } from '@harness-engineering/types';
+import { Orchestrator } from './orchestrator.js';
+import { MockBackend } from './agent/backends/mock.js';
+
+/**
+ * bug-fleet HUNT (area: orchestrator-runloop-A) — reproduces a stale-abort
+ * cross-attempt contamination in `runAgentInBackgroundTask`.
+ *
+ * `stopIssue()` (fired e.g. by stall_detected) aborts the AbortController
+ * captured in the CLOSURE of the background task for a given `issue.id`. The
+ * background task only notices the abort on its NEXT generator step, which
+ * can be arbitrarily far in the future for a real backend. If a retry fires
+ * and redispatches the SAME `issue.id` before the stale task notices its own
+ * abort, `runAgentInBackgroundTask` re-populates `this.state.running` for the
+ * NEW attempt.  When the STALE task's generator finally settles, it guards
+ * the post-loop `emitWorkerExit('error', …, 'Stopped by reconciliation')`
+ * call with `this.state.running.has(issue.id)` — a check that cannot
+ * distinguish "my own entry is still there" from "a newer attempt's entry is
+ * there". The stale task wins the race and fires a bogus worker-exit for the
+ * CURRENT (unrelated, non-aborted) attempt, corrupting its state.
+ *
+ * This test drives that exact sequence deterministically (no timers, no
+ * real races) by calling the private `runAgentInBackgroundTask` /
+ * `stopIssue` methods directly and gating the fake backend's generator on
+ * manually-resolved promises.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const noopExecFileFn = ((...args: unknown[]) => {
+  const cb = args[args.length - 1];
+  if (typeof cb === 'function') process.nextTick(() => cb(null, '0\n', ''));
+  return undefined as any;
+}) as typeof execFile;
+(noopExecFileFn as any)[Symbol.for('nodejs.util.promisify.custom')] = () =>
+  Promise.resolve({ stdout: '0\n', stderr: '' });
+const noopExecFile: typeof execFile = noopExecFileFn;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let tmpDir: string;
+
+function makeMockTracker(): IssueTrackerClient {
+  return {
+    fetchCandidateIssues: vi.fn().mockResolvedValue(Ok([])),
+    fetchIssuesByStates: vi.fn().mockResolvedValue(Ok([])),
+    fetchIssueStatesByIds: vi.fn().mockResolvedValue(Ok(new Map())),
+    markIssueComplete: vi.fn().mockResolvedValue(Ok(undefined)),
+    claimIssue: vi.fn().mockResolvedValue(Ok(undefined)),
+    releaseIssue: vi.fn().mockResolvedValue(Ok(undefined)),
+  } as unknown as IssueTrackerClient;
+}
+
+function makeConfig(): WorkflowConfig {
+  return {
+    tracker: { kind: 'mock', activeStates: ['planned'], terminalStates: ['done'] },
+    polling: { intervalMs: 1000 },
+    workspace: { root: path.join(tmpDir, '.harness', 'workspaces') },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 1000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 2,
+      maxTurns: 3,
+      maxRetryBackoffMs: 1000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: { planned: 1 },
+      turnTimeoutMs: 5000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 5000,
+    },
+    server: { port: null },
+  } as unknown as WorkflowConfig;
+}
+
+const ISSUE: Issue = {
+  id: 'issue-race-1',
+  identifier: 'H-RACE-1',
+  title: 'Race test issue',
+  description: 'd',
+  priority: 1,
+  state: 'planned',
+  branchName: 'feat/race',
+  url: null,
+  labels: [],
+  blockedBy: [],
+  spec: null,
+  plans: [],
+  createdAt: null,
+  updatedAt: null,
+  externalId: null,
+} as unknown as Issue;
+
+/** A fake `AgentRunner` whose session generator pauses on an externally-controlled gate. */
+function makeGatedRunner(): { runner: unknown; release: () => void } {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Intentionally yields nothing: simulates a real backend whose process was
+  // SIGTERM'd mid-turn with no further events to drain. The for-await loop in
+  // runAgentInBackgroundTask completes with zero iterations, and control
+  // falls through to the post-loop abort check.
+  const runner = {
+    // eslint-disable-next-line require-yield
+    runSession: async function* () {
+      await gate;
+    },
+  };
+  return { runner, release };
+}
+
+async function flush(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+describe('runAgentInBackgroundTask — stale-abort cross-attempt contamination', () => {
+  let orchestrator: Orchestrator;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-stale-abort-'));
+    execSync(
+      'git init && git config user.email "t@t" && git config user.name "t" && git commit --allow-empty -m init',
+      { cwd: tmpDir, stdio: 'ignore' }
+    );
+    fs.mkdirSync(path.join(tmpDir, '.harness', 'workspaces'), { recursive: true });
+
+    orchestrator = new Orchestrator(makeConfig(), 'TEMPLATE', {
+      tracker: makeMockTracker(),
+      backend: new MockBackend(),
+      execFileFn: noopExecFile,
+    });
+  });
+
+  afterEach(async () => {
+    if (orchestrator) await orchestrator.stop();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('does not fire emitWorkerExit for a stale aborted attempt once a newer attempt owns the running entry', async () => {
+    const orch = orchestrator as unknown as {
+      state: { running: Map<string, unknown> };
+      runAgentInBackgroundTask: (
+        issue: Issue,
+        workspacePath: string,
+        prompt: string,
+        attempt: number | null,
+        runner: unknown,
+        routedBackendName?: string
+      ) => void;
+      stopIssue: (issueId: string) => Promise<void>;
+      emitWorkerExit: (...args: unknown[]) => Promise<void>;
+    };
+
+    const emitWorkerExitSpy = vi
+      .spyOn(orch, 'emitWorkerExit')
+      .mockResolvedValue(undefined as unknown as void);
+
+    const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'h-race-1');
+    fs.mkdirSync(workspacePath, { recursive: true });
+
+    // --- Attempt 1: dispatched, then stalls and gets stopped ---
+    orch.state.running.set(ISSUE.id, {
+      issueId: ISSUE.id,
+      identifier: ISSUE.identifier,
+      issue: ISSUE,
+      attempt: 1,
+      workspacePath,
+      startedAt: new Date().toISOString(),
+      phase: 'StreamingTurn',
+      session: null,
+    });
+
+    const attempt1 = makeGatedRunner();
+    orch.runAgentInBackgroundTask(ISSUE, workspacePath, 'prompt-1', 1, attempt1.runner, 'mock');
+
+    // Let the background IIFE actually start and reach `await gate`.
+    await flush();
+
+    // Stall detected -> handleEffect('stop') -> stopIssue(). Aborts attempt 1's
+    // controller. Does NOT touch state.running (mirrors real stall handling,
+    // which removes the running entry via the state machine's own effects,
+    // orthogonal to stopIssue's abort side of the world).
+    await orch.stopIssue(ISSUE.id);
+
+    // --- Attempt 2: a retry fires and redispatches the SAME issue.id BEFORE
+    // attempt 1's generator has noticed the abort (it is still parked on its
+    // gate) ---
+    orch.state.running.set(ISSUE.id, {
+      issueId: ISSUE.id,
+      identifier: ISSUE.identifier,
+      issue: ISSUE,
+      attempt: 2,
+      workspacePath,
+      startedAt: new Date().toISOString(),
+      phase: 'StreamingTurn',
+      session: null,
+    });
+
+    const attempt2 = makeGatedRunner();
+    orch.runAgentInBackgroundTask(ISSUE, workspacePath, 'prompt-2', 2, attempt2.runner, 'mock');
+    await flush();
+
+    // Now let attempt 1's stale generator settle. It sees its OWN
+    // abortController aborted, and the (buggy) guard only checks
+    // `state.running.has(issue.id)` — true, because attempt 2 legitimately
+    // owns that entry now. It should NOT treat attempt 2's live run as its
+    // own abort outcome.
+    attempt1.release();
+    await flush(10);
+
+    expect(emitWorkerExitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2979,6 +2979,25 @@ export class Orchestrator extends EventEmitter {
     const abortController = new AbortController();
     this.abortControllers.set(issue.id, { controller: abortController, pid: null });
 
+    // bug-fleet (orchestrator-runloop-A): identity guard against stale-abort
+    // cross-attempt contamination. `stopIssue()` aborts THIS task's
+    // `abortController` but does not touch `state.running` or
+    // `abortControllers` — a stall-triggered stop only signals; the running
+    // entry is cleared by the state machine's own effects, and this task
+    // only notices the abort on its NEXT generator step (which may be
+    // arbitrarily far away for a real backend). If a retry redispatches the
+    // SAME `issue.id` before this (now-stale) task notices, a NEWER
+    // `runAgentInBackgroundTask` call overwrites this entry in
+    // `abortControllers` (and `state.running`) for the new attempt. Without
+    // this guard, the stale task's post-loop `state.running.has(issue.id)`
+    // check — and the unconditional `finally` cleanup below — cannot tell
+    // "my own entry is still there" from "a newer attempt's entry is
+    // there", so it fires a bogus `emitWorkerExit('Stopped by
+    // reconciliation')` against the live newer attempt and evicts the newer
+    // attempt's tracked controller/pid out from under it.
+    const isCurrentAttempt = (): boolean =>
+      this.abortControllers.get(issue.id)?.controller === abortController;
+
     (async () => {
       try {
         this.logger.info(`Calling runner.runSession for ${issue.identifier}`);
@@ -3010,10 +3029,13 @@ export class Orchestrator extends EventEmitter {
           );
         }
         if (abortController.signal.aborted) {
-          // Only emit worker exit if the issue is still tracked in state.
+          // Only emit worker exit if this is still the CURRENT attempt for
+          // this issue.id AND the issue is still tracked in state.
           // stall_detected already processes the state transition and effects —
-          // firing emitWorkerExit again would cause double-escalation.
-          if (this.state.running.has(issue.id)) {
+          // firing emitWorkerExit again would cause double-escalation. A stale
+          // (superseded) attempt must never fire it against a newer attempt's
+          // live running entry — see isCurrentAttempt() above.
+          if (isCurrentAttempt() && this.state.running.has(issue.id)) {
             await this.emitWorkerExit(issue.id, 'error', attempt, 'Stopped by reconciliation');
           }
         } else {
@@ -3028,9 +3050,17 @@ export class Orchestrator extends EventEmitter {
             `afterRun hook failed for ${issue.identifier}: ${afterRunResult.error.message}`
           );
         }
-        await this.emitWorkerExit(issue.id, 'error', attempt, String(error));
+        // A stale (superseded) attempt's own failure is moot once a newer
+        // attempt owns issue.id — see isCurrentAttempt() above.
+        if (isCurrentAttempt()) {
+          await this.emitWorkerExit(issue.id, 'error', attempt, String(error));
+        }
       } finally {
-        this.abortControllers.delete(issue.id);
+        // Only remove the tracking entry if it is still THIS task's own —
+        // never evict a newer attempt's live controller/pid out from under it.
+        if (isCurrentAttempt()) {
+          this.abortControllers.delete(issue.id);
+        }
       }
     })().catch((err) => {
       this.logger.error('Fatal error in background task', { error: String(err) });


### PR DESCRIPTION
## Defect

In `Orchestrator.runAgentInBackgroundTask` (packages/orchestrator/src/orchestrator.ts), `stopIssue()` (fired e.g. by `stall_detected`) aborts the `AbortController` captured in the background task's closure for a given `issue.id`, but the task only notices the abort on its **next generator step**, which can be arbitrarily far in the future for a real backend. If a retry redispatches the **same** `issue.id` before the stale task notices, a newer `runAgentInBackgroundTask` call overwrites the `state.running` and `abortControllers` entries for the new attempt.

When the stale task finally settles it guarded `emitWorkerExit('error', …, 'Stopped by reconciliation')` and its `finally` cleanup only with `this.state.running.has(issue.id)` — a check that cannot distinguish "my own entry is still there" from "a newer attempt's entry is there". The stale task wins the race, fires a bogus worker-exit against the live newer attempt, and deletes the newer attempt's tracked controller/pid out from under it.

## Fix

Capture an `isCurrentAttempt()` identity predicate (`abortControllers.get(issue.id)?.controller === abortController`) and gate all three post-settle side effects on it: the abort-path `emitWorkerExit`, the error-path `emitWorkerExit`, and the `finally` `abortControllers.delete`. A superseded attempt now no-ops instead of corrupting the current attempt.

## Repro test

`packages/orchestrator/src/orchestrator.stale-abort-race.test.ts` — drives the exact interleaving deterministically (no timers) by calling the private `runAgentInBackgroundTask` / `stopIssue` and gating the fake backend generator on manually-resolved promises. Independently verified: **FAILS on current `main` source, PASSES with the fix.**

## Assumptions / provenance

Proactive bug-fleet hunt finding (orchestrator-runloop-A area) — no pre-existing tracker issue, so no `Closes #`. The reproducing test is the artifact.

## Stack

This is the base of a two-PR stack on `packages/orchestrator/src/orchestrator.ts`. The sibling PR (`bugfleet/orch-runloop-b-routing-terminal-workspace-leak`) is stacked on **this** branch to keep both diffs conflict-free.
