### PR TITLE
feat: refinement-request instrumentation (progressive-context demand signal) — Refs #1632

### DIFF
--- a/.changeset/progressive-context-refinement-instrumentation-1632.md
+++ b/.changeset/progressive-context-refinement-instrumentation-1632.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+Add refinement-request instrumentation (progressive-context demand signal, scoped slice of #1632).
+
+Logs every refinement request (`code_outline` / `code_search` / `code_unfold`) with its
+progressive context class (`file-content` | `history` | `telemetry` | `knowledge`) to
+`.harness/metrics/refinement-events.jsonl`, and aggregates it into refinement-frequency-per-context-class —
+the demand signal for rate-distortion compaction and trained-dictionary membership scoring.
+
+- `@harness-engineering/core`: new pure `refinement-demand` module (taxonomy, `classifyRefinement`,
+  `aggregateDemand` — enumerates every class so a never-read class ranks last).
+- `@harness-engineering/cli`: non-fatal JSONL writer/reader (`refinement-telemetry`), instrumentation
+  wired into the three code-nav handlers, and a new `harness mcp refinement-demand [--json]` report subcommand.
+
+Deferred to a follow-up slice: the progressive-by-default contract for every context class and the
+prefetch/batching policy.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '5f8bb71d0830892c10bb2459709a4f690ea5b6ebce8a3b8a6ebb6971d638820b'
+sourceHash: '71dd88f109469e45383b954fb6e9c0b83bd6733d781f66d16d7eb977b59945bd'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -205,6 +205,7 @@ export createMcpCommand
 export createMcpContextReportCommand
 export createMcpGuardCommand
 export createMcpListCapabilitiesCommand
+export createMcpRefinementDemandCommand
 export createMigrateCommand
 export createModelsCommand
 export createNamingCraftCommand
@@ -261,6 +262,7 @@ export formatCapabilitiesByPermission
 export formatCapabilitiesTable
 export formatCompiledUnits
 export formatContextReport
+export formatRefinementDemand
 export gatherGuardianSafe
 export gatherSignalsSafe
 export generateAgentDefinitions
@@ -422,6 +424,7 @@ import { runDesignCraft } from '../mcp/tools/design-craft'
 import { runDetectDrift } from '../mcp/tools/detect-drift'
 import { handleGetImpact } from '../mcp/tools/graph/index'
 import { runInstructionDensityAudit } from '../mcp/tools/instruction-density'
+import from '../mcp/tools/refinement-telemetry.js'
 import { resolveAnalysisProvider } from '../mcp/utils/analysis-provider'
 import { loadGraphStore } from '../mcp/utils/graph-loader'
 import { IdentifierKind, NamingCraftInput, NamingCraftOutput, runNamingCraft } from '../naming-craft/index.js'

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: 'a0065595035f830e59b66e0522f6c9cd14baf4421533556791aa13a65378f7e8'
+sourceHash: 'f0a5501c39996cf06f614bbf82fe3151a8f66b5d65f800f2eb8860ffde1de839'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -78,6 +78,7 @@ members:
     'pulse.ts',
     'put-comprehension.ts',
     'recommend-skills.ts',
+    'refinement-telemetry.ts',
     'review-changes.ts',
     'review-pipeline.ts',
     'roadmap-auto-sync.ts',
@@ -158,6 +159,7 @@ export MAX_INVARIANT_CHARS
 export MAX_SUMMARY_CHARS
 export NamingCraftInput
 export NamingCraftOutput
+export REFINEMENT_EVENTS_FILE
 export RiskLevel
 export SKILL_EVENTS_FILE
 export SecurityCraftInput
@@ -378,8 +380,10 @@ export predictConflictsDefinition
 export predictFailuresDefinition
 export putComprehensionDefinition
 export readAdr
+export readRefinementDemand
 export readStrategyDefinition
 export recommendSkillsDefinition
+export recordRefinement
 export releaseCompoundLockDefinition
 export renderBatch
 export renderConfirmation
@@ -550,6 +554,7 @@ import { EmitInteractionInputSchema, InteractionBatch, InteractionBatchSchema, I
 import { handlePlanParallelization, planParallelizationDefinition } from './parallelization'
 import from './performance.js'
 import { handleSeedPulseFromStrategy, handleWritePulseConfig, seedPulseFromStrategyDefinition, writePulseConfigDefinition } from './pulse'
+import { recordRefinement } from './refinement-telemetry.js'
 import from './review-pipeline.js'
 import { RowLinkOutcome, autoSyncRoadmap, triggerExternalSync, triggerScopedExternalSync } from './roadmap-auto-sync.js'
 import { handleManageRoadmapFileLess } from './roadmap-file-less.js'
@@ -560,7 +565,7 @@ import { handleSummarizeSession, summarizeSessionDefinition } from './summarize-
 import { handleUatSignoff, uatSignoffDefinition } from './uat-signoff.js'
 import from './validate.js'
 import { handleSubscribeWebhook, subscribeWebhookDefinition } from './webhook-tools'
-import { CHARS_PER_TOKEN, COMPREHENSION_ROOT, CompactionPipeline, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, ConflictError, DEFAULT_INSTRUCTION_BUDGET, DriftConfig, Err, ExtractStatic, FeaturePatch, GenerateSemantic, LevelInstructionDensity, NewFeatureInput, Ok, PackedEnvelope, Result, RoadmapPromoteCoreResult, RoadmapTrackerClient, SourceFile, StaticExtraction, StructuralStrategy, TrackedFeature, TrackerSyncAdapter, TruncationStrategy, analyzeSkillInstructionDensity, applyRoadmapDiff, archiveDoneShardsForProject, computeLoadPlan, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, createTrackerClient, decidePromotionForRow, detectRoadmapStorageMode, estimateTokens, extractLevel, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, paginate, renderServedUnit, resolveRoadmapStore, roadmapSourceExists, serializeEnvelope, serveGate, slugifyFeatureName } from '@harness-engineering/core'
+import { CHARS_PER_TOKEN, COMPREHENSION_ROOT, CompactionPipeline, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, ConflictError, DEFAULT_INSTRUCTION_BUDGET, DriftConfig, Err, ExtractStatic, FeaturePatch, GenerateSemantic, LevelInstructionDensity, NewFeatureInput, Ok, PackedEnvelope, RefinementContextClass, RefinementDemandReport, RefinementOperation, RefinementRequest, Result, RoadmapPromoteCoreResult, RoadmapTrackerClient, SourceFile, StaticExtraction, StructuralStrategy, TrackedFeature, TrackerSyncAdapter, TruncationStrategy, aggregateDemand, analyzeSkillInstructionDensity, applyRoadmapDiff, archiveDoneShardsForProject, classifyRefinement, computeLoadPlan, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, createTrackerClient, decidePromotionForRow, detectRoadmapStorageMode, estimateTokens, extractLevel, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, paginate, renderServedUnit, resolveRoadmapStore, roadmapSourceExists, serializeEnvelope, serveGate, slugifyFeatureName } from '@harness-engineering/core'
 import { skipDirGlobs } from '@harness-engineering/graph'
 import { AnalysisProvider, CanaryAdapter, CanaryFrameworkInfo, GuardianAnalysis, createCanaryAdapter, readGuardianAnalyses, resolveTestCommand } from '@harness-engineering/intelligence'
 import from '@harness-engineering/linter-gen'
@@ -574,7 +579,7 @@ import from 'fs/promises'
 import from 'glob'
 import { execSync } from 'node:child_process'
 import * as crypto, { randomUUID } from 'node:crypto'
-import * as fs, { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import * as fs, { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import * as fs, { mkdir, readFile } from 'node:fs/promises'
 import * as os, { tmpdir } from 'node:os'
 import * as nodePath, * as path, path, { join } from 'node:path'

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: 'f0a5501c39996cf06f614bbf82fe3151a8f66b5d65f800f2eb8860ffde1de839'
+sourceHash: '600a10e61918c7b8d771af2fbf5dbb35604211d822fca7c43066c54c71650e64'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'f0c7157d34c3ee944c41948faf57c8bd10f02bc1a5a112c7e16f6808c4483687'
+sourceHash: 'fc17fe93070df21b25c269a2c16468c95f4a7ca12d23e880bdff5c64aa9ba679'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'c6262e1cb5ddcba925f3ddce2febe86e24cfb6f51d9baed7e0ddcc96bf1d28db'
+sourceHash: 'f0c7157d34c3ee944c41948faf57c8bd10f02bc1a5a112c7e16f6808c4483687'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -64,6 +64,7 @@ members:
     'maintenance-run-selection.test.ts',
     'mcp-guard.test.ts',
     'mcp-list-capabilities.test.ts',
+    'mcp-refinement-demand.test.ts',
     'migrate-backends.test.ts',
     'migrate.test.ts',
     'models-probe.test.ts',
@@ -197,7 +198,7 @@ import { SyncIO, runSyncIntegrations } from '../../src/commands/integrations/syn
 import { createGenerateCommand } from '../../src/commands/linter/generate'
 import { createMaintenanceCommand } from '../../src/commands/maintenance'
 import { MaintenanceRunDeps, aggregateReport, buildTaskRunner, createCheckRunner, createFixDispatcher, deriveExitCode, loadRunHistory, makeResolveBackend, parseConcurrency, renderTable, resolveHarnessSpawn, resolveSelection, runMaintenanceRun } from '../../src/commands/maintenance-run'
-import { formatCapabilitiesByPermission, formatCapabilitiesTable } from '../../src/commands/mcp'
+import { createMcpRefinementDemandCommand, formatCapabilitiesByPermission, formatCapabilitiesTable, formatRefinementDemand } from '../../src/commands/mcp'
 import { extractNpmPackages, parseNpmSpec, runMcpGuardCheck } from '../../src/commands/mcp-guard'
 import { detectLegacyArtifacts, runMigrate } from '../../src/commands/migrate'
 import { runMigrateBackends } from '../../src/commands/migrate-backends'
@@ -286,7 +287,7 @@ import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
 import * as clack from '@clack/prompts'
-import { CiReviewResult, DiffInfo, Err, Ok, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
+import { CiReviewResult, DiffInfo, Err, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
 import from '@harness-engineering/graph'
 import { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION, GuardianAnalysis, OutcomeVerdict } from '@harness-engineering/intelligence'
 import { AnalysisRecord, MockBackend, RunMode, RunResult, SyncMainResult, TaskDefinition, renderAnalysisComment } from '@harness-engineering/orchestrator'

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/mcp/tools'
-sourceHash: 'f4effe056631f1c5879430fe383f824e2bf7f8a86c37e4a0a53fba88081d26d3'
+sourceHash: '9ed5d987a20eef9c3d19ac6bd5c16ec57740510b76a57cf13d11840fc34d3a00'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -57,6 +57,7 @@ members:
     'predict-failures.test.ts',
     'put-comprehension.test.ts',
     'recommend-skills.test.ts',
+    'refinement-telemetry.test.ts',
     'review-changes.test.ts',
     'review-pipeline.test.ts',
     'roadmap-auto-sync.test.ts',
@@ -143,6 +144,7 @@ import { checkPhaseGateDefinition } from '../../../src/mcp/tools/phase-gate'
 import { handlePredictFailures, predictFailuresDefinition } from '../../../src/mcp/tools/predict-failures.js'
 import { AttachSemanticDeps, attachSemantic, handlePutComprehension } from '../../../src/mcp/tools/put-comprehension'
 import { handleRecommendSkills, recommendSkillsDefinition } from '../../../src/mcp/tools/recommend-skills.js'
+import { REFINEMENT_EVENTS_FILE, readRefinementDemand, recordRefinement } from '../../../src/mcp/tools/refinement-telemetry'
 import { handleReviewChanges, reviewChangesDefinition } from '../../../src/mcp/tools/review-changes'
 import { reviewChangesDefinition } from '../../../src/mcp/tools/review-changes.js'
 import { handleRunCodeReview, runCodeReviewDefinition } from '../../../src/mcp/tools/review-pipeline'

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/mcp/tools'
-sourceHash: '9ed5d987a20eef9c3d19ac6bd5c16ec57740510b76a57cf13d11840fc34d3a00'
+sourceHash: 'b258fb855a32ff2019f63014dbf1f7f39804f5264447f0e800cf705a828ba4d5'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/src/context/_module.md
+++ b/.harness/comprehension/packages/core/src/context/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/context'
-sourceHash: '75abce14352a9f350df3cf828e1c9109cfea740b19c6c3b6deb210af9ca5da89'
-compiledAt: '2026-08-28T01:22:10.371Z'
+sourceHash: '0c7f206b64d9c19e93bfdcdd3304f099ca2ff105248660b1228729346bb1f2f8'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'agents-map.ts',
@@ -22,25 +21,11 @@ members:
     'instruction-density.ts',
     'knowledge-map.ts',
     'progressive-loader.ts',
+    'refinement-demand.ts',
     'section-parser.ts',
     'types.ts',
   ]
 ---
-
-## Summary
-
-`packages/core/src/context` is a token-and-context-budgeting subsystem for AI agent context consumption. It allocates the nominal context window into six categories (systemPrompt 15%, projectManifest 5%, taskSpec 20%, activeCode 40%, interfaces 10%, reserve 10%) and flags contributors that exceed their share. It classifies context surfaces into three classes—always-loaded (fixed per-turn tax), path-scoped (loaded by working-set path), invoked-only (loaded on-demand)—ranks contributors by token cost, and supports exact counting via Anthropic's API with graceful fallback to a chars÷4 heuristic. It validates AGENTS.md for required sections and link integrity, parses SKILL.md into four progressive-loading levels for deferred content, measures imperative-instruction density against the HumanLayer budget, and monitors resident token consumption within a turn against research-backed trip wires (warn/trip thresholds are window-class-anchored, not percentages).
-
-## Invariants
-
-- Token budget ratios are normalized—allocation functions normalize and enforce minimums to guarantee six categories always sum to 100% of allocable window
-- Context class ↔ budget category mapping is fixed 1:1—always-loaded→systemPrompt, path-scoped→projectManifest, invoked-only→interfaces; changing this mapping breaks the entire attribution model
-- Section-level classification is exhaustive and stable—SECTION_LEVEL_MAP defines every known H2 heading's progressive-disclosure tier (1–4) and defaults to 3; tier cumulation is strict (level-N includes all N−1 content)
-- Window band boundaries are absolute token anchors, never percentages—fixed thresholds (1M: warn 250K/trip 350K; 200K: warn 80K/trip 100K) because % thresholds produce degradation on large windows
-- EFFECTIVE_WINDOW_RATIO = 0.6—usable context is ~60% of nominal window per RULER research; trip wires and utilization calculations depend on this constant
-- Attribution never hard-fails—buildAttributionReport catches token-counter exceptions per entry and falls back to heuristic; report marks degradation but never throws
-- REQUIRED_SECTIONS in AGENTS.md is non-negotiable—validateAgentsMap rejects any validation if a required section is missing; this is load-bearing for agent-capability discovery
-- Trip verdicts are keyed to resident token count, not utilization—evaluateContextBudget returns trip when usedTokens ≥ tripAt (absolute), never when a percentage crosses a threshold
 
 ## Interface Contract
 
@@ -57,6 +42,7 @@ export BuildAttributionReportOptions
 export CLASS_TO_BUDGET_CATEGORY
 export CONTEXT_CLASSES
 export ClassAttribution
+export ClassDemand
 export ContextBudgetEvaluation
 export ContextBudgetThresholds
 export ContextBudgetVerdict
@@ -79,8 +65,14 @@ export GraphCoverageData
 export IntegrityReport
 export LevelInstructionDensity
 export LoaderConfig
+export OPERATION_CONTEXT_CLASS
 export ParsedSection
+export REFINEMENT_CONTEXT_CLASSES
 export REQUIRED_SECTIONS
+export RefinementContextClass
+export RefinementDemandReport
+export RefinementOperation
+export RefinementRequest
 export ResolvedCounterMode
 export ResolvedTokenCounter
 export SkillInstructionDensityReport
@@ -89,9 +81,11 @@ export TokenBudget
 export TokenBudgetOverrides
 export TokenCounter
 export WorkflowPhase
+export aggregateDemand
 export analyzeSkillInstructionDensity
 export buildAttributionReport
 export checkDocCoverage
+export classifyRefinement
 export computeLoadPlan
 export contextBudget
 export contextFilter

--- a/.harness/comprehension/packages/core/tests/context/_module.md
+++ b/.harness/comprehension/packages/core/tests/context/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/context'
-sourceHash: '510db5cda804ca1c6928abff85c870f2c78d9e8ffb9a083f9c86e99fab5f0d9e'
-compiledAt: '2026-08-28T01:22:10.825Z'
+sourceHash: '4c32ef5d8007159d358feaf778663e56b863827f26682f8bc59adeaab8da7fcf'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'agents-map.test.ts',
@@ -20,22 +19,10 @@ members:
     'instruction-density.test.ts',
     'knowledge-map.test.ts',
     'progressive-loader.test.ts',
+    'refinement-demand.test.ts',
     'section-parser.test.ts',
   ]
 ---
-
-## Summary
-
-The `packages/core/tests/context` module validates the context management system that allocates and tracks token budgets across different input types. It spans five subsystems: agents-map (parses and validates AGENTS.md documentation, extracts markdown links and sections, detects broken references); attribution (tracks token consumption per context class, flags over-budget entries, degrades to heuristic counting on counter failure); budget (allocates a fixed token window proportionally across six categories: systemPrompt 15%, projectManifest 5%, taskSpec 20%, activeCode 40%, interfaces 10%, reserve 10%); plus progressive-loader, filters, instruction-density, doc-coverage, and knowledge-map (handle load-planning, phase-aware filtering, instruction analysis, and cross-reference validation).
-
-## Invariants
-
-- Budget allocation is proportional and zero-sum: all six categories sum to ≤total window (floor rounding may drop <10 tokens); budget overrides redistribute remainder proportionally and never exceed the total
-- Attribution tracks both exact and heuristic counting: exact counters (API-based) preferred; fallback to heuristicTokenCounter (chars÷4) on failure, mark entry degraded, set report counterMode to 'mixed' or 'exact'
-- Over-budget flagging is class-scoped: an entry exceeds budget only if its token sum > contextBudget()[CLASS_TO_BUDGET_CATEGORY[class]]; report tracks per-class allocations independently
-- Agents map validation is multi-dimensional: must report valid sections, broken links, and total link count as independent properties even when some are empty; return structured Result type with ok/error/value
-- Section association is line-aware: extracted markdown links and sections preserve line numbers; links assigned to containing section by descending line order; descriptions capture multi-line prose until next heading
-- Doc links are filesystem-relative: path validation resolves links relative to AGENTS.md location; ./missing.md and ./exists.md are distinct checks; non-existent files flag brokenLinks, not missing sections
 
 ## Interface Contract
 
@@ -58,6 +45,7 @@ import { generateAgentsMap } from '../../src/context/generate'
 import { DEFAULT_INSTRUCTION_BUDGET, analyzeSkillInstructionDensity, countImperativeInstructions } from '../../src/context/instruction-density'
 import { validateKnowledgeMap } from '../../src/context/knowledge-map'
 import { DEFAULT_LOADER_CONFIG, computeLoadPlan } from '../../src/context/progressive-loader'
+import { OPERATION_CONTEXT_CLASS, REFINEMENT_CONTEXT_CLASSES, RefinementRequest, aggregateDemand, classifyRefinement } from '../../src/context/refinement-demand'
 import { extractLevel, parseSections } from '../../src/context/section-parser'
 import { skipDirGlobs } from '@harness-engineering/graph'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'

--- a/docs/changes/progressive-context-refinement-instrumentation-1632/plans/plan.md
+++ b/docs/changes/progressive-context-refinement-instrumentation-1632/plans/plan.md
@@ -1,0 +1,161 @@
+# Plan: Refinement-request instrumentation (progressive-context demand signal)
+
+**Date:** 2026-08-31 | **Spec:** `docs/changes/progressive-context-refinement-instrumentation-1632/proposal.md` | **Tasks:** 7 | **Time:** ~30 min | **Integration Tier:** medium
+
+## Goal
+
+Add a measurement layer that logs every refinement request (`code_outline` / `code_search` / `code_unfold`) tagged with a progressive-domain context class, and aggregates the log into a per-class demand signal exposed via `harness mcp refinement-demand`. Zero behavioral change to the three existing tools.
+
+## Scope
+
+This is the scoped instrumentation half of #1632. **DEFERRED — do NOT plan or build:** the progressive-by-default contract for every context class, and the prefetch/batching policy. Those are follow-up slices that consume this slice's demand log.
+
+## Observable Truths (Acceptance Criteria)
+
+1. **Each refinement request is logged with a context class.** When `handleCodeOutline` / `handleCodeSearch` / `handleCodeUnfold` succeeds, one JSONL line is appended to `.harness/metrics/refinement-events.jsonl` carrying `operation`, `contextClass`, and a stamped `timestamp`; the three wired operations classify as `file-content`. (Testable: invoke a handler against a fixture, assert the line exists and classifies `file-content`.)
+2. **Aggregation produces refinement-frequency-per-context-class.** `aggregateDemand` / `readRefinementDemand` returns one `ClassDemand` per class with `count` and `frequency = count/total` (0 when total is 0). (Testable: feed a known mix, assert exact counts and frequencies.)
+3. **A never-read class ranks last.** `aggregateDemand` enumerates ALL classes; untouched classes appear at the bottom with `count: 0, frequency: 0`, sorted count-desc then canonical class order. (Testable: seed only `file-content` + `knowledge`; assert `history` and `telemetry` sort last with zero counts.)
+4. **Instrumentation is non-fatal.** An unwritable metrics dir never throws and never changes a tool's response. (Testable: point the writer at an unwritable path; assert no throw and unchanged handler result.)
+5. **Read surface is wired.** `harness mcp refinement-demand [--json]` is registered under `createMcpCommand()` and prints the ranked per-class demand (`--json` emits `RefinementDemandReport`).
+
+## File Map
+
+- CREATE `packages/core/src/context/refinement-demand.ts`
+- CREATE `packages/core/tests/context/refinement-demand.test.ts`
+- MODIFY `packages/core/src/context/index.ts` (add exports)
+- CREATE `packages/cli/src/mcp/tools/refinement-telemetry.ts`
+- CREATE `packages/cli/tests/mcp/tools/refinement-telemetry.test.ts`
+- MODIFY `packages/cli/src/mcp/tools/code-nav.ts` (add `recordRefinement` on success in 3 handlers)
+- MODIFY `packages/cli/tests/mcp/tools/code-nav-handlers.test.ts` (add logging-on-success assertion)
+- MODIFY `packages/cli/src/commands/mcp.ts` (add `createMcpRefinementDemandCommand`, register in `createMcpCommand`)
+- CREATE `packages/cli/tests/commands/mcp-refinement-demand.test.ts`
+- REGEN `docs/reference/*` via `pnpm run generate-docs` (new subcommand)
+
+## Repo conventions (apply to every task)
+
+- **Build the CLI before committing.** The pre-commit arch hook runs the _built_ CLI. After code changes and before `git commit`, run `pnpm build` (turbo builds core + cli). Editing source alone leaves `dist/` stale.
+- **NEVER use `--no-verify`.** All gates must pass honestly.
+- **Core barrel is automatic.** `packages/core/src/index.ts` already does `export * from './context'`, so adding exports to `context/index.ts` flows to the core barrel with **no** `generate-core-barrel` allowlist edit.
+- **Single-file test runs:** core → `pnpm --filter @harness-engineering/core exec vitest run tests/context/<file>`; cli → `pnpm --filter @harness-engineering/cli exec vitest run <path-relative-to-package>`.
+
+## Tasks
+
+### Task 1: Core demand module — types, table, classifier, `aggregateDemand` (TDD, test first)
+
+**Files:** `packages/core/tests/context/refinement-demand.test.ts` | **DependsOn:** none
+
+1. Create the test file `packages/core/tests/context/refinement-demand.test.ts`. Import from `../../src/context/refinement-demand`. Cover:
+   - `REFINEMENT_CONTEXT_CLASSES` equals `['file-content','history','telemetry','knowledge']` (canonical order).
+   - `OPERATION_CONTEXT_CLASS` maps `outline|search|unfold → file-content`, `expand-diff → history`, `expand-rationale → knowledge`, `expand-telemetry → telemetry`.
+   - `classifyRefinement('unfold')` returns `'file-content'`; `classifyRefinement('expand-telemetry')` returns `'telemetry'`.
+   - `aggregateDemand([])` returns `{ total: 0, byClass: [...4 classes...] }` each with `count: 0, frequency: 0`, in canonical order.
+   - Truth 2: a known mix (e.g. 3×`file-content`, 1×`knowledge`) yields `total: 4`, `file-content` `count 3 frequency 0.75`, `knowledge` `count 1 frequency 0.25`, and exact frequencies.
+   - Truth 3: seed only `file-content` + `knowledge`; assert `history` and `telemetry` appear LAST with `count: 0`, and that ties break by canonical class order (e.g. two zero classes stay in canonical order).
+   - Sort is count-desc primary, canonical-order tiebreak.
+2. Run: `pnpm --filter @harness-engineering/core exec vitest run tests/context/refinement-demand.test.ts` — observe failure (module missing).
+3. Create `packages/core/src/context/refinement-demand.ts` implementing exactly the spec's data structures (proposal §"Data structures"): `RefinementContextClass`, `REFINEMENT_CONTEXT_CLASSES`, `RefinementOperation`, `OPERATION_CONTEXT_CLASS` (const `Record`), `RefinementRequest`, `classifyRefinement`, `ClassDemand`, `RefinementDemandReport`, `aggregateDemand`. Pure/IO-free. `aggregateDemand` enumerates every class from `REFINEMENT_CONTEXT_CLASSES`, counts by `request.contextClass`, computes `frequency = total === 0 ? 0 : count / total`, and sorts `byClass` by count desc then index in `REFINEMENT_CONTEXT_CLASSES`.
+4. Run the test again — observe pass.
+5. Run: `harness validate` (or `pnpm --filter @harness-engineering/core typecheck` if `harness` unavailable in worktree).
+6. Commit: `feat(core): add refinement-demand taxonomy and aggregateDemand`
+
+### Task 2: Export the core module via `context/index.ts`
+
+**Files:** `packages/core/src/context/index.ts` | **DependsOn:** Task 1
+
+1. Add to `packages/core/src/context/index.ts` a documented export block mirroring the existing style:
+   - Value exports: `REFINEMENT_CONTEXT_CLASSES`, `OPERATION_CONTEXT_CLASS`, `classifyRefinement`, `aggregateDemand`.
+   - Type exports: `RefinementContextClass`, `RefinementOperation`, `RefinementRequest`, `ClassDemand`, `RefinementDemandReport`.
+2. No allowlist edit needed (core barrel re-exports `./context` via `export *`).
+3. Run: `pnpm --filter @harness-engineering/core build` then `node -e "const c=require('./packages/core/dist/index.js'); console.log(typeof c.aggregateDemand, typeof c.classifyRefinement)"` — expect `function function`.
+4. Run: `harness validate` (or core `typecheck`).
+5. Commit: `feat(core): re-export refinement-demand from context barrel`
+
+### Task 3: CLI telemetry writer/reader (TDD, test first)
+
+**Files:** `packages/cli/tests/mcp/tools/refinement-telemetry.test.ts` | **DependsOn:** Task 2
+
+1. Create `packages/cli/tests/mcp/tools/refinement-telemetry.test.ts`, mirroring `skill-telemetry.test.ts` (temp-dir helper with `mkdtempSync` + `afterEach` cleanup). Import `recordRefinement`, `readRefinementDemand`, `REFINEMENT_EVENTS_FILE` from `../../../src/mcp/tools/refinement-telemetry`. Cover:
+   - `REFINEMENT_EVENTS_FILE` contains `metrics` and `refinement-events.jsonl`.
+   - `recordRefinement(dir, { operation: 'outline', target: 'x.ts' })` writes one JSONL line at `<dir>/.harness/metrics/refinement-events.jsonl` with `operation: 'outline'`, `contextClass: 'file-content'` (derived), and a string `timestamp`.
+   - Explicit `contextClass` override wins: `recordRefinement(dir, { operation: 'unfold', contextClass: 'knowledge' })` records `contextClass: 'knowledge'`.
+   - Successive calls append (multiple lines).
+   - Truth 4 non-fatal: `recordRefinement('/proc/nonexistent-unwritable', { operation: 'search' })` (or a path guaranteed unwritable) does NOT throw.
+   - `readRefinementDemand` on a missing file returns the all-zero 4-class report (`total: 0`).
+   - `readRefinementDemand` after seeding a known mix returns the aggregated report; a malformed/garbage line is skipped without throwing (parse-tolerant).
+2. Run: `pnpm --filter @harness-engineering/cli exec vitest run tests/mcp/tools/refinement-telemetry.test.ts` — observe failure.
+3. Create `packages/cli/src/mcp/tools/refinement-telemetry.ts` copying the `skill-telemetry.ts` contract verbatim: `REFINEMENT_EVENTS_FILE = join('.harness','metrics','refinement-events.jsonl')`; `recordRefinement(projectPath, input)` — derive `contextClass = input.contextClass ?? classifyRefinement(input.operation)`, build `{ operation, contextClass, target?, timestamp: new Date().toISOString() }`, `mkdirSync(recursive)` + `appendFileSync`, ALL wrapped in `try/catch {}` (silent). `readRefinementDemand(projectPath)` — read the file if present (return `aggregateDemand([])` on missing/empty), split lines, `JSON.parse` each inside try/catch skipping bad lines, collect valid `RefinementRequest`s, return `aggregateDemand(requests)`. Import `classifyRefinement`, `aggregateDemand`, and the types from `@harness-engineering/core`.
+4. Run the test again — observe pass.
+5. Run: `harness validate` (or cli `typecheck`).
+6. Commit: `feat(cli): add refinement telemetry writer/reader`
+
+### Task 4: Wire `recordRefinement` into the 3 code-nav handlers (TDD, test first)
+
+**Files:** `packages/cli/tests/mcp/tools/code-nav-handlers.test.ts`, `packages/cli/src/mcp/tools/code-nav.ts` | **DependsOn:** Task 3
+
+1. Add a `describe('refinement instrumentation')` block to `packages/cli/tests/mcp/tools/code-nav-handlers.test.ts`. Because the writer uses `root = process.cwd()`, drive the test through cwd:
+   - In `beforeEach`, `mkdtempSync` a temp project dir and `process.chdir(tmp)`; in `afterEach`, restore the original cwd and `rmSync` the temp dir.
+   - Write an absolute fixture source file (e.g. a small `.ts` with an exported function) — either inside the temp dir or reuse a `packages/core/tests/fixtures/code-nav` fixture via absolute path.
+   - Call `handleCodeOutline({ path: <fixtureAbs> })`; assert the result is NOT an error AND `<tmp>/.harness/metrics/refinement-events.jsonl` exists with one line whose `operation` is `'outline'` and `contextClass` is `'file-content'`.
+   - (Optional, same pattern) assert `handleCodeSearch` logs `'search'` and `handleCodeUnfold` logs `'unfold'`.
+   - Assert the error path does NOT log: `handleCodeOutline({ path: '/nonexistent/xyz' })` leaves no new line.
+2. Run: `pnpm --filter @harness-engineering/cli exec vitest run tests/mcp/tools/code-nav-handlers.test.ts` — observe failure.
+3. Edit `packages/cli/src/mcp/tools/code-nav.ts`: add a static import `import { recordRefinement } from './refinement-telemetry.js';` at the top. In each handler, AFTER a successful result is computed and immediately before returning the success `content` (NOT in the `catch`/error branches):
+   - `handleCodeOutline` (both the `isFile()` and `isDirectory()` success returns): `recordRefinement(process.cwd(), { operation: 'outline', target: input.path });`
+   - `handleCodeSearch` (success return): `recordRefinement(process.cwd(), { operation: 'search', target: input.query });`
+   - `handleCodeUnfold` (both the `symbol` and `startLine/endLine` success returns): `recordRefinement(process.cwd(), { operation: 'unfold', target: input.symbol ?? input.path });`
+     The recorder is non-fatal by its own try/catch (belt-and-suspenders with placement after the result). Do NOT alter what any handler returns.
+4. Run the test again — observe pass. Also rerun the full `code-nav-handlers.test.ts` and `code-nav.test.ts` to confirm no behavioral regression.
+5. Run: `harness validate`.
+6. Commit: `feat(cli): record refinement demand from code-nav handlers`
+
+### Task 5: `harness mcp refinement-demand [--json]` subcommand (TDD, test first)
+
+**Files:** `packages/cli/tests/commands/mcp-refinement-demand.test.ts`, `packages/cli/src/commands/mcp.ts` | **DependsOn:** Task 3
+
+1. Create `packages/cli/tests/commands/mcp-refinement-demand.test.ts`, mirroring `mcp-list-capabilities.test.ts`. Test the pure formatter (export a `formatRefinementDemand(report)` alongside the command, as `mcp.ts` does for `formatContextReport`):
+   - Given a `RefinementDemandReport` with a ranked mix, the human format lists every class with count + frequency, ranked, and a total line.
+   - A zero-count class renders at the bottom with `0`.
+   - Assert the command object built by `createMcpRefinementDemandCommand()` has name `refinement-demand` and a `--json` option.
+2. Run: `pnpm --filter @harness-engineering/cli exec vitest run tests/commands/mcp-refinement-demand.test.ts` — observe failure.
+3. Edit `packages/cli/src/commands/mcp.ts`:
+   - Add `export function formatRefinementDemand(report): string` rendering the ranked per-class table (reuse the local `padEnd` helper), mirroring `formatContextReport`'s style.
+   - Add `export function createMcpRefinementDemandCommand(): Command` mirroring `createMcpContextReportCommand()`: `new Command('refinement-demand')`, `.description(...)`, `.option('--json', ...)`, `.action` that reads `opts` via `optsWithGlobals()`, dynamically imports `readRefinementDemand` from `../mcp/tools/refinement-telemetry.js`, calls it with `process.cwd()`, then `console.log(JSON.stringify(report, null, 2))` under `--json` else `console.log(formatRefinementDemand(report))`.
+   - In `createMcpCommand()`, add `command.addCommand(createMcpRefinementDemandCommand());` next to the existing `createMcpContextReportCommand()` registration.
+4. Run the test again — observe pass.
+5. Run: `harness validate`.
+6. Commit: `feat(cli): add harness mcp refinement-demand subcommand`
+
+### Task 6: Regenerate CLI reference docs (integration)
+
+**Files:** `docs/reference/*` (generated) | **DependsOn:** Task 5 | **Category:** integration
+
+1. Build first so the generator sees the new subcommand: `pnpm build`.
+2. Run: `pnpm run generate-docs`.
+3. Verify the new subcommand appears in the regenerated `harness mcp` reference (grep `refinement-demand` under `docs/reference/`). This clears the pre-push reference-docs freshness gate.
+4. Run: `harness validate`.
+5. Commit: `docs(cli): regenerate reference for harness mcp refinement-demand`
+
+### Task 7: Full build, validate, and verify (integration)
+
+**Files:** (no source edits) | **DependsOn:** Task 6 | **Category:** integration
+
+1. Run `pnpm build` (turbo — builds core + cli so the pre-commit arch hook runs the current CLI).
+2. Run the affected suites: `pnpm --filter @harness-engineering/core exec vitest run tests/context/refinement-demand.test.ts` and `pnpm --filter @harness-engineering/cli exec vitest run tests/mcp/tools/refinement-telemetry.test.ts tests/mcp/tools/code-nav-handlers.test.ts tests/commands/mcp-refinement-demand.test.ts`.
+3. Manual smoke: from the worktree root, run `node packages/cli/dist/bin/harness.js mcp refinement-demand --json` — expect an all-zero 4-class `RefinementDemandReport` (or seeded counts if `.harness/metrics/refinement-events.jsonl` exists).
+4. Run `harness validate`. NEVER `--no-verify`.
+5. Write `provenance.json` (per the change's convention) and open the PR with `Refs #1632`.
+
+## Sequencing & Dependencies
+
+- Task 1 → Task 2 (module before its barrel export).
+- Task 2 → Task 3 (writer imports the core exports).
+- Task 3 → Task 4 and Task 3 → Task 5 (both depend on the writer/reader; **Tasks 4 and 5 are independent of each other** — different files, may proceed in parallel).
+- Tasks 4 & 5 → Task 6 (docs regen needs the registered subcommand).
+- Task 6 → Task 7 (final verify).
+
+## Notes / Constraints carried from the spec
+
+- **D1:** name is `RefinementContextClass` (domain axis), distinct from the existing `ContextClass` (loading axis) in `attribution.ts`. Do not conflate or reuse.
+- **D3:** pure logic in core, IO in cli — copy `skill-telemetry.ts` contract verbatim (non-fatal, append-only JSONL, timestamp on write).
+- **D5:** read surface is a CLI subcommand, not a new MCP tool — no tool-tier/capability churn.
+- Instrumentation is strictly additive: no change to any handler's returned `content` or `isError`.

--- a/docs/changes/progressive-context-refinement-instrumentation-1632/proposal.md
+++ b/docs/changes/progressive-context-refinement-instrumentation-1632/proposal.md
@@ -1,0 +1,278 @@
+# Refinement-request instrumentation (progressive context, demand signal)
+
+> Scoped slice of #1632 "Progressive context encoding". Builds ONLY the
+> refinement-request instrumentation stream — the independent, higher-value
+> half the issue calls out. Progressive-by-default contracts and the
+> prefetch/batching policy are **deferred** to a follow-up slice.
+
+**Keywords:** progressive-context, refinement, context-class, demand-signal, code-unfold, telemetry, instrumentation, jsonl
+
+## Overview
+
+Full-resolution-by-default context spends tokens against the _possibility_ of
+attention rather than its presence. Progressive serving replaces that guess with
+a measured demand signal: refinement frequency per context class. The refinement
+operations already exist as MCP tools — `code_outline`, `code_search`,
+`code_unfold` (`packages/cli/src/mcp/tools/code-nav.ts`), backed by the
+AST-bounded `packages/core/src/code-nav` engine. What is missing is the
+**measurement layer**: a log of every refinement request tagged with its context
+class, and an aggregation that turns that log into the demand signal downstream
+compaction and dictionary work consume.
+
+This slice builds exactly that layer. It does not change how any refinement
+operation behaves and it does not make anything progressive-by-default.
+
+### Goals
+
+- Log every refinement request with a **context class** the moment it is served.
+- Aggregate the log into **refinement frequency per context class** (the demand
+  signal).
+- Rank the classes by demand so a **never-read class sorts to the bottom**.
+- Zero behavioral change to `code_outline` / `code_search` / `code_unfold`;
+  instrumentation is strictly additive and never blocks a tool response.
+
+### Out of scope (deferred — flagged for manual reconciliation of #1632)
+
+- **Progressive-by-default contract** for every context class (coarse layer +
+  refinement operations applied as the default for file content, history,
+  telemetry, knowledge). Not built here.
+- **Prefetch / batching policy** (task-class refinement priors that batch
+  predictable unfolds to bound round-trip latency). Not built here.
+- **Paired evaluation** (token cost vs. task outcomes, progressive vs.
+  full-resolution). Not built here — it consumes this slice's demand log later.
+
+## Decisions made
+
+### D1 — Context-class taxonomy is the progressive _domain_ taxonomy, not the attribution loading taxonomy
+
+`packages/core/src/context/attribution.ts` already defines a `ContextClass`
+(`always-loaded | path-scoped | invoked-only`) that classifies _how_ a surface
+loads. That is a different axis from what #1632 asks for. The demand signal is
+keyed on the progressive **domain** the refinement touches:
+
+`file-content | history | telemetry | knowledge`
+
+These are named directly in the issue's Deliverables ("applied as the default
+for file content, history, telemetry, and knowledge"). To avoid a name clash
+with the existing `ContextClass`, this slice names its type
+**`RefinementContextClass`**.
+
+_Rationale:_ the two taxonomies answer different questions and must not be
+conflated; a downstream reader that scores dictionary membership by demand needs
+the domain axis, not the loading axis.
+
+### D2 — Classification is operation-driven with an explicit override
+
+Each refinement **operation** maps to a default context class via a fixed,
+documented table:
+
+| Operation          | Default context class | Backing tool (today) |
+| ------------------ | --------------------- | -------------------- |
+| `outline`          | `file-content`        | `code_outline`       |
+| `search`           | `file-content`        | `code_search`        |
+| `unfold`           | `file-content`        | `code_unfold`        |
+| `expand-diff`      | `history`             | _(future)_           |
+| `expand-rationale` | `knowledge`           | _(future)_           |
+| `expand-telemetry` | `telemetry`           | _(future)_           |
+
+The recorder accepts an optional explicit `contextClass` that overrides the
+default, so a future caller unfolding a decision's rationale from a knowledge
+node can record `knowledge` even though it reuses the `unfold` operation. The
+three operations wired **in this slice** are the three that have real tools
+today (all `file-content`); the future operations exist in the taxonomy so the
+demand aggregation enumerates every class (see D4).
+
+### D3 — Split pure logic (core) from filesystem IO (cli), mirroring skill-telemetry
+
+- **Pure, IO-free, unit-tested logic** lives in
+  `packages/core/src/context/refinement-demand.ts`: the taxonomy, the classifier,
+  the record shape, and `aggregateDemand()`.
+- **Filesystem IO** lives in `packages/cli/src/mcp/tools/refinement-telemetry.ts`,
+  following the exact contract of the existing
+  `packages/cli/src/mcp/tools/skill-telemetry.ts`: non-fatal (never throws,
+  never blocks an MCP response), append-only JSONL under
+  `.harness/metrics/refinement-events.jsonl`, timestamp stamped on write.
+
+_Rationale:_ this is the established seam in the repo — pure core + IO-injected
+CLI writer — and it keeps the demand math trivially testable without a
+filesystem.
+
+### D4 — Aggregation enumerates all classes so never-read classes rank last
+
+`aggregateDemand()` always emits a row for **every** `RefinementContextClass`,
+including classes with zero recorded requests, and sorts by count descending
+(ties broken by canonical class order). A class nobody refined therefore lands at
+the bottom of the ranking with `count: 0, frequency: 0`. This is the mechanism
+behind acceptance criterion 3 and the issue's "demand log doubles as a report of
+which context classes were never worth sending".
+
+### D5 — Read surface is a CLI subcommand under `harness mcp`
+
+The demand report is exposed as `harness mcp refinement-demand [--json]`,
+mirroring the sibling `harness mcp context-report`
+(`packages/cli/src/commands/mcp.ts`). It reads the JSONL and prints the ranked
+per-class demand. No new MCP tool, no tool-tier/capability churn — the smallest
+wired, exercised read surface.
+
+## Technical design
+
+### Data structures (`packages/core/src/context/refinement-demand.ts`)
+
+```ts
+export type RefinementContextClass = 'file-content' | 'history' | 'telemetry' | 'knowledge';
+
+export const REFINEMENT_CONTEXT_CLASSES: readonly RefinementContextClass[] = [
+  'file-content',
+  'history',
+  'telemetry',
+  'knowledge',
+];
+
+export type RefinementOperation =
+  | 'outline'
+  | 'search'
+  | 'unfold'
+  | 'expand-diff'
+  | 'expand-rationale'
+  | 'expand-telemetry';
+
+/** Fixed operation → default context-class table (documented, stable). */
+export const OPERATION_CONTEXT_CLASS: Record<RefinementOperation, RefinementContextClass>;
+
+/** One logged refinement request (the JSONL line shape, sans stamped timestamp). */
+export interface RefinementRequest {
+  operation: RefinementOperation;
+  contextClass: RefinementContextClass;
+  target?: string; // e.g. file path or symbol, non-identifying label
+  timestamp?: string; // ISO; stamped by the writer
+}
+
+/** Classify an operation to its default context class (override wins upstream). */
+export function classifyRefinement(operation: RefinementOperation): RefinementContextClass;
+
+export interface ClassDemand {
+  contextClass: RefinementContextClass;
+  count: number;
+  frequency: number; // count / total; 0 when total is 0
+}
+
+export interface RefinementDemandReport {
+  total: number;
+  byClass: ClassDemand[]; // ranked: count desc, then canonical class order
+}
+
+/** Pure aggregation: enumerate every class, rank, never-read classes sort last. */
+export function aggregateDemand(requests: readonly RefinementRequest[]): RefinementDemandReport;
+```
+
+### Writer / reader (`packages/cli/src/mcp/tools/refinement-telemetry.ts`)
+
+```ts
+export const REFINEMENT_EVENTS_FILE = join('.harness', 'metrics', 'refinement-events.jsonl');
+
+/** Non-fatal append. Derives contextClass from operation when not given. */
+export function recordRefinement(
+  projectPath: string,
+  input: { operation: RefinementOperation; contextClass?: RefinementContextClass; target?: string }
+): void;
+
+/** Read + parse the JSONL and aggregate. Missing/empty file → empty report. */
+export function readRefinementDemand(projectPath: string): RefinementDemandReport;
+```
+
+Contract copied verbatim from `skill-telemetry.ts`: `mkdirSync(recursive)`,
+`appendFileSync`, all wrapped in a `try/catch` that silently swallows — telemetry
+must never interfere with tool execution. `readRefinementDemand` tolerates a
+missing file (returns an all-zero report) and skips unparseable lines.
+
+### Wiring (`packages/cli/src/mcp/tools/code-nav.ts`)
+
+After each **successful** handler result, and only then, call `recordRefinement`:
+
+- `handleCodeOutline` → `recordRefinement(root, { operation: 'outline', target })`
+- `handleCodeSearch` → `recordRefinement(root, { operation: 'search', target })`
+- `handleCodeUnfold` → `recordRefinement(root, { operation: 'unfold', target })`
+
+`root` resolves to `process.cwd()` (the MCP server's project root, consistent
+with the other filesystem-touching tools). The call sits outside the response
+path — a thrown recorder can never change what the tool returns (guaranteed by
+the writer's own try/catch, belt-and-suspenders with placement after the result
+is computed).
+
+### Read command (`packages/cli/src/commands/mcp.ts`)
+
+`createMcpRefinementDemandCommand()` → `harness mcp refinement-demand [--json]`,
+added to `createMcpCommand()` alongside `context-report`. Human format prints a
+ranked table; `--json` emits `RefinementDemandReport`.
+
+## Integration Points
+
+### Entry Points
+
+- New pure module `packages/core/src/context/refinement-demand.ts`.
+- New CLI-owned writer/reader `packages/cli/src/mcp/tools/refinement-telemetry.ts`.
+- New CLI subcommand `harness mcp refinement-demand`.
+- Instrumentation call sites inside the three existing `code-nav` MCP handlers.
+
+### Registrations Required
+
+- Add the new exports to `packages/core/src/context/index.ts` (the curated
+  re-export point; `core/src/index.ts` already does `export * from './context'`,
+  so no core-barrel allowlist edit is needed).
+- Register `createMcpRefinementDemandCommand()` in `createMcpCommand()`.
+- Regenerate CLI reference docs (`pnpm run generate-docs`) — the pre-push
+  reference-docs freshness gate blocks on a new subcommand otherwise.
+
+### Documentation Updates
+
+- Reference docs for `harness mcp` regenerate to include the subcommand.
+- A short note in the change's own docs; no AGENTS.md change (additive tool).
+
+### Architectural Decisions
+
+None rise to a standalone ADR. D1 (taxonomy separation) is the only decision with
+architectural weight and it is fully captured here; it introduces a parallel,
+clearly-named type rather than altering the existing `ContextClass`.
+
+### Knowledge Impact
+
+Concepts entering the graph: _refinement request_, _refinement context class_,
+_demand signal_ (refinement frequency per context class), and the relationship
+"demand signal feeds rate-distortion compaction and trained-dictionary
+membership scoring" (the downstream consumers named in #1632's Dependencies).
+
+## Success Criteria
+
+Seeded from #1632's acceptance criteria, narrowed to this slice:
+
+1. **Each refinement request is logged with a context class.** When
+   `code_outline` / `code_search` / `code_unfold` is invoked and succeeds, a
+   JSONL line is appended to `.harness/metrics/refinement-events.jsonl` carrying
+   `operation`, a `contextClass`, and a timestamp. _(Testable: invoke the
+   handler against a fixture file, assert the line exists and classifies as
+   `file-content`.)_
+2. **An aggregation produces refinement-frequency-per-context-class.**
+   `aggregateDemand` / `readRefinementDemand` returns one `ClassDemand` per
+   class with `count` and `frequency = count/total`. _(Testable: feed a known
+   mix, assert exact counts and frequencies.)_
+3. **The demand log correctly ranks a seeded never-read context class at the
+   bottom.** Given requests that touch some classes but not others, the untouched
+   class appears last with `count: 0`. _(Testable: seed only `file-content` +
+   `knowledge`, assert `telemetry` and `history` sort to the bottom with zero
+   counts.)_
+4. **Instrumentation is non-fatal.** A failing/unwritable metrics dir never
+   changes a tool's response or throws. _(Testable: point the writer at an
+   unwritable path, assert no throw and an unchanged handler result.)_
+
+## Implementation Order
+
+1. **Core demand module** — `refinement-demand.ts` (taxonomy, classifier,
+   `aggregateDemand`) + unit tests; export via `context/index.ts`.
+2. **CLI telemetry writer/reader** — `refinement-telemetry.ts` (`recordRefinement`,
+   `readRefinementDemand`) + unit tests (append, non-fatal, parse-tolerant).
+3. **Wire the three code-nav handlers** — additive `recordRefinement` calls +
+   a handler-level test asserting a line is logged on success.
+4. **Read subcommand** — `harness mcp refinement-demand [--json]`; regenerate
+   reference docs.
+5. **Provenance + verify** — write `provenance.json`, run build/typecheck/tests,
+   push, open PR with `Refs #1632`.

--- a/docs/changes/progressive-context-refinement-instrumentation-1632/provenance.json
+++ b/docs/changes/progressive-context-refinement-instrumentation-1632/provenance.json
@@ -1,0 +1,11 @@
+{
+  "issue": [1632],
+  "route": "feature",
+  "stages": ["brainstorming", "autopilot"],
+  "planArtifact": "docs/changes/progressive-context-refinement-instrumentation-1632/plans/plan.md",
+  "closingKeyword": "Refs",
+  "assumptions": [
+    "Scope limited to instrumenting the refinement-request stream (the independent half) per orchestrator default; progressive-by-default contract + prefetch/batching policy deferred to a follow-up slice",
+    "Demand signal recorded = refinement frequency per context class, over existing unfold/outline mechanics"
+  ]
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1330,6 +1330,14 @@ Audit each MCP tool: read/write/exec scope, network access, and trust tag
 - `--by-permission` — Group tools by read/write/exec/network scope
 - `--json` — Emit machine-readable JSON
 
+### `harness mcp refinement-demand`
+
+Report refinement frequency per progressive-context class (demand signal)
+
+**Options:**
+
+- `--json` — Emit machine-readable JSON
+
 ## Mcp-guard Commands
 
 Pre-launch OSV malware guard for MCP/npx packages

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -262,6 +262,62 @@ export function createMcpContextReportCommand(): Command {
     });
 }
 
+interface RefinementDemandReportShape {
+  total: number;
+  byClass: ReadonlyArray<{
+    contextClass: string;
+    count: number;
+    frequency: number;
+  }>;
+}
+
+/**
+ * Render the refinement-demand report as a ranked, terminal-friendly table.
+ * Classes arrive pre-ranked (count desc, canonical order tiebreak), so a
+ * never-read class lands at the bottom with a zero count.
+ */
+export function formatRefinementDemand(report: RefinementDemandReportShape): string {
+  const lines: string[] = [];
+  lines.push('# Refinement demand by context class (ranked by count desc)');
+  lines.push('# demand signal = refinement frequency per progressive-domain context class');
+  lines.push('');
+  lines.push(`  ${padEnd('CLASS', 14)}  ${padEnd('COUNT', 6)}  FREQUENCY`);
+  for (const c of report.byClass) {
+    lines.push(
+      `  ${padEnd(c.contextClass, 14)}  ${padEnd(String(c.count), 6)}  ${c.frequency.toFixed(4)}`
+    );
+  }
+  lines.push('');
+  lines.push(`Total: ${report.total} refinement requests across the measured surface.`);
+  return lines.join('\n');
+}
+
+/**
+ * `harness mcp refinement-demand [--json]`
+ *
+ * Reads the progressive-context refinement-demand log
+ * (`.harness/metrics/refinement-events.jsonl`) and prints the ranked per-class
+ * demand signal — how often each context class was refined. `--json` emits the
+ * raw `RefinementDemandReport`. Never hard-fails (a missing log is an all-zero
+ * report). Sibling of `context-report`; no new MCP tool.
+ */
+export function createMcpRefinementDemandCommand(): Command {
+  return new Command('refinement-demand')
+    .description('Report refinement frequency per progressive-context class (demand signal)')
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async function (this: Command) {
+      const opts = this.optsWithGlobals() as { json?: boolean };
+      const { readRefinementDemand } = await import('../mcp/tools/refinement-telemetry.js');
+      const report = readRefinementDemand(process.cwd());
+
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+        return;
+      }
+      console.log(formatRefinementDemand(report));
+    });
+}
+
 export function createMcpCommand(): Command {
   const command = new Command('mcp')
     .description('Start the MCP (Model Context Protocol) server on stdio')
@@ -303,5 +359,6 @@ export function createMcpCommand(): Command {
 
   command.addCommand(createMcpListCapabilitiesCommand());
   command.addCommand(createMcpContextReportCommand());
+  command.addCommand(createMcpRefinementDemandCommand());
   return command;
 }

--- a/packages/cli/src/mcp/tools/code-nav.ts
+++ b/packages/cli/src/mcp/tools/code-nav.ts
@@ -1,4 +1,5 @@
 import { sanitizePath } from '../utils/sanitize-path.js';
+import { recordRefinement } from './refinement-telemetry.js';
 
 // --- code_outline ---
 
@@ -62,6 +63,7 @@ export async function handleCodeOutline(input: {
 
     if (stats?.isFile()) {
       const outline = await getOutline(targetPath);
+      recordRefinement(process.cwd(), { operation: 'outline', target: input.path });
       return { content: [{ type: 'text' as const, text: formatOutline(outline) }] };
     }
 
@@ -89,6 +91,7 @@ export async function handleCodeOutline(input: {
         results.push(formatOutline(outline));
       }
 
+      recordRefinement(process.cwd(), { operation: 'outline', target: input.path });
       return {
         content: [
           {
@@ -176,6 +179,7 @@ export async function handleCodeSearch(input: { query: string; directory: string
       lines.push(`\nSkipped ${result.skipped.length} files (unsupported or parse failed)`);
     }
 
+    recordRefinement(process.cwd(), { operation: 'search', target: input.query });
     return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
   } catch (error) {
     return {
@@ -251,6 +255,7 @@ export async function handleCodeUnfold(input: {
       const header = result.warning
         ? `${result.file}:${result.startLine}-${result.endLine} ${result.warning}\n`
         : `${result.file}:${result.startLine}-${result.endLine}\n`;
+      recordRefinement(process.cwd(), { operation: 'unfold', target: input.symbol ?? input.path });
       return { content: [{ type: 'text' as const, text: header + result.content }] };
     }
 
@@ -258,6 +263,7 @@ export async function handleCodeUnfold(input: {
       const { unfoldRange } = await import('@harness-engineering/core');
       const result = await unfoldRange(filePath, input.startLine, input.endLine);
       const header = `${result.file}:${result.startLine}-${result.endLine}\n`;
+      recordRefinement(process.cwd(), { operation: 'unfold', target: input.symbol ?? input.path });
       return { content: [{ type: 'text' as const, text: header + result.content }] };
     }
 

--- a/packages/cli/src/mcp/tools/refinement-telemetry.ts
+++ b/packages/cli/src/mcp/tools/refinement-telemetry.ts
@@ -1,0 +1,82 @@
+/**
+ * Refinement-request telemetry writer/reader (progressive-context demand signal).
+ *
+ * The filesystem half of the measurement layer defined in
+ * `@harness-engineering/core`'s `refinement-demand`. Every served refinement
+ * request (`code_outline` / `code_search` / `code_unfold`, and future `expand-*`
+ * operations) is appended as one JSONL line tagged with its progressive-domain
+ * context class; `readRefinementDemand` reads that log back and aggregates it
+ * into the ranked per-class demand signal.
+ *
+ * Contract copied verbatim from the sibling `skill-telemetry.ts`: non-fatal
+ * (never throws, never blocks an MCP response), append-only JSONL under
+ * `.harness/metrics/refinement-events.jsonl`, timestamp stamped on write.
+ */
+import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { aggregateDemand, classifyRefinement } from '@harness-engineering/core';
+import type {
+  RefinementContextClass,
+  RefinementDemandReport,
+  RefinementOperation,
+  RefinementRequest,
+} from '@harness-engineering/core';
+
+/** Relative path (under the project root) of the refinement-demand log. */
+export const REFINEMENT_EVENTS_FILE = join('.harness', 'metrics', 'refinement-events.jsonl');
+
+/**
+ * Record one refinement request. Errors are silently swallowed — telemetry must
+ * never interfere with tool execution. Derives `contextClass` from the operation
+ * when not given, stamps a timestamp, and appends one JSONL line (crash-safe
+ * append).
+ */
+export function recordRefinement(
+  projectPath: string,
+  input: {
+    operation: RefinementOperation;
+    contextClass?: RefinementContextClass;
+    target?: string;
+  }
+): void {
+  try {
+    const metricsDir = join(projectPath, '.harness', 'metrics');
+    mkdirSync(metricsDir, { recursive: true });
+    const record: RefinementRequest = {
+      operation: input.operation,
+      contextClass: input.contextClass ?? classifyRefinement(input.operation),
+      ...(input.target !== undefined ? { target: input.target } : {}),
+      timestamp: new Date().toISOString(),
+    };
+    appendFileSync(join(metricsDir, 'refinement-events.jsonl'), JSON.stringify(record) + '\n');
+  } catch {
+    // Silent — telemetry must never block MCP tool responses.
+  }
+}
+
+/**
+ * Read the refinement-demand log and aggregate it into the demand signal. A
+ * missing/empty file yields the all-zero 4-class report; unparseable lines are
+ * skipped without throwing.
+ */
+export function readRefinementDemand(projectPath: string): RefinementDemandReport {
+  let raw: string;
+  try {
+    raw = readFileSync(join(projectPath, REFINEMENT_EVENTS_FILE), 'utf-8');
+  } catch {
+    return aggregateDemand([]);
+  }
+
+  const requests: RefinementRequest[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      requests.push(JSON.parse(trimmed) as RefinementRequest);
+    } catch {
+      // Skip malformed lines — parse-tolerant by design.
+    }
+  }
+
+  return aggregateDemand(requests);
+}

--- a/packages/cli/tests/commands/mcp-refinement-demand.test.ts
+++ b/packages/cli/tests/commands/mcp-refinement-demand.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import type { RefinementDemandReport } from '@harness-engineering/core';
+import { formatRefinementDemand, createMcpRefinementDemandCommand } from '../../src/commands/mcp';
+
+const report: RefinementDemandReport = {
+  total: 4,
+  byClass: [
+    { contextClass: 'file-content', count: 3, frequency: 0.75 },
+    { contextClass: 'knowledge', count: 1, frequency: 0.25 },
+    { contextClass: 'history', count: 0, frequency: 0 },
+    { contextClass: 'telemetry', count: 0, frequency: 0 },
+  ],
+};
+
+describe('formatRefinementDemand', () => {
+  it('lists every class with count and frequency, ranked, plus a total line', () => {
+    const out = formatRefinementDemand(report);
+    expect(out).toContain('file-content');
+    expect(out).toContain('history');
+    expect(out).toContain('telemetry');
+    expect(out).toContain('knowledge');
+    expect(out).toContain('3');
+    expect(out).toContain('0.75');
+    expect(out).toContain('Total: 4');
+  });
+
+  it('renders zero-count classes at the bottom of the ranking', () => {
+    const out = formatRefinementDemand(report);
+    const idxFileContent = out.indexOf('file-content');
+    const idxHistory = out.indexOf('history');
+    const idxTelemetry = out.indexOf('telemetry');
+    expect(idxFileContent).toBeLessThan(idxHistory);
+    expect(idxFileContent).toBeLessThan(idxTelemetry);
+  });
+
+  it('handles an all-zero report gracefully', () => {
+    const empty: RefinementDemandReport = {
+      total: 0,
+      byClass: [
+        { contextClass: 'file-content', count: 0, frequency: 0 },
+        { contextClass: 'history', count: 0, frequency: 0 },
+        { contextClass: 'telemetry', count: 0, frequency: 0 },
+        { contextClass: 'knowledge', count: 0, frequency: 0 },
+      ],
+    };
+    const out = formatRefinementDemand(empty);
+    expect(out).toContain('Total: 0');
+  });
+});
+
+describe('createMcpRefinementDemandCommand', () => {
+  it('builds a refinement-demand command with a --json option', () => {
+    const cmd = createMcpRefinementDemandCommand();
+    expect(cmd.name()).toBe('refinement-demand');
+    const hasJson = cmd.options.some((o) => o.long === '--json');
+    expect(hasJson).toBe(true);
+  });
+});

--- a/packages/cli/tests/mcp/tools/code-nav-handlers.test.ts
+++ b/packages/cli/tests/mcp/tools/code-nav-handlers.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   handleCodeOutline,
   handleCodeSearch,
@@ -112,5 +115,69 @@ describe('handleCodeUnfold', () => {
     // May return fallback content or error — either way should have content
     expect(result.content).toHaveLength(1);
     expect(result.content[0].text.length).toBeGreaterThan(0);
+  });
+});
+
+describe('refinement instrumentation', () => {
+  // The writer resolves its root from process.cwd(); drive the assertion by
+  // pointing cwd at a temp project dir and reading the metrics log it writes.
+  let originalCwd: string;
+  let tmpDir: string;
+  let fixtureFile: string;
+
+  const eventsPath = () => path.join(tmpDir, '.harness', 'metrics', 'refinement-events.jsonl');
+  const readEvents = () =>
+    fs.existsSync(eventsPath())
+      ? fs
+          .readFileSync(eventsPath(), 'utf-8')
+          .split('\n')
+          .filter((l) => l.trim())
+          .map((l) => JSON.parse(l))
+      : [];
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-nav-refinement-'));
+    fixtureFile = path.join(tmpDir, 'fixture.ts');
+    fs.writeFileSync(fixtureFile, 'export function hello(): string {\n  return "hi";\n}\n');
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('logs an outline refinement (file-content) on success', async () => {
+    const result = await handleCodeOutline({ path: fixtureFile });
+    expect(result.isError).toBeFalsy();
+    const events = readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].operation).toBe('outline');
+    expect(events[0].contextClass).toBe('file-content');
+  });
+
+  it('logs a search refinement (file-content) on success', async () => {
+    const result = await handleCodeSearch({ query: 'hello', directory: tmpDir });
+    expect(result.isError).toBeFalsy();
+    const events = readEvents();
+    expect(events.some((e) => e.operation === 'search' && e.contextClass === 'file-content')).toBe(
+      true
+    );
+  });
+
+  it('logs an unfold refinement (file-content) on success', async () => {
+    const result = await handleCodeUnfold({ path: fixtureFile, symbol: 'hello' });
+    expect(result.isError).toBeFalsy();
+    const events = readEvents();
+    expect(events.some((e) => e.operation === 'unfold' && e.contextClass === 'file-content')).toBe(
+      true
+    );
+  });
+
+  it('does NOT log on the error path', async () => {
+    const result = await handleCodeOutline({ path: path.join(tmpDir, 'nonexistent-xyz.ts') });
+    expect(result.isError).toBe(true);
+    expect(readEvents()).toHaveLength(0);
   });
 });

--- a/packages/cli/tests/mcp/tools/refinement-telemetry.test.ts
+++ b/packages/cli/tests/mcp/tools/refinement-telemetry.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  recordRefinement,
+  readRefinementDemand,
+  REFINEMENT_EVENTS_FILE,
+} from '../../../src/mcp/tools/refinement-telemetry';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function tmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'refinement-telemetry-'));
+  tmpDirs.push(d);
+  return d;
+}
+
+function readLines(dir: string): string[] {
+  const filePath = path.join(dir, '.harness', 'metrics', 'refinement-events.jsonl');
+  if (!fs.existsSync(filePath)) return [];
+  return fs
+    .readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim());
+}
+
+describe('REFINEMENT_EVENTS_FILE', () => {
+  it('lives under .harness/metrics as refinement-events.jsonl', () => {
+    expect(REFINEMENT_EVENTS_FILE).toContain('metrics');
+    expect(REFINEMENT_EVENTS_FILE).toContain('refinement-events.jsonl');
+  });
+});
+
+describe('recordRefinement', () => {
+  it('appends one classified JSONL line with a stamped timestamp', () => {
+    const dir = tmp();
+    recordRefinement(dir, { operation: 'outline', target: 'x.ts' });
+    const lines = readLines(dir);
+    expect(lines).toHaveLength(1);
+    const rec = JSON.parse(lines[0]);
+    expect(rec.operation).toBe('outline');
+    expect(rec.contextClass).toBe('file-content');
+    expect(rec.target).toBe('x.ts');
+    expect(typeof rec.timestamp).toBe('string');
+  });
+
+  it('lets an explicit contextClass override the operation default', () => {
+    const dir = tmp();
+    recordRefinement(dir, { operation: 'unfold', contextClass: 'knowledge' });
+    const rec = JSON.parse(readLines(dir)[0]);
+    expect(rec.operation).toBe('unfold');
+    expect(rec.contextClass).toBe('knowledge');
+  });
+
+  it('appends successive calls', () => {
+    const dir = tmp();
+    recordRefinement(dir, { operation: 'outline' });
+    recordRefinement(dir, { operation: 'search' });
+    recordRefinement(dir, { operation: 'unfold' });
+    expect(readLines(dir)).toHaveLength(3);
+  });
+
+  it('never throws on an unwritable path (non-fatal, Truth 4)', () => {
+    expect(() => recordRefinement('/nonexistent\0bad', { operation: 'search' })).not.toThrow();
+  });
+});
+
+describe('readRefinementDemand', () => {
+  it('returns the all-zero 4-class report when the file is missing', () => {
+    const dir = tmp();
+    const report = readRefinementDemand(dir);
+    expect(report.total).toBe(0);
+    expect(report.byClass).toHaveLength(4);
+    for (const c of report.byClass) {
+      expect(c.count).toBe(0);
+      expect(c.frequency).toBe(0);
+    }
+  });
+
+  it('aggregates a seeded mix and tolerates malformed lines', () => {
+    const dir = tmp();
+    recordRefinement(dir, { operation: 'outline' });
+    recordRefinement(dir, { operation: 'search' });
+    recordRefinement(dir, { operation: 'unfold' });
+    recordRefinement(dir, { operation: 'expand-rationale' });
+    // Inject a garbage line — must be skipped, not throw.
+    const filePath = path.join(dir, '.harness', 'metrics', 'refinement-events.jsonl');
+    fs.appendFileSync(filePath, 'not-json{{{\n');
+
+    const report = readRefinementDemand(dir);
+    expect(report.total).toBe(4);
+    const byClass = new Map(report.byClass.map((c) => [c.contextClass, c]));
+    expect(byClass.get('file-content')).toMatchObject({ count: 3, frequency: 0.75 });
+    expect(byClass.get('knowledge')).toMatchObject({ count: 1, frequency: 0.25 });
+  });
+});

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -62,6 +62,26 @@ export type {
 } from './count-tokens';
 
 /**
+ * Refinement-request demand taxonomy — the progressive-domain context classes,
+ * the operation → class classifier, and the pure aggregateDemand() rollup that
+ * turns a log of refinement requests into refinement-frequency-per-context-class
+ * (never-read classes rank last).
+ */
+export {
+  REFINEMENT_CONTEXT_CLASSES,
+  OPERATION_CONTEXT_CLASS,
+  classifyRefinement,
+  aggregateDemand,
+} from './refinement-demand';
+export type {
+  RefinementContextClass,
+  RefinementOperation,
+  RefinementRequest,
+  ClassDemand,
+  RefinementDemandReport,
+} from './refinement-demand';
+
+/**
  * Section parser for progressive skill content loading.
  */
 export { parseSections, extractLevel } from './section-parser';

--- a/packages/core/src/context/refinement-demand.ts
+++ b/packages/core/src/context/refinement-demand.ts
@@ -1,0 +1,123 @@
+/**
+ * Refinement-request demand taxonomy and aggregation (progressive context).
+ *
+ * Full-resolution-by-default context spends tokens against the *possibility* of
+ * attention rather than its presence. Progressive serving replaces that guess
+ * with a measured demand signal: refinement frequency per context class. This
+ * module is the pure, IO-free half of that measurement layer — the taxonomy,
+ * the operation → context-class classifier, the logged-request shape, and the
+ * {@link aggregateDemand} rollup. The filesystem writer/reader lives in the CLI
+ * (`packages/cli/src/mcp/tools/refinement-telemetry.ts`), mirroring the
+ * skill-telemetry seam (pure core + IO-injected CLI).
+ *
+ * The taxonomy here is the progressive **domain** axis
+ * (`file-content | history | telemetry | knowledge`) — deliberately distinct
+ * from the loading-axis `ContextClass` in `./attribution` (D1). A downstream
+ * reader scoring dictionary membership by demand needs the domain axis.
+ */
+
+/**
+ * The progressive-domain context classes. This is the *domain* a refinement
+ * touches — distinct from the loading-axis {@link ContextClass} in
+ * `./attribution` (see spec D1). Do not conflate the two.
+ */
+export type RefinementContextClass = 'file-content' | 'history' | 'telemetry' | 'knowledge';
+
+/** All refinement context classes, in canonical report order. */
+export const REFINEMENT_CONTEXT_CLASSES: readonly RefinementContextClass[] = [
+  'file-content',
+  'history',
+  'telemetry',
+  'knowledge',
+];
+
+/**
+ * The refinement operations. The first three (`outline` / `search` / `unfold`)
+ * have real MCP tools today; the `expand-*` operations exist in the taxonomy so
+ * the demand aggregation enumerates every class even before their tools land.
+ */
+export type RefinementOperation =
+  | 'outline'
+  | 'search'
+  | 'unfold'
+  | 'expand-diff'
+  | 'expand-rationale'
+  | 'expand-telemetry';
+
+/**
+ * Fixed operation → default context-class table (documented, stable). A caller
+ * may override the default per request (e.g. an `unfold` of a knowledge node's
+ * rationale records `knowledge`), but absent an override this table decides.
+ */
+export const OPERATION_CONTEXT_CLASS: Record<RefinementOperation, RefinementContextClass> = {
+  outline: 'file-content',
+  search: 'file-content',
+  unfold: 'file-content',
+  'expand-diff': 'history',
+  'expand-rationale': 'knowledge',
+  'expand-telemetry': 'telemetry',
+};
+
+/**
+ * One logged refinement request — the JSONL line shape. `timestamp` is stamped
+ * by the writer on append.
+ */
+export interface RefinementRequest {
+  operation: RefinementOperation;
+  contextClass: RefinementContextClass;
+  /** e.g. file path or symbol; a non-identifying label. */
+  target?: string;
+  /** ISO 8601; stamped by the writer. */
+  timestamp?: string;
+}
+
+/** Classify an operation to its default context class (an override wins upstream). */
+export function classifyRefinement(operation: RefinementOperation): RefinementContextClass {
+  return OPERATION_CONTEXT_CLASS[operation];
+}
+
+/** Per-class demand: how often the class was refined, absolute and normalized. */
+export interface ClassDemand {
+  contextClass: RefinementContextClass;
+  count: number;
+  /** count / total; 0 when total is 0. */
+  frequency: number;
+}
+
+/** The aggregated demand signal: total refinements and a ranked per-class table. */
+export interface RefinementDemandReport {
+  total: number;
+  /** Ranked: count desc, then canonical class order. Every class appears. */
+  byClass: ClassDemand[];
+}
+
+/**
+ * Pure aggregation of refinement requests into the demand signal.
+ *
+ * Enumerates **every** {@link RefinementContextClass} — including classes with
+ * zero recorded requests — computes `frequency = count / total` (0 when total is
+ * 0), and ranks by count descending with ties broken by canonical class order.
+ * A class nobody refined therefore sorts to the bottom with `count: 0`, which is
+ * the mechanism behind the never-read-ranks-last guarantee (spec D4).
+ */
+export function aggregateDemand(requests: readonly RefinementRequest[]): RefinementDemandReport {
+  const counts = new Map<RefinementContextClass, number>();
+  for (const cls of REFINEMENT_CONTEXT_CLASSES) counts.set(cls, 0);
+  for (const request of requests) {
+    counts.set(request.contextClass, (counts.get(request.contextClass) ?? 0) + 1);
+  }
+
+  const total = requests.length;
+  const canonicalIndex = (cls: RefinementContextClass): number =>
+    REFINEMENT_CONTEXT_CLASSES.indexOf(cls);
+
+  const byClass: ClassDemand[] = REFINEMENT_CONTEXT_CLASSES.map((contextClass) => {
+    const count = counts.get(contextClass) ?? 0;
+    return { contextClass, count, frequency: total === 0 ? 0 : count / total };
+  }).sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return canonicalIndex(a.contextClass) - canonicalIndex(b.contextClass);
+  });
+
+  return { total, byClass };
+}

--- a/packages/core/tests/context/refinement-demand.test.ts
+++ b/packages/core/tests/context/refinement-demand.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  REFINEMENT_CONTEXT_CLASSES,
+  OPERATION_CONTEXT_CLASS,
+  classifyRefinement,
+  aggregateDemand,
+} from '../../src/context/refinement-demand';
+import type { RefinementRequest } from '../../src/context/refinement-demand';
+
+/** Build a request with the operation's default context class. */
+function req(operation: RefinementRequest['operation']): RefinementRequest {
+  return { operation, contextClass: classifyRefinement(operation) };
+}
+
+describe('REFINEMENT_CONTEXT_CLASSES', () => {
+  it('enumerates the four progressive-domain classes in canonical order', () => {
+    expect(REFINEMENT_CONTEXT_CLASSES).toEqual([
+      'file-content',
+      'history',
+      'telemetry',
+      'knowledge',
+    ]);
+  });
+});
+
+describe('OPERATION_CONTEXT_CLASS', () => {
+  it('maps every operation to its default context class', () => {
+    expect(OPERATION_CONTEXT_CLASS).toEqual({
+      outline: 'file-content',
+      search: 'file-content',
+      unfold: 'file-content',
+      'expand-diff': 'history',
+      'expand-rationale': 'knowledge',
+      'expand-telemetry': 'telemetry',
+    });
+  });
+});
+
+describe('classifyRefinement', () => {
+  it('classifies the wired file-content operations', () => {
+    expect(classifyRefinement('outline')).toBe('file-content');
+    expect(classifyRefinement('search')).toBe('file-content');
+    expect(classifyRefinement('unfold')).toBe('file-content');
+  });
+
+  it('classifies the future operations', () => {
+    expect(classifyRefinement('expand-diff')).toBe('history');
+    expect(classifyRefinement('expand-rationale')).toBe('knowledge');
+    expect(classifyRefinement('expand-telemetry')).toBe('telemetry');
+  });
+});
+
+describe('aggregateDemand', () => {
+  it('returns an all-zero report over every class for an empty input', () => {
+    const report = aggregateDemand([]);
+    expect(report.total).toBe(0);
+    expect(report.byClass.map((c) => c.contextClass)).toEqual([
+      'file-content',
+      'history',
+      'telemetry',
+      'knowledge',
+    ]);
+    for (const c of report.byClass) {
+      expect(c.count).toBe(0);
+      expect(c.frequency).toBe(0);
+    }
+  });
+
+  it('counts a known mix with exact frequencies (Truth 2)', () => {
+    const report = aggregateDemand([
+      req('outline'),
+      req('search'),
+      req('unfold'),
+      req('expand-rationale'),
+    ]);
+    expect(report.total).toBe(4);
+    const byClass = new Map(report.byClass.map((c) => [c.contextClass, c]));
+    expect(byClass.get('file-content')).toMatchObject({ count: 3, frequency: 0.75 });
+    expect(byClass.get('knowledge')).toMatchObject({ count: 1, frequency: 0.25 });
+    expect(byClass.get('history')).toMatchObject({ count: 0, frequency: 0 });
+    expect(byClass.get('telemetry')).toMatchObject({ count: 0, frequency: 0 });
+    // Every class enumerated exactly once.
+    expect(report.byClass).toHaveLength(4);
+  });
+
+  it('ranks a seeded never-read class last, ties break by canonical order (Truth 3)', () => {
+    const report = aggregateDemand([req('outline'), req('outline'), req('expand-rationale')]);
+    const order = report.byClass.map((c) => c.contextClass);
+    // file-content (2) first, knowledge (1) next, then the two never-read
+    // classes at the bottom in canonical order: history before telemetry.
+    expect(order).toEqual(['file-content', 'knowledge', 'history', 'telemetry']);
+    expect(report.byClass[2]).toMatchObject({ contextClass: 'history', count: 0, frequency: 0 });
+    expect(report.byClass[3]).toMatchObject({ contextClass: 'telemetry', count: 0, frequency: 0 });
+  });
+
+  it('sorts primarily by count desc', () => {
+    const report = aggregateDemand([
+      req('expand-diff'), // history x1
+      req('expand-telemetry'), // telemetry x1
+      req('expand-telemetry'), // telemetry x2
+      req('expand-rationale'), // knowledge x1
+      req('expand-rationale'), // knowledge x2
+      req('expand-rationale'), // knowledge x3
+    ]);
+    expect(report.byClass.map((c) => c.contextClass)).toEqual([
+      'knowledge', // 3
+      'telemetry', // 2
+      'history', // 1
+      'file-content', // 0
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Scoped slice of #1632 "Progressive context encoding" — builds **only** the
**refinement-request instrumentation stream**, the independent, higher-value half
the issue calls out. It does **not** make anything progressive-by-default and it
does **not** build a prefetch/batching policy (both deferred — see below).

Every refinement request (`code_outline` / `code_search` / `code_unfold`) is now
logged with its progressive **context class** (`file-content` | `history` |
`telemetry` | `knowledge`) to `.harness/metrics/refinement-events.jsonl`, and
aggregated into **refinement-frequency-per-context-class** — the demand signal
that rate-distortion compaction and trained-context-dictionary membership scoring
consume as a prior.

## What's in this slice

- **`@harness-engineering/core`** — new pure `context/refinement-demand.ts`:
  the `RefinementContextClass` domain taxonomy (deliberately distinct from the
  existing loading-axis `ContextClass` in `attribution.ts`), `classifyRefinement`,
  and `aggregateDemand` — which enumerates **every** class so a never-read class
  deterministically ranks last (`count: 0, frequency: 0`).
- **`@harness-engineering/cli`** — `mcp/tools/refinement-telemetry.ts`, a
  non-fatal JSONL writer/reader mirroring the existing `skill-telemetry.ts`
  contract (never throws, never blocks a tool response); `recordRefinement`
  wired into the three `code-nav` handlers on their success paths only; and a new
  `harness mcp refinement-demand [--json]` report subcommand next to
  `context-report`.

## Acceptance (this slice)

1. Each refinement request is logged with a context class. ✔
2. An aggregation produces refinement-frequency-per-context-class. ✔
3. The demand log correctly ranks a seeded never-read context class at the bottom. ✔
4. Instrumentation is non-fatal — never alters a handler's return value or throws. ✔

End-to-end verified: two real `code_outline` handler invocations log 2
`file-content` refinements (frequency 1.0) with `history`/`telemetry`/`knowledge`
ranked last at count 0. Tests: core 8/8, CLI 27/27; full build + typecheck clean;
reference docs regenerated.

## Assumptions made

- **Scope was narrowed to the instrumentation half per the orchestrator default.**
  The following parts of #1632 are **deferred to a follow-up slice** and are NOT
  in this PR — the issue should be flagged for manual reconciliation, not closed:
  - the **progressive-by-default contract** for every context class (coarse layer
    + refinement operations as the default for file content, history, telemetry,
    knowledge);
  - the **prefetch / batching policy** (task-class refinement priors that batch
    predictable unfolds to bound round-trip latency);
  - the **paired evaluation** (token cost vs. task outcomes, progressive vs.
    full-resolution) — it consumes this slice's demand log later.
- The demand signal recorded is **refinement frequency per context class**, layered
  over the existing unfold/outline mechanics (`code_unfold` / `code_outline` /
  `code_search`) rather than replacing them.
- Only the three operations with real tools today are wired (all `file-content`);
  the `history` / `telemetry` / `knowledge` operations exist in the taxonomy so the
  demand report enumerates every class (and a never-read one ranks last).

## Pipeline provenance

Built via the real feature pipeline (harness-brainstorming → harness-autopilot).
Spec, plan, and provenance:
- `docs/changes/progressive-context-refinement-instrumentation-1632/proposal.md`
- `docs/changes/progressive-context-refinement-instrumentation-1632/plans/plan.md`
- `docs/changes/progressive-context-refinement-instrumentation-1632/provenance.json`

Refs #1632

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga
