### PR TITLE
fix(orchestrator): clean up the worktree on a fail-closed routing terminal

### DIFF
--- a/.changeset/bugfleet-orch-runloop-b-workspace-leak.md
+++ b/.changeset/bugfleet-orch-runloop-b-workspace-leak.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): clean up the worktree on a fail-closed routing terminal. `finalizeRoutingTerminal` now calls `cleanWorkspaceWithGuard` for the attempt, so a deterministic `PrivacyNoMatch` / budget-exhausted terminal no longer leaks the git worktree that `ensureWorkspace` already created before `route()` threw — matching every other terminal completion path.

--- a/.harness/comprehension/packages/orchestrator/src/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src'
-sourceHash: '4d45c181ed0b5db223a30e15e58d1e99907292d8d44de380af87ec0631e9906e'
+sourceHash: '890ba227809ca2e0b68fb25e0d76353c84e7436b6ffa31351bc03384692466c7'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/orchestrator/src/agent/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/agent/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src/agent'
-sourceHash: '5ae6f45ea32e1db96d6f8f5c651ebc643bc51fd18c9708d35118c26bc1d11001'
+sourceHash: '5ecb531eff7f7aa4ce2a0b90c9b206849a5d558e571804a011a4b32a9bca3478'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/orchestrator/src/agent/adaptive-router.privacy-terminal.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.privacy-terminal.test.ts
@@ -221,4 +221,19 @@ describe('PrivacyNoMatch fail-closed is TERMINAL, not a retry loop (review block
     expect(snap.running.find(([id]) => id === ISSUE.id)).toBeUndefined();
     expect(snap.claimed).not.toContain(ISSUE.id);
   });
+
+  it('does NOT leak the worktree ensureWorkspace already created before the fail-closed route() throw', async () => {
+    const { orch } = await dispatchWithPrivacyNoMatch();
+    // `dispatchIssue` calls `ensureWorkspace(issue.identifier)` — which really
+    // creates a `git worktree add` on disk — BEFORE `adaptiveRouter.route()` is
+    // called. When route() fail-closes, `handleRoutingFailure` routes to
+    // `finalizeRoutingTerminal`, which deletes `running`/`claimed` and persists
+    // the terminal lane but never cleans up the worktree that was already
+    // created for this dispatch — unlike every other terminal completion path
+    // (`settleWorkflowTerminal` explicitly calls `cleanWorkspaceWithGuard`).
+    const wsPath = (
+      orch as unknown as { workspace: { resolvePath: (id: string) => string } }
+    ).workspace.resolvePath(ISSUE.identifier);
+    expect(fs.existsSync(wsPath)).toBe(false);
+  });
 });

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -3981,12 +3981,24 @@ export class Orchestrator extends EventEmitter {
    * (`persistLaneSafe` never throws). No transport/escalation outcome is recorded —
    * that stays the sole job of the single `routing:no-tier-match` escalation already
    * queued by `escalateRoutingToHuman`.
+   *
+   * bug-fleet orchestrator-runloop-B: `route()` throws AFTER `dispatchIssue`
+   * already ran `ensureWorkspace` (step 1) — the worktree for this attempt exists
+   * on disk by the time this fail-closed path fires. Every OTHER terminal
+   * completion path cleans it up (`settleWorkflowTerminal` calls
+   * `cleanWorkspaceWithGuard`; a normal `worker_exit` emits the `cleanWorkspace`
+   * effect) — this one didn't, leaking a git worktree per deterministic
+   * privacy-no-match/budget-exhausted terminal. `cleanWorkspaceWithGuard` is
+   * itself safe to call here: no branch was ever pushed (the agent never
+   * started), so it falls straight through to `removeWorkspace`.
    */
   private async finalizeRoutingTerminal(issueId: string): Promise<void> {
+    const identifier = this.state.running.get(issueId)?.identifier ?? issueId;
     this.state.running.delete(issueId);
     this.state.claimed.delete(issueId);
     // abandon → canceled (terminal). Best-effort; never blocks or throws.
     await this.persistLaneSafe(issueId, 'abandon');
+    await this.cleanWorkspaceWithGuard(identifier, issueId);
     this.emit('state_change', this.getSnapshot());
   }
 


### PR DESCRIPTION
## Defect

`dispatchIssue` calls `ensureWorkspace(issue.identifier)` — a real `git worktree add` on disk — as step 1, **before** `adaptiveRouter.route()` is called. When `route()` fails closed with a deterministic `PrivacyNoMatch` (or budget-exhausted terminal), `handleRoutingFailure` routes to `finalizeRoutingTerminal`, which deletes the `running`/`claimed` entries and persists the terminal lane but **never cleaned up the worktree** that was already created for this dispatch. Every other terminal completion path cleans it (`settleWorkflowTerminal` calls `cleanWorkspaceWithGuard`; a normal `worker_exit` emits the `cleanWorkspace` effect) — this one leaked a git worktree per deterministic privacy-no-match / budget-exhausted terminal.

## Fix

`finalizeRoutingTerminal` now resolves the attempt's identifier and calls `cleanWorkspaceWithGuard(identifier, issueId)`. This is safe here: no branch was ever pushed (the agent never started), so the guard falls straight through to `removeWorkspace`.

## Repro test

`packages/orchestrator/src/agent/adaptive-router.privacy-terminal.test.ts` — the added 4th case ("does NOT leak the worktree ensureWorkspace already created before the fail-closed route() throw") stubs the live `AdaptiveRouter.route()` to reject with `PrivacyNoMatch`, dispatches through `dispatchAdHoc`, and asserts the resolved workspace path does **not** exist on disk. Independently verified against the stack base: **the leak test FAILS without this fix, PASSES with it** (the other 3 terminal-behavior assertions pass both ways).

## Assumptions / provenance

Proactive bug-fleet hunt finding (orchestrator-runloop-B area) — no pre-existing tracker issue, so no `Closes #`. The reproducing test is the artifact.

## Stack

**Stacked on `bugfleet/orch-runloop-a-stale-abort-race` (PR #1752)** — this PR's base is that branch, not `main`, because both fixes edit `packages/orchestrator/src/orchestrator.ts`. Reviewing/merging #1752 first keeps this diff clean and conflict-free. This PR's own diff is just the `finalizeRoutingTerminal` cleanup + its repro test.
