### PR TITLE
fix(orchestrator): pruneCompleted no longer evicts entries inside the grace period

### DIFF
--- a/.changeset/bugfleet-orch-prune-completed-grace.md
+++ b/.changeset/bugfleet-orch-prune-completed-grace.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): `pruneCompleted` no longer evicts entries still inside the completion grace period. Over-threshold pruning now skips any `completed` entry younger than `pollIntervalMs * COMPLETED_GRACE_MULTIPLIER` (the same window `reconcileCompletedAndClaimed` uses), so a just-finished issue can't be dropped from `completed` in the tick it finished and re-dispatched on the next tick.

--- a/.harness/comprehension/packages/orchestrator/src/core/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/core/_module.md
@@ -1,30 +1,42 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/core"
-sourceHash: "d45a248e1442639d27ec4277f0c3d9c3c3c55b5149d31ad38cdc31afbe3b1c9e"
-compiledAt: "2026-08-28T01:22:12.292Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["analysis-archive.ts", "analysis-comment.ts", "budget-governor.ts", "candidate-selection.ts", "claim-manager.ts", "concurrency.ts", "context-budget-governor.test.ts", "context-budget-governor.ts", "flight-recorder.test.ts", "flight-recorder.ts", "highlight-extractor.ts", "index.ts", "interaction-queue.test.ts", "interaction-queue.ts", "lane-persistence.ts", "model-router.ts", "orchestrator-identity.ts", "pr-detector.ts", "published-index.ts", "rate-limit-events.ts", "rate-limiter.ts", "reconciliation.ts", "retry.ts", "stall-detector.ts", "state-helpers.ts", "state-machine.ts", "stream-recorder.ts", "triage-router.ts"]
+module: 'packages/orchestrator/src/core'
+sourceHash: '078d626c02b18d54734464d03d04aafae2ac517b9f204a6927fcd692c1c2135a'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'analysis-archive.ts',
+    'analysis-comment.ts',
+    'budget-governor.ts',
+    'candidate-selection.ts',
+    'claim-manager.ts',
+    'concurrency.ts',
+    'context-budget-governor.test.ts',
+    'context-budget-governor.ts',
+    'flight-recorder.test.ts',
+    'flight-recorder.ts',
+    'highlight-extractor.ts',
+    'index.ts',
+    'interaction-queue.test.ts',
+    'interaction-queue.ts',
+    'lane-persistence.ts',
+    'model-router.ts',
+    'orchestrator-identity.ts',
+    'pr-detector.ts',
+    'published-index.ts',
+    'rate-limit-events.ts',
+    'rate-limiter.ts',
+    'reconciliation.ts',
+    'retry.ts',
+    'stall-detector.ts',
+    'state-helpers.ts',
+    'state-machine.ts',
+    'stream-recorder.ts',
+    'triage-router.ts',
+  ]
 ---
-
-## Summary
-
-**packages/orchestrator/src/core** is the orchestrator's coordination and state-management kernel. It provides immutable, event-driven abstractions for budget enforcement, forensic logging, async interaction management, and issue routing.
-
-The module splits into six load-bearing subsystems: (1) Budget Governor enforces per-period token spend envelopes (global + per-fleet) with auto-rolling windows; dispatch halts cleanly at lane boundaries once budgets exhaust. (2) Flight Recorder persists forensic audit trails to `.harness/black-box/<runId>/run.json` (verdicts, gate reasons, SideEffects—not rendered prompts). (3) Interaction Queue buffers async question/answer cycles and replays them on state transitions. (4) Analysis Archive stores intelligence pipeline results (spec, complexity, simulation) keyed by issueId—one file per issue, overwrites on re-analysis. (5) Model Router classifies issues by scope tier (MICRO/SMALL/MEDIUM/LARGE) to determine artifact presence rules and backend routing. (6) Triage & Reconciliation selects lanes by heuristics (assignee, milestone, state) and reconciles published index with live tracker state to detect stale rows.
-
-## Invariants
-
-- Budget window immutability: every event clones OrchestratorState including BudgetState; windows roll on read (not write), so elapsed periods always report zero spend until the next transition
-- Lane-boundary graceful stop: dispatch halts at lane boundaries once budget exhausts; lanes in flight complete undisturbed; global exhaustion stops all fleets, fleet exhaustion stops only that fleet
-- One analysis per issue: AnalysisArchive overwrites on save—latest analysis always wins, issueId is canonical key
-- Scope tier gates artifacts: detectScopeTier drives artifact synthesis and routing decisions; LARGE issues skip synthesis artifacts and route to heavyweight models
-- Flight record captures verdicts and gate reasons but NOT rendered prompts—read those from orchestrator state seam or run the render path independently
-- Per-fleet spend tracked separately: fleet budgets slice the global envelope; a fleet's exhaustion does not affect sibling fleets sharing the same global bucket
-- Interaction closure before ship: pending interactions must be resolved or explicitly cleared before a run ships—unresolved interactions block finalization
-- Triage eligibility is state-aware: only issues in activeStates (planned/in-progress) are eligible for dispatch; stale rows in published index are detected and marked for re-sync
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/orchestrator/tests/core/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/core/_module.md
@@ -1,27 +1,44 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/tests/core"
-sourceHash: "a1f06a6a058c708937e730ec4c164e6fa6538bab87ab91757d7c18150a34b91a"
-compiledAt: "2026-08-28T01:22:12.707Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["analysis-archive.test.ts", "analysis-comment.test.ts", "auto-publish.test.ts", "budget-governor.behavior.test.ts", "budget-governor.wired.test.ts", "candidate-selection.test.ts", "circuit-breaker.test.ts", "claim-manager.test.ts", "concurrency.test.ts", "heartbeat.test.ts", "highlight-extractor.test.ts", "interaction-queue.test.ts", "lane-effect-persistence.test.ts", "lane-persistence.test.ts", "lane-readback.test.ts", "model-router.test.ts", "orchestrator-identity.test.ts", "published-index.test.ts", "rate-limit.test.ts", "rate-limiter.test.ts", "reconciliation.test.ts", "retry.test.ts", "stale-claim.test.ts", "stall-detector.test.ts", "startup-reconciliation.test.ts", "state-machine.test.ts", "stream-recorder.test.ts", "tick-jitter.test.ts", "triage-router.test.ts"]
+module: 'packages/orchestrator/tests/core'
+sourceHash: '23cb6ee3b93ff54bc3442f8561e92c13d475cf878307b9685aaab01f241297b4'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'analysis-archive.test.ts',
+    'analysis-comment.test.ts',
+    'auto-publish.test.ts',
+    'budget-governor.behavior.test.ts',
+    'budget-governor.wired.test.ts',
+    'candidate-selection.test.ts',
+    'circuit-breaker.test.ts',
+    'claim-manager.test.ts',
+    'concurrency.test.ts',
+    'heartbeat.test.ts',
+    'highlight-extractor.test.ts',
+    'interaction-queue.test.ts',
+    'lane-effect-persistence.test.ts',
+    'lane-persistence.test.ts',
+    'lane-readback.test.ts',
+    'model-router.test.ts',
+    'orchestrator-identity.test.ts',
+    'published-index.test.ts',
+    'rate-limit.test.ts',
+    'rate-limiter.test.ts',
+    'reconciliation.test.ts',
+    'retry.test.ts',
+    'stale-claim.test.ts',
+    'stall-detector.test.ts',
+    'startup-reconciliation.test.ts',
+    'state-machine.prune-completed.test.ts',
+    'state-machine.test.ts',
+    'stream-recorder.test.ts',
+    'tick-jitter.test.ts',
+    'triage-router.test.ts',
+  ]
 ---
-
-## Summary
-
-This test suite validates the orchestrator's core data-flow infrastructure: analysis persistence, publication tracking, and comment rendering. Three main test files cover AnalysisArchive (file-based storage for enriched issue analysis with round-trip fidelity and path-safety), AnalysisComment (markdown rendering with embedded discriminator JSON for auto-publish deduplication), and auto-publish flow (integration of config discovery, published-index tracking, and comment persistence). The module sits at the data model layer and does not test dispatch logic, gating, or backend invocation.
-
-## Invariants
-
-- AnalysisRecord shape is load-bearing — issueId (primary key), identifier, spec, score, simulation, analyzedAt, externalId must all round-trip faithfully through JSON serialization.
-- Path safety gates — issueIds must not escape the archive directory; get() returns null on escape attempts, save() throws.
-- Latest-wins overwrite — duplicate issueId entries keep only the most recent record; list/get operations never surface stale versions.
-- Null normalization — missing or deleted externalId fields always normalize to null (not undefined), so legacy records merge correctly with new schema.
-- Directory auto-creation — archive directory is created on first save() even if nested; doesn't pre-require setup.
-- Graceful rendering with partial data — renderAnalysisComment() handles null score, null spec, and null simulation without breaking; comment still embeds discriminator JSON.
-- Published-index deduplication — loadPublishedIndex() + savePublishedIndex() gate repeated publication of the same record by externalId.
 
 ## Interface Contract
 

--- a/packages/orchestrator/src/core/state-machine.ts
+++ b/packages/orchestrator/src/core/state-machine.ts
@@ -259,20 +259,6 @@ function resolveBackend(action: string, hasLocalBackend: boolean): 'local' | 'pr
 }
 
 /**
- * Prune completed entries that no longer have pending retries, running
- * tasks, or active claims. Only runs when the set exceeds the threshold.
- */
-function pruneCompleted(next: OrchestratorState): void {
-  if (next.completed.size <= COMPLETED_PRUNE_THRESHOLD) return;
-  for (const [id] of next.completed) {
-    const hasPending = next.retryAttempts.has(id) || next.running.has(id) || next.claimed.has(id);
-    if (!hasPending) {
-      next.completed.delete(id);
-    }
-  }
-}
-
-/**
  * Default grace period multiplier applied to pollIntervalMs.
  * A completed issue must be older than `pollIntervalMs * GRACE_MULTIPLIER`
  * before it can be released from `completed` when it reappears in active
@@ -280,6 +266,29 @@ function pruneCompleted(next: OrchestratorState): void {
  * after completion when the tracker write-back may not have persisted.
  */
 const COMPLETED_GRACE_MULTIPLIER = 2;
+
+/**
+ * Prune completed entries that no longer have pending retries, running
+ * tasks, or active claims. Only runs when the set exceeds the threshold.
+ *
+ * Entries younger than the same grace period `reconcileCompletedAndClaimed`
+ * uses are never pruned, even once the set is over threshold: without this
+ * age check, a just-finished issue (well inside its grace window) could be
+ * evicted from `completed` in the same tick it finished, silently dropping
+ * the "already finished in this orchestrator process" guard `isEligible`
+ * relies on and reopening it to duplicate dispatch on the very next tick.
+ */
+function pruneCompleted(next: OrchestratorState, nowMs: number): void {
+  if (next.completed.size <= COMPLETED_PRUNE_THRESHOLD) return;
+  const minAgeMs = next.pollIntervalMs * COMPLETED_GRACE_MULTIPLIER;
+  for (const [id, completedAtMs] of next.completed) {
+    if (nowMs - completedAtMs < minAgeMs) continue;
+    const hasPending = next.retryAttempts.has(id) || next.running.has(id) || next.claimed.has(id);
+    if (!hasPending) {
+      next.completed.delete(id);
+    }
+  }
+}
 
 /**
  * Reconcile the `completed` set against current active candidates.
@@ -512,7 +521,7 @@ function handleTick(
     dispatchEligibleIssue(next, issue, event, escalationConfig, config, effects);
   }
 
-  pruneCompleted(next);
+  pruneCompleted(next, nowMs);
 
   return { nextState: next, effects };
 }

--- a/packages/orchestrator/tests/core/state-machine.prune-completed.test.ts
+++ b/packages/orchestrator/tests/core/state-machine.prune-completed.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { applyEvent } from '../../src/core/state-machine';
+import { createEmptyState } from '../../src/core/state-helpers';
+import type { WorkflowConfig } from '@harness-engineering/types';
+import type { OrchestratorEvent } from '../../src/types/events';
+
+function makeConfig(overrides: Partial<WorkflowConfig> = {}): WorkflowConfig {
+  return {
+    tracker: {
+      kind: 'roadmap',
+      activeStates: ['Todo', 'In Progress'],
+      terminalStates: ['Done', 'Cancelled'],
+    },
+    polling: { intervalMs: 30000 },
+    workspace: { root: '/tmp/ws' },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 60000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 3,
+      maxTurns: 20,
+      maxRetryBackoffMs: 300000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: {},
+      turnTimeoutMs: 3600000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 300000,
+    },
+    server: { port: null },
+    ...overrides,
+  };
+}
+
+describe('applyEvent - tick prunes `completed` without an age check', () => {
+  it('does not evict a just-completed entry (well inside the grace period) once the completed set crosses the prune threshold', () => {
+    const config = makeConfig();
+    const state = createEmptyState(config);
+
+    const nowMs = 1706745600000;
+    // reconcileCompletedAndClaimed's own grace period -- an issue must be older
+    // than this before it is safe to release from `completed` for re-dispatch.
+    const gracePeriodMs = config.polling.intervalMs * 2; // 60000ms
+
+    // Seed the `completed` map past COMPLETED_PRUNE_THRESHOLD (100), all with no
+    // pending running/retry/claimed activity so every entry is prune-eligible.
+    // One entry ("recent-1") completed 1ms ago -- deep inside the grace period
+    // that guards against re-dispatching a just-finished issue.
+    state.completed.set('recent-1', nowMs - 1);
+    for (let i = 0; i < 100; i++) {
+      state.completed.set(`old-${i}`, nowMs - gracePeriodMs * 5);
+    }
+    expect(state.completed.size).toBe(101);
+
+    const event: OrchestratorEvent = {
+      type: 'tick',
+      candidates: [],
+      runningStates: new Map(),
+      nowMs,
+    };
+
+    const { nextState } = applyEvent(state, event, config);
+
+    // pruneCompleted must not throw away an entry that hasn't cleared the
+    // grace period yet -- doing so drops the "already finished in this
+    // orchestrator process" guard (candidate-selection.ts's isEligible) and
+    // reopens the issue to duplicate dispatch on the very next tick.
+    expect(nextState.completed.has('recent-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Defect

`pruneCompleted` (packages/orchestrator/src/core/state-machine.ts) runs on every tick once the `completed` set exceeds `COMPLETED_PRUNE_THRESHOLD`, evicting any entry with no pending retry, running task, or active claim — **with no age check**. But `reconcileCompletedAndClaimed` relies on the `completed` set as the "already finished in this orchestrator process" guard, honoring a grace period (`pollIntervalMs * COMPLETED_GRACE_MULTIPLIER`) before releasing a completed issue that reappears in active candidates. When the set is over threshold, `pruneCompleted` could evict a just-finished issue **in the same tick it finished** — well inside that grace window — silently dropping the dedup guard and reopening the issue to duplicate dispatch on the very next tick, before the tracker write-back is guaranteed to have persisted.

## Fix

`pruneCompleted` now takes `nowMs` and skips any entry younger than `pollIntervalMs * COMPLETED_GRACE_MULTIPLIER` — the same grace window `reconcileCompletedAndClaimed` uses — even when the set is over threshold. Older entries prune exactly as before. (`COMPLETED_GRACE_MULTIPLIER` is hoisted above `pruneCompleted` so both consumers share the one constant.)

## Repro test

`packages/orchestrator/tests/core/state-machine.prune-completed.test.ts` — drives a tick where the `completed` set has crossed the prune threshold and a just-completed entry sits well inside its grace period, and asserts that entry survives the prune. Independently verified: **FAILS on current `main` source, PASSES with the fix.**

## Assumptions / provenance

Proactive bug-fleet hunt finding (orchestrator core-state area) — no pre-existing tracker issue, so no `Closes #`. The reproducing test is the artifact.

## Stack

Base of a two-PR stack on `packages/orchestrator/src/core/state-machine.ts`. The sibling PR (`bugfleet/orch-core-state-diagnostic-stall-budget`) is stacked on **this** branch to keep both diffs conflict-free.
