### PR TITLE
feat(provenance): machine-readable provenance trailer from agent commits (#1531)

### DIFF
--- a/.changeset/machine-readable-provenance-trailer-1531.md
+++ b/.changeset/machine-readable-provenance-trailer-1531.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/orchestrator': minor
+---
+
+feat(provenance): emit a machine-readable provenance trailer from agent-authored
+commits (#1531).
+
+Adds a distinct, governed git commit **trailer** carrying the provenance of an
+autonomous, agent-authored commit, so AI-authored work — specifically the
+_autonomous_ tier — is mechanically countable, joinable to cost, and auditable
+on gated paths. A pure `commit-trailer` primitive in `core` defines the schema
+(`Harness-Run: <skill>@<version>` plus `Harness-Provenance-Version`,
+`Harness-Run-Id`, `Harness-Lane`, `Harness-Agent`, `Harness-Model`,
+`Harness-Session`), a deterministic formatter/appender, and a parser that returns
+`null` for non-fleet commits. The trailer uses a distinct `Harness-*` namespace
+rather than co-opting `Co-authored-by:`, so mechanical tier detection is possible.
+
+The orchestrator's autonomous ship path (`WorkspaceManager.shipWorkspace`) stamps
+the trailer onto the commit message and — because the repo squash-merges — mirrors
+it into the PR body so the record survives the squash. Interactive and
+third-party commits (no run context threaded) are byte-unaffected.
+
+Scope note: this slice is the schema + formatter + parser + emission + docs. A CI
+check that verifies trailer presence/shape and a `harness provenance <sha>` reader
+CLI are deferred to follow-ups (see `Refs #1531`).

--- a/.harness/arch/allowances/feat-machine-readable-provenance-trailer-1531.json
+++ b/.harness/arch/allowances/feat-machine-readable-provenance-trailer-1531.json
@@ -1,0 +1,13 @@
+{
+  "reason": "New provenance commit-trailer module (#1531): parseProvenanceTrailer at complexity 13 is a data-driven trailer parser (warning-tier, under the 15 hard threshold); the +4 aggregate delta is the inherent cost of adding a new, well-tested pure module.",
+  "categories": {
+    "complexity": 348
+  },
+  "violationIds": [
+    "746f2580c73490d2a69f4b5967cfa3527401ea8ecc27fae0a9bfd4898ba76d8c",
+    "9b6e6ca5cb568d3408af642b7100f3259e94d47ef7b42a02b66cfeb0587cb9b2",
+    "dae272e27723db65c1058858ada8ce26de50ee308e18568ad2a22d43a9e41d72",
+    "e5ffc5fa84742381e8fe1025a28615e6b0499271e7647dc81d0cf49a236e7d8a"
+  ],
+  "createdFrom": "9f5c3c6e7"
+}

--- a/.harness/comprehension/packages/core/src/provenance/_module.md
+++ b/.harness/comprehension/packages/core/src/provenance/_module.md
@@ -1,44 +1,47 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/provenance'
-sourceHash: 'b541af53ecc8e09499ba7e67feaeeab967ba29160bf9fc57633f0c2f96c00738'
-compiledAt: '2026-08-28T01:22:10.447Z'
+sourceHash: 'c72fcc03f896629d7f523b792a96ecc978f386ea133c2909265b5f759c6a49c2'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['index.ts', 'io.test.ts', 'io.ts', 'report.test.ts', 'report.ts']
+model: null
+semantic: absent
+members:
+  [
+    'commit-trailer.test.ts',
+    'commit-trailer.ts',
+    'index.ts',
+    'io.test.ts',
+    'io.ts',
+    'report.test.ts',
+    'report.ts',
+  ]
 ---
-
-## Summary
-
-`packages/core/src/provenance` is a rule-to-solution provenance reporter that joins enforced rules (each with an optional `origin` back-pointer to a solution slug or issue ref) with solution docs (each with an optional `enforces` list claiming which rule ids it hardened). It detects two advisory flags: **unexplained constraints** (rules with no origin and not claimed by any solution) and **dead rule candidates** (broken links—rules pointing to non-existent solutions, or solutions enforcing STRENGTH rule ids absent from the registry). Main exports: `buildProvenanceReport(rules, solutions)` yields metrics + advisories; `collectSolutionEnforcements(cwd)` walks `docs/solutions`, parses frontmatter, extracts `enforces:` lists. The reporter is advisory metadata, never a gate—authority stays with enforcement gates.
-
-## Invariants
-
-- Slug matching is three-tier: a slug-shaped origin resolves to a solution by full match, trailing-segment match, or basename match (e.g., 'worktree-race' finds 'bug-track/logic-errors/worktree-race')
-- Only STRENGTH-\d+ ids are checked for missing enforcements; non-STRENGTH scopes (arch:_, sec:_, etc.) skip this check entirely
-- Issue refs (#1469, 1469) and URLs (https://...) bypass slug resolution and are never flagged as unresolved
-- A rule with an origin counts as explained even if that origin is broken (unresolved slug)—unexplained fires only when there is NO origin AND no solution claims the rule
-- Empty or missing enforces lists don't contribute; only non-empty enforces lists create SolutionEnforcement entries
-- Graceful degradation when docs/solutions is absent: collectSolutionEnforcements returns [] with no error
-- Non-string enforces entries are silently filtered; invalid YAML values (numbers, booleans, empty strings) disappear
 
 ## Interface Contract
 
 ```ts
 export DeadRuleCandidate
 export DeadRuleReason
+export PROVENANCE_TRAILER_KEYS
+export PROVENANCE_TRAILER_VERSION
 export ProvenanceReport
+export ProvenanceTrailer
+export ProvenanceTrailerInput
 export RuleProvenanceInput
 export SolutionEnforcement
 export UnexplainedConstraint
+export appendProvenanceTrailer
 export buildProvenanceReport
 export collectSolutionEnforcements
+export formatProvenanceTrailer
+export hasProvenanceTrailer
+export parseProvenanceTrailer
 ```
 
 ## Dependency Slice
 
 ```
+import { PROVENANCE_TRAILER_KEYS, PROVENANCE_TRAILER_VERSION, ProvenanceTrailerInput, appendProvenanceTrailer, formatProvenanceTrailer, hasProvenanceTrailer, parseProvenanceTrailer } from './commit-trailer'
 import { collectSolutionEnforcements } from './io'
 import { RuleProvenanceInput, SolutionEnforcement, buildProvenanceReport } from './report'
 import matter from 'gray-matter'

--- a/.harness/comprehension/packages/orchestrator/src/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src'
-sourceHash: '890ba227809ca2e0b68fb25e0d76353c84e7436b6ffa31351bc03384692466c7'
+sourceHash: 'fe26846001c876f35aa425fac3ec741cade6d4281792d7d01a8a28a61787fcf1'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -280,7 +280,7 @@ import { scanWorkspaceConfig } from './workspace/config-scanner'
 import { detectEcosystem } from './workspace/ecosystem'
 import { WorkspaceHooks } from './workspace/hooks'
 import { WorkspaceManager } from './workspace/manager'
-import { CacheMetricsRecorder, GitHubIssuesSyncAdapter, Issue, IssueTrackerClient, OTLPExporter, SecurityScanner, TrackerClientConfig, applyResourceBudgets, createModelProposal, createTrackerClient, eventSourcing, listProposals, loadTrackerSyncConfig, sharedRateBudget, updateProposal, writeTaint } from '@harness-engineering/core'
+import { CacheMetricsRecorder, GitHubIssuesSyncAdapter, HARNESS_VERSION, Issue, IssueTrackerClient, OTLPExporter, ProvenanceTrailerInput, SecurityScanner, TrackerClientConfig, applyResourceBudgets, createModelProposal, createTrackerClient, eventSourcing, listProposals, loadTrackerSyncConfig, sharedRateBudget, updateProposal, writeTaint } from '@harness-engineering/core'
 import { GraphStore } from '@harness-engineering/graph'
 import { AnalysisProvider, EnrichedSpec, IntelligencePipeline, OpenAICompatibleAnalysisProvider, OutcomeEvaluator, TriagePrediction } from '@harness-engineering/intelligence'
 import { DEFAULT_HARNESS_FIT_TASKS, DedupPair, DedupPairs, DiscoverCandidatesOptions, DiscoverCandidatesResult, FrozenCandidate, HardwareDetector, HardwareProfile, HarnessFitCacheFileStore, HarnessFitProbeDeps, HarnessFitProbeTask, InstallAdapter, OllamaInstallAdapter, PoolManager, PoolStateProvider, PoolStateStore, RankerCandidate, RefreshScheduler, SchedulerTimerHandle, createBuildQualityReRanker, createNativeRecommender, curationFromCandidates, loadFrozenCandidates, probeToolCalling, runRefreshTick, selectCandidates } from '@harness-engineering/local-models'

--- a/.harness/comprehension/packages/orchestrator/src/workspace/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/workspace/_module.md
@@ -1,26 +1,22 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/workspace"
-sourceHash: "5f2683bcaff6266dc66f7c182c69df0ab1f3745e7bda3eb37ee5fac0173ee127"
-compiledAt: "2026-08-28T01:22:12.447Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["config-scanner.ts", "ecosystem.test.ts", "ecosystem.ts", "hooks.ts", "manager.introduced-diff.test.ts", "manager.preserve.test.ts", "manager.ship.test.ts", "manager.ts"]
+module: 'packages/orchestrator/src/workspace'
+sourceHash: '69e00604bb36cf373aa3f08c0725074b1e717014d5a184015b6b0110aaab9f07'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'config-scanner.ts',
+    'ecosystem.test.ts',
+    'ecosystem.ts',
+    'hooks.ts',
+    'manager.introduced-diff.test.ts',
+    'manager.preserve.test.ts',
+    'manager.ship.test.ts',
+    'manager.ts',
+  ]
 ---
-
-## Summary
-
-`packages/orchestrator/src/workspace` provides language-agnostic ecosystem detection and workspace config security scanning. **Ecosystem detection** solves the problem that the enforced gate was hardcoded to `pnpm -w run …`, failing for non-JS workspaces. It detects the workspace ecosystem from manifest/lockfile presence and returns the correct install and verify commands for each language (Node, Python, Rust, Go, Ruby, Java). The core matcher is a pure function—filenames in, descriptor out—enabling testable priority logic. **Config scanning** mirrors `harness scan-config`: it sweeps CLAUDE.md, AGENTS.md, .gemini/settings.json, and skill.yaml for injection patterns and security rule violations. Critically, it downgrades severity for noisy patterns (false positives on documentation) so documentation mentions of `eval(` don't block dispatch; only blocking injection categories (INJ-UNI-*, INJ-REROL-*) fail-close. The module unblocks local enforcement by making verify commands language-aware and workspace configs inspectable without CLI dependency.
-
-## Invariants
-
-- Ecosystem priority order is strict: lockfiles beat manifests (most-specific wins); declared priority in ECOSYSTEM_RULES applies; node beats non-node in polyglot repos (harness default)
-- Pure matcher contract: detectEcosystemFromFiles(filenames) is side-effect-free and testable in isolation; filesystem wrapper is thin and delegates
-- Verify commands are whitespace-splittable: non-node verify commands split cleanly on whitespace with no shell quoting—enables cross-platform spawn() without shell invocation
-- Security scanning downgrades documentation noise: INJ-* and specified SEC-* rules (SEC-AGT-006, SEC-INJ-001) downgrade from high to medium severity in doc files; only blocking injection prefixes (INJ-UNI-, INJ-REROL-*) remain dispatch-blocking
-- File-glob filtering prevents false positives: scanner.scanFile() applies fileGlob filtering (not scanContent) so rules like SEC-AGT-007 (hooks.json only) and SEC-MCP-002 (.mcp.json only) don't fire on CLAUDE.md/AGENTS.md
-- Graceful degradation: both detectEcosystem() and config scanning return null or skip missing files instead of throwing; unreadable/absent paths are safe fallbacks, not errors
 
 ## Interface Contract
 
@@ -41,7 +37,7 @@ export scanWorkspaceConfig
 import { IntroducedHunk, parseIntroducedHunks } from '../agent/quality-verdict.js'
 import { ECOSYSTEM_RULES, EcosystemId, detectEcosystem, detectEcosystemFromFiles } from './ecosystem.js'
 import { WorkspaceManager } from './manager'
-import { ScanConfigFileResult, ScanConfigFinding, ScanConfigResult, SecurityScanner, assignNumber, computeOverallSeverity, computeScanExitCode, ensureIdentity, mapInjectionFindings, mapSecurityFindings, parseSecurityConfig, readHarnessIdentity, scanForInjection } from '@harness-engineering/core'
+import { ProvenanceTrailerInput, ScanConfigFileResult, ScanConfigFinding, ScanConfigResult, SecurityScanner, appendProvenanceTrailer, assignNumber, computeOverallSeverity, computeScanExitCode, ensureIdentity, mapInjectionFindings, mapSecurityFindings, parseProvenanceTrailer, parseSecurityConfig, readHarnessIdentity, scanForInjection } from '@harness-engineering/core'
 import { Err, HarnessIdentity, HooksConfig, Ok, Result, WorkspaceConfig } from '@harness-engineering/types'
 import * as fs from 'fs'
 import { execFile, spawn } from 'node:child_process'

--- a/docs/changes/machine-readable-provenance-trailer-1531/plans/plan.md
+++ b/docs/changes/machine-readable-provenance-trailer-1531/plans/plan.md
@@ -1,0 +1,61 @@
+# Plan — Machine-readable provenance trailer from agent-authored commits (#1531)
+
+**Keywords:** provenance, commit-trailer, fleet, orchestrator, shipWorkspace, parser, squash-survival, tier-detection
+
+## Overview
+
+Implement a governed, deterministically-parseable `Harness-*` commit trailer, emit it on the orchestrator's autonomous ship path, and ship a pure parser. Deferred remainder (CI presence gate, `harness provenance` CLI) is out of scope for this slice — `Refs #1531`.
+
+## Decisions
+
+| Decision          | Choice                                                     | Rationale                                                             |
+| ----------------- | ---------------------------------------------------------- | --------------------------------------------------------------------- |
+| Trailer namespace | `Harness-*` keys, primary `Harness-Run: <skill>@<version>` | Distinct from `Co-authored-by:`; mechanical tier detection            |
+| Location          | `packages/core/src/provenance/commit-trailer.ts` (pure)    | IO-free, reused by emit + parse; alongside existing provenance module |
+| Emit chokepoint   | `WorkspaceManager.shipWorkspace`                           | Single autonomous commit site; other callers unaffected               |
+| Squash survival   | Mirror trailer into PR body                                | Repo squash-merges; PR body carries equivalent record                 |
+| Idempotency       | `appendProvenanceTrailer` no-ops if `Harness-Run` present  | Resumed ships must not double-stamp                                   |
+| Closing keyword   | `Refs #1531`                                               | Slice; CI gate + CLI reader deferred                                  |
+
+## Tasks
+
+### T1 — Core primitive: schema + formatter + appender + parser
+
+- **File (new):** `packages/core/src/provenance/commit-trailer.ts`
+- `PROVENANCE_TRAILER_VERSION = 1`; `ProvenanceTrailer` + `ProvenanceTrailerInput` types.
+- `formatProvenanceTrailer(input)` — deterministic ordered `Key: value` block; omit absent optional fields; strip CR/LF from values.
+- `appendProvenanceTrailer(message, input)` — append block separated by a blank line; no-op if `Harness-Run` already present.
+- `parseProvenanceTrailer(message)` — scan the trailing block for `Harness-*` keys; return structured record or `null` when `Harness-Run` absent; tolerate other trailing trailers (e.g. `Claude-Session:`, `Co-authored-by:`).
+- **Verification:** unit-tested in T2 (TDD — tests first).
+
+### T2 — Tests for the primitive (TDD)
+
+- **File (new):** `packages/core/src/provenance/commit-trailer.test.ts`
+- format determinism + field ordering; omitted optionals; format→parse round-trip; `parseProvenanceTrailer` returns `null` on non-fleet message (interactive commit unaffected); coexistence with a `Claude-Session:` line; value sanitization (embedded newline cannot forge a key); `appendProvenanceTrailer` idempotency.
+
+### T3 — Export from the provenance barrel
+
+- **File:** `packages/core/src/provenance/index.ts` — re-export the new symbols. Core `index.ts` already `export * from './provenance'`, so it flows to `@harness-engineering/core`. Run `pnpm run generate:barrels` if the barrel check flags staleness.
+
+### T4 — Wire emission into the ship path
+
+- **File:** `packages/orchestrator/src/workspace/manager.ts` — `shipWorkspace` gains optional `opts.provenance`; when present, commit message = `appendProvenanceTrailer(title, provenance)` and PR body = `appendProvenanceTrailer(body, provenance)`.
+- **File:** `packages/orchestrator/src/orchestrator.ts` — at the `settleWorkflowSuccessLocal` ship call, build the provenance input from live run context (skill/lane, backend model, flight-recorder run id, issue) and thread it into `shipWorkspace`. Degrade field-by-field when context absent.
+
+### T5 — Wiring tests
+
+- **File:** `packages/orchestrator/src/workspace/manager.ship.test.ts` — assert the committed message carries a parseable trailer when `provenance` is supplied, and is byte-identical to today when it is not; assert the PR body carries the trailer block.
+
+### T6 — Document the schema
+
+- **File (new):** `docs/reference/provenance-trailer.md` — the key list, ordering, example block, parse contract, and squash-survival note. Link from an existing reference index if one enumerates provenance/telemetry.
+
+### T7 — Verify & ship
+
+- `pnpm turbo build`; targeted vitest for the new + changed files; `pnpm run generate:barrels --check` (or regenerate); typecheck. Commit through the real pre-commit gate (no `--no-verify`); add a changeset. Push; open PR with `Refs #1531` + Assumptions section flagging the deferred CI gate and CLI reader.
+
+## Risks / mitigations
+
+- **Barrel staleness** — `pnpm run generate:barrels` before commit (pre-push checks freshness).
+- **Changeset gate** — add a changeset for `@harness-engineering/core` (+ orchestrator).
+- **Orchestrator context plumbing** — if the live skill/lane/session are not readily available at the ship site, thread the fields that are (model, runId, issue-derived agent) and omit the rest; the schema tolerates absent optionals. If wiring the orchestrator call site proves to touch broad state, keep emission behind the optional opt and land the primitive + manager wiring + a synthesized-context test rather than parking.

--- a/docs/changes/machine-readable-provenance-trailer-1531/proposal.md
+++ b/docs/changes/machine-readable-provenance-trailer-1531/proposal.md
@@ -1,0 +1,88 @@
+# Emit a machine-readable provenance trailer from agent-authored commits
+
+**Status:** Draft · **Tier:** Small · **Type:** feature (core primitive + orchestrator wiring)
+**Issue:** github:Intense-Visions/harness-engineering#1531 · **Milestone:** v5.0 — Trust & Security Model · **Priority:** P1
+**Keywords:** provenance, commit-trailer, fleet, orchestrator, ship, telemetry, tier-detection, git, parser, accountability
+
+## Overview
+
+Harness-authored work is statistically invisible. Measured across two orgs, a dogfood product repo carries 974 AI co-author trailers in 4,618 commits (21%) while its highest-volume author shows 5 trailers across 3,988 commits — because the autonomous fleet/orchestrator commit path emits nothing machine-readable that distinguishes it from an ordinary commit. The consequences compound: org-wide AI-adoption reporting undercounts by roughly 5x and cannot separate the autonomous tier from interactive assistance; cost attribution has no key to join spend to authorship; and in a regulated codebase there is no record of which agent, skill and version produced a change touching a gated path.
+
+Today the only provenance carried by a commit is a freeform `Claude-Session:` URL line appended by the interactive Claude Code client — an ad-hoc convention that is not emitted by the autonomous ship path and is not a governed, parseable schema. This change introduces a **distinct, structured, machine-readable git commit trailer** carrying provenance for agent-authored commits, emits it on the commit path the orchestrator's autonomous ship uses, and ships a **deterministic parser** so telemetry and tier-detection can read it mechanically. It deliberately does **not** co-opt `Co-authored-by:` — a distinct namespace (`Harness-*`) keeps tier detection mechanical and lets the trailer double as the accountability record.
+
+### Goals
+
+1. Define a governed, deterministically-parseable commit-trailer schema (key:value lines) carrying the run's provenance: skill@version, run id, model, session id, lane, agent id, and a schema version.
+2. Emit the trailer on the autonomous fleet/orchestrator commit path (`WorkspaceManager.shipWorkspace`) so every fleet-authored commit carries it — without co-opting `Co-authored-by:`.
+3. Ship a pure parser utility that extracts the trailer from any commit message and returns a structured record (or `null` for a non-fleet commit), so telemetry / tier-detection reads it mechanically.
+4. Survive the repo's squash-merge path: the same trailer block is also appended to the PR body, so the provenance record survives even when the branch commit's message is discarded by a squash.
+5. Leave interactive (non-fleet) commits byte-unaffected.
+
+### Non-goals (YAGNI — deferred remainder, tracked on #1531)
+
+- A CI check that verifies trailer presence/shape on every agent commit (`Suggested surfaces: git plumbing` — a follow-up gate).
+- A `harness provenance <sha>` CLI reader command (downstream ergonomics, a follow-up).
+- The downstream consumers themselves (cost-per-merged-PR attribution, autonomy-ratio, contagion tracing) — this change is the _foundation_ those consume; they are separate roadmap items.
+- Retrofitting historical commits.
+
+## Decisions made
+
+1. **Distinct `Harness-*` trailer namespace, not `Co-authored-by:`.** The issue is explicit: co-opting `Co-authored-by:` would conflate the autonomous tier with interactive AI assistance (which already emits co-author trailers) and make mechanical tier detection impossible. The primary key is `Harness-Run: <skill>@<version>`; the record is completed by `Harness-Lane`, `Harness-Agent`, `Harness-Run-Id`, `Harness-Model`, `Harness-Session`, and a `Harness-Provenance-Version` schema-version key. All keys share the `Harness-` prefix so a parser keys off the namespace, and the presence of `Harness-Run` is the mechanical tier signal.
+
+2. **Git-trailer syntax (`Key: value`, one per line, in a trailing block).** The trailer conforms to the same `Key: value` convention `git interpret-trailers` and `Co-authored-by:`/`Signed-off-by:` already use, so it is `git log --grep`-friendly and survives standard git tooling. Values are single-line and any embedded newline/CR is stripped at format time so a value can never break the block structure or forge extra keys.
+
+3. **A pure core primitive, IO-free, in `packages/core/src/provenance`.** The schema, formatter, appender and parser are pure functions with no git/IO dependency — the same shape as the existing rule-provenance reporter that already lives there. This keeps them trivially testable and reusable by both the orchestrator (emit) and any future telemetry/CLI consumer (parse). The existing ADR-0100 rule-to-failure reporter is a different provenance concept; the new commit-trailer file lives alongside it under the same module with a clearly distinct name.
+
+4. **Emit at the single autonomous commit chokepoint (`shipWorkspace`).** The orchestrator's `WorkspaceManager.shipWorkspace` is the one place the autonomous pipeline turns accumulated worktree work into a commit (`git commit -m <title>`). The trailer is appended to that commit message there, sourced from an optional `provenance` field on the ship options which the orchestrator populates from live run context (skill/lane, backend model, run id, issue). When no provenance context is threaded (any other caller, or an adopter running the manager directly), the commit message is byte-identical to today — interactive and third-party commits are unaffected.
+
+5. **Append idempotently; also mirror into the PR body for squash survival.** `appendProvenanceTrailer` is a no-op when a `Harness-Run` trailer is already present (a resumed ship re-committing does not double-stamp). Because the repo squash-merges PRs (which discards individual branch-commit messages), the same rendered trailer block is appended to the PR body under a stable marker, so the provenance record survives the squash even if the commit trailer does not reach `main`. This directly satisfies the "survives the squash-merge path, or the PR body carries the equivalent record" acceptance criterion.
+
+## Technical design
+
+### New primitive — `packages/core/src/provenance/commit-trailer.ts`
+
+```ts
+export const PROVENANCE_TRAILER_VERSION = 1;
+
+export interface ProvenanceTrailer {
+  schemaVersion: number; // Harness-Provenance-Version
+  skill: string; // left of @ in Harness-Run
+  skillVersion: string; // right of @ in Harness-Run
+  runId?: string; // Harness-Run-Id
+  model?: string; // Harness-Model
+  sessionId?: string; // Harness-Session
+  lane?: string; // Harness-Lane
+  agent?: string; // Harness-Agent
+}
+
+// Deterministic, ordered `Key: value` block. Optional fields omitted when absent.
+export function formatProvenanceTrailer(input): string;
+
+// Append the block to a commit/PR message. No-op if a Harness-Run trailer is already present.
+export function appendProvenanceTrailer(message: string, input): string;
+
+// Parse the trailing trailer block. Returns null when no Harness-Run key is present
+// (an interactive / non-fleet commit).
+export function parseProvenanceTrailer(message: string): ProvenanceTrailer | null;
+```
+
+Ordering is fixed (`Harness-Run`, `Harness-Provenance-Version`, `Harness-Run-Id`, `Harness-Lane`, `Harness-Agent`, `Harness-Model`, `Harness-Session`) so output is deterministic. `formatProvenanceTrailer` and `parseProvenanceTrailer` round-trip. Values are sanitized (CR/LF stripped) at format time.
+
+### Wiring — `WorkspaceManager.shipWorkspace`
+
+`shipWorkspace(identifier, opts)` gains an optional `opts.provenance: ProvenanceTrailerInput`. When present:
+
+- the commit message becomes `appendProvenanceTrailer(opts.title, opts.provenance)`;
+- the PR body becomes `appendProvenanceTrailer(opts.body, opts.provenance)` (survives squash).
+
+The orchestrator's local-ship call site (`settleWorkflowSuccessLocal`) builds the input from live context: `skill`/`lane` from the running workflow, `model` from the last backend definition, `runId` from the flight recorder, `agent`/`session` where available. Absent context degrades field-by-field (the field is simply omitted) — never a crash.
+
+## Acceptance criteria (from #1531)
+
+- [x] Every fleet-authored commit in a fixture run carries a parseable trailer — covered by the `shipWorkspace` wiring test (commit message threaded through `formatProvenanceTrailer`) plus a format→parse round-trip test.
+- [x] Interactive (non-fleet) commits are unaffected — covered by (a) `shipWorkspace` with no `provenance` opt producing a byte-identical message, and (b) `parseProvenanceTrailer` returning `null` on a message with no `Harness-Run` key.
+- [x] Trailer survives the squash-merge path the repo uses, or the PR body carries the equivalent record — the PR body carries the rendered trailer block.
+
+## Slice boundary
+
+This lands the trailer schema + formatter + parser + orchestrator emission (commit and PR body) + docs + tests — a coherent, mergeable foundation that satisfies all three acceptance criteria mechanically. The **CI presence/shape gate** and the **`harness provenance <sha>` reader CLI** named in the issue's "Suggested surfaces" / "Adopter usage" narrative are deferred as follow-up remainder. Closing keyword: **`Refs #1531`** (a slice), remainder flagged in the PR body.

--- a/docs/changes/machine-readable-provenance-trailer-1531/provenance.json
+++ b/docs/changes/machine-readable-provenance-trailer-1531/provenance.json
@@ -1,0 +1,14 @@
+{
+  "issue": [1531],
+  "route": "feature",
+  "stages": ["brainstorming", "autopilot"],
+  "planArtifact": "docs/changes/machine-readable-provenance-trailer-1531/plans/plan.md",
+  "closingKeyword": "Refs",
+  "closingKeywordReason": "Slice: schema + formatter + parser + orchestrator emission (commit and PR body) + docs + tests land and satisfy all three acceptance criteria mechanically. The issue's narrative 'Suggested surfaces' (a CI presence/shape gate) and 'Adopter usage' (a `harness provenance <sha>` reader CLI) are deferred as follow-up remainder, so this is a slice (Refs) not a full close.",
+  "assumptions": [
+    "Trailer schema: git-trailer `Key: value` lines under a distinct `Harness-*` namespace (primary `Harness-Run: <skill>@<version>`, plus `Harness-Provenance-Version`, `Harness-Run-Id`, `Harness-Lane`, `Harness-Agent`, `Harness-Model`, `Harness-Session`), deterministically parseable and NOT co-opting `Co-authored-by:`.",
+    "Emitted on the autonomous fleet/orchestrator commit path (`WorkspaceManager.shipWorkspace`); the freeform `Claude-Session:` line is complemented, not removed. Interactive / third-party commits are byte-unaffected (no `provenance` opt threaded).",
+    "Squash-merge survival: the same rendered trailer block is mirrored into the PR body, satisfying 'survives the squash-merge path, or the PR body carries the equivalent record'.",
+    "Skill identity for the autonomous path is `orchestrator`; skill version is sourced from the harness core `VERSION`; runId from the flight recorder; model + agent from the executing backend; lane from the work unit. Absent context degrades field-by-field (the field is omitted), never a crash."
+  ]
+}

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -56,6 +56,10 @@ Canonical, regenerate-and-gated catalog serializing each MCP tool's full live in
 
 Complete catalog of all 741 skills across all tiers.
 
+### [Provenance Commit Trailer](./provenance-trailer.md)
+
+The governed, machine-readable `Harness-*` git commit trailer emitted by the autonomous ship path — its schema, parse contract, and squash-merge survival.
+
 ### [Source Map](./source-map.md)
 
 Comprehensive source file index for navigating the codebase.

--- a/docs/reference/provenance-trailer.md
+++ b/docs/reference/provenance-trailer.md
@@ -1,0 +1,81 @@
+# Provenance commit trailer
+
+A governed, machine-readable git commit **trailer** that carries the provenance
+of an autonomous, agent-authored commit. It makes AI-authored work — specifically
+the _autonomous_ tier — mechanically countable, joinable to cost, and auditable
+on gated paths. Implemented as a pure primitive in
+[`provenance/commit-trailer.ts`](../../packages/core/src/provenance/commit-trailer.ts)
+and emitted by the orchestrator's autonomous ship path
+([`WorkspaceManager.shipWorkspace`](../../packages/orchestrator/src/workspace/manager.ts)).
+
+## Why a distinct trailer
+
+The only provenance an interactive commit carries today is a freeform
+`Claude-Session:` URL line, which the autonomous ship path does not emit and
+which is not a parseable schema. The trailer deliberately does **not** co-opt
+`Co-authored-by:` — that would conflate the autonomous tier with interactive AI
+assistance (which already emits co-author trailers) and defeat mechanical tier
+detection. A distinct `Harness-*` namespace keeps tier detection mechanical and
+lets the trailer double as the accountability record.
+
+## Schema
+
+Standard git-trailer syntax (`Key: value`, one per line, in a trailing block).
+The presence of a `Harness-Run` key is the mechanical **autonomous-tier signal**.
+
+| Key                          | Required | Meaning                                                                        |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------ |
+| `Harness-Run`                | yes      | `<skill>@<version>` — the primary key; its presence marks an autonomous commit |
+| `Harness-Provenance-Version` | yes      | Schema version (currently `1`); bump on any incompatible change                |
+| `Harness-Run-Id`             | no       | The orchestrator/fleet run this commit belongs to                              |
+| `Harness-Lane`               | no       | The fleet lane / work unit                                                     |
+| `Harness-Agent`              | no       | The agent / backend identity that executed the change                          |
+| `Harness-Model`              | no       | The model that authored the change                                             |
+| `Harness-Session`            | no       | The agent session id, when known                                               |
+
+Keys are emitted in the order above; optional keys are omitted when their value
+is absent. Values are single-line — any embedded newline is stripped at format
+time so a value can never break the block structure or forge an extra key.
+
+### Example
+
+```
+feat(core): add machine-readable provenance trailer
+
+Harness-Run: orchestrator@0.25.0
+Harness-Provenance-Version: 1
+Harness-Run-Id: run-abc123
+Harness-Lane: ISS-1531
+Harness-Agent: anthropic
+Harness-Model: claude-opus-4-8
+```
+
+## Parsing
+
+`parseProvenanceTrailer(message)` scans every `Key: value` line, returns a
+structured `ProvenanceTrailer`, and returns `null` when no `Harness-Run` key is
+present — i.e. an interactive / non-fleet commit is left entirely unclaimed.
+Other trailers (`Claude-Session:`, `Co-authored-by:`) coexisting in the same
+message are ignored. `formatProvenanceTrailer` and `parseProvenanceTrailer`
+round-trip.
+
+## Squash-merge survival
+
+Because this repo squash-merges PRs (which discards individual branch-commit
+messages), `shipWorkspace` also appends the same rendered trailer block to the
+**PR body**. So the provenance record survives the squash even when the commit
+trailer does not reach the default branch.
+
+## Emission scope
+
+The trailer is emitted only when run context is threaded into
+`shipWorkspace(identifier, { …, provenance })`. Any caller that does not thread
+it — an interactive commit, or an adopter driving the workspace manager
+directly — produces a byte-identical commit and PR body to before.
+
+## Deferred (follow-up on #1531)
+
+- A CI check that verifies trailer presence/shape on every agent commit.
+- A `harness provenance <sha>` reader CLI.
+- Downstream consumers (cost-per-merged-PR attribution, autonomy-ratio,
+  contagion tracing) that read this trailer.

--- a/packages/core/src/provenance/commit-trailer.test.ts
+++ b/packages/core/src/provenance/commit-trailer.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROVENANCE_TRAILER_VERSION,
+  PROVENANCE_TRAILER_KEYS,
+  formatProvenanceTrailer,
+  appendProvenanceTrailer,
+  hasProvenanceTrailer,
+  parseProvenanceTrailer,
+  type ProvenanceTrailerInput,
+} from './commit-trailer';
+
+const full: ProvenanceTrailerInput = {
+  skill: 'roadmap-fleet',
+  skillVersion: '5.12.0',
+  runId: 'run_abc123',
+  model: 'claude-opus-4-8',
+  sessionId: 'sess_789',
+  lane: 'build',
+  agent: 'harness-task-executor',
+};
+
+describe('formatProvenanceTrailer', () => {
+  it('emits the primary Harness-Run key as <skill>@<version> plus the schema version', () => {
+    const block = formatProvenanceTrailer(full);
+    expect(block.split('\n')[0]).toBe('Harness-Run: roadmap-fleet@5.12.0');
+    expect(block).toContain(`${PROVENANCE_TRAILER_KEYS.version}: ${PROVENANCE_TRAILER_VERSION}`);
+  });
+
+  it('is deterministic and ordered', () => {
+    const a = formatProvenanceTrailer(full);
+    const b = formatProvenanceTrailer(full);
+    expect(a).toBe(b);
+    expect(a).toBe(
+      [
+        'Harness-Run: roadmap-fleet@5.12.0',
+        'Harness-Provenance-Version: 1',
+        'Harness-Run-Id: run_abc123',
+        'Harness-Lane: build',
+        'Harness-Agent: harness-task-executor',
+        'Harness-Model: claude-opus-4-8',
+        'Harness-Session: sess_789',
+      ].join('\n')
+    );
+  });
+
+  it('omits optional fields that are absent', () => {
+    const block = formatProvenanceTrailer({ skill: 'autopilot', skillVersion: '1.0.0' });
+    expect(block).toBe('Harness-Run: autopilot@1.0.0\nHarness-Provenance-Version: 1');
+    expect(block).not.toContain('Harness-Run-Id');
+    expect(block).not.toContain('Harness-Model');
+  });
+
+  it('defaults an omitted skill version to 0.0.0', () => {
+    const block = formatProvenanceTrailer({ skill: 'autopilot' });
+    expect(block.split('\n')[0]).toBe('Harness-Run: autopilot@0.0.0');
+  });
+
+  it('sanitizes embedded newlines so a value cannot forge an extra key', () => {
+    const block = formatProvenanceTrailer({
+      skill: 'x',
+      skillVersion: '1.0.0',
+      model: 'evil\nHarness-Lane: injected',
+    });
+    // The injected newline must not create a second Harness-Lane line.
+    const laneLines = block.split('\n').filter((l) => l.startsWith('Harness-Lane:'));
+    expect(laneLines).toHaveLength(0);
+    expect(block).toContain('Harness-Model: evil Harness-Lane: injected');
+  });
+});
+
+describe('parseProvenanceTrailer', () => {
+  it('round-trips a fully-populated trailer', () => {
+    const parsed = parseProvenanceTrailer(formatProvenanceTrailer(full));
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      skill: 'roadmap-fleet',
+      skillVersion: '5.12.0',
+      runId: 'run_abc123',
+      model: 'claude-opus-4-8',
+      sessionId: 'sess_789',
+      lane: 'build',
+      agent: 'harness-task-executor',
+    });
+  });
+
+  it('round-trips a minimal trailer (skill + version only)', () => {
+    const parsed = parseProvenanceTrailer(formatProvenanceTrailer({ skill: 'autopilot' }));
+    expect(parsed).toEqual({ schemaVersion: 1, skill: 'autopilot', skillVersion: '0.0.0' });
+  });
+
+  it('returns null for an interactive / non-fleet commit (no Harness-Run key)', () => {
+    const interactive = 'feat: do a thing\n\nClaude-Session: https://claude.ai/code/session_x';
+    expect(parseProvenanceTrailer(interactive)).toBeNull();
+  });
+
+  it('returns null for an empty message', () => {
+    expect(parseProvenanceTrailer('')).toBeNull();
+  });
+
+  it('finds the trailer when it coexists with other trailers', () => {
+    const message = [
+      'fix: patch something',
+      '',
+      'Co-authored-by: Someone <s@example.com>',
+      'Harness-Run: bug-fleet@2.0.0',
+      'Harness-Provenance-Version: 1',
+      'Harness-Model: sonnet',
+      'Claude-Session: https://claude.ai/code/session_y',
+    ].join('\n');
+    const parsed = parseProvenanceTrailer(message);
+    expect(parsed).toMatchObject({ skill: 'bug-fleet', skillVersion: '2.0.0', model: 'sonnet' });
+  });
+
+  it('falls back to the current schema version when the version line is missing/garbage', () => {
+    const parsed = parseProvenanceTrailer(
+      'x\n\nHarness-Run: s@1.0.0\nHarness-Provenance-Version: NaN'
+    );
+    expect(parsed?.schemaVersion).toBe(PROVENANCE_TRAILER_VERSION);
+  });
+});
+
+describe('appendProvenanceTrailer / hasProvenanceTrailer', () => {
+  it('appends the block separated by a blank line and remains parseable', () => {
+    const out = appendProvenanceTrailer('feat: add feature', full);
+    expect(out.startsWith('feat: add feature\n\nHarness-Run:')).toBe(true);
+    expect(parseProvenanceTrailer(out)).not.toBeNull();
+  });
+
+  it('is idempotent — a message that already has a Harness-Run trailer is unchanged', () => {
+    const once = appendProvenanceTrailer('feat: add feature', full);
+    const twice = appendProvenanceTrailer(once, full);
+    expect(twice).toBe(once);
+  });
+
+  it('returns just the block when the base message is empty', () => {
+    const out = appendProvenanceTrailer('', full);
+    expect(out).toBe(formatProvenanceTrailer(full));
+  });
+
+  it('hasProvenanceTrailer detects presence/absence', () => {
+    expect(hasProvenanceTrailer('feat: x')).toBe(false);
+    expect(hasProvenanceTrailer(appendProvenanceTrailer('feat: x', full))).toBe(true);
+  });
+});

--- a/packages/core/src/provenance/commit-trailer.ts
+++ b/packages/core/src/provenance/commit-trailer.ts
@@ -1,0 +1,193 @@
+/**
+ * Machine-readable provenance commit trailer (#1531).
+ *
+ * Autonomous, agent-authored commits are statistically invisible: the only
+ * provenance a commit carries today is a freeform `Claude-Session:` URL appended
+ * by the interactive client, which the autonomous fleet/orchestrator ship path
+ * does not emit and which is not a governed, parseable schema. This module
+ * defines a distinct, structured, deterministically-parseable git trailer that
+ * the ship path emits so AI-authored work — specifically the *autonomous* tier —
+ * is mechanically countable, joinable to cost, and auditable on gated paths.
+ *
+ * DESIGN
+ * - Distinct `Harness-*` namespace, NEVER `Co-authored-by:`. Co-opting the
+ *   co-author trailer would conflate the autonomous tier with interactive AI
+ *   assistance (which already emits co-author trailers) and defeat mechanical
+ *   tier detection. The presence of a `Harness-Run` key IS the tier signal.
+ * - Standard git-trailer syntax (`Key: value`, one per line, trailing block) so
+ *   the trailer is `git log --grep`-friendly and survives ordinary git tooling.
+ * - Pure + IO-free: formatter, appender and parser are pure functions reused by
+ *   the orchestrator (emit) and any telemetry/CLI consumer (parse). This is a
+ *   different concept from the ADR-0100 rule-to-failure provenance reporter that
+ *   also lives in this module — hence the distinct file name.
+ */
+
+/**
+ * Schema version stamped as `Harness-Provenance-Version`. Bump on any
+ * backwards-incompatible change to the key set or value grammar so a parser can
+ * branch on it.
+ */
+export const PROVENANCE_TRAILER_VERSION = 1;
+
+/** The `Harness-*` trailer keys, in canonical emission order. */
+export const PROVENANCE_TRAILER_KEYS = {
+  /** `<skill>@<version>` — the primary key; its presence is the tier signal. */
+  run: 'Harness-Run',
+  version: 'Harness-Provenance-Version',
+  runId: 'Harness-Run-Id',
+  lane: 'Harness-Lane',
+  agent: 'Harness-Agent',
+  model: 'Harness-Model',
+  session: 'Harness-Session',
+} as const;
+
+/** A parsed provenance trailer. `schemaVersion`, `skill`, `skillVersion` are always present. */
+export interface ProvenanceTrailer {
+  /** From `Harness-Provenance-Version`. Falls back to {@link PROVENANCE_TRAILER_VERSION} if unparseable. */
+  schemaVersion: number;
+  /** Left of `@` in `Harness-Run`. */
+  skill: string;
+  /** Right of `@` in `Harness-Run`. */
+  skillVersion: string;
+  /** `Harness-Run-Id` — the orchestrator/fleet run this commit belongs to. */
+  runId?: string;
+  /** `Harness-Model` — the model that authored the change. */
+  model?: string;
+  /** `Harness-Session` — the agent session id, when known. */
+  sessionId?: string;
+  /** `Harness-Lane` — the fleet lane / workflow, when known. */
+  lane?: string;
+  /** `Harness-Agent` — the agent identity, when known. */
+  agent?: string;
+}
+
+/** Input to {@link formatProvenanceTrailer}. `skillVersion` defaults to `0.0.0` when omitted. */
+export interface ProvenanceTrailerInput {
+  skill: string;
+  skillVersion?: string;
+  runId?: string;
+  model?: string;
+  sessionId?: string;
+  lane?: string;
+  agent?: string;
+}
+
+/**
+ * Collapse a value to a single safe trailer line: strip CR/LF (so an attacker-
+ * or accident-supplied newline can never break the block or forge an extra key)
+ * and trim surrounding whitespace. Returns `''` for nullish input.
+ */
+function sanitizeValue(value: string | undefined): string {
+  if (value === undefined || value === null) return '';
+  return String(value)
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
+}
+
+/**
+ * Render a deterministic, ordered `Key: value` trailer block for the given
+ * provenance. Optional fields whose value is empty after sanitization are
+ * omitted. Always emits `Harness-Run` and `Harness-Provenance-Version`.
+ *
+ * The `skill` is emitted even when empty (as `@<version>`) so the block always
+ * carries the tier-signal key; callers should pass a non-empty skill.
+ */
+export function formatProvenanceTrailer(input: ProvenanceTrailerInput): string {
+  const K = PROVENANCE_TRAILER_KEYS;
+  const skill = sanitizeValue(input.skill);
+  const skillVersion = sanitizeValue(input.skillVersion) || '0.0.0';
+
+  const lines: string[] = [
+    `${K.run}: ${skill}@${skillVersion}`,
+    `${K.version}: ${PROVENANCE_TRAILER_VERSION}`,
+  ];
+
+  const optional: Array<[string, string | undefined]> = [
+    [K.runId, input.runId],
+    [K.lane, input.lane],
+    [K.agent, input.agent],
+    [K.model, input.model],
+    [K.session, input.sessionId],
+  ];
+  for (const [key, raw] of optional) {
+    const value = sanitizeValue(raw);
+    if (value !== '') lines.push(`${key}: ${value}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * True when the message already carries a `Harness-Run` trailer — used to keep
+ * {@link appendProvenanceTrailer} idempotent (a resumed ship re-committing the
+ * same work must not double-stamp).
+ */
+export function hasProvenanceTrailer(message: string): boolean {
+  return new RegExp(`^${PROVENANCE_TRAILER_KEYS.run}:\\s`, 'm').test(message);
+}
+
+/**
+ * Append the provenance trailer block to a commit or PR-body message, separated
+ * from the existing body by a blank line. Idempotent: if the message already
+ * carries a `Harness-Run` trailer the message is returned unchanged.
+ */
+export function appendProvenanceTrailer(message: string, input: ProvenanceTrailerInput): string {
+  if (hasProvenanceTrailer(message)) return message;
+  const block = formatProvenanceTrailer(input);
+  const base = message.replace(/\s+$/, '');
+  if (base === '') return block;
+  return `${base}\n\n${block}`;
+}
+
+/** Parse a single `Key: value` line into a `[key, value]` tuple, or `null`. */
+function parseTrailerLine(line: string): [string, string] | null {
+  const match = line.match(/^([A-Za-z][A-Za-z0-9-]*):\s?(.*)$/);
+  if (match === null) return null;
+  return [match[1]!, match[2]!.trim()];
+}
+
+/**
+ * Extract the provenance trailer from a commit or PR-body message.
+ *
+ * Returns `null` when no `Harness-Run` key is present — i.e. an interactive /
+ * non-fleet commit, which this function leaves entirely unclaimed. Scans every
+ * `Key: value` line in the message (co-existing trailers such as
+ * `Claude-Session:` or `Co-authored-by:` are ignored), so a `Harness-Run` line
+ * is found regardless of what other trailers surround it.
+ */
+export function parseProvenanceTrailer(message: string): ProvenanceTrailer | null {
+  const K = PROVENANCE_TRAILER_KEYS;
+  const found = new Map<string, string>();
+  for (const rawLine of message.split(/\r?\n/)) {
+    const parsed = parseTrailerLine(rawLine.trim());
+    if (parsed === null) continue;
+    const [key, value] = parsed;
+    if (key.startsWith('Harness-')) found.set(key, value);
+  }
+
+  const run = found.get(K.run);
+  if (run === undefined) return null;
+
+  const atIndex = run.lastIndexOf('@');
+  const [skill, skillVersion] =
+    atIndex >= 0 ? [run.slice(0, atIndex), run.slice(atIndex + 1)] : [run, ''];
+
+  const parsedVersion = Number.parseInt(found.get(K.version) ?? '', 10);
+  const schemaVersion = Number.isFinite(parsedVersion) ? parsedVersion : PROVENANCE_TRAILER_VERSION;
+
+  const trailer: ProvenanceTrailer = { schemaVersion, skill, skillVersion };
+  // Copy each optional field from its trailer key onto its typed property, skipping
+  // absent/empty values. Data-driven so the branch count stays flat as keys grow.
+  const optionalFields: Array<[string, 'runId' | 'lane' | 'agent' | 'model' | 'sessionId']> = [
+    [K.runId, 'runId'],
+    [K.lane, 'lane'],
+    [K.agent, 'agent'],
+    [K.model, 'model'],
+    [K.session, 'sessionId'],
+  ];
+  for (const [key, field] of optionalFields) {
+    const value = found.get(key);
+    if (value !== undefined && value !== '') trailer[field] = value;
+  }
+  return trailer;
+}

--- a/packages/core/src/provenance/index.ts
+++ b/packages/core/src/provenance/index.ts
@@ -8,3 +8,13 @@ export {
   type ProvenanceReport,
 } from './report';
 export { collectSolutionEnforcements } from './io';
+export {
+  PROVENANCE_TRAILER_VERSION,
+  PROVENANCE_TRAILER_KEYS,
+  formatProvenanceTrailer,
+  appendProvenanceTrailer,
+  hasProvenanceTrailer,
+  parseProvenanceTrailer,
+  type ProvenanceTrailer,
+  type ProvenanceTrailerInput,
+} from './commit-trailer';

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -156,6 +156,7 @@ import { wireTelemetryFanout } from './gateway/telemetry/fanout';
 import { SinkRegistry } from './notifications/registry';
 import { wireNotificationSinks } from './notifications/events';
 import { CacheMetricsRecorder, OTLPExporter } from '@harness-engineering/core';
+import { VERSION as HARNESS_VERSION, type ProvenanceTrailerInput } from '@harness-engineering/core';
 import { StructuredLogger } from './logging/logger';
 import { scanWorkspaceConfig } from './workspace/config-scanner';
 import { InteractionQueue } from './core/interaction-queue';
@@ -4112,6 +4113,9 @@ export class Orchestrator extends EventEmitter {
       const ship = await this.workspace.shipWorkspace(shipIdentifier, {
         ...this.buildShipPr(issue),
         workspacePath,
+        // #1531 — stamp the autonomous commit + PR body with a machine-readable
+        // provenance trailer so this tier is mechanically countable and auditable.
+        provenance: this.buildShipProvenance(issue, lastBackendName, lastDef),
       });
       if (!ship.ok) {
         await this.handleStagedGateFailure(
@@ -4184,6 +4188,40 @@ export class Orchestrator extends EventEmitter {
    * a real number the trailer is omitted so the PR does not close an unrelated
    * issue. Pure; no side effects.
    */
+  /**
+   * #1531 — build the machine-readable provenance trailer input for an autonomous
+   * ship. Sourced entirely from live run context: the harness version as the
+   * skill version, the flight-recorder run id, the executing backend's model + name,
+   * and the work unit as the lane. Every optional field degrades to omission when
+   * its context is absent — {@link appendProvenanceTrailer} tolerates that — so this
+   * never throws. The `skill` is `orchestrator` (the autonomous ship path identity),
+   * distinguishing the autonomous tier from interactive assistance.
+   */
+  private buildShipProvenance(
+    issue: Issue,
+    backendName: string | undefined,
+    backendDef: import('@harness-engineering/types').BackendDef | undefined
+  ): ProvenanceTrailerInput {
+    // `model` is absent on some backend variants (e.g. mock) — narrow before reading.
+    const rawModel =
+      backendDef !== undefined && 'model' in backendDef ? backendDef.model : undefined;
+    const model = Array.isArray(rawModel)
+      ? rawModel.filter((m): m is string => typeof m === 'string').join(',')
+      : typeof rawModel === 'string'
+        ? rawModel
+        : undefined;
+    const input: ProvenanceTrailerInput = {
+      skill: 'orchestrator',
+      skillVersion: HARNESS_VERSION,
+      runId: this.flightRunId,
+    };
+    if (model !== undefined && model !== '') input.model = model;
+    if (backendName !== undefined && backendName !== '') input.agent = backendName;
+    const lane = issue.identifier;
+    if (lane !== undefined && lane !== '') input.lane = lane;
+    return input;
+  }
+
   private buildShipPr(issue: Issue): { title: string; body: string } {
     const title = issue.title?.trim() || issue.identifier;
     // Parse a trailing `#<digits>` off the external tracker id, if present.

--- a/packages/orchestrator/src/workspace/manager.ship.test.ts
+++ b/packages/orchestrator/src/workspace/manager.ship.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as path from 'node:path';
 import { WorkspaceManager } from './manager';
 import type { WorkspaceConfig } from '@harness-engineering/types';
+import { parseProvenanceTrailer } from '@harness-engineering/core';
 
 /**
  * staged-verify-gate-convergence D4 — `WorkspaceManager.shipWorkspace` turns a
@@ -190,6 +191,60 @@ describe('WorkspaceManager.shipWorkspace (D4)', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBeInstanceOf(Error);
+  });
+
+  // #1531 — machine-readable provenance trailer on the autonomous ship path.
+  it('stamps a parseable provenance trailer onto the commit AND the PR body when provenance is supplied', async () => {
+    const wm = new ShipStubWM(config());
+    const result = await wm.shipWorkspace('ISS-1', {
+      title: 'feat: do the thing',
+      body: 'PR body prose.',
+      provenance: {
+        skill: 'orchestrator',
+        skillVersion: '9.9.9',
+        runId: 'run-xyz',
+        model: 'claude-opus-4-8',
+        lane: 'ISS-1',
+        agent: 'anthropic',
+      },
+    });
+    expect(result.ok).toBe(true);
+
+    // The commit message carries the trailer.
+    const commit = wm.gitCalls.find((c) => c[0] === 'commit');
+    const commitMsg = commit?.[2] ?? '';
+    const commitTrailer = parseProvenanceTrailer(commitMsg);
+    expect(commitTrailer).toMatchObject({
+      skill: 'orchestrator',
+      skillVersion: '9.9.9',
+      runId: 'run-xyz',
+      model: 'claude-opus-4-8',
+    });
+    expect(commitMsg.startsWith('feat: do the thing')).toBe(true);
+
+    // The PR body ALSO carries it — so the record survives the repo's squash-merge.
+    const pr = wm.ghCalls.find((c) => c[0] === 'pr' && c[1] === 'create');
+    const bodyIdx = (pr ?? []).indexOf('--body');
+    const prBody = bodyIdx >= 0 ? pr![bodyIdx + 1]! : '';
+    expect(parseProvenanceTrailer(prBody)).toMatchObject({
+      skill: 'orchestrator',
+      runId: 'run-xyz',
+    });
+    expect(prBody.startsWith('PR body prose.')).toBe(true);
+  });
+
+  it('leaves the commit + PR body byte-identical when no provenance is supplied (interactive/third-party unaffected)', async () => {
+    const wm = new ShipStubWM(config());
+    const result = await wm.shipWorkspace('ISS-1', { title: 'plain title', body: 'plain body' });
+    expect(result.ok).toBe(true);
+
+    const commit = wm.gitCalls.find((c) => c[0] === 'commit');
+    expect(commit?.[2]).toBe('plain title');
+    expect(parseProvenanceTrailer(commit?.[2] ?? '')).toBeNull();
+
+    const pr = wm.ghCalls.find((c) => c[0] === 'pr' && c[1] === 'create');
+    const bodyIdx = (pr ?? []).indexOf('--body');
+    expect(pr?.[bodyIdx + 1]).toBe('plain body');
   });
 });
 

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -4,7 +4,13 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { WorkspaceConfig, Result, Ok, Err } from '@harness-engineering/types';
 import type { HarnessIdentity } from '@harness-engineering/types';
-import { ensureIdentity, assignNumber, readHarnessIdentity } from '@harness-engineering/core';
+import {
+  ensureIdentity,
+  assignNumber,
+  readHarnessIdentity,
+  appendProvenanceTrailer,
+  type ProvenanceTrailerInput,
+} from '@harness-engineering/core';
 import { parseIntroducedHunks, type IntroducedHunk } from '../agent/quality-verdict.js';
 
 /**
@@ -673,7 +679,21 @@ export class WorkspaceManager {
    */
   public async shipWorkspace(
     identifier: string,
-    opts: { title: string; body: string; workspacePath?: string }
+    opts: {
+      title: string;
+      body: string;
+      workspacePath?: string;
+      /**
+       * Machine-readable provenance (#1531). When supplied, a `Harness-*` trailer
+       * (see {@link appendProvenanceTrailer}) is appended to BOTH the autonomous
+       * commit message and the PR body — so the autonomous tier is mechanically
+       * countable and, because the repo squash-merges, the PR body carries the
+       * record even when the branch commit's message is discarded by the squash.
+       * Omitted for any caller that does not thread run context, leaving the
+       * commit + PR byte-identical to today (interactive commits unaffected).
+       */
+      provenance?: ProvenanceTrailerInput;
+    }
   ): Promise<Result<{ branch: string; prUrl?: string }, Error>> {
     try {
       // S1: prefer the caller's ALREADY-KNOWN, gate-verified worktree path so the
@@ -720,10 +740,15 @@ export class WorkspaceManager {
         // a hook blocks (arch regression, missing changeset, formatting), the commit
         // throws → shipWorkspace returns Err → the staged gate re-dispatches with the
         // hook output as feedback so the NEXT attempt addresses it.
-        await this.git(
-          ['commit', '-m', opts.title || `orchestrator: ${identifier}`],
-          workspacePath
-        );
+        // #1531 — stamp the machine-readable provenance trailer onto the
+        // autonomous commit when run context was threaded. No-op / byte-identical
+        // when `opts.provenance` is absent (interactive + third-party commits).
+        const commitMessage = opts.title || `orchestrator: ${identifier}`;
+        const stampedCommit =
+          opts.provenance !== undefined
+            ? appendProvenanceTrailer(commitMessage, opts.provenance)
+            : commitMessage;
+        await this.git(['commit', '-m', stampedCommit], workspacePath);
       }
 
       // 2. Move onto the SLASH-prefixed branch. On a RESUMED ship the branch may
@@ -762,7 +787,12 @@ export class WorkspaceManager {
         '--title',
         opts.title,
         '--body',
-        opts.body,
+        // #1531 — mirror the provenance trailer into the PR body so the record
+        // survives the repo's squash-merge (which discards the branch commit's
+        // message). Byte-identical when no provenance context was threaded.
+        opts.provenance !== undefined
+          ? appendProvenanceTrailer(opts.body, opts.provenance)
+          : opts.body,
       ];
       // Run `gh pr create` from the REPO ROOT, not the detached worktree: gh infers
       // repo/head context from the working dir, and a detached-HEAD worktree makes it


### PR DESCRIPTION
## What

Introduces a distinct, governed, machine-readable git commit **trailer** carrying provenance for autonomous, agent-authored commits, emits it on the orchestrator's autonomous ship path, and ships a deterministic parser. This makes AI-authored work — specifically the *autonomous* tier — mechanically countable, joinable to cost, and auditable on gated paths.

Today the only provenance a commit carries is a freeform `Claude-Session:` URL (interactive-only, not a parseable schema). This adds a governed schema the autonomous path emits.

## Changes

- **New pure primitive** `packages/core/src/provenance/commit-trailer.ts`:
  - Schema: `Harness-Run: <skill>@<version>` (primary/tier-signal key) plus `Harness-Provenance-Version`, `Harness-Run-Id`, `Harness-Lane`, `Harness-Agent`, `Harness-Model`, `Harness-Session`.
  - `formatProvenanceTrailer` (deterministic, ordered, CR/LF-sanitized), `appendProvenanceTrailer` (idempotent), `parseProvenanceTrailer` (returns `null` for non-fleet commits), `hasProvenanceTrailer`.
  - Distinct `Harness-*` namespace — **not** `Co-authored-by:` — so tier detection is mechanical.
- **Emit on the ship path** (`WorkspaceManager.shipWorkspace`): stamps the commit message and **mirrors the trailer into the PR body** so the record survives the repo's squash-merge. Interactive / third-party commits (no run context threaded) are byte-identical.
- **Orchestrator wiring**: threads live run context (skill=`orchestrator`, harness version, flight-recorder run id, backend model + name, work-unit lane) into the ship; every optional field degrades to omission when absent — never throws.
- **Docs**: `docs/reference/provenance-trailer.md` (schema, parse contract, squash-survival) linked from the reference index.
- **Tests**: 15 primitive tests (format/parse round-trip, non-fleet `null`, idempotency, value-injection sanitization, coexistence with `Claude-Session:`/`Co-authored-by:`) + 2 ship-path wiring tests (trailer on commit + PR body; byte-identical without provenance).

## Acceptance criteria (#1531)

- [x] Every fleet-authored commit in a fixture run carries a parseable trailer — ship-path wiring test + round-trip test.
- [x] Interactive (non-fleet) commits are unaffected — byte-identical `shipWorkspace` without `provenance`; parser returns `null` on non-fleet messages.
- [x] Trailer survives the squash-merge path, or the PR body carries the equivalent record — the PR body carries the rendered trailer block.

## Assumptions made

- Trailer uses git-trailer `Key: value` syntax under a distinct `Harness-*` namespace; `Claude-Session:` is complemented, not removed.
- The autonomous path's `skill` identity is `orchestrator`; `skillVersion` is sourced from the harness core `VERSION`. (Version sourcing can be refined later; the schema is versioned via `Harness-Provenance-Version`.)
- Emission is gated on an optional `shipWorkspace` `provenance` opt, so only the autonomous path stamps; all other callers are unaffected.
- An `.harness/arch/allowances/` file is included: `parseProvenanceTrailer` is complexity 13 (warning-tier, under the 15 hard threshold) and the new module adds a small aggregate-complexity delta; `baselines.json` is byte-identical to base.

## Slice boundary (`Refs #1531`)

This is a **slice**, not a full close. It lands the schema + formatter + parser + orchestrator emission (commit + PR body) + docs + tests, satisfying all three acceptance criteria mechanically. **Deferred remainder** (flagged for follow-up): a CI check that verifies trailer presence/shape on every agent commit, and a `harness provenance <sha>` reader CLI.

Refs #1531

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga