### PR TITLE
fix(cli): drop redundant intelligence peerDependency (phantom cli major → 12.2.0)

### DIFF
--- a/.changeset/cli-drop-redundant-intelligence-peerdep.md
+++ b/.changeset/cli-drop-redundant-intelligence-peerdep.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): drop the redundant optional `@harness-engineering/intelligence`
+peerDependency. It was listed as BOTH a normal `dependency` and an optional
+`peerDependency` (workspace:\*), and Changesets majors any package whose
+peerDependency takes a ≥minor bump — so `intelligence`'s routine 0.12→0.13
+minor cascaded a phantom `cli` **major** (13.0.0) on release despite no
+breaking change in cli. `intelligence` remains a normal dependency, so cli's
+runtime is unchanged; this only removes the vestigial peer entry and lets cli
+release as the minor it actually is (12.2.0).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,13 +60,9 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@harness-engineering/intelligence": "workspace:*",
     "playwright": "^1.48.0"
   },
   "peerDependenciesMeta": {
-    "@harness-engineering/intelligence": {
-      "optional": true
-    },
     "playwright": {
       "optional": true
     }


### PR DESCRIPTION
## Problem

The pending release (version PR #1698) computes **cli@13.0.0 — a major** — but nothing in cli is breaking. Root cause (confirmed by isolation test): cli lists `@harness-engineering/intelligence` as **both** a normal `dependency` **and** an optional `peerDependency` (`workspace:*`). Changesets **majors any package whose peerDependency takes a ≥minor bump**, so `intelligence`'s routine **0.12.1 → 0.13.0** minor (from the #1710 generic-CLI-provider work) cascaded a **phantom cli major**.

cli is the only package in the repo with this peer entry, and it's redundant — `intelligence` is already a normal dependency.

## Fix

Remove `@harness-engineering/intelligence` from cli's `peerDependencies` + `peerDependenciesMeta` (the `playwright` peer is untouched). `intelligence` stays a normal dependency, so **cli's runtime is unchanged** — this only removes the vestigial peer entry.

## Verified

Simulated `changeset version` off current `main` **with** this change → cli computes **12.2.0** (was 13.0.0). This also stops the phantom-major from recurring on every future release where a peer dep bumps ≥minor.

## Merge order

Land this first → the changesets bot recomputes **#1698 to cli@12.2.0** → merge #1698 to publish a clean minor.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga