### PR TITLE
fix(mcp): fail loudly instead of green-ticking zero pattern rules (#1792)

### DIFF
--- a/.changeset/mcp-entropy-patterns-empty-ruleset-1792.md
+++ b/.changeset/mcp-entropy-patterns-empty-ruleset-1792.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(mcp): stop `detect_entropy(type: "patterns")` from reporting a false pass over zero rules (#1792)
+
+The MCP entropy tool passed `patterns` as a bare boolean, which the `EntropyAnalyzer` coerces into an empty rule set (`{ patterns: [] }`) — evaluating zero pattern rules yet reporting zero violations, a pass indistinguishable from a real check that found nothing. This is the same empty-ruleset false-pass fixed on the CLI `harness cleanup -t patterns` path in #1760 (PR #1791). The tool now reads pattern rules from the `entropy.patterns` config block, threads the configured rules into the analyzer, and fails loudly (`isError`) when `type: "patterns"` is requested with no rules configured instead of green-ticking an empty check. For `type: "all"`, patterns are skipped when unconfigured, preserving the common no-config path.

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: '600a10e61918c7b8d771af2fbf5dbb35604211d822fca7c43066c54c71650e64'
+sourceHash: '82e11cde90b0edf1f6473274e549395b219fe85364b80fbfaf11e4885d709f89'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -565,7 +565,7 @@ import { handleSummarizeSession, summarizeSessionDefinition } from './summarize-
 import { handleUatSignoff, uatSignoffDefinition } from './uat-signoff.js'
 import from './validate.js'
 import { handleSubscribeWebhook, subscribeWebhookDefinition } from './webhook-tools'
-import { CHARS_PER_TOKEN, COMPREHENSION_ROOT, CompactionPipeline, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, ConflictError, DEFAULT_INSTRUCTION_BUDGET, DriftConfig, Err, ExtractStatic, FeaturePatch, GenerateSemantic, LevelInstructionDensity, NewFeatureInput, Ok, PackedEnvelope, RefinementContextClass, RefinementDemandReport, RefinementOperation, RefinementRequest, Result, RoadmapPromoteCoreResult, RoadmapTrackerClient, SourceFile, StaticExtraction, StructuralStrategy, TrackedFeature, TrackerSyncAdapter, TruncationStrategy, aggregateDemand, analyzeSkillInstructionDensity, applyRoadmapDiff, archiveDoneShardsForProject, classifyRefinement, computeLoadPlan, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, createTrackerClient, decidePromotionForRow, detectRoadmapStorageMode, estimateTokens, extractLevel, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, paginate, renderServedUnit, resolveRoadmapStore, roadmapSourceExists, serializeEnvelope, serveGate, slugifyFeatureName } from '@harness-engineering/core'
+import { CHARS_PER_TOKEN, COMPREHENSION_ROOT, CompactionPipeline, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, ConflictError, DEFAULT_INSTRUCTION_BUDGET, DriftConfig, Err, ExtractStatic, FeaturePatch, GenerateSemantic, LevelInstructionDensity, NewFeatureInput, Ok, PackedEnvelope, PatternConfig, RefinementContextClass, RefinementDemandReport, RefinementOperation, RefinementRequest, Result, RoadmapPromoteCoreResult, RoadmapTrackerClient, SourceFile, StaticExtraction, StructuralStrategy, TrackedFeature, TrackerSyncAdapter, TruncationStrategy, aggregateDemand, analyzeSkillInstructionDensity, applyRoadmapDiff, archiveDoneShardsForProject, classifyRefinement, computeLoadPlan, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, createTrackerClient, decidePromotionForRow, detectRoadmapStorageMode, estimateTokens, extractLevel, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, paginate, renderServedUnit, resolveRoadmapStore, roadmapSourceExists, serializeEnvelope, serveGate, slugifyFeatureName } from '@harness-engineering/core'
 import { skipDirGlobs } from '@harness-engineering/graph'
 import { AnalysisProvider, CanaryAdapter, CanaryFrameworkInfo, GuardianAnalysis, createCanaryAdapter, readGuardianAnalyses, resolveTestCommand } from '@harness-engineering/intelligence'
 import from '@harness-engineering/linter-gen'

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/mcp/tools'
-sourceHash: 'b258fb855a32ff2019f63014dbf1f7f39804f5264447f0e800cf705a828ba4d5'
+sourceHash: '0f47fcc8d4da413ace144b32d4afd5220c0672725f27002c713ca6da45cba193'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -29,6 +29,7 @@ members:
     'docs-craft.test.ts',
     'docs.test.ts',
     'entropy-config-threading.test.ts',
+    'entropy-patterns-empty-ruleset.test.ts',
     'entropy.test.ts',
     'event-emitter.test.ts',
     'events-jsonl-retired.guard.test.ts',

--- a/docs/changes/mcp-entropy-patterns-empty-ruleset-1792/provenance.json
+++ b/docs/changes/mcp-entropy-patterns-empty-ruleset-1792/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issue": [1792],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/cli/tests/mcp/tools/entropy-patterns-empty-ruleset.test.ts",
+  "closingKeyword": "Closes",
+  "assumptions": [
+    "Mirrors #1791/#1760 fix on the MCP surface; reuses the entropy.patterns schema/config now on main",
+    "Root cause: handleDetectEntropy in packages/cli/src/mcp/tools/entropy.ts passed `patterns: typeFilter === 'all' || typeFilter === 'patterns'` (a bare boolean). EntropyAnalyzer coerces a bare-boolean true into `{ patterns: [] }` (analyzer.ts:129-133), so zero rules were evaluated yet the report showed zero violations / passRate 1 — a false pass.",
+    "Fix: read `entropy.patterns` (PatternConfig, added to the CLI EntropyConfigSchema by #1791), thread the configured rules into the analyzer, and return an MCP error (isError) when `type: patterns` is explicitly requested with no rules configured. For `type: all`, patterns are skipped (false) when unconfigured, preserving the common no-config path.",
+    "Reproducing test is integration-style (real config loader + analyzer + pattern detector, no mocks). Proven fail-before/pass-after by stashing only the entropy.ts source change: the two behavioral tests (fail-loud on zero rules; evaluate configured rules and report the real violation) fail against the old source and pass with the fix."
+  ]
+}

--- a/packages/cli/src/mcp/tools/entropy.ts
+++ b/packages/cli/src/mcp/tools/entropy.ts
@@ -1,5 +1,5 @@
 import { Ok } from '@harness-engineering/core';
-import type { DriftConfig } from '@harness-engineering/core';
+import type { DriftConfig, PatternConfig } from '@harness-engineering/core';
 import { skipDirGlobs } from '@harness-engineering/graph';
 import { resultToMcpResponse } from '../utils/result-adapter.js';
 import { sanitizePath } from '../utils/sanitize-path.js';
@@ -171,6 +171,38 @@ export async function handleDetectEntropy(input: {
     const driftConfig = entropy?.drift as Partial<DriftConfig> | undefined;
     const driftEnabled = typeFilter === 'all' || typeFilter === 'drift';
 
+    // Pattern rules come from `entropy.patterns` in harness.config.json. The
+    // previous implementation passed `patterns` as a bare boolean, which the
+    // EntropyAnalyzer coerces into an empty rule set (`{ patterns: [] }`). That
+    // evaluated ZERO rules yet reported zero violations / passRate 1 — a pass
+    // indistinguishable from a real pattern check that actually found nothing.
+    // This is the same empty-ruleset false-pass fixed on the CLI path in #1760
+    // (PR #1791). Read the configured rules instead, and refuse to green-tick a
+    // patterns check that has nothing to evaluate (#1792).
+    const patternsRequested = typeFilter === 'all' || typeFilter === 'patterns';
+    const patternConfig = entropy?.patterns as PatternConfig | undefined;
+    const configuredRuleCount =
+      (patternConfig?.patterns?.length ?? 0) + (patternConfig?.customPatterns?.length ?? 0);
+    const hasPatternRules = configuredRuleCount > 0;
+
+    // Fail loudly when patterns is the explicitly requested check but no rules
+    // are configured — an empty rule set cannot honestly report a pass (#1792).
+    if (typeFilter === 'patterns' && !hasPatternRules) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              'No pattern rules are configured, so detect_entropy(type: "patterns") has nothing ' +
+              'to evaluate. Add rules under `entropy.patterns` in harness.config.json, or request ' +
+              'a different check (type: "drift" | "dead-code"). Refusing to report a pass over ' +
+              'zero rules.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     // Project-wide analysis.exclude globs apply on top of the entropy-specific
     // excludes (or the built-in defaults when no entropy block is configured).
     const analysisExclude = loadAnalysisExclude(projectPath);
@@ -187,7 +219,10 @@ export async function handleDetectEntropy(input: {
       analyze: {
         drift: driftEnabled ? (driftConfig ?? true) : false,
         deadCode: typeFilter === 'all' || typeFilter === 'dead-code',
-        patterns: typeFilter === 'all' || typeFilter === 'patterns',
+        // Only run the pattern analyzer when real rules exist; a bare boolean
+        // becomes an empty rule set that misrepresents "checked" as "passed"
+        // (#1792). For `all`, patterns are simply skipped when unconfigured.
+        patterns: patternsRequested && hasPatternRules && patternConfig ? patternConfig : false,
       },
     });
 

--- a/packages/cli/tests/mcp/tools/entropy-patterns-empty-ruleset.test.ts
+++ b/packages/cli/tests/mcp/tools/entropy-patterns-empty-ruleset.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { handleDetectEntropy } from '../../../src/mcp/tools/entropy';
+
+// Regression for issue #1792: the MCP entropy tool used to pass `patterns` as a
+// bare boolean, which the EntropyAnalyzer coerces into an empty rule set
+// (`{ patterns: [] }`). That evaluated ZERO pattern rules yet reported zero
+// violations — a pass indistinguishable from a real check that found nothing —
+// the same empty-ruleset false-pass fixed on the CLI path in #1760 (PR #1791).
+//
+// This exercises the REAL config loader + analyzer + pattern detector (no mocks)
+// so it proves the tool actually threads configured rules through and refuses to
+// green-tick zero rules.
+let projectDir: string;
+
+function writeConfig(config: Record<string, unknown>): void {
+  fs.writeFileSync(
+    path.join(projectDir, 'harness.config.json'),
+    JSON.stringify({ version: 1, rootDir: '.', ...config }, null, 2)
+  );
+}
+
+// A source file that exports `banned` — a rule forbidding that export must fire.
+function writeSource(): void {
+  fs.mkdirSync(path.join(projectDir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectDir, 'src', 'example.ts'),
+    'export const banned = 1;\nexport const allowed = 2;\n'
+  );
+}
+
+// A declarative pattern rule that the source file above violates.
+const bannedExportRule = {
+  name: 'no-banned-export',
+  description: 'The `banned` symbol must not be exported',
+  severity: 'error' as const,
+  files: ['src/**/*.ts'],
+  rule: { type: 'no-export' as const, names: ['banned'] },
+};
+
+describe('detect_entropy — patterns empty-ruleset false-pass (issue #1792)', () => {
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-entropy-patterns-'));
+    writeSource();
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  // Fail-before: bare boolean → empty rule set → "no violations", isError
+  // undefined (a false pass). Pass-after: refuses to report a pass over zero
+  // rules.
+  it('fails loudly when type=patterns has no configured rules', async () => {
+    writeConfig({ entropy: { entryPoints: ['src/example.ts'] } });
+    const result = await handleDetectEntropy({ path: projectDir, type: 'patterns' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/no pattern rules/i);
+  });
+
+  // Fail-before: bare boolean → empty rule set → the configured rule is never
+  // evaluated, so the real violation is missed and the tool reports clean.
+  // Pass-after: the configured rule is threaded through and the violation is
+  // reported.
+  it('evaluates configured pattern rules and reports real violations', async () => {
+    writeConfig({
+      entropy: { entryPoints: ['src/example.ts'], patterns: { patterns: [bannedExportRule] } },
+    });
+    const result = await handleDetectEntropy({ path: projectDir, type: 'patterns' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    const violations: Array<{ pattern: string }> = data.patterns?.violations ?? [];
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.some((v) => v.pattern === 'no-banned-export')).toBe(true);
+  });
+
+  // The common no-config path (`type=all`) must NOT start failing: patterns are
+  // simply skipped when unconfigured, while drift/dead-code still run.
+  it('skips patterns (no error) for type=all when no rules are configured', async () => {
+    writeConfig({ entropy: { entryPoints: ['src/example.ts'] } });
+    const result = await handleDetectEntropy({ path: projectDir, type: 'all' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    // No pattern report is produced when patterns is skipped, so there are no
+    // pattern violations green-ticked from an empty rule set.
+    const violations: Array<unknown> = data.patterns?.violations ?? [];
+    expect(violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1792

## Root cause
The MCP entropy tool `handleDetectEntropy` (`packages/cli/src/mcp/tools/entropy.ts`) passed the analyzer's `patterns` field as a **bare boolean** (`typeFilter === 'all' || typeFilter === 'patterns'`). `EntropyAnalyzer` coerces a bare-boolean `true` into an empty rule set (`{ patterns: [] }`, see `analyzer.ts:129-133`), so `detect_entropy(type: "patterns")` evaluated **zero** pattern rules yet reported zero violations / `passRate: 1` — a pass indistinguishable from a real pattern check that actually evaluated rules and found nothing.

This is the same empty-ruleset false-pass fixed on the CLI `harness cleanup -t patterns` path in #1760 (PR #1791, now merged). #1791 added `entropy.patterns` (reusing core's `PatternConfigSchema`) to the CLI config schema; this PR applies the parallel fix on the MCP surface.

## Fix
- Read pattern rules from the `entropy.patterns` config block and thread the **configured** rules into the analyzer (mirroring how `entropy.drift` is already threaded), instead of passing a bare boolean.
- When `type: "patterns"` is the explicitly requested check but **no** rules are configured, return an MCP error response (`isError: true`) with an actionable message instead of green-ticking an empty check.
- For `type: "all"`, the pattern analyzer is skipped (`patterns: false`) when no rules exist, preserving the common no-config path without a false "checked" claim.

## Reproducing test
`packages/cli/tests/mcp/tools/entropy-patterns-empty-ruleset.test.ts` — integration-style (real config loader + analyzer + pattern detector, no mocks):
- `fails loudly when type=patterns has no configured rules` — asserts `isError === true`.
- `evaluates configured pattern rules and reports real violations` — a configured `no-export` rule against a source file that exports the forbidden symbol is threaded through and the real violation is reported (not a hardcoded empty set).
- `skips patterns (no error) for type=all when no rules are configured` — guards the common no-config path against regression.

Proven fail-before/pass-after by stashing only the `entropy.ts` source change: the two behavioral tests fail against the old source and pass with the fix. Typecheck clean; existing MCP entropy suites (`entropy.test.ts`, `entropy-config-threading.test.ts`) green.

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga