### PR TITLE
fix(mcp): fire toolchain version-skew guard on the MCP surface (#1301)

### DIFF
--- a/.changeset/version-skew-guard-mcp-surface-1301.md
+++ b/.changeset/version-skew-guard-mcp-surface-1301.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(mcp): fire the toolchain version-skew guard on the MCP surface (#1301).
+
+The version-skew guard added in #1293 refuses to produce findings when the
+running CLI is sharply out of step with the workspace's declared
+`toolchain.cliVersion`. It was wired only as a commander `preAction` hook, so it
+fired on CLI invocations but not on MCP tool calls, which reach the same
+findings-producing check implementations in-process through the server's
+`CallToolRequest` handler — a separate entry point the hook never runs. A stale
+`harness-mcp` shim therefore reproduced the original incident unmitigated.
+
+Adds an MCP dispatch-boundary middleware (`applyVersionGuard`) that calls the
+same shared evaluator (`evaluateVersionGuard`) the CLI hook uses, so the two
+surfaces cannot diverge on when to refuse. A refusal returns an `isError` result
+(the MCP analogue of the CLI's exit 3) and the tool never runs; a warning
+proceeds with the notice prepended; `HARNESS_NO_VERSION_GUARD` downgrades a
+refusal to a warning exactly as on the CLI. The gated set is the findings tools
+that are the in-process twins of the guarded CLI commands. The two entry points
+are disjoint, so no request is double-guarded and the CLI path is unchanged.

--- a/.harness/comprehension/packages/cli/src/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp'
-sourceHash: '83f436e5244c88a373814eb39452ca6183816470b27a6a165689f978e7b86755'
+sourceHash: '7d8e13f6e8230c09fe322a96dd4f97ed79bc81b49e1e8345357333152618ba07'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -37,6 +37,7 @@ import { getToolDefinitions } from './index.js'
 import { applyCompaction } from './middleware/compaction.js'
 import { applyContextBudget } from './middleware/context-budget.js'
 import { applyInjectionGuard } from './middleware/injection-guard.js'
+import { applyVersionGuard } from './middleware/version-guard.js'
 import { getBusinessKnowledgeResource } from './resources/business-knowledge.js'
 import { getEntitiesResource, getGraphResource, getRelationshipsResource } from './resources/graph.js'
 import { getLearningsResource } from './resources/learnings.js'

--- a/.harness/comprehension/packages/cli/src/mcp/middleware/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/middleware/_module.md
@@ -1,28 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/middleware'
-sourceHash: '97c42675e3e98bbce894e77a193318815d04de497e2dc7af8764c6db978bfb15'
-compiledAt: '2026-08-28T01:22:09.241Z'
+sourceHash: '1e573924b76e5a34085473c5877937fb6aeedc55f53c8eade61147f6a2d26080'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['compaction.ts', 'context-budget.ts', 'injection-guard.ts']
+model: null
+semantic: absent
+members: ['compaction.ts', 'context-budget.ts', 'injection-guard.ts', 'version-guard.ts']
 ---
-
-## Summary
-
-**packages/cli/src/mcp/middleware** provides three layers of middleware wrapping for MCP tool handlers: Compaction (lossless + lossy token reduction with disk spill for large outputs), Context Budget (per-response token enforcement for manual sessions using the same budget primitive as the orchestrator), and Injection Guard (taint detection/prevention). All three are fail-open and driven by tool-specific routing: certain tools (run_skill, emit_interaction, manage_state, manage_roadmap, etc.) use structural-only compaction to preserve behavioral completeness, while others accept lossy truncation. Escape hatches (compact: false, zero budget) disable enforcement; when unconfigured, context-budget is byte-identical no-op.
-
-## Invariants
-
-- Lossless-only tool set is fixed: run_skill, emit_interaction, manage_state, code_unfold, init_project, generate_linter, manage_roadmap, run_persona, and generated-artifact tools are never lossy-truncated because they carry instructions or structured state that must arrive complete
-- Spill recovery is opt-in per-result: only large truncated outputs spill to disk; small results within budget return as-is, with recovery locators appended for later grep
-- Header tokens are self-accounted: compaction headers include their own token cost in the budget to avoid surprise overruns from the header itself
-- Shared budget primitive prevents divergence: manual and orchestrator sessions both use evaluateSessionContextBudget, so token-over-budget decisions never diverge between paths
-- Fail-open on all errors: try-catch in every layer means middleware failures never corrupt the response; original handler result is returned
-- Escape hatches are respected: compact: false bypasses compaction; undefined/zero maxTokens makes context-budget a no-op (byte-identical)
-- Tool names drive pipeline routing: compact tool skips double-wrapping; lossless-only tools skip truncation strategy; different tools get structural-only or structural+truncation pipelines
-- Context budget is WARN authority, not reject: over-budget responses append a steer notice toward graph-scoped retrieval (code_outline, code_unfold, find_context_for) but never hard-fail the tool
 
 ## Interface Contract
 
@@ -30,14 +14,19 @@ members: ['compaction.ts', 'context-budget.ts', 'injection-guard.ts']
 export applyCompaction
 export applyContextBudget
 export applyInjectionGuard
+export applyVersionGuard
 export wrapWithCompaction
 export wrapWithContextBudget
 export wrapWithInjectionGuard
+export wrapWithVersionGuard
 ```
 
 ## Dependency Slice
 
 ```
+import { envEnabled } from '../../utils/env-flag.js'
+import { GUARDED_MCP_TOOLS, evaluateVersionGuard, findProjectRoot, resolveExpectedVersion } from '../../utils/version-guard.js'
+import { CLI_VERSION } from '../../version.js'
 import { CompactionPipeline, DEFAULT_TOKEN_BUDGET, DESTRUCTIVE_BASH, InjectionFinding, StructuralStrategy, TruncationStrategy, checkTaint, estimateTokens, evaluateSessionContextBudget, scanForInjection, spillIfNeeded, writeTaint } from '@harness-engineering/core'
 import { realpathSync } from 'node:fs'
 import { resolve } from 'node:path'

--- a/.harness/comprehension/packages/cli/src/utils/_module.md
+++ b/.harness/comprehension/packages/cli/src/utils/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/utils'
-sourceHash: 'e66cece86d5e273c931ed94a40b9b60df27560b32c289b95b7e0dd29c1c135ac'
-compiledAt: '2026-08-28T01:22:09.518Z'
+sourceHash: '7725781afcf97977b80b91d43a22bd90e0ecf4d548384086d532257c931dd608'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'concurrency.ts',
@@ -22,26 +21,13 @@ members:
   ]
 ---
 
-## Summary
-
-`packages/cli/src/utils` is a foundational support library providing error handling (semantic exit codes), directory discovery and path resolution (walking up to locate `agents/`, `personas/`, `skills/`), concurrency control, file discovery with shared ignore patterns, Node version validation, one-time setup tracking via marker file in `~/.harness/`, and degrade-safe guardian diff-coverage context loading. It bridges framework-level and project-level concerns, distinguishing harness bundled resources from adopter project resources.
-
-## Invariants
-
-- Project vs. harness distinction via null return — resolveProjectSkillsDir() and resolveProjectPersonasDir() return null (not fallback to bundled), preventing adopter projects from accidentally writing to the harness's own bundled skill/persona directories.
-- Dual-path fallback for bundled resources — Path resolvers first walk up from \_\_dirname (dev/monorepo), then fall back to dist/ bundled paths (production). This dual-path is required for both monorepo dev and npm-installed harness to work.
-- Marker files distinguish framework dirs from code — findUpFrom() uses marker files (e.g., base/template.json for templates/, personas subdir for agents/) to disambiguate actual framework directories from same-named code directories.
-- Exit codes are semantic and must be distinct — ExitCode.VALIDATION_FAILED (1), ERROR (2), and ZERO_DENOMINATOR (3) are consumed by gates and CI to distinguish validation issues from runtime errors from 'examined nothing' abstentions.
-- Guardian coverage is degrade-safe — loadGuardianCoverage() never throws; missing intelligence package or archives return undefined. Commands that call it must handle undefined and degrade gracefully.
-- Concurrency errors don't sink the batch — mapWithConcurrency() places per-task errors in the results array rather than rejecting wholesale, so maintenance sweeps complete even if some items fail.
-- First-run setup is CI-aware and idempotent — markSetupComplete() is safe to call repeatedly; printFirstRunWelcome() skips in CI, when --quiet is set, or if marker file exists.
-
 ## Interface Contract
 
 ```ts
 export CLIError
 export ExitCode
 export GUARDED_COMMANDS
+export GUARDED_MCP_TOOLS
 export REQUIRED_NODE_VERSION
 export checkNodeVersion
 export envEnabled

--- a/.harness/comprehension/packages/cli/tests/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/_module.md
@@ -1,32 +1,23 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/mcp"
-sourceHash: "34e4f8500a485d17691d9a48a77b3be5625c26501da9dc2af9115276be89f3a7"
-compiledAt: "2026-08-29T14:14:27.817Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["config-resolver.test.ts", "context-surface.test.ts", "dispatch-skills.test.ts", "result-adapter.test.ts", "server-integration.test.ts", "server.test.ts", "tool-tiers.test.ts", "update-check-hook.test.ts"]
+module: 'packages/cli/tests/mcp'
+sourceHash: '727b316c63b7d5d046ca58a72fded631670a27e5564068a17de2897f1a80b016'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'config-resolver.test.ts',
+    'context-surface.test.ts',
+    'dispatch-skills.test.ts',
+    'result-adapter.test.ts',
+    'server-integration.test.ts',
+    'server.test.ts',
+    'tool-tiers.test.ts',
+    'update-check-hook.test.ts',
+    'version-guard-surface.test.ts',
+  ]
 ---
-
-## Summary
-
-`packages/cli/tests/mcp` is the test suite for the Harness MCP (Model Context Protocol) server that exposes harness CLI capabilities to Claude and other LLM clients. The module tests four layers: **config resolution** (finding `harness.config.json`), **tool registration** (115 tools + 9 resources), **context budgeting** (a three-tier system exposing core/standard/full subsets based on token budget), and **tool handlers** (converting internal Result types to MCP responses, routing dispatch_skills to auto-detect or explicit modes).
-
-The tests cover config loading via Result-type error handling, a three-tier system where CORE ⊂ STANDARD ⊂ FULL with budget-driven tier selection, server initialization verifying tool/resource counts and preventing leakage of removed tools, context surface gathering producing per-tier token attribution reports, dispatch_skills routing with conditional paths (auto-detect via git vs. explicit via enrichment), Result adapter format conversion, and middleware wrapping for context budgets and prompt injection guards.
-
-## Invariants
-
-- Tier hierarchy: CORE_TOOL_NAMES is a strict subset of STANDARD_TOOL_NAMES; both are subsets of all tools. Violations break budget-driven tier selection.
-- Server registration count: Exactly 115 tools and 9 resources. Any tool add/removal updates this count.
-- Tool presence: validate_project, check_dependencies, manage_adr, outcome_eval, dispatch_skills must be registered. Removed tools (manage_handoff, apply_fixes) must NOT appear.
-- dispatch_skills routing: No files + no commitMessage → dispatchSkillsFromGit; either field present → enrichSnapshotForDispatch + dispatchSkills. Violating this breaks skill discovery.
-- Result adapter JSON wrapping: Ok(string) bypasses JSON; Ok(object) gets stringified; Err(e) sets isError:true. Broken wrapping breaks downstream parsing.
-- Context budget no-op: wrapWithContextBudget is byte-identical pass-through when maxTokens ≤ 0. Modifying content in this case breaks transparent layering.
-- Resource stability metadata: Every resource must declare _meta.stability ∈ {static, session, ephemeral}. Missing or invalid hints break client caching assumptions.
-- Tool tier enforcement: selectTier filters to only tools defined in the registry; override/budget can narrow but not widen to undefined tools.
-- dispatch_skills schema: All input fields optional (required:[]). Description must contain 'skill sequence'. Violations break schema contracts.
-- Core tier coverage: CORE must include essential tools (validate_project, code_search, compact) so the server can function in ultra-tight contexts.
 
 ## Interface Contract
 
@@ -50,8 +41,11 @@ import { Err, Ok, buildAttributionReport, getUpdateNotification, heuristicTokenC
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import * as fs, { readFileSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import * as os from 'os'
 import * as path, { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/docs/changes/version-skew-guard-mcp-surface-1301/provenance.json
+++ b/docs/changes/version-skew-guard-mcp-surface-1301/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issue": [1301],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/cli/tests/mcp/version-guard-surface.test.ts",
+  "closingKeyword": "Closes",
+  "assumptions": [
+    "Guard relocated/duplicated to the shared check-impl entry so both CLI and MCP fire it: the shared evaluator evaluateVersionGuard (and resolveExpectedVersion/findProjectRoot) in packages/cli/src/utils/version-guard.ts is now invoked from the MCP dispatch boundary via a new applyVersionGuard middleware, in addition to the existing commander preAction hook.",
+    "No double-guarding: the CLI commander hook and the MCP middleware are disjoint entry points (an MCP call never passes through commander; a CLI action never passes through the MCP handler map), so a given findings request is evaluated exactly once.",
+    "Gated MCP tools are the in-process twins of the guarded CLI commands (run_security_scan, check_docs, check_dependencies, check_performance, validate_project, run_ci_checks, validate_cross_check, detect_entropy); non-findings tools are never gated so a session can still recover.",
+    "MCP enforcement adapts the surface: refuse -> isError result (analogue of CLI exit 3, tool never runs); warn -> proceed with notice prepended; HARNESS_NO_VERSION_GUARD downgrades refuse->warn identically to the CLI."
+  ]
+}

--- a/packages/cli/src/mcp/middleware/version-guard.ts
+++ b/packages/cli/src/mcp/middleware/version-guard.ts
@@ -1,0 +1,121 @@
+/**
+ * MCP-surface toolchain version guard.
+ *
+ * PR #1293 added a version-skew guard that refuses to produce findings when the
+ * running CLI is sharply out of step with the workspace's declared
+ * `toolchain.cliVersion`. It was wired as a commander `preAction` hook, so it
+ * fires only on CLI invocations. MCP tools call the same check implementations
+ * in-process through a different entry point (`bin/harness-mcp` → the server's
+ * `CallToolRequest` handler), which never runs the commander hook — so a stale
+ * `harness-mcp` shim reproduced the original incident unmitigated (#1301).
+ *
+ * This middleware closes that gap by applying the SAME decision logic
+ * ({@link evaluateVersionGuard}) at the MCP dispatch boundary. It is NOT a second
+ * copy of the ladder: the CLI hook and this wrapper both call the one shared
+ * evaluator, so the two surfaces can never diverge on when to refuse. There is no
+ * double-guarding — the two entry points are disjoint (an MCP call never passes
+ * through commander, and a CLI action never passes through this map), so a given
+ * findings request is evaluated exactly once, on whichever surface it arrived.
+ *
+ * Enforcement is adapted to the surface: a refusal returns an `isError` result
+ * (the MCP analogue of the CLI's exit 3) and the underlying tool never runs; a
+ * warning proceeds and prepends the notice so the session still sees it. The
+ * `HARNESS_NO_VERSION_GUARD` escape hatch downgrades a refusal to a warning here
+ * exactly as it does on the CLI.
+ *
+ * Fail-open: any error while deciding returns the raw handler unchanged — a
+ * broken guard must never break the MCP server, mirroring the CLI hook's
+ * try/catch.
+ */
+
+import { CLI_VERSION } from '../../version.js';
+import { envEnabled } from '../../utils/env-flag.js';
+import {
+  GUARDED_MCP_TOOLS,
+  evaluateVersionGuard,
+  findProjectRoot,
+  resolveExpectedVersion,
+} from '../../utils/version-guard.js';
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+type ToolHandler = (input: Record<string, unknown>) => Promise<ToolResult>;
+
+/** Configuration for the MCP version-guard middleware. */
+export interface VersionGuardMiddlewareOptions {
+  /**
+   * The server's resolved project root. Used to resolve the expected CLI version
+   * when a tool call carries no `path` argument of its own.
+   */
+  projectRoot: string;
+}
+
+/** Prepend the version-skew notice as a leading text item. */
+function prependNotice(result: ToolResult, notice: string): ToolResult {
+  return {
+    ...result,
+    content: [{ type: 'text', text: notice }, ...result.content],
+  };
+}
+
+/**
+ * Wrap one findings-producing MCP tool handler with the version-skew guard.
+ *
+ * The workspace evaluated is the one the call targets: findings tools take a
+ * `path` argument naming the project to scan, so its `harness.config.json`
+ * pin is what governs — falling back to the server's `projectRoot` when the
+ * call carries no `path`. This mirrors the CLI guard, which resolves the pin
+ * from the directory the command operates on.
+ */
+export function wrapWithVersionGuard(
+  toolName: string,
+  handler: ToolHandler,
+  options: VersionGuardMiddlewareOptions
+): ToolHandler {
+  if (!GUARDED_MCP_TOOLS.has(toolName)) return handler;
+
+  return async (input: Record<string, unknown>): Promise<ToolResult> => {
+    let result;
+    try {
+      const callPath = typeof input['path'] === 'string' ? (input['path'] as string) : undefined;
+      const projectRoot = findProjectRoot(callPath ?? options.projectRoot);
+      result = evaluateVersionGuard(CLI_VERSION, resolveExpectedVersion(projectRoot), {
+        bypass: envEnabled(process.env['HARNESS_NO_VERSION_GUARD']),
+        commandPath: toolName,
+      });
+    } catch {
+      // Fail-open: a broken guard must never break the tool. Deciding not to
+      // scan is deliberate; crashing on the way to deciding is not.
+      return handler(input);
+    }
+
+    if (result.status === 'refuse') {
+      // The MCP analogue of the CLI's exit 3: the tool examined nothing, so the
+      // caller must not mistake this for a completed scan. The handler is never
+      // invoked.
+      return { content: [{ type: 'text', text: result.message }], isError: true };
+    }
+
+    if (result.status === 'warn') {
+      const out = await handler(input);
+      return prependNotice(out, result.message);
+    }
+
+    // ok / unknown — proceed untouched.
+    return handler(input);
+  };
+}
+
+/**
+ * Wrap every findings-producing handler in a handlers map with the version
+ * guard. Non-findings handlers are returned unwrapped (byte-identical no-op).
+ */
+export function applyVersionGuard(
+  handlers: Record<string, ToolHandler>,
+  options: VersionGuardMiddlewareOptions
+): Record<string, ToolHandler> {
+  const wrapped: Record<string, ToolHandler> = {};
+  for (const [name, handler] of Object.entries(handlers)) {
+    wrapped[name] = wrapWithVersionGuard(name, handler, options);
+  }
+  return wrapped;
+}

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -14,6 +14,7 @@ import {
 import { applyInjectionGuard } from './middleware/injection-guard.js';
 import { applyCompaction } from './middleware/compaction.js';
 import { applyContextBudget } from './middleware/context-budget.js';
+import { applyVersionGuard } from './middleware/version-guard.js';
 import { validateToolDefinition, handleValidateProject } from './tools/validate.js';
 import { checkDependenciesDefinition, handleCheckDependencies } from './tools/architecture.js';
 import { checkDocsDefinition, handleCheckDocs } from './tools/docs.js';
@@ -784,7 +785,12 @@ export function createHarnessServer(projectRoot?: string, toolFilter?: string[])
   const trustedOutputTools = new Set(
     definitions.filter((t) => t.trustedOutput === true).map((t) => t.name)
   );
-  const guardedHandlers = applyInjectionGuard(handlers, {
+  // Version-skew guard FIRST (innermost), so a refusal short-circuits before the
+  // findings tool runs and before any output-scanning middleware wraps it. This
+  // is the MCP twin of the CLI commander preAction hook (#1301): both surfaces
+  // now route findings requests through the same shared evaluator.
+  const versionGuardedHandlers = applyVersionGuard(handlers, { projectRoot: resolvedRoot });
+  const guardedHandlers = applyInjectionGuard(versionGuardedHandlers, {
     projectRoot: resolvedRoot,
     trustedOutputTools,
   });

--- a/packages/cli/src/utils/version-guard.ts
+++ b/packages/cli/src/utils/version-guard.ts
@@ -63,6 +63,43 @@ export const GUARDED_COMMANDS: ReadonlySet<string> = new Set([
   'review-ci',
 ]);
 
+/**
+ * The MCP tools whose output is a findings list a human or an orchestrator acts
+ * on. These are the in-process twins of {@link GUARDED_COMMANDS}: an MCP client
+ * calls the same check implementations the guarded CLI commands wrap, but the
+ * commander `preAction` hook that installs the CLI guard never runs on the MCP
+ * surface (it is a separate entry point — `bin/harness-mcp` → a request handler,
+ * not a commander action). So a stale `harness-mcp` shim reproduces the original
+ * version-skew incident unmitigated (#1301). This set lets the MCP server apply
+ * the SAME decision logic ({@link evaluateVersionGuard}) at its own entry point.
+ *
+ * Each entry maps to its guarded CLI twin so the two lists cannot silently
+ * diverge on what "findings-producing" means:
+ *   run_security_scan   → check-security
+ *   check_docs          → check-docs
+ *   check_dependencies  → check-deps
+ *   check_performance   → check-perf
+ *   validate_project    → validate
+ *   run_ci_checks       → review-ci
+ *   validate_cross_check→ cross-check
+ *   detect_entropy      → cleanup
+ *
+ * Kept in this module — the shared home of the guard's decision logic — rather
+ * than in the MCP layer, so both surfaces read the same definition of what is
+ * gated. Non-findings tools (context/graph/state/craft) are never gated: a guard
+ * that blocked them would block the very tools a session needs to recover.
+ */
+export const GUARDED_MCP_TOOLS: ReadonlySet<string> = new Set([
+  'run_security_scan',
+  'check_docs',
+  'check_dependencies',
+  'check_performance',
+  'validate_project',
+  'run_ci_checks',
+  'validate_cross_check',
+  'detect_entropy',
+]);
+
 export type VersionGuardStatus = 'ok' | 'unknown' | 'warn' | 'refuse';
 export type ExpectedVersionSource = 'config' | 'dependency';
 

--- a/packages/cli/tests/mcp/version-guard-surface.test.ts
+++ b/packages/cli/tests/mcp/version-guard-surface.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Reproducing test for #1301 — the toolchain version-skew guard (PR #1293) was
+ * wired only as a commander preAction hook, so it fired on CLI invocations but
+ * NOT on the MCP surface. MCP tools call the same findings-producing check
+ * implementations in-process through the server's CallToolRequest handler, which
+ * never runs the commander hook — a stale `harness-mcp` shim reproduced the
+ * original incident unmitigated.
+ *
+ * These tests drive the REAL MCP dispatch path end-to-end (a linked in-memory
+ * client/server pair against `createHarnessServer`), so they exercise the shared
+ * entry point both surfaces share rather than a mocked seam.
+ *
+ * Before the fix: a findings call under sharp version skew is NOT blocked — the
+ * scan runs and returns a normal result. After the fix: it is refused with an
+ * `isError` result and the tool never runs.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createHarnessServer } from '../../src/mcp/server';
+
+type ToolCallResult = {
+  isError?: boolean;
+  content: Array<{ type: string; text?: string }>;
+};
+
+function resultText(result: ToolCallResult): string {
+  return result.content
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text ?? '')
+    .join('\n');
+}
+
+async function callTool(
+  projectRoot: string,
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolCallResult> {
+  const server = createHarnessServer(projectRoot);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' }, { capabilities: {} });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  try {
+    return (await client.callTool({ name, arguments: args })) as unknown as ToolCallResult;
+  } finally {
+    await client.close();
+  }
+}
+
+describe('MCP surface version-skew guard (#1301)', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'harness-version-guard-mcp-'));
+    // The guard reads process.env at call time; keep the escape hatch off so the
+    // refusal path is the one under test unless a test opts in explicitly.
+    delete process.env['HARNESS_NO_VERSION_GUARD'];
+  });
+
+  afterEach(() => {
+    delete process.env['HARNESS_NO_VERSION_GUARD'];
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  function pinCliVersion(range: string): void {
+    writeFileSync(
+      join(projectRoot, 'harness.config.json'),
+      JSON.stringify({ toolchain: { cliVersion: range } }, null, 2)
+    );
+  }
+
+  it('refuses an MCP findings call when the CLI is sharply out of step', async () => {
+    // A workspace that expects a far-newer CLI line than the one running. The
+    // running CLI is many majors behind, which is the "refuse" rung of the ladder.
+    pinCliVersion('>=9999.0.0');
+
+    const result = await callTool(projectRoot, 'run_security_scan', { path: projectRoot });
+
+    // Fails before the fix (the scan ran and returned a normal result); passes
+    // after (the guard blocks the findings call on the MCP surface too).
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain('refusing to run');
+  });
+
+  it('does not block when the running CLI satisfies the workspace pin', async () => {
+    // An any-CLI pin the running version always satisfies — the guard stays
+    // silent, and the tool runs normally (no false positive, CLI path unaffected).
+    pinCliVersion('>=1.0.0');
+
+    const result = await callTool(projectRoot, 'run_security_scan', { path: projectRoot });
+
+    expect(result.isError).toBeFalsy();
+    expect(resultText(result)).not.toContain('refusing to run');
+  });
+
+  it('does not block a non-findings tool even under sharp skew', async () => {
+    // The guard gates only findings-producing tools. A context/graph/state tool
+    // a session needs to recover must never be blocked.
+    pinCliVersion('>=9999.0.0');
+
+    const result = await callTool(projectRoot, 'manage_state', {
+      action: 'get',
+      path: projectRoot,
+    });
+
+    expect(resultText(result)).not.toContain('refusing to run');
+  });
+
+  it('HARNESS_NO_VERSION_GUARD downgrades a refusal to a warning and still runs', async () => {
+    pinCliVersion('>=9999.0.0');
+    process.env['HARNESS_NO_VERSION_GUARD'] = '1';
+
+    const result = await callTool(projectRoot, 'run_security_scan', { path: projectRoot });
+
+    // Downgraded: not an error, the scan ran, but the notice is still surfaced.
+    expect(result.isError).toBeFalsy();
+    expect(resultText(result)).toContain('HARNESS_NO_VERSION_GUARD is set');
+  });
+});


### PR DESCRIPTION
Closes #1301

## Root cause

The version-skew guard added in #1293 refuses findings-producing commands when the running CLI is sharply out of step with the workspace's declared `toolchain.cliVersion`. It was wired as a **commander `preAction` hook** (`installVersionGuard`), so it only fires on CLI invocations. MCP tools call the same findings-producing check implementations **in-process** through the server's `CallToolRequest` handler — a separate entry point (`bin/harness-mcp`) the commander hook never runs. A stale `harness-mcp` shim therefore reproduced the original incident unmitigated: the tool emitted well-formed, confident, wrong findings with no refusal.

#1293's own body named this explicitly (assumption #12): "The MCP surface is out of scope and now says so explicitly ... Named as the natural follow-up." This is that follow-up.

## Fix

Add an MCP dispatch-boundary middleware, `applyVersionGuard` (`packages/cli/src/mcp/middleware/version-guard.ts`), wired into `createHarnessServer` **first** (innermost), so a refusal short-circuits before the findings tool runs and before any output-scanning middleware.

- It calls the **same shared evaluator** — `evaluateVersionGuard` / `resolveExpectedVersion` / `findProjectRoot` in `packages/cli/src/utils/version-guard.ts` — that the CLI hook uses. Not a second copy of the ladder; the two surfaces cannot diverge on when to refuse.
- **No double-guarding.** The commander hook and this middleware are disjoint entry points (an MCP call never passes through commander; a CLI action never passes through the MCP handler map), so a given findings request is evaluated exactly once. The CLI path is unchanged.
- The gated set (`GUARDED_MCP_TOOLS`, kept in the shared guard module next to `GUARDED_COMMANDS`) is the findings tools that are the in-process twins of the guarded CLI commands: `run_security_scan`, `check_docs`, `check_dependencies`, `check_performance`, `validate_project`, `run_ci_checks`, `validate_cross_check`, `detect_entropy`. Non-findings tools are never gated so a session can still recover.
- Enforcement adapts to the surface: **refuse** → `isError` result (the MCP analogue of the CLI's exit 3) and the tool never runs; **warn** → proceed with the notice prepended; `HARNESS_NO_VERSION_GUARD` downgrades a refusal to a warning exactly as on the CLI.
- Fail-open: any error while deciding returns the raw handler unchanged — a broken guard must never break the MCP server.

## Reproducing test

`packages/cli/tests/mcp/version-guard-surface.test.ts` drives the **real MCP dispatch path end-to-end** (a linked in-memory client/server pair against `createHarnessServer`), exercising the shared entry point rather than a mocked seam.

- **FAILS before:** under a `>=9999` pin, `run_security_scan` runs and returns a normal scan result (not blocked) — verified by temporarily disabling the wiring: the refuse + bypass tests fail with the raw scan output.
- **PASSES after:** the call is refused with `isError` and "refusing to run"; the tool never runs.
- Also covers: satisfied pin proceeds silently, non-findings tool (`manage_state`) never blocked, and `HARNESS_NO_VERSION_GUARD` downgrade-to-warn.

## Verification

- New test: 4/4 pass; fail-before/pass-after confirmed by toggling the wiring.
- `tests/mcp/{server,server-integration}` + `tests/utils/version-guard{,-wiring}` — 107/107 pass (tool-count assertion unaffected; no MCP tools added).
- `pnpm --filter @harness-engineering/cli typecheck` / `lint` clean (2 pre-existing unrelated warnings). CLI built. Pre-commit + pre-push gates passed without `--no-verify`.

Provenance: `docs/changes/version-skew-guard-mcp-surface-1301/provenance.json`. Changeset: patch on `@harness-engineering/cli`.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga