### PR TITLE
fix(roadmap): preserve multi-line summary across serialize/parse round-trip

### DIFF
--- a/.changeset/roadmap-multiline-summary-1756.md
+++ b/.changeset/roadmap-multiline-summary-1756.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/core': patch
+---
+
+Fix roadmap serialize/parse round-trip silently truncating a multi-line
+`RoadmapFeature.summary` to its first line (#1756). The Summary free-text field
+is now encoded with a reversible single-line escape on write and decoded on
+read, so an embedded newline survives parse → serialize → parse intact across
+the monolith roadmap, the shard store, and comprehension shards. Plain
+single-line summaries are unaffected.

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '5751674267b5fb50ca1e3319bacfcf149f278c7c1b3f88f8be5d2b9291380bf4'
+sourceHash: '57cf13fb3e3e88a5da946d41ee94da82490edcdad43bf6be882d554d26cbf366'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '1880488940754d399883e89435880d9f61d19fd44798087f500e70e948c11d26'
-compiledAt: '2026-08-28T01:22:10.571Z'
+sourceHash: '5751674267b5fb50ca1e3319bacfcf149f278c7c1b3f88f8be5d2b9291380bf4'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'assignee-lifecycle.ts',
@@ -27,26 +26,13 @@ members:
     'referenced-issues.ts',
     'serialize.ts',
     'status-rank.ts',
+    'summary-field.ts',
     'sync-engine.ts',
     'sync.ts',
     'tracker-config.ts',
     'tracker-sync.ts',
   ]
 ---
-
-## Summary
-
-The `roadmap` module is the authoritative layer for feature planning and tracking. It manages the dual representation of features: a local markdown-based aggregate (monolith or sharded) and an external GitHub tracker. Core responsibilities include parsing/serializing roadmap markdown with canonical grammars, enforcing the assignee lifecycle invariant, bidirectional sync with GitHub (reconcile closed issues as done, push status changes, handle conflicts), roadmap health validation, feature scoring and promotion through release pipelines, and storage abstraction supporting both monolith and sharded modes. Acts as the boundary between the orchestrator (claim/release rows), GitHub adapter (outbound push), storage layer, and type system.
-
-## Invariants
-
-- Assignee Lifecycle (S4-001): assignee ≠ null ⟺ status === 'in-progress'. A feature carries an assignee iff actively executing. The assigneeInvariantHolds(), claim(), release(), and setStatus() functions form a chokepoint enforcing this at every state transition. Violation breaks sync, health checks, and orchestrator concurrency guards.
-- First-Claim-Wins (S4-003): isClaimableBy(feature, assignee) enforces compare-and-set semantics—a row is claimable only if unassigned or already held by that assignee. Prevents race conditions where orchestrator and human (or peer orchestrators) dispatch onto the same row concurrently.
-- Machine Assignee Opacity: Orchestrator IDs (orchestrator-{8-hex} or {name}-{8-hex}) are local-only and never synced to GitHub's assignee field. Only real GitHub logins push outbound via pushAssigneeToExternal(). isMachineAssignee() is the single source of truth to prevent dual-adapter drift.
-- External-ID Format Canonicality: github:owner/repo#NNN is the one regex-defined format for tracking GitHub issues across sync and reconcile paths. parseExternalId() and buildExternalId() export the canonical grammar to prevent divergence between adapter and auto-done reconciler.
-- H3 Heading Grammar Convergence: Lenient read (\s+ after ### and Feature:), strict emit (one space). matchFeatureHeadings() and serializeFeatureHeading() share the same grammar so parse → serialize → parse is an identity, preventing silent reclassification of tracked rows.
-- Roadmap Storage Mode Consistency: Mode (monolith vs. sharded) is detected once and pinned throughout a session via detectRoadmapStorageMode() and getRoadmapMode(). Switching modes mid-session breaks row identity; the store factory enforces consistency.
-- Assignment History Auditability: Every assignee change appends an AssignmentRecord to roadmap.assignmentHistory with action (assigned/unassigned), executor name, and timestamp. This immutable audit trail provides S4 claim/release compliance tracking.
 
 ## Interface Contract
 
@@ -151,6 +137,7 @@ import { isRegression } from './status-rank'
 import { applyRoadmapDiff } from './store/apply-diff'
 import { resolveRoadmapStore } from './store/factory'
 import { RoadmapStore } from './store/roadmap-store'
+import { decodeSummaryField, encodeSummaryField } from './summary-field'
 import { TrackedFeature } from './tracker'
 import { ExternalSyncOptions, TicketWriteOptions, TrackerSyncAdapter, resolveReverseStatus } from './tracker-sync'
 import { TrackerClientConfig } from './tracker/factory'

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: 'f18ce5fbcd17d41db0f2c600a36004a284825f6b702c4ed048edce6a5c9ffdb6'
-compiledAt: '2026-08-28T01:22:11.057Z'
+sourceHash: '95807281b2027ca3fa0bc250f6843c485b6c83487890333710faa877e11acf82'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'assignee-lifecycle.test.ts',
@@ -33,6 +32,7 @@ members:
     'referenced-issues.test.ts',
     'serialize-extended.test.ts',
     'serialize-groups.test.ts',
+    'serialize-summary-multiline.test.ts',
     'serialize.test.ts',
     'sync-engine-guards.test.ts',
     'sync-engine.test.ts',
@@ -40,20 +40,6 @@ members:
     'tracker-sync.test.ts',
   ]
 ---
-
-## Summary
-
-`packages/core/tests/roadmap` is a comprehensive fixture and test suite for the roadmap subsystem, which manages feature planning, assignment tracking, and synchronization with external trackers (GitHub Issues). The module exports test fixtures (markdown and parsed roadmap objects in various states) and test suites exercising assignee lifecycle (claiming, releasing, status-driven semantics), repo derivation from git remotes, parse/serialize round-trips, tracker sync, pilot scoring, health checks, and store operations (sharding, migration, regeneration). The suite acts as the behavioral contract for roadmap integrity across the entire pipeline—from user edits in markdown, through orchestrator mutations, to external sync and back.
-
-## Invariants
-
-- Assignee ⟺ in-progress: A feature has a non-null assignee if and only if its status is in-progress. Violations indicate either the pilot bug (human assigned to a non-in-progress row) or an orphan (in-progress with no owner).
-- First-claim-wins (S4-003): An orchestrator cannot steal an active claim from a different owner. Claim operations on a feature already assigned to a peer are idempotent no-ops.
-- Status-exit clears assignee (S4-001): Moving a feature away from in-progress automatically unassigns it and logs the release action. Prevents stale assignment metadata.
-- Machine assignee format: Assignee strings matching orchestrator-<id> or <hostname>-<hash> are machine-generated; human handles (@user, user@domain) are never auto-cleared by status changes.
-- Config derivation hierarchy: Explicit harness.config.json settings win over git remote derivation; only when repo is missing do loaders fall back to origin URL parsing.
-- Semantic round-trip (store/migration): A parsed roadmap must serialize and re-parse to an equivalent structure. Lossy serialization (e.g., dropping prose comments) breaks this contract.
-- External ID Single-Shard: Each feature's externalId (GitHub issue number) is canonical per shard. Drift in External-ID causes a feature to become invisible to the pilot and remain open despite resolution.
 
 ## Interface Contract
 
@@ -100,6 +86,7 @@ import { writeRegeneratedRoadmap } from '../../src/roadmap/store/regenerator'
 import { RoadmapStore, Shard } from '../../src/roadmap/store/roadmap-store'
 import { parseShard, serializeShard } from '../../src/roadmap/store/shard'
 import { ShardIO } from '../../src/roadmap/store/shard-store'
+import { decodeSummaryField, encodeSummaryField } from '../../src/roadmap/summary-field'
 import { syncRoadmap } from '../../src/roadmap/sync'
 import { _resetSyncMutex, fullSync, syncFromExternal, syncRowToExternal, syncToExternal } from '../../src/roadmap/sync-engine'
 import { TrackedFeature } from '../../src/roadmap/tracker'

--- a/docs/changes/roadmap-multiline-summary-truncation-1756/provenance.json
+++ b/docs/changes/roadmap-multiline-summary-truncation-1756/provenance.json
@@ -1,0 +1,12 @@
+{
+  "issue": [1756],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/core/tests/roadmap/serialize-summary-multiline.test.ts",
+  "closingKeyword": "Closes",
+  "assumptions": [
+    "Scoped to multi-line-summary truncation; sibling comma-split bug #1757 left out of scope",
+    "Fix is a reversible single-line escape codec (backslash/newline/carriage-return) applied only to the Summary free-text field in the shared serializeFeature/parseFeatureBlock seam, so the monolith roadmap.md, shard store, and comprehension shards all keep byte-stable round-trips; the line-oriented grammar and the comma-list grammar are untouched",
+    "Backward-compatible: plain single-line summaries contain none of the escaped characters, so encode/decode are identities on all existing roadmap content (verified: no tracked Summary bullet contains a backslash)"
+  ]
+}

--- a/packages/core/src/roadmap/parse.ts
+++ b/packages/core/src/roadmap/parse.ts
@@ -14,6 +14,10 @@ import { Ok, Err } from '@harness-engineering/types';
 // `./heading`, the single source of truth shared with the emitter and the shard
 // reader, so no copy can drift and silently reclassify a tracked row (#1261).
 import { GROUP_PREFIX, matchFeatureHeadings } from './heading';
+// The summary escape codec lives in `./summary-field`, the single source of truth
+// shared with the serializer, so the continuation of a multi-line summary is
+// restored on read rather than silently dropped by the line grammar (#1756).
+import { decodeSummaryField } from './summary-field';
 
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   'backlog',
@@ -315,7 +319,7 @@ export function parseFeatureBlock(name: string, body: string): Result<RoadmapFea
     spec: optionalField(fieldMap, 'Spec'),
     plans: parseListField(fieldMap, 'Plans', 'Plan'),
     blockedBy: parseListField(fieldMap, 'Blocked by', 'Blockers'),
-    summary: fieldMap.get('Summary') ?? '',
+    summary: decodeSummaryField(fieldMap.get('Summary') ?? ''),
     assignee: optionalField(fieldMap, 'Assignee'),
     priority: priorityResult.value,
     externalId: optionalField(fieldMap, 'External-ID'),

--- a/packages/core/src/roadmap/serialize.ts
+++ b/packages/core/src/roadmap/serialize.ts
@@ -7,6 +7,10 @@ import type {
 // The H3 heading emitter lives in `./heading`, the single source of truth shared
 // with both readers, so the emitter cannot drift from them (#1261).
 import { serializeFeatureHeading } from './heading';
+// The summary escape codec lives in `./summary-field`, the single source of truth
+// shared with the parser, so a multi-line summary survives the line-oriented
+// grammar's parse → serialize round-trip intact (#1756).
+import { encodeSummaryField } from './summary-field';
 
 const EM_DASH = '\u2014';
 
@@ -119,7 +123,7 @@ export function serializeFeature(feature: RoadmapFeature): string[] {
     '',
     `- **Status:** ${feature.status}`,
     `- **Spec:** ${orDash(feature.spec)}`,
-    `- **Summary:** ${feature.summary}`,
+    `- **Summary:** ${encodeSummaryField(feature.summary)}`,
     `- **Blockers:** ${listOrDash(feature.blockedBy)}`,
     `- **Plan:** ${listOrDash(feature.plans)}`,
     ...serializeExtendedLines(feature),

--- a/packages/core/src/roadmap/summary-field.ts
+++ b/packages/core/src/roadmap/summary-field.ts
@@ -13,7 +13,7 @@
  * scoped to this one field: encode embedded control characters into a reversible
  * single-line escape on write, decode them back on read. The line grammar itself
  * is untouched, so the shard store, the comprehension shards, and the monolith
- * `roadmap.md` all keep byte-stable round-trips through the shared
+ * roadmap document all keep byte-stable round-trips through the shared
  * `serializeFeature` / `parseFeatureBlock` seam.
  *
  * Encoding order matters: the backslash is escaped FIRST so every backslash in the

--- a/packages/core/src/roadmap/summary-field.ts
+++ b/packages/core/src/roadmap/summary-field.ts
@@ -1,0 +1,36 @@
+/**
+ * Escape codec for the free-text `- **Summary:** <value>` bullet.
+ *
+ * The roadmap grammar is line-oriented: `serializeFeature` emits every field on a
+ * single `- **Field:** value` line and `extractFieldMap` reads each one back with a
+ * per-line, non-dotAll regex (`/^- \*\*(.+?):\*\* (.+)$/gm`). A `summary` that
+ * carries an embedded newline therefore split across two markdown lines on write
+ * and had its continuation silently dropped on the next parse (#1756).
+ *
+ * Summary is the only free-text field a caller can put a newline into (status,
+ * spec, priority, ids are constrained; blockers/plans are comma lists — the comma
+ * grammar is a SEPARATE bug, #1757, deliberately out of scope here). So the fix is
+ * scoped to this one field: encode embedded control characters into a reversible
+ * single-line escape on write, decode them back on read. The line grammar itself
+ * is untouched, so the shard store, the comprehension shards, and the monolith
+ * `roadmap.md` all keep byte-stable round-trips through the shared
+ * `serializeFeature` / `parseFeatureBlock` seam.
+ *
+ * Encoding order matters: the backslash is escaped FIRST so every backslash in the
+ * output is the start of exactly one `\\` / `\n` / `\r` pair, which makes
+ * {@link decodeSummaryField} an exact left-to-right inverse. A plain single-line
+ * summary contains none of these characters, so both directions are identities on
+ * legacy content — existing roadmaps are unaffected.
+ */
+export function encodeSummaryField(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\r/g, '\\r').replace(/\n/g, '\\n');
+}
+
+/** Exact inverse of {@link encodeSummaryField}. */
+export function decodeSummaryField(value: string): string {
+  return value.replace(/\\([\\rn])/g, (_, ch: string) => {
+    if (ch === 'n') return '\n';
+    if (ch === 'r') return '\r';
+    return '\\';
+  });
+}

--- a/packages/core/tests/roadmap/serialize-summary-multiline.test.ts
+++ b/packages/core/tests/roadmap/serialize-summary-multiline.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import { encodeSummaryField, decodeSummaryField } from '../../src/roadmap/summary-field';
+import { VALID_ROADMAP } from './fixtures';
+
+// Regression guard for #1756: `RoadmapFeature.summary` used to round-trip lossily
+// through `serializeRoadmap` → `parseRoadmap`. The grammar is line-oriented
+// (`- **Summary:** <value>` on one line, read back by a per-line non-dotAll
+// regex), so a summary carrying an embedded newline split across two markdown
+// lines on write and had its continuation silently dropped on the next parse.
+//
+// Before the fix these assertions FAIL (the reparsed summary is truncated to its
+// first line); after the escape codec is wired into `serializeFeature` /
+// `parseFeatureBlock` they PASS. The sibling comma-in-list bug (#1757) is a
+// SEPARATE grammar defect and is intentionally NOT exercised here.
+describe('roadmap round-trip: multi-line summary (#1756)', () => {
+  it('preserves a summary with an embedded newline through parse(serialize(roadmap))', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[0]!.summary =
+      'Email and in-app notifications with polling\nfollow-up: add push channel';
+
+    const markdown = serializeRoadmap(roadmap);
+    const reparsed = parseRoadmap(markdown);
+
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+
+    // The whole roadmap (summary continuation included) survives intact.
+    expect(reparsed.value).toEqual(roadmap);
+    expect(reparsed.value.milestones[0]!.features[0]!.summary).toBe(
+      'Email and in-app notifications with polling\nfollow-up: add push channel'
+    );
+  });
+
+  it('keeps the multi-line summary stable across a second round-trip (idempotent)', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[0]!.summary = 'line one\nline two\r\nline three';
+
+    const once = serializeRoadmap(roadmap);
+    const twice = serializeRoadmap(
+      (() => {
+        const r = parseRoadmap(once);
+        expect(r.ok).toBe(true);
+        if (!r.ok) throw new Error('parse failed');
+        return r.value;
+      })()
+    );
+
+    // Byte-stable regen: re-serializing the reparsed roadmap yields the same bytes.
+    expect(twice).toBe(once);
+  });
+
+  it('does not split the summary bullet across markdown lines on write', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[0]!.summary = 'first\nsecond';
+
+    const markdown = serializeRoadmap(roadmap);
+    const lines = markdown.split('\n');
+
+    // The continuation is escaped onto the single Summary bullet rather than
+    // leaking onto an orphan second markdown line.
+    expect(lines).toContain('- **Summary:** first\\nsecond');
+    expect(lines).not.toContain('second');
+  });
+
+  it('leaves a plain single-line summary byte-for-byte unchanged (legacy content)', () => {
+    const plain = 'Email and in-app notifications with polling';
+    expect(encodeSummaryField(plain)).toBe(plain);
+    expect(decodeSummaryField(plain)).toBe(plain);
+  });
+
+  it('is an exact inverse for values containing backslashes and control chars', () => {
+    for (const value of [
+      'a\nb',
+      'a\\nb', // a literal backslash-n, must NOT be mistaken for a newline
+      'path\\to\\thing',
+      'carriage\r\nreturn',
+      'mixed \\ and \n and \\n',
+      '',
+    ]) {
+      expect(decodeSummaryField(encodeSummaryField(value))).toBe(value);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

The roadmap grammar is line-oriented. `serializeFeature` emits every field on one `- **Field:** value` line, and `extractFieldMap` reads each back with a per-line, non-dotAll regex (`/^- \*\*(.+?):\*\* (.+)$/gm`). A `RoadmapFeature.summary` carrying an embedded newline therefore split across two markdown lines on write, and only the first line was captured back on the next parse — the continuation vanished silently. Because the monolith roadmap, the shard store, and the comprehension shards all reuse this same `serializeFeature` / `parseFeatureBlock` seam, any tool that re-serialized the roadmap truncated a multi-line summary.

## Fix

A reversible single-line escape codec (`packages/core/src/roadmap/summary-field.ts`, the single source of truth shared by the serializer and parser) encodes backslash / newline / carriage-return on write and decodes them on read, scoped to the `Summary` free-text field only:

- `serializeFeature` -> `encodeSummaryField(feature.summary)`
- `parseFeatureBlock` -> `decodeSummaryField(fieldMap.get('Summary') ?? '')`

The line grammar itself is untouched, so the monolith roadmap, the shard store, and the comprehension shards all keep byte-stable round-trips. Backward-compatible: plain single-line summaries contain none of the escaped characters, so encode/decode are identities on all existing content (verified: no tracked Summary bullet contains a backslash). Encoding order (backslash first) makes decode an exact left-to-right inverse.

## Reproducing test

`packages/core/tests/roadmap/serialize-summary-multiline.test.ts` — verified **fails before** the fix (summary truncated to its first line; 3 of 5 assertions fail on unfixed code) and **passes after** (round-trip preserves the summary, byte-stable across a second round-trip, exact inverse for backslash/control-char values). Full roadmap suite: 655 pass / 1 skip. Typecheck clean.

## Scope

The sibling comma-in-list bug (#1757: a comma inside a `blockedBy`/`plan` list item splits it) is a **separate** defect in the same grammar and is deliberately **out of scope** here — this change does not touch the comma-list grammar.

Closes #1756

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga