### PR TITLE
fix(roadmap): escape commas inside blockedBy/plan list items (#1757)

### DIFF
--- a/.changeset/roadmap-comma-in-list-item-1757.md
+++ b/.changeset/roadmap-comma-in-list-item-1757.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(roadmap): preserve a comma inside a single `Blockers`/`Plan` list item
+across a serialize → parse round-trip (#1757).
+
+The roadmap grammar joined a feature's `blockedBy` / `plans` array with `", "`
+on write and split the re-read value back on `","` with no escaping on read, so a
+single list item that itself contained a comma — e.g. a feature name authored via
+the MCP `manage_roadmap` write path, `"Notification System, phase 2"` — split
+into two items on the next parse, silently fabricating a blocker (or plan step)
+that never existed.
+
+Adds a reversible comma-escape codec (`roadmap/list-field.ts`, mirroring the
+sibling summary codec from #1756) wired into the shared `serializeFeature` /
+`parseFeatureBlock` seam. Plain comma-free items are an identity under the codec,
+so existing roadmaps re-serialize byte-for-byte unchanged.

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '57cf13fb3e3e88a5da946d41ee94da82490edcdad43bf6be882d554d26cbf366'
+sourceHash: 'bd2857a9a116227e1acf98f7888236b5ed209bd2e7a0a213b2f7b46568facdd7'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -13,6 +13,7 @@ members:
     'heading.ts',
     'health.ts',
     'index.ts',
+    'list-field.ts',
     'load-mode.test.ts',
     'load-mode.ts',
     'load-tracker-client-config.ts',
@@ -130,6 +131,7 @@ import * as eventSourcing from '../state/event-sourcing'
 import { assigneeInvariantHolds, isMachineAssignee, setStatus } from './assignee-lifecycle'
 import { deriveRepoFromGitRemote } from './derive-repo'
 import { GROUP_PREFIX, matchFeatureHeadings, serializeFeatureHeading } from './heading'
+import { decodeListField, encodeListField } from './list-field'
 import { detectRoadmapStorageMode } from './load-mode'
 import { RoadmapMode, RoadmapModeConfig, getRoadmapMode } from './mode'
 import { scoreRoadmapCandidatesFileLess } from './pilot-scoring-file-less'

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '95807281b2027ca3fa0bc250f6843c485b6c83487890333710faa877e11acf82'
+sourceHash: '0774acae016cddbadd9a652344de3c23338b36112f5befadafea23e77e1e4851'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -32,6 +32,7 @@ members:
     'referenced-issues.test.ts',
     'serialize-extended.test.ts',
     'serialize-groups.test.ts',
+    'serialize-list-field-comma.test.ts',
     'serialize-summary-multiline.test.ts',
     'serialize.test.ts',
     'sync-engine-guards.test.ts',
@@ -67,6 +68,7 @@ import { assigneeInvariantHolds, claim, isClaimableBy, isMachineAssignee, pushAs
 import { deriveRepoFromGitRemote, parseOwnerRepoFromRemoteUrl } from '../../src/roadmap/derive-repo'
 import { FEATURE_PREFIX, GROUP_PREFIX, matchFeatureHeadings, parseFeatureHeading, serializeFeatureHeading } from '../../src/roadmap/heading'
 import { checkRoadmapHealth, defaultIsArchive, groomRoadmap, isUnactionablePlanned } from '../../src/roadmap/health'
+import { decodeListField, encodeListItem } from '../../src/roadmap/list-field'
 import { loadProjectRoadmapMode } from '../../src/roadmap/load-mode'
 import { loadTrackerClientConfigFromProject } from '../../src/roadmap/load-tracker-client-config'
 import { RoadmapMode, getRoadmapMode } from '../../src/roadmap/mode'

--- a/docs/changes/roadmap-comma-in-list-item-1757/provenance.json
+++ b/docs/changes/roadmap-comma-in-list-item-1757/provenance.json
@@ -1,0 +1,10 @@
+{
+  "issue": [1757],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/core/tests/roadmap/serialize-list-field-comma.test.ts",
+  "closingKeyword": "Closes",
+  "assumptions": [
+    "Scoped to blockedBy/plan comma-in-item; builds on the #1756 codec already on main"
+  ]
+}

--- a/packages/core/src/roadmap/list-field.ts
+++ b/packages/core/src/roadmap/list-field.ts
@@ -1,0 +1,79 @@
+/**
+ * Escape codec for the comma-separated list bullets `- **Blockers:** a, b` and
+ * `- **Plan:** a, b`.
+ *
+ * The roadmap grammar joins a feature's `blockedBy` / `plans` array with `", "`
+ * on write (`listOrDash`) and splits the re-read value back on `","` on read
+ * (`parseListField`). With no escaping, a single list item that itself contains a
+ * comma — e.g. a feature name authored via the MCP `manage_roadmap` write path,
+ * `"Notification System, phase 2"` — split into TWO items on the next parse,
+ * silently fabricating a blocker (or plan step) that never existed (#1757).
+ *
+ * The fix mirrors the sibling summary codec (#1756, `./summary-field`): encode the
+ * separator into a reversible per-item escape on write, decode it back on read.
+ * The line grammar is untouched — items are still emitted on one `- **Field:**`
+ * bullet joined by `", "` — so the shard store, the comprehension shards, and the
+ * monolith roadmap document all keep byte-stable round-trips through the shared
+ * `serializeFeature` / `parseFeatureBlock` seam.
+ *
+ * Encoding order matters: the backslash is escaped FIRST so every backslash in the
+ * output is the start of exactly one `\\` / `\,` pair, which makes
+ * {@link decodeListField} an exact left-to-right inverse. A plain item contains no
+ * backslash and no comma, so both directions are identities on legacy content —
+ * existing roadmaps are unaffected. A legacy item that happens to contain a bare
+ * backslash (never an escape the old serializer emitted) decodes unchanged because
+ * an unrecognized `\x` sequence is preserved verbatim.
+ */
+
+/** Encode a single list item so its commas and backslashes survive the join/split. */
+export function encodeListItem(item: string): string {
+  return item.replace(/\\/g, '\\\\').replace(/,/g, '\\,');
+}
+
+/**
+ * Serialize a list field to its bullet value: encode each item, join with `", "`.
+ * Returns `undefined` for an empty list so the caller can emit the em-dash form.
+ */
+export function encodeListField(items: string[]): string | null {
+  if (items.length === 0) return null;
+  return items.map(encodeListItem).join(', ');
+}
+
+/**
+ * Split an encoded list-field value back into its items, honoring `\,` escapes,
+ * and decode each one. The scan is a strict left-to-right inverse of
+ * {@link encodeListItem}: only a comma NOT part of a `\,` escape is a separator.
+ * Items are trimmed to preserve the historical `", "` join spacing.
+ */
+export function decodeListField(raw: string): string[] {
+  const items: string[] = [];
+  let current = '';
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === '\\' && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      if (next === '\\') {
+        current += '\\';
+        i += 1;
+        continue;
+      }
+      if (next === ',') {
+        current += ',';
+        i += 1;
+        continue;
+      }
+      // Unrecognized escape (e.g. legacy content with a bare backslash): keep the
+      // backslash literally so decode is a no-op on pre-codec roadmaps.
+      current += ch;
+      continue;
+    }
+    if (ch === ',') {
+      items.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  items.push(current.trim());
+  return items;
+}

--- a/packages/core/src/roadmap/parse.ts
+++ b/packages/core/src/roadmap/parse.ts
@@ -18,6 +18,10 @@ import { GROUP_PREFIX, matchFeatureHeadings } from './heading';
 // shared with the serializer, so the continuation of a multi-line summary is
 // restored on read rather than silently dropped by the line grammar (#1756).
 import { decodeSummaryField } from './summary-field';
+// The list-field escape codec lives in `./list-field`, the single source of truth
+// for the reversible comma escaping shared by the `Blockers` / `Plan` bullets
+// (see that module for the grammar rationale, #1757).
+import { decodeListField } from './list-field';
 
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   'backlog',
@@ -260,7 +264,7 @@ function parseListField(fieldMap: Map<string, string>, ...keys: string[]): strin
     }
   }
   if (raw === EM_DASH || raw === 'none') return [];
-  return raw.split(',').map((s) => s.trim());
+  return decodeListField(raw);
 }
 
 /** Validate and return the status field, or an Err if invalid. */

--- a/packages/core/src/roadmap/serialize.ts
+++ b/packages/core/src/roadmap/serialize.ts
@@ -11,6 +11,10 @@ import { serializeFeatureHeading } from './heading';
 // shared with the parser, so a multi-line summary survives the line-oriented
 // grammar's parse → serialize round-trip intact (#1756).
 import { encodeSummaryField } from './summary-field';
+// The list-field escape codec lives in `./list-field`, the single source of truth
+// for the reversible comma escaping shared by the `Blockers` / `Plan` bullets
+// (see that module for the grammar rationale, #1757).
+import { encodeListField } from './list-field';
 
 const EM_DASH = '\u2014';
 
@@ -90,7 +94,7 @@ function orDash(value: string | null | undefined): string {
 }
 
 function listOrDash(items: string[]): string {
-  return items.length > 0 ? items.join(', ') : EM_DASH;
+  return encodeListField(items) ?? EM_DASH;
 }
 
 function serializeExtendedLines(feature: RoadmapFeature): string[] {

--- a/packages/core/tests/roadmap/serialize-list-field-comma.test.ts
+++ b/packages/core/tests/roadmap/serialize-list-field-comma.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import { encodeListItem, decodeListField } from '../../src/roadmap/list-field';
+import { VALID_ROADMAP } from './fixtures';
+
+// Regression guard for #1757: the `Blocked by` / `Plan` roadmap list fields used
+// to round-trip lossily through `serializeRoadmap` → `parseRoadmap`. `listOrDash`
+// joined a feature's array with ", " and `parseListField` split the re-read value
+// back on "," with NO escaping, so a single list item that itself contained a
+// comma — e.g. a feature name authored via the MCP `manage_roadmap` write path,
+// "Notification System, phase 2" — split into TWO items on the next parse,
+// silently fabricating a blocker (or plan step) that never existed.
+//
+// Before the fix the round-trip assertions FAIL (one authored item comes back as
+// two); after the reversible comma-escape codec is wired into `serializeFeature`
+// / `parseFeatureBlock` they PASS. The sibling multi-line summary bug (#1756) is a
+// SEPARATE grammar defect and is intentionally NOT exercised here.
+describe('roadmap round-trip: comma inside a list item (#1757)', () => {
+  it('preserves a blockedBy item containing a comma through parse(serialize(roadmap))', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[1]!.blockedBy = ['Notification System, phase 2'];
+
+    const reparsed = parseRoadmap(serializeRoadmap(roadmap));
+
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+
+    // The whole roadmap survives intact — the one blocker stays one blocker.
+    expect(reparsed.value).toEqual(roadmap);
+    expect(reparsed.value.milestones[0]!.features[1]!.blockedBy).toEqual([
+      'Notification System, phase 2',
+    ]);
+  });
+
+  it('preserves a plan item containing a comma, and keeps sibling items separate', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[0]!.plans = [
+      'Ship email, in-app, and push channels',
+      'docs/plans/2026-03-15-notification-phase-2-plan.md',
+    ];
+
+    const reparsed = parseRoadmap(serializeRoadmap(roadmap));
+
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+
+    // The comma-bearing item stays whole AND the genuine ", " item boundary still
+    // splits: two authored items round-trip as exactly two items.
+    expect(reparsed.value.milestones[0]!.features[0]!.plans).toEqual([
+      'Ship email, in-app, and push channels',
+      'docs/plans/2026-03-15-notification-phase-2-plan.md',
+    ]);
+  });
+
+  it('keeps a comma-bearing list item stable across a second round-trip (idempotent)', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[1]!.blockedBy = ['Auth, SSO, and MFA', 'Billing'];
+
+    const once = serializeRoadmap(roadmap);
+    const reparsed = parseRoadmap(once);
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+    const twice = serializeRoadmap(reparsed.value);
+
+    // Byte-stable regen: re-serializing the reparsed roadmap yields the same bytes.
+    expect(twice).toBe(once);
+  });
+
+  it('escapes the embedded comma onto the single Blockers bullet on write', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.milestones[0]!.features[1]!.blockedBy = ['Notification System, phase 2'];
+
+    const lines = serializeRoadmap(roadmap).split('\n');
+
+    // The comma is escaped in place rather than read back as an item boundary.
+    expect(lines).toContain('- **Blockers:** Notification System\\, phase 2');
+  });
+
+  it('leaves plain comma-free list items byte-for-byte unchanged (legacy content)', () => {
+    // A path with no comma and no backslash is an identity under the codec, so
+    // existing roadmaps re-serialize to the exact same bytes.
+    const roadmap = structuredClone(VALID_ROADMAP);
+    const once = serializeRoadmap(roadmap);
+    const reparsed = parseRoadmap(once);
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+    expect(serializeRoadmap(reparsed.value)).toBe(once);
+    expect(encodeListItem('docs/plans/a-plan.md')).toBe('docs/plans/a-plan.md');
+  });
+
+  it('decodeListField is an exact inverse of encodeListItem for tricky values', () => {
+    for (const items of [
+      ['a, b'],
+      ['a', 'b'],
+      ['trailing comma,'],
+      ['path\\to\\thing'], // a bare backslash must survive untouched
+      ['back\\, slash then comma'],
+      ['多, 语言'],
+      [''],
+    ]) {
+      const encoded = items.map(encodeListItem).join(', ');
+      expect(decodeListField(encoded)).toEqual(items);
+    }
+  });
+});


### PR DESCRIPTION
Closes #1757

## Root cause

The roadmap serialize/parse grammar round-tripped list fields lossily:

- `listOrDash` joined a feature's `blockedBy` / `plans` array with `", "` (`packages/core/src/roadmap/serialize.ts`).
- `parseListField` split the re-read value back on `","` with **no escaping** (`packages/core/src/roadmap/parse.ts`).

So a single list item that itself contained a comma — e.g. a feature name authored via the MCP `manage_roadmap` write path, `"Notification System, phase 2"` — split into **two** items on the next parse, silently fabricating a blocker (or plan step) that never existed (and whose fabricated half does not even name a real feature).

## Fix

Adds a reversible comma-escape codec `packages/core/src/roadmap/list-field.ts` (`encodeListItem` / `encodeListField` / `decodeListField`), mirroring the sibling multi-line-summary codec from #1756 (`summary-field.ts`). On write each item escapes `\` → `\\` then `,` → `\,` (backslash first, so decode is an exact left-to-right inverse); items are still joined by `", "` on one bullet. On read the value is split only on an **un-escaped** comma and each item decoded. Wired into the shared `serializeFeature` / `parseFeatureBlock` seam, so the shard store, comprehension shards, and monolith roadmap all benefit.

The line grammar is untouched and plain comma-free items are an identity under the codec, so **existing roadmaps re-serialize byte-for-byte unchanged**. A legacy item carrying a bare backslash decodes verbatim (unrecognized `\x` is preserved), so pre-codec content is never corrupted.

## Test

`packages/core/tests/roadmap/serialize-list-field-comma.test.ts` — a proper regression guard (not `it.fails`). Proven **fail-before / pass-after**: reverting just the two grammar lines fails 3 assertions (blockedBy round-trip, plan round-trip + sibling-split, single-bullet escape); with the fix all 6 pass, and the full 662-test roadmap suite is green. Covers both `blockedBy` and `plans`, idempotent byte-stable regen, legacy identity, and a codec-inverse property sweep (backslashes, trailing comma, unicode).

Provenance: `docs/changes/roadmap-comma-in-list-item-1757/provenance.json`.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga