### PR TITLE
feat(ci): content-addressed gate memoization — an action cache for verdicts (#1639)

### DIFF
--- a/.changeset/content-addressed-gate-memoization-1639.md
+++ b/.changeset/content-addressed-gate-memoization-1639.md
@@ -1,0 +1,34 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+feat(ci): content-addressed memoization cache for gate verdicts — an action
+cache that skips recomputing an unchanged check (#1639).
+
+Adds an opt-in (default OFF), local, content-addressed `VerdictCache` wired
+transparently into the CI check orchestrator. Each check's verdict is keyed by a
+SHA-256 over `(check identity × gate version × config hash × input hash)`, where
+the input hash is a single content digest of the project's tracked
+source/config/docs tree computed once per run and shared by every check. On a
+hit the stored `CICheckResult` is returned instead of re-running the check; on a
+miss the check runs and records its verdict.
+
+Correct-by-construction: only checks whose full verdict closure the source-tree
+hash covers are memoized. `arch` and `traceability` are excluded because their
+verdicts depend on `.harness` baseline/graph state (and, for `arch`, the git
+base-ref) that no working-tree hash captures — so they always run and are never
+cached. For the memoized checks the closure is an honest over-approximation, so
+any changed input yields a different hash and forces a miss (it may over-miss,
+which only wastes compute). Gate-version and config changes miss by construction;
+a check that threw is never cached; entries are written atomically. Hit/miss
+telemetry is
+attached as an optional `cacheStats` field on `CICheckReport`, absent on the
+default cache-off path so existing report output is byte-identical.
+
+Enable per project via `cache.verdicts.enabled` (dir defaults to
+`.harness/cache/verdicts`). Scope note: this slice is a local cache with
+over-approximated closures; per-gate input-closure declaration + runtime
+access-recorder, a shareable/distributed backend, and per-gate savings telemetry
+are deferred (see `Refs #1639`).

--- a/.harness/comprehension/packages/cli/src/commands/ci/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/ci/_module.md
@@ -1,35 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands/ci'
-sourceHash: '2de5d46aa76b3964b495c6e180d9c482f28ccb42b82295c9e4f0af908d54f852'
-compiledAt: '2026-08-28T01:22:08.777Z'
+sourceHash: '4afc71a8f7ec95b98612f34190e3f7b5e15a141b04884fee5901455bcf43f6c5'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['check.ts', 'index.ts', 'init.ts', 'notify.ts']
 ---
-
-## Summary
-
-`packages/cli/src/commands/ci` is a CLI command container that orchestrates CI/CD integration through three subcommands:
-
-**`check`** — runs the harness gate suite (validate, deps, docs, entropy, security, perf, phase-gate, arch, traceability) against the current project, with options to skip checks, set failure thresholds per severity, and enforce constraint stages (pre-commit/pre-merge/pre-release). Reports results in JSON or human-readable format, respecting the global `--quiet` flag.
-
-**`init`** — scaffolds boilerplate CI configuration files (GitHub Actions `.yml`, GitLab `.yml`, or generic shell script) that wire up the harness gate as a CI step. Accepts a platform selector and optional language hint to generate language-appropriate setup/build/lint/test steps.
-
-**`notify`** — (referenced but not shown in digest) likely handles reporting check results to external systems.
-
-The command delegates actual check execution to `@harness-engineering/core`'s `runCIChecks`, which is config-driven. All three subcommands honor the global config path and output mode.
-
-## Invariants
-
-- Fixed check registry: Valid checks are hardcoded (9 names: validate, deps, docs, entropy, security, perf, phase-gate, arch, traceability); only these parse from --skip or config. Unknown checks silently ignored during init but never run.
-- Stage validation is fail-hard: If --stage is supplied but unrecognized, the command exits with error rather than silently running all stages. Caller who asks for one stage must get exactly that stage enforced.
-- Constraint packs are optional but audible: If a constraint pack is configured but the security check is skipped, a warning is emitted—silent no-op would hide misconfiguration.
-- Exit code ownership: Check result's exitCode field determines process exit, not the command logic. Command never invents its own exit code.
-- Language-aware generation: CI init generates language-specific setup steps (actions, install, build, lint, test); default is TypeScript/Node. Each language maps to a fixed step template.
-- Output mode is global, not per-check: JSON/quiet/normal mode is resolved once from global opts and applied uniformly; check-specific options (skip, failOn, stage) never override output framing.
-- Skip flag inversion: init computes skip flags by filtering out enabled checks from the full list—if no checks are disabled, the flag is empty. This is order-independent and declarative.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/src/config/_module.md
+++ b/.harness/comprehension/packages/cli/src/config/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/config'
-sourceHash: 'f6a4b3c00fe4f25546ac2ce7f25589aaf6a6a8526b709e6624baeeba5e69f3ca'
+sourceHash: '086378850b22bdbf5f2d5d3e8b54f10e822a33ffd0291f97904beb411233ce51'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/src/ci/_module.md
+++ b/.harness/comprehension/packages/core/src/ci/_module.md
@@ -1,12 +1,19 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/ci'
-sourceHash: '96c07b01b211571da7b908e3914156933ec306c28af03cfd9415154649934cf7'
+sourceHash: '1179e7f5c98caa5ecc52de0c5435ac63e96374aba220763e114eb54683390823'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
-  ['base-freshness.ts', 'check-orchestrator.ts', 'index.ts', 'notifier.ts', 'report-formatter.ts']
+  [
+    'base-freshness.ts',
+    'check-orchestrator.ts',
+    'index.ts',
+    'notifier.ts',
+    'report-formatter.ts',
+    'verdict-cache.ts',
+  ]
 ---
 
 ## Interface Contract
@@ -16,10 +23,21 @@ export BaseFreshnessInput
 export BaseFreshnessTrust
 export BaseFreshnessVerdict
 export CINotifier
+export DEFAULT_VERDICT_CACHE_DIR
+export GATE_VERSIONS
+export MEMOIZABLE_CHECKS
 export RunCIChecksInput
+export VerdictCache
+export VerdictCacheConfig
+export VerdictCacheStatsCollector
 export classifyBaseFreshness
+export computeConfigHash
+export computeProjectInputHash
+export computeVerdictKey
 export formatCIReportAsMarkdown
+export parseVerdictCacheConfig
 export runCIChecks
+export shouldCacheResult
 ```
 
 ## Dependency Slice
@@ -29,6 +47,7 @@ import { ArchConfigSchema, runArchCollectors } from '../architecture'
 import { ArchBaselineManager } from '../architecture/baseline-manager'
 import { filterDiffByAllowances, loadArchAllowances, resolveArchBaseline } from '../architecture/baseline-resolver'
 import { diff } from '../architecture/diff'
+import { computeSourceHash } from '../comprehension/source-hash'
 import { defineLayer, validateDependencies } from '../constraints/dependencies'
 import { ResolvedConstraintPacks, resolveConstraintPacks } from '../constraints/packs'
 import { validateAgentsMap } from '../context/agents-map'
@@ -43,8 +62,11 @@ import { SecurityScanner } from '../security/scanner'
 import { TypeScriptParser } from '../shared/parsers'
 import { Err, Ok, Result } from '../shared/result'
 import { formatCIReportAsMarkdown } from './report-formatter'
+import { GATE_VERSIONS, MEMOIZABLE_CHECKS, VerdictCache, VerdictCacheStatsCollector, computeConfigHash, computeProjectInputHash, computeVerdictKey, parseVerdictCacheConfig } from './verdict-cache'
 import { GraphStore, queryTraceability, resolveGraphDir, skipDirGlobs } from '@harness-engineering/graph'
-import { CICheckIssue, CICheckName, CICheckReport, CICheckResult, CICheckSummary, CIFailOnSeverity, CINotifyOptions, ConstraintPackCompliance, ConstraintPackComplianceStatus, ConstraintStage, GateMeasurement } from '@harness-engineering/types'
-import from 'glob'
+import { CICheckIssue, CICheckName, CICheckReport, CICheckResult, CICheckSummary, CIFailOnSeverity, CINotifyOptions, ConstraintPackCompliance, ConstraintPackComplianceStatus, ConstraintStage, GateMeasurement, VerdictCacheStats } from '@harness-engineering/types'
+import { glob } from 'glob'
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
 import * as path from 'node:path'
 ```

--- a/.harness/comprehension/packages/core/tests/ci/_module.md
+++ b/.harness/comprehension/packages/core/tests/ci/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/ci'
-sourceHash: 'a9ed09e141975f868b8a588e085df0b800d2bf4ed82b4d7f9c558173812b89a9'
-compiledAt: '2026-08-28T01:22:10.761Z'
+sourceHash: 'effaaa26b359b54fe8b626d1d71c986d7420b28cbc33748818ac0884e1ef4fbf'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'base-freshness.behavior.test.ts',
@@ -14,21 +13,9 @@ members:
     'constraint-packs-real-scanner.test.ts',
     'notifier.test.ts',
     'report-formatter.test.ts',
+    'verdict-cache.test.ts',
   ]
 ---
-
-## Summary
-
-packages/core/tests/ci validates the CI gate orchestration and reporting layer. It tests three components: (1) base-freshness classification (whether a test result's base SHA is trustworthy for merge by detecting if main has advanced), (2) check orchestration (running 9 gates in deterministic order: validate, deps, docs, entropy, security, perf, phase-gate, arch, traceability, mostly in parallel but always outputting in canonical order), and (3) constraint-pack wiring (overlaying security policy on base config). Tests exercise pass/fail/skip paths, exit-code semantics, and mock all heavyweight I/O (fs, glob, subprocess scanners) while running orchestrator logic live.
-
-## Invariants
-
-- Base freshness trust model: when strictRequired=true OR base SHA hasn't advanced since test, verdict is trust='verified'; when strictRequired=false AND base advanced, downgrade to trust='degraded'. The reason field must include short (7-char) SHAs of both tested and current base for drift reporting.
-- Check execution order is canonical: output always reflects [validate, deps, docs, entropy, security, perf, phase-gate, arch, traceability] regardless of parallel completion; skipped checks do not reorder.
-- Exit code is deterministic: exitCode=0 iff all non-skipped checks pass; exitCode=1 if any check fails OR warnings exist when failOn='warning'.
-- Check report uniformity: every check produces {name, status, durationMs, reason, …} regardless of type; status ∈ {pass|fail|skip}; duration is recorded for all non-skipped checks.
-- Constraint-pack overlay is composable: security checks receive base config + constraint-pack overlay; overlay augments (not replaces) base config; overlay properties are observable on the config object passed to the check.
-- Mock orchestration is hermetic: all heavyweight I/O (glob, scanners, fs) is mocked; only orchestrator control-flow logic runs live to verify check ordering and aggregation.
 
 ## Interface Contract
 
@@ -43,12 +30,14 @@ import { classifyBaseFreshness } from '../../src/ci/base-freshness'
 import { runCIChecks } from '../../src/ci/check-orchestrator'
 import { CINotifier } from '../../src/ci/notifier'
 import { formatCIReportAsMarkdown } from '../../src/ci/report-formatter'
+import { DEFAULT_VERDICT_CACHE_DIR, GATE_VERSIONS, MEMOIZABLE_CHECKS, VerdictCache, VerdictCacheStatsCollector, computeConfigHash, computeProjectInputHash, computeVerdictKey, parseVerdictCacheConfig, shouldCacheResult } from '../../src/ci/verdict-cache'
 import from '../../src/context/agents-map'
 import from '../../src/context/doc-coverage'
 import { TrackerSyncAdapter } from '../../src/roadmap/tracker-sync'
-import { CICheckName, CICheckReport, Err, Ok } from '@harness-engineering/types'
+import { CICheckName, CICheckReport, CICheckResult, Err, Ok } from '@harness-engineering/types'
+import * as fs from 'node:fs'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/.harness/comprehension/packages/types/src/_module.md
+++ b/.harness/comprehension/packages/types/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/types/src'
-sourceHash: 'ffa98379041177e00032317e142b3aa7c06c2c3a8b6ee6ace6b5f21f83ef7c00'
+sourceHash: 'ffb7f71106c83f7c89cd308ae46b7a269a4b8a0942d2ceb9a09e3544c55cf694'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -395,6 +395,8 @@ export TurnParams
 export TurnResult
 export UsageRecord
 export UsageSection
+export VerdictCacheEntry
+export VerdictCacheStats
 export WebhookDelivery
 export WebhookDeliverySchema
 export WebhookDeliveryStatus

--- a/docs/changes/content-addressed-gate-memoization-1639/plans/plan-content-addressed-gate-memoization.md
+++ b/docs/changes/content-addressed-gate-memoization-1639/plans/plan-content-addressed-gate-memoization.md
@@ -1,0 +1,43 @@
+# Plan — Content-addressed gate memoization (#1639)
+
+Route: FEATURE (brainstorming → autopilot). Base: fresh `origin/main` (incl. #1673 GateMeasurement).
+
+## Tasks
+
+1. **Types** (`packages/types/src/ci.ts`)
+   - Add `VerdictCacheStats` (`enabled`, `hits`, `misses`, `entries: {check,outcome,key}[]`).
+   - Add optional `cacheStats?: VerdictCacheStats` to `CICheckReport` (absent when disabled → byte-stable default).
+
+2. **Cache module** (`packages/core/src/ci/verdict-cache.ts`)
+   - `parseVerdictCacheConfig(config, projectRoot)` → `{ enabled, dir }` (default off, `.harness/cache/verdicts`).
+   - `GATE_VERSIONS: Record<CICheckName, number>` — per-check invalidation lever.
+   - `computeConfigHash(config)` — canonical JSON sha256, excludes the `cache` subtree.
+   - `computeProjectInputHash(projectRoot, extraExcludes)` — glob source/config/docs tree
+     (excl. skipDirGlobs + `.harness` + cache dir), read contents, reuse `computeSourceHash`.
+   - `computeVerdictKey({check,gateVersion,configHash,inputHash})` — sha256 hex.
+   - `class VerdictCache` — `get(key)`, `set(key,result)`, safe JSON round-trip, corrupt-entry tolerance.
+   - `class VerdictCacheStatsCollector` — records hit/miss per check, `toStats()`.
+   - `shouldCacheResult(result)` — false when a check threw (transient-error guard).
+
+3. **Wire orchestrator** (`packages/core/src/ci/check-orchestrator.ts`)
+   - In `runCIChecks`: build cache + stats when enabled; compute shared `inputHash`, `configHash` once.
+   - Thread through `runAllChecks`; wrap `runSingleCheck` in `runSingleCheckMemoized`.
+   - Attach `cacheStats` to report only when enabled.
+
+4. **Exports** (`packages/core/src/ci/index.ts`) — export cache surface + types.
+
+5. **Config schema** (`packages/cli/src/config/schema.ts`) — add `cache.verdicts` section so the
+   key survives config resolution (top-level schema strips unknown keys).
+
+6. **CLI output** (`packages/cli/src/commands/ci/check.ts`) — print cache hit/miss summary in human mode.
+
+7. **Tests** (`packages/core/tests/ci/verdict-cache.test.ts`)
+   - hit on unchanged inputs; miss on changed closure file; miss on config change; miss on gateVersion bump.
+   - errored result not cached; corrupt cache entry → miss (no throw).
+   - key determinism / canonicalization.
+   - orchestrator integration: enabled → second run hits; disabled → no `cacheStats`, byte-stable.
+
+## Verify
+
+- `pnpm turbo build`, targeted `vitest run` on new tests, `tsc` typecheck, lint, full pre-push gates.
+- Behavioral: run `harness ci check` twice with cache enabled on a temp project; confirm 2nd run reports hits.

--- a/docs/changes/content-addressed-gate-memoization-1639/proposal.md
+++ b/docs/changes/content-addressed-gate-memoization-1639/proposal.md
@@ -1,0 +1,145 @@
+# Content-addressed gate memoization — an action cache for verdicts (#1639)
+
+## Context
+
+Redundant re-verification is a top compute/token sink: the CI check orchestrator
+(`packages/core/src/ci/check-orchestrator.ts`) re-runs every check on every
+invocation, even when the inputs those checks read are byte-for-byte unchanged
+(a rebase that touched nothing they read, the same file tree re-scanned across
+pipeline stages and fleet members). Build systems solved this a decade ago with
+the content-addressed action cache: key each action by a hash of its inputs and
+return the stored result on an identical-input hit without re-executing.
+
+Issue #1639 (Wave-1 P1) applies that pattern to the gate stack. The full issue
+scopes an ambitious surface — per-gate input-closure _declaration_, a runtime
+access-recorder that fails on undeclared reads (closure audit), a shareable
+cross-fleet backend, and per-gate-class telemetry feeding basal-metabolism
+accounting. This change delivers the **first correct-by-construction slice**:
+an opt-in, local, content-addressed memoization cache for check verdicts, with
+hit/miss telemetry. It builds cleanly on the `GateMeasurement` work merged in
+#1673 (the orchestrator's `CheckContribution` / measurement plumbing is left
+untouched and flows through the cache transparently).
+
+## Decision
+
+Add a `VerdictCache` that memoizes each `CICheckResult` keyed by a content hash
+of the check's input closure, wired transparently into the orchestrator's
+per-check execution path. Opt-in, default OFF, local-only.
+
+### Cache key (correct-by-construction)
+
+The key for a check is `sha256` over the canonical tuple:
+
+```
+{ check: <name>, gateVersion: GATE_VERSIONS[name], configHash, inputHash }
+```
+
+- **`inputHash`** — a single content hash over the project's tracked
+  source/config/docs tree (source code across languages, `*.md`, `*.json`,
+  `*.yaml`/`*.yml`, `*.toml`), computed once per run and shared by every check.
+  Reuses the membership+content digest discipline of `computeSourceHash`
+  (path-length-prefixed, sorted, full SHA-256). This is the **honest
+  over-approximation** of every source-scanning check's true closure: a changed
+  input always changes the hash (→ miss), so a stale hit is impossible. It may
+  _over_-miss (an unrelated file change busts the cache), which is safe — only
+  compute is lost, never correctness.
+- **`configHash`** — `sha256` of the canonicalized effective config (minus the
+  cache's own subtree). Any config change → miss by construction.
+- **`gateVersion`** — a per-check integer in `GATE_VERSIONS`. Bumping a check's
+  version (its logic changed) invalidates that check's cache by construction,
+  independent of inputs.
+
+### Correctness invariants
+
+1. **No stale hits.** The input closure is a superset of what source-scanning
+   checks read; any change to a read input changes `inputHash`. (Tested: touch
+   one closure file → miss.)
+2. **Rebase touching nothing → hit.** Identical tree + config + versions → same
+   key → stored verdict returned. (Tested.)
+3. **Version/config bumps miss by construction.** (Tested.)
+4. **Errored runs are not cached.** A check that _threw_ (an internal error,
+   potentially transient) is never stored, so a transient failure cannot be
+   memoized as a durable verdict.
+
+### Wiring
+
+The memoization layer wraps `runSingleCheck` inside `runAllChecks`. On a hit it
+returns the stored `CICheckResult`; on a miss it runs the check and records the
+result. Skipped checks bypass the cache entirely. The wrapper is transparent —
+no check is rewritten, and `measurements` (#1673) round-trip through the store.
+
+Only checks whose full verdict closure the source-tree hash covers are memoized
+(`MEMOIZABLE_CHECKS`). Two checks are deliberately excluded because their verdict
+depends on state OUTSIDE that closure:
+
+- `traceability` reads the derived graph under `.harness` (which the closure
+  omits), so caching it could serve a stale verdict after a graph re-ingest with
+  unchanged source.
+- `arch` diffs against a baseline (`.harness/arch/baselines.json`) and per-PR
+  allowances, and in a PR context resolves that baseline from the git BASE ref /
+  `HARNESS_ARCH_BASE_REF` — none of which is a working-tree file a tree hash can
+  capture. A regenerated baseline, a new allowance, or an advanced base ref would
+  change the verdict with the source byte-identical.
+
+A non-memoizable check always runs and never appears in `cacheStats`. Letting
+them opt in needs the deferred per-gate closure declaration (fold the
+baseline/allowance contents + base-ref SHA, or the graph digest, into the key —
+issue #1639).
+
+### Correctness safeguards
+
+- **Atomic writes.** Entries are written to a unique temp file and renamed into
+  place, so a crash or a concurrent writer can never leave a half-written entry.
+  (Parallel writers to the same key are otherwise safe — identical inputs ⇒
+  identical content.)
+- **Dotfiles hashed.** The closure glob runs with `dot: true` so a hidden
+  source/config input never silently drops out of the hash.
+
+### Known limitation (deferred)
+
+The transient-error guard only refuses to cache a check that THREW to the
+orchestrator's top-level catch. A check that catches its own failure and reports
+it as an issue (e.g. an analyzer IO error surfaced as a warning) is still
+cacheable; on the same inputs it is deterministic in the common case, but a truly
+transient internal failure could be memoized until the inputs change. Making
+those internal-failure paths uncacheable is folded into the deferred access-
+recorder work (issue #1639).
+
+Hit/miss telemetry is attached as an optional `cacheStats` field on
+`CICheckReport`. The field is **absent** when the cache is disabled, preserving
+byte-identical report output for the default path.
+
+### Opt-in config
+
+```jsonc
+"cache": {
+  "verdicts": {
+    "enabled": false,          // default OFF
+    "dir": ".harness/cache/verdicts"
+  }
+}
+```
+
+## Scope / deferred (Refs #1639, not Closes)
+
+Delivered: opt-in local content-addressed verdict cache; correct-by-construction
+keying; hit/miss stats; dogfoodable on this repo's own gate stack.
+
+Deferred (remainder tracked on #1639):
+
+- Per-gate **input-closure declaration** + runtime **access-recorder / closure
+  audit** (the issue's "hard part"). This slice over-approximates the closure
+  instead, which is safe but coarser-grained.
+- **Shareable / distributed** cache backend (artifact store). Local dir only.
+- Per-gate-class savings telemetry feeding **basal-metabolism** accounting.
+- `harness cache stats` / `harness cache explain` CLI surface.
+
+## Alternatives considered
+
+- **Per-check declared file globs** for a finer closure: rejected for this slice
+  because under-declaration silently yields stale hits (a correctness bug) — the
+  exact hazard the issue flags as the hard part, and it needs the deferred
+  access-recorder to be safe. Over-approximation is correct now.
+- **git-tree hash**: attractive (matches rebase semantics) but only captures
+  committed content; a working-tree content walk captures staged+unstaged edits
+  too, matching what the checks actually read.

--- a/docs/changes/content-addressed-gate-memoization-1639/provenance.json
+++ b/docs/changes/content-addressed-gate-memoization-1639/provenance.json
@@ -1,0 +1,14 @@
+{
+  "issue": [1639],
+  "route": "feature",
+  "stages": ["brainstorming", "autopilot"],
+  "planArtifact": "docs/changes/content-addressed-gate-memoization-1639/plans/plan-content-addressed-gate-memoization.md",
+  "closingKeyword": "Refs",
+  "closingKeywordReason": "First correct-by-construction slice: opt-in local content-addressed verdict cache with hit/miss telemetry. Deferred remainder tracked on #1639 — per-gate input-closure declaration + runtime access-recorder/closure audit (over-approximated here instead), shareable/distributed cache backend, per-gate-class savings telemetry into basal-metabolism, and the `harness cache stats`/`explain` CLI surface.",
+  "assumptions": [
+    "Opt-in local content-addressed verdict cache; changed input => different hash => miss (no stale hits); remote/distributed backend deferred",
+    "Input closure is an honest over-approximation (whole tracked source/config/docs tree) shared across checks; may over-miss but never returns a stale hit",
+    "A check that threw an internal error is never cached (transient-error guard)",
+    "cacheStats is emission-only telemetry and never influences exitCode or any check status; absent on the default cache-off path for byte-stable reports"
+  ]
+}

--- a/packages/cli/src/commands/ci/check.ts
+++ b/packages/cli/src/commands/ci/check.ts
@@ -116,6 +116,12 @@ function printCheckReport(report: CICheckReport): void {
     }
   }
   printConstraintPacks(report);
+  if (report.cacheStats) {
+    const { hits, misses } = report.cacheStats;
+    logger.dim(
+      `Verdict cache: ${hits} hit${hits === 1 ? '' : 's'}, ${misses} miss${misses === 1 ? '' : 'es'}`
+    );
+  }
   console.log('');
   if (report.exitCode === 0) {
     logger.success(`All checks passed (${report.summary.passed}/${report.summary.total})`);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1138,6 +1138,28 @@ export const HarnessConfigSchema = z.object({
   security: SecurityConfigSchema.optional(),
   /** Performance and complexity budget settings */
   performance: PerformanceConfigSchema.optional(),
+  /**
+   * Content-addressed gate memoization (issue #1639) — an action cache for CI
+   * check verdicts. Opt-in, default OFF: a check whose input closure hashes
+   * unchanged returns its stored verdict instead of recomputing. Correct-by-
+   * construction (a changed input ⇒ a different hash ⇒ a miss, never a stale
+   * hit). `.passthrough()` keeps the section forward-compatible for the deferred
+   * remote/shared backend.
+   */
+  cache: z
+    .object({
+      verdicts: z
+        .object({
+          /** Master switch. Default false — the cache is a pure no-op unless enabled. */
+          enabled: z.boolean().default(false),
+          /** Local directory for cached entries (relative to project root). */
+          dir: z.string().default('.harness/cache/verdicts'),
+        })
+        .passthrough()
+        .optional(),
+    })
+    .passthrough()
+    .optional(),
   /** Compiled-comprehension substrate settings (see docs — phase 6). */
   comprehension: ComprehensionConfigSchema.optional(),
   /** Project template settings (used by 'harness init') */

--- a/packages/core/src/ci/check-orchestrator.ts
+++ b/packages/core/src/ci/check-orchestrator.ts
@@ -34,6 +34,16 @@ import { SECURITY_SCAN_GLOB } from '../security/scan-targets';
 import { TypeScriptParser } from '../shared/parsers';
 import { ArchConfigSchema, runAll as runArchCollectors } from '../architecture';
 import { GraphStore, queryTraceability, resolveGraphDir } from '@harness-engineering/graph';
+import {
+  parseVerdictCacheConfig,
+  VerdictCache,
+  VerdictCacheStatsCollector,
+  computeConfigHash,
+  computeProjectInputHash,
+  computeVerdictKey,
+  GATE_VERSIONS,
+  MEMOIZABLE_CHECKS,
+} from './verdict-cache';
 
 export interface RunCIChecksInput {
   projectRoot: string;
@@ -679,13 +689,60 @@ function attachConstraintPackResults(
 }
 
 /**
+ * The content-addressed memoization context for a run: the shared verdict cache,
+ * the per-run input + config hashes every check's key is derived from, and the
+ * hit/miss stats collector. Present only when the verdict cache is opted in
+ * (issue #1639); when absent, checks run unmemoized exactly as before.
+ */
+interface MemoContext {
+  cache: VerdictCache;
+  stats: VerdictCacheStatsCollector;
+  inputHash: string;
+  configHash: string;
+}
+
+/**
+ * Run one check through the verdict cache when a memoization context is present:
+ * a cache hit returns the stored verdict without recomputing; a miss runs the
+ * check and records the result. Without a context this is exactly
+ * `runSingleCheck`. Skipped checks never reach here.
+ */
+async function runSingleCheckMaybeCached(
+  name: CICheckName,
+  projectRoot: string,
+  config: Record<string, unknown>,
+  memo: MemoContext | undefined
+): Promise<CICheckResult> {
+  // Bypass the cache entirely (and leave it out of the stats) for a check whose
+  // input closure the source-tree hash does not fully cover — memoizing it could
+  // return a stale hit. Such checks always run.
+  if (!memo || !MEMOIZABLE_CHECKS.has(name)) return runSingleCheck(name, projectRoot, config);
+  const key = computeVerdictKey({
+    check: name,
+    gateVersion: GATE_VERSIONS[name],
+    configHash: memo.configHash,
+    inputHash: memo.inputHash,
+  });
+  const hit = memo.cache.get(key);
+  if (hit) {
+    memo.stats.record(name, 'hit', key);
+    return hit;
+  }
+  const result = await runSingleCheck(name, projectRoot, config);
+  memo.cache.set(key, result);
+  memo.stats.record(name, 'miss', key);
+  return result;
+}
+
+/**
  * Run every check (validate first, the rest in parallel), honoring the skip
  * set. Extracted so the top-level orchestrator stays small.
  */
 async function runAllChecks(
   projectRoot: string,
   config: Record<string, unknown>,
-  skippedSet: Set<CICheckName>
+  skippedSet: Set<CICheckName>,
+  memo: MemoContext | undefined
 ): Promise<CICheckResult[]> {
   const checks: CICheckResult[] = [];
 
@@ -693,7 +750,7 @@ async function runAllChecks(
   if (skippedSet.has('validate')) {
     checks.push({ name: 'validate', status: 'skip', issues: [], durationMs: 0 });
   } else {
-    checks.push(await runSingleCheck('validate', projectRoot, config));
+    checks.push(await runSingleCheckMaybeCached('validate', projectRoot, config, memo));
   }
 
   // Phase 2: all remaining checks in parallel
@@ -702,12 +759,41 @@ async function runAllChecks(
       if (skippedSet.has(name)) {
         return { name, status: 'skip' as const, issues: [] as CICheckIssue[], durationMs: 0 };
       }
-      return runSingleCheck(name, projectRoot, config);
+      return runSingleCheckMaybeCached(name, projectRoot, config, memo);
     })
   );
   checks.push(...phase2Results);
 
   return checks;
+}
+
+/**
+ * Build the content-addressed memoization context for a run (issue #1639), or
+ * `undefined` when the verdict cache is not opted in. When present, it carries
+ * one input hash over the project's source/config/docs closure and one config
+ * hash, from which every check derives its cache key. When absent, checks run
+ * exactly as before (byte-identical report, no `cacheStats`).
+ */
+async function buildMemoContext(
+  projectRoot: string,
+  config: Record<string, unknown>,
+  effectiveConfig: Record<string, unknown>
+): Promise<MemoContext | undefined> {
+  const cacheConfig = parseVerdictCacheConfig(config, projectRoot);
+  if (!cacheConfig.enabled) return undefined;
+  const inputHash = await computeProjectInputHash(
+    projectRoot,
+    cacheConfig.dir,
+    // Use the effective (pack-overlaid) config the checks actually run on, so the
+    // closure excludes match what the scanners see.
+    analysisExclude(effectiveConfig)
+  );
+  return {
+    cache: new VerdictCache(cacheConfig),
+    stats: new VerdictCacheStatsCollector(),
+    inputHash,
+    configHash: computeConfigHash(effectiveConfig),
+  };
 }
 
 export async function runCIChecks(input: RunCIChecksInput): Promise<Result<CICheckReport, Error>> {
@@ -723,7 +809,10 @@ export async function runCIChecks(input: RunCIChecksInput): Promise<Result<CIChe
     );
     const effectiveConfig = applyConstraintPackOverlay(config, resolvedPacks);
 
-    const checks = await runAllChecks(projectRoot, effectiveConfig, new Set(skip));
+    // Content-addressed verdict memoization (issue #1639), opt-in / default OFF.
+    const memo = await buildMemoContext(projectRoot, config, effectiveConfig);
+
+    const checks = await runAllChecks(projectRoot, effectiveConfig, new Set(skip), memo);
 
     const summary = buildSummary(checks);
     const exitCode = determineExitCode(summary, failOn);
@@ -738,6 +827,12 @@ export async function runCIChecks(input: RunCIChecksInput): Promise<Result<CIChe
     };
 
     attachConstraintPackResults(report, resolvedPacks, checks, stage);
+
+    // Attach hit/miss telemetry only when the cache ran, so the default path's
+    // report shape is unchanged. Emission only — never alters `exitCode`.
+    if (memo) {
+      report.cacheStats = memo.stats.toStats();
+    }
 
     return Ok(report);
   } catch (error) {

--- a/packages/core/src/ci/index.ts
+++ b/packages/core/src/ci/index.ts
@@ -8,3 +8,16 @@ export type {
   BaseFreshnessVerdict,
   BaseFreshnessTrust,
 } from './base-freshness';
+export {
+  parseVerdictCacheConfig,
+  VerdictCache,
+  VerdictCacheStatsCollector,
+  computeConfigHash,
+  computeProjectInputHash,
+  computeVerdictKey,
+  shouldCacheResult,
+  GATE_VERSIONS,
+  MEMOIZABLE_CHECKS,
+  DEFAULT_VERDICT_CACHE_DIR,
+} from './verdict-cache';
+export type { VerdictCacheConfig } from './verdict-cache';

--- a/packages/core/src/ci/verdict-cache.ts
+++ b/packages/core/src/ci/verdict-cache.ts
@@ -1,0 +1,323 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { glob } from 'glob';
+import { skipDirGlobs } from '@harness-engineering/graph';
+import type { CICheckName, CICheckResult, VerdictCacheStats } from '@harness-engineering/types';
+import { computeSourceHash } from '../comprehension/source-hash';
+
+/**
+ * Content-addressed memoization cache for CI check verdicts (issue #1639) — an
+ * action cache for gate results. Key each check by a content hash of its input
+ * closure and return the stored verdict on an identical-input hit instead of
+ * recomputing; on a miss, run and record. Opt-in, default OFF, local-only.
+ *
+ * Correct-by-construction: for the memoized checks (see {@link MEMOIZABLE_CHECKS})
+ * the input closure is an honest *over-approximation* of what the check reads —
+ * the whole tracked source/config/docs tree — so any change to a real input
+ * changes the hash and forces a miss; a stale hit is impossible. It may over-miss
+ * (an unrelated change busts the cache), which only wastes compute, never
+ * correctness. Checks whose verdict also depends on state OUTSIDE that closure
+ * (baselines/allowances/graph under `.harness`, or git base-ref history) are NOT
+ * memoized at all, precisely because the tree hash is not a superset of their
+ * inputs. Finer per-gate closures and the runtime access-recorder that would let
+ * them opt in are deferred (see proposal / issue #1639).
+ */
+
+/** Resolved verdict-cache settings for one run. */
+export interface VerdictCacheConfig {
+  /** Master switch. Default false — cache is a no-op unless explicitly opted in. */
+  enabled: boolean;
+  /** Absolute directory the content-addressed entries are stored under. */
+  dir: string;
+}
+
+/** Default location for cached verdict entries, relative to the project root. */
+export const DEFAULT_VERDICT_CACHE_DIR = path.join('.harness', 'cache', 'verdicts');
+
+/**
+ * Per-check cache-schema version. Bump a check's number when its logic changes
+ * in a way that could alter its verdict for unchanged inputs — that invalidates
+ * every cached entry for the check by construction, independent of the input or
+ * config hash. This is the "gate-version bumps miss by construction" invariant.
+ */
+export const GATE_VERSIONS: Record<CICheckName, number> = {
+  validate: 1,
+  deps: 1,
+  docs: 1,
+  entropy: 1,
+  security: 1,
+  perf: 1,
+  'phase-gate': 1,
+  arch: 1,
+  traceability: 1,
+};
+
+/**
+ * The checks safe to memoize under the current input closure. A check is
+ * memoizable only when EVERYTHING that determines its verdict is covered by the
+ * source/config/docs closure hash — otherwise it could return a stale hit,
+ * violating the cardinal invariant. Two checks are deliberately EXCLUDED because
+ * their verdict inputs live outside that closure:
+ *
+ * - `traceability` reads the derived graph under `.harness` (which the closure
+ *   omits, see {@link computeProjectInputHash}), so a graph re-ingest with an
+ *   unchanged source tree could serve a stale verdict.
+ * - `arch` diffs against a baseline (`.harness/arch/baselines.json`) and per-PR
+ *   allowances (also under `.harness`), and in a PR context resolves that
+ *   baseline from the git BASE ref / `HARNESS_ARCH_BASE_REF` — none of which is
+ *   a file in the working tree, so no tree hash can capture them. A regenerated
+ *   baseline, a new allowance, or an advanced base ref changes the arch verdict
+ *   with the source tree byte-identical.
+ *
+ * Non-memoizable checks always run and are never cached. Letting them opt in
+ * needs the deferred per-gate closure declaration (folding the baseline/allowance
+ * contents + base-ref SHA, or the graph digest, into the key) — issue #1639.
+ */
+export const MEMOIZABLE_CHECKS: ReadonlySet<CICheckName> = new Set<CICheckName>([
+  'validate',
+  'deps',
+  'docs',
+  'entropy',
+  'security',
+  'perf',
+  'phase-gate',
+]);
+
+/**
+ * Read the opt-in verdict-cache config from the raw project config. Shape:
+ * `cache.verdicts.{ enabled?, dir? }`. Absent/malformed ⇒ disabled with the
+ * default directory (a pure no-op, current behavior).
+ */
+export function parseVerdictCacheConfig(
+  config: Record<string, unknown>,
+  projectRoot: string
+): VerdictCacheConfig {
+  const cache = (config.cache as Record<string, unknown> | undefined) ?? {};
+  const verdicts = (cache.verdicts as Record<string, unknown> | undefined) ?? {};
+  const enabled = verdicts.enabled === true;
+  const rawDir = typeof verdicts.dir === 'string' ? verdicts.dir : DEFAULT_VERDICT_CACHE_DIR;
+  const dir = path.isAbsolute(rawDir) ? rawDir : path.join(projectRoot, rawDir);
+  return { enabled, dir };
+}
+
+/**
+ * Canonicalize an arbitrary JSON-ish value into a stable string: object keys are
+ * sorted recursively so two configs that differ only in key order hash equal.
+ * Non-plain values (functions, symbols) are dropped by JSON semantics.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = canonicalize(obj[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * SHA-256 of the canonicalized effective config, EXCLUDING the cache's own
+ * `cache` subtree (toggling the cache must not change other checks' keys — that
+ * would guarantee a cold cache on the very run that turns it on). Any other
+ * config change ⇒ a different hash ⇒ a miss by construction.
+ */
+export function computeConfigHash(config: Record<string, unknown>): string {
+  const { cache: _cache, ...rest } = config;
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(canonicalize(rest)))
+    .digest('hex');
+}
+
+/**
+ * Extensions that make up the memoization input closure: source code across the
+ * languages the checks scan, plus the config/doc formats they read. A broad,
+ * safe superset — including a file a check never reads only costs extra misses.
+ */
+const INPUT_CLOSURE_GLOB =
+  '**/*.{ts,tsx,js,jsx,mjs,cjs,cts,mts,py,rb,java,go,rs,php,cs,kt,swift,scala,md,mdx,json,jsonc,yaml,yml,toml}';
+
+/**
+ * Content hash of the project's tracked source/config/docs tree — the shared
+ * input closure for every memoized check on a run. Reuses the membership +
+ * content digest discipline of {@link computeSourceHash} (path-length-prefixed,
+ * sorted, full SHA-256), so adding, removing, renaming, or editing any closure
+ * file changes the hash.
+ *
+ * The `.harness` runtime dir (volatile state + the cache itself) and the usual
+ * build/vendor dirs are excluded: hashing the cache's own entries would make the
+ * hash self-referential (every write busts the next read), and hashing volatile
+ * run state would drive the hit rate to zero. The consequence — that a check
+ * reading state under `.harness` (the traceability graph, the arch baseline and
+ * allowances) is not covered by this closure — is exactly why those checks are
+ * excluded from {@link MEMOIZABLE_CHECKS} rather than served a possibly-stale
+ * verdict. Dotfiles ARE hashed (`dot: true`) so a hidden source/config input
+ * never silently drops out of the closure.
+ */
+export async function computeProjectInputHash(
+  projectRoot: string,
+  cacheDir: string,
+  extraExcludes: string[] = []
+): Promise<string> {
+  const relCacheDir = path.relative(projectRoot, cacheDir).replaceAll('\\', '/');
+  const ignore = [
+    ...skipDirGlobs(),
+    '**/.harness/**',
+    // Exclude the cache dir explicitly in case it lives outside `.harness`.
+    `${relCacheDir || '.'}/**`,
+    ...extraExcludes,
+  ];
+  const matches = await glob(INPUT_CLOSURE_GLOB, {
+    cwd: projectRoot,
+    ignore,
+    absolute: true,
+    nodir: true,
+    // Hash dotfiles too: the excludes above already drop `.git`/`.harness`/etc,
+    // and omitting hidden source/config would be a silent closure gap.
+    dot: true,
+  });
+  const files = matches
+    .map((abs) => {
+      let content: string;
+      try {
+        content = fs.readFileSync(abs, 'utf8');
+      } catch {
+        // A file that vanished between glob and read simply drops out of the
+        // closure; its absence is itself reflected on the next run's membership.
+        return undefined;
+      }
+      return { path: path.relative(projectRoot, abs).replaceAll('\\', '/'), content };
+    })
+    .filter((f): f is { path: string; content: string } => f !== undefined);
+  return computeSourceHash(files);
+}
+
+/**
+ * The content-addressed cache key for a check: SHA-256 over the canonical tuple
+ * of (check identity × gate version × config hash × input hash). Any change to
+ * any component yields a different key, so a stored verdict is returned only for
+ * a byte-identical (check, logic, config, inputs) tuple.
+ */
+export function computeVerdictKey(params: {
+  check: CICheckName;
+  gateVersion: number;
+  configHash: string;
+  inputHash: string;
+}): string {
+  const canonical = JSON.stringify({
+    check: params.check,
+    gateVersion: params.gateVersion,
+    configHash: params.configHash,
+    inputHash: params.inputHash,
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/** Envelope stored on disk for one cached verdict. */
+interface VerdictCacheRecord {
+  /** Store-schema version, so a format change can be ignored rather than misread. */
+  schema: 1;
+  /** The check this verdict is for (sanity cross-check against the key). */
+  check: CICheckName;
+  /** ISO timestamp the entry was written (diagnostics only). */
+  storedAt: string;
+  /** The memoized check result. */
+  result: CICheckResult;
+}
+
+/**
+ * A check result is safe to cache unless the check itself THREW — a thrown check
+ * surfaces as an `error` issue whose message carries the orchestrator's sentinel
+ * (`Check '<name>' threw:`). Such failures may be transient (a racing graph load,
+ * a transient IO error), so memoizing one would durably pin a false failure.
+ * Deterministic pass/fail verdicts are always cacheable.
+ */
+export function shouldCacheResult(result: CICheckResult): boolean {
+  return !result.issues.some(
+    (i) => i.severity === 'error' && i.message.startsWith(`Check '${result.name}' threw:`)
+  );
+}
+
+/**
+ * Local, content-addressed store of `{ key → CICheckResult }`, one JSON file per
+ * key under {@link VerdictCacheConfig.dir}. Reads tolerate a missing or corrupt
+ * entry by returning `undefined` (treated as a miss) rather than throwing, so a
+ * damaged cache degrades to recomputation, never to a crash.
+ */
+export class VerdictCache {
+  private readonly dir: string;
+
+  constructor(config: VerdictCacheConfig) {
+    this.dir = config.dir;
+  }
+
+  private entryPath(key: string): string {
+    return path.join(this.dir, `${key}.json`);
+  }
+
+  /** Return the memoized result for `key`, or `undefined` on a miss / unreadable entry. */
+  get(key: string): CICheckResult | undefined {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.entryPath(key), 'utf8');
+    } catch {
+      return undefined;
+    }
+    try {
+      const record = JSON.parse(raw) as VerdictCacheRecord;
+      if (record?.schema !== 1 || !record.result) return undefined;
+      return record.result;
+    } catch {
+      // Corrupt entry — treat as a miss; it will be overwritten on the recompute.
+      return undefined;
+    }
+  }
+
+  /** Store `result` under `key`. Best-effort: a write failure never fails the run. */
+  set(key: string, result: CICheckResult): void {
+    if (!shouldCacheResult(result)) return;
+    const record: VerdictCacheRecord = {
+      schema: 1,
+      check: result.name,
+      storedAt: new Date().toISOString(),
+      result,
+    };
+    try {
+      fs.mkdirSync(this.dir, { recursive: true });
+      // Write to a unique temp file then atomically rename into place, so a
+      // crash or a concurrent writer can never leave a half-written entry that
+      // would read as corrupt (and always-miss) on the next run.
+      const finalPath = this.entryPath(key);
+      const tmpPath = `${finalPath}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify(record));
+      fs.renameSync(tmpPath, finalPath);
+    } catch {
+      // A cache that cannot be written simply yields future misses.
+    }
+  }
+}
+
+/**
+ * Accumulates per-check hit/miss outcomes across a run and renders the
+ * {@link VerdictCacheStats} attached to the report.
+ */
+export class VerdictCacheStatsCollector {
+  private readonly entries: VerdictCacheStats['entries'] = [];
+
+  record(check: CICheckName, outcome: 'hit' | 'miss', key: string): void {
+    this.entries.push({ check, outcome, key });
+  }
+
+  toStats(): VerdictCacheStats {
+    return {
+      enabled: true,
+      hits: this.entries.filter((e) => e.outcome === 'hit').length,
+      misses: this.entries.filter((e) => e.outcome === 'miss').length,
+      entries: [...this.entries],
+    };
+  }
+}

--- a/packages/core/tests/ci/verdict-cache.test.ts
+++ b/packages/core/tests/ci/verdict-cache.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { CICheckResult } from '@harness-engineering/types';
+import {
+  parseVerdictCacheConfig,
+  VerdictCache,
+  VerdictCacheStatsCollector,
+  computeConfigHash,
+  computeProjectInputHash,
+  computeVerdictKey,
+  shouldCacheResult,
+  GATE_VERSIONS,
+  MEMOIZABLE_CHECKS,
+  DEFAULT_VERDICT_CACHE_DIR,
+} from '../../src/ci/verdict-cache';
+import type { CICheckName } from '@harness-engineering/types';
+import { runCIChecks } from '../../src/ci/check-orchestrator';
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+const ALL_CHECK_NAMES: readonly CICheckName[] = [
+  'validate',
+  'deps',
+  'docs',
+  'entropy',
+  'security',
+  'perf',
+  'phase-gate',
+  'arch',
+  'traceability',
+];
+const MEMOIZED_CHECK_NAMES: readonly CICheckName[] = [
+  'validate',
+  'deps',
+  'docs',
+  'entropy',
+  'security',
+  'perf',
+];
+
+const passResult: CICheckResult = { name: 'docs', status: 'pass', issues: [], durationMs: 3 };
+
+describe('computeVerdictKey — content-addressed key', () => {
+  const base = { check: 'docs' as const, gateVersion: 1, configHash: 'cfg', inputHash: 'inp' };
+
+  it('is deterministic for the same tuple', () => {
+    expect(computeVerdictKey(base)).toBe(computeVerdictKey({ ...base }));
+  });
+
+  it('changes when any component changes (never a stale hit)', () => {
+    const k0 = computeVerdictKey(base);
+    expect(computeVerdictKey({ ...base, check: 'deps' })).not.toBe(k0);
+    expect(computeVerdictKey({ ...base, gateVersion: 2 })).not.toBe(k0);
+    expect(computeVerdictKey({ ...base, configHash: 'other' })).not.toBe(k0);
+    expect(computeVerdictKey({ ...base, inputHash: 'other' })).not.toBe(k0);
+  });
+});
+
+describe('computeConfigHash', () => {
+  it('is order-independent over object keys', () => {
+    expect(computeConfigHash({ a: 1, b: 2 })).toBe(computeConfigHash({ b: 2, a: 1 }));
+  });
+
+  it('changes when a non-cache value changes', () => {
+    expect(computeConfigHash({ security: { enabled: true } })).not.toBe(
+      computeConfigHash({ security: { enabled: false } })
+    );
+  });
+
+  it('ignores the cache subtree so toggling the cache does not cold-start other checks', () => {
+    const off = computeConfigHash({ name: 'p', cache: { verdicts: { enabled: false } } });
+    const on = computeConfigHash({ name: 'p', cache: { verdicts: { enabled: true } } });
+    expect(off).toBe(on);
+  });
+});
+
+describe('parseVerdictCacheConfig', () => {
+  it('defaults to disabled with the default dir', () => {
+    const cfg = parseVerdictCacheConfig({}, '/root');
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.dir).toBe(path.join('/root', DEFAULT_VERDICT_CACHE_DIR));
+  });
+
+  it('honors enabled + a custom relative dir (resolved against the root)', () => {
+    const cfg = parseVerdictCacheConfig(
+      { cache: { verdicts: { enabled: true, dir: 'tmp/vc' } } },
+      '/root'
+    );
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.dir).toBe(path.join('/root', 'tmp/vc'));
+  });
+
+  it('keeps an absolute dir as-is', () => {
+    const cfg = parseVerdictCacheConfig(
+      { cache: { verdicts: { enabled: true, dir: '/abs/vc' } } },
+      '/root'
+    );
+    expect(cfg.dir).toBe('/abs/vc');
+  });
+});
+
+describe('computeProjectInputHash — the input closure', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tmpDir('vc-input-');
+    fs.writeFileSync(path.join(root, 'a.ts'), 'export const a = 1;');
+    fs.writeFileSync(path.join(root, 'README.md'), '# hi');
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const cacheDir = (r: string) => path.join(r, DEFAULT_VERDICT_CACHE_DIR);
+
+  it('is stable across two reads of an unchanged tree', async () => {
+    const h1 = await computeProjectInputHash(root, cacheDir(root));
+    const h2 = await computeProjectInputHash(root, cacheDir(root));
+    expect(h1).toBe(h2);
+  });
+
+  it('changes when a closure file changes (→ miss on the next run)', async () => {
+    const before = await computeProjectInputHash(root, cacheDir(root));
+    fs.writeFileSync(path.join(root, 'a.ts'), 'export const a = 2;');
+    const after = await computeProjectInputHash(root, cacheDir(root));
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when a file is added (membership is part of the closure)', async () => {
+    const before = await computeProjectInputHash(root, cacheDir(root));
+    fs.writeFileSync(path.join(root, 'b.ts'), 'export const b = 1;');
+    const after = await computeProjectInputHash(root, cacheDir(root));
+    expect(after).not.toBe(before);
+  });
+
+  it('excludes the .harness runtime dir and the cache dir (no self-reference)', async () => {
+    const before = await computeProjectInputHash(root, cacheDir(root));
+    fs.mkdirSync(path.join(root, '.harness', 'cache', 'verdicts'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.harness', 'state.json'), '{"x":1}');
+    fs.writeFileSync(path.join(root, '.harness', 'cache', 'verdicts', 'deadbeef.json'), '{"y":2}');
+    const after = await computeProjectInputHash(root, cacheDir(root));
+    expect(after).toBe(before);
+  });
+});
+
+describe('VerdictCache store', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = tmpDir('vc-store-');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('round-trips a stored verdict', () => {
+    const cache = new VerdictCache({ enabled: true, dir });
+    expect(cache.get('k1')).toBeUndefined();
+    cache.set('k1', passResult);
+    expect(cache.get('k1')).toEqual(passResult);
+  });
+
+  it('returns undefined (a miss) for a corrupt entry instead of throwing', () => {
+    const cache = new VerdictCache({ enabled: true, dir });
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'bad.json'), 'not json{');
+    expect(cache.get('bad')).toBeUndefined();
+  });
+
+  it('does not cache a check that threw (transient-error guard)', () => {
+    const cache = new VerdictCache({ enabled: true, dir });
+    const threw: CICheckResult = {
+      name: 'security',
+      status: 'fail',
+      issues: [{ severity: 'error', message: `Check 'security' threw: boom` }],
+      durationMs: 1,
+    };
+    cache.set('kt', threw);
+    expect(cache.get('kt')).toBeUndefined();
+  });
+});
+
+describe('shouldCacheResult', () => {
+  it('is true for a normal pass/fail verdict', () => {
+    expect(shouldCacheResult(passResult)).toBe(true);
+    expect(
+      shouldCacheResult({
+        name: 'deps',
+        status: 'fail',
+        issues: [{ severity: 'error', message: 'layer violation' }],
+        durationMs: 2,
+      })
+    ).toBe(true);
+  });
+
+  it('is false when the check threw', () => {
+    expect(
+      shouldCacheResult({
+        name: 'arch',
+        status: 'fail',
+        issues: [{ severity: 'error', message: `Check 'arch' threw: nope` }],
+        durationMs: 2,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('VerdictCacheStatsCollector', () => {
+  it('counts hits and misses and preserves entry order', () => {
+    const c = new VerdictCacheStatsCollector();
+    c.record('validate', 'miss', 'a');
+    c.record('docs', 'hit', 'b');
+    c.record('deps', 'hit', 'c');
+    const stats = c.toStats();
+    expect(stats).toEqual({
+      enabled: true,
+      hits: 2,
+      misses: 1,
+      entries: [
+        { check: 'validate', outcome: 'miss', key: 'a' },
+        { check: 'docs', outcome: 'hit', key: 'b' },
+        { check: 'deps', outcome: 'hit', key: 'c' },
+      ],
+    });
+  });
+});
+
+describe('MEMOIZABLE_CHECKS', () => {
+  it('excludes checks whose verdict inputs live outside the source closure', () => {
+    // traceability reads the .harness graph; arch reads the .harness baseline +
+    // allowances and the git base-ref — none covered by the source-tree hash.
+    expect(MEMOIZABLE_CHECKS.has('traceability')).toBe(false);
+    expect(MEMOIZABLE_CHECKS.has('arch')).toBe(false);
+  });
+
+  it('includes the source/config/docs-scanning checks', () => {
+    for (const name of MEMOIZED_CHECK_NAMES) {
+      expect(MEMOIZABLE_CHECKS.has(name)).toBe(true);
+    }
+  });
+});
+
+describe('GATE_VERSIONS', () => {
+  it('declares a version for every check name', () => {
+    for (const name of ALL_CHECK_NAMES) {
+      expect(GATE_VERSIONS[name]).toBeTypeOf('number');
+    }
+  });
+});
+
+describe('runCIChecks — memoization integration (issue #1639)', () => {
+  let root: string;
+  const skip = ['entropy', 'security', 'perf', 'arch', 'traceability', 'deps'] as const;
+  beforeEach(() => {
+    root = tmpDir('vc-run-');
+    fs.writeFileSync(path.join(root, 'a.ts'), 'export const a = 1;');
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  function cfg(enabled: boolean): Record<string, unknown> {
+    return {
+      version: 1,
+      name: 'tmp',
+      cache: { verdicts: { enabled, dir: path.join(root, '.harness/cache/verdicts') } },
+    };
+  }
+
+  it('misses on the first run and hits on an unchanged second run', async () => {
+    const r1 = await runCIChecks({ projectRoot: root, config: cfg(true), skip: [...skip] });
+    expect(r1.ok).toBe(true);
+    if (!r1.ok) return;
+    expect(r1.value.cacheStats).toBeDefined();
+    expect(r1.value.cacheStats!.hits).toBe(0);
+    expect(r1.value.cacheStats!.misses).toBeGreaterThan(0);
+
+    const r2 = await runCIChecks({ projectRoot: root, config: cfg(true), skip: [...skip] });
+    expect(r2.ok).toBe(true);
+    if (!r2.ok) return;
+    // Every check that missed on run 1 is served from cache on run 2.
+    expect(r2.value.cacheStats!.misses).toBe(0);
+    expect(r2.value.cacheStats!.hits).toBe(r1.value.cacheStats!.misses);
+    // The memoized verdicts are identical to the freshly-computed ones.
+    expect(r2.value.checks).toEqual(r1.value.checks);
+  });
+
+  it('misses again after a closure file changes (correct-by-construction, no stale hit)', async () => {
+    await runCIChecks({ projectRoot: root, config: cfg(true), skip: [...skip] });
+    fs.writeFileSync(path.join(root, 'a.ts'), 'export const a = 999;');
+    const r = await runCIChecks({ projectRoot: root, config: cfg(true), skip: [...skip] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.cacheStats!.hits).toBe(0);
+    expect(r.value.cacheStats!.misses).toBeGreaterThan(0);
+  });
+
+  it('never records a non-memoizable check (arch, traceability) in the cache stats', async () => {
+    // arch and traceability RUN (not skipped) but must bypass the cache — their
+    // verdicts depend on .harness baseline/graph state not covered by the source
+    // hash, so caching them could serve a stale verdict.
+    const skipRest = ['entropy', 'security', 'perf', 'deps'] as const;
+    const r = await runCIChecks({ projectRoot: root, config: cfg(true), skip: [...skipRest] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.checks.some((c) => c.name === 'arch')).toBe(true);
+    expect(r.value.checks.some((c) => c.name === 'traceability')).toBe(true);
+    expect(r.value.cacheStats!.entries.some((e) => e.check === 'arch')).toBe(false);
+    expect(r.value.cacheStats!.entries.some((e) => e.check === 'traceability')).toBe(false);
+  });
+
+  it('attaches no cacheStats when the cache is disabled (byte-stable default path)', async () => {
+    const r = await runCIChecks({ projectRoot: root, config: cfg(false), skip: [...skip] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.cacheStats).toBeUndefined();
+  });
+});

--- a/packages/types/src/ci.ts
+++ b/packages/types/src/ci.ts
@@ -151,6 +151,36 @@ export interface ConstraintPackCompliance {
 }
 
 /**
+ * Outcome of a single check's cache lookup during a memoized CI run
+ * (content-addressed gate memoization, issue #1639).
+ */
+export interface VerdictCacheEntry {
+  /** The check this lookup was for. */
+  check: CICheckName;
+  /** Whether the check's verdict was served from cache (`hit`) or computed (`miss`). */
+  outcome: 'hit' | 'miss';
+  /** The content-addressed cache key the check hashed to (sha256 hex). */
+  key: string;
+}
+
+/**
+ * Hit/miss telemetry for a memoized CI run (content-addressed gate memoization,
+ * issue #1639). Present on a {@link CICheckReport} only when the verdict cache
+ * is opted in; absent otherwise so the default report shape stays byte-identical.
+ * Emission only — never influences any check's status or the run exit code.
+ */
+export interface VerdictCacheStats {
+  /** Whether the verdict cache was enabled for this run (always true when present). */
+  enabled: boolean;
+  /** Number of checks whose verdict was served from cache. */
+  hits: number;
+  /** Number of checks that were computed and recorded. */
+  misses: number;
+  /** Per-check lookup outcomes, in the order the checks resolved. */
+  entries: VerdictCacheEntry[];
+}
+
+/**
  * Final report for a CI run.
  */
 export interface CICheckReport {
@@ -176,6 +206,13 @@ export interface CICheckReport {
    * Absent when every configured name resolved.
    */
   unknownConstraintPacks?: string[];
+  /**
+   * Content-addressed verdict-cache hit/miss telemetry (issue #1639). Present
+   * only when the verdict cache is opted in; absent for the default (cache-off)
+   * path so the serialized report shape is byte-identical to before. Emission
+   * only — never affects `exitCode` or any check's `status`.
+   */
+  cacheStats?: VerdictCacheStats;
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -50,6 +50,8 @@ export type {
   CICheckResult,
   CICheckSummary,
   CICheckReport,
+  VerdictCacheEntry,
+  VerdictCacheStats,
   CIFailOnSeverity,
   CICheckOptions,
   CIPlatform,


### PR DESCRIPTION
## Summary

Implements **issue #1639 — content-addressed gate memoization** (an action cache for verdicts), Wave-1 P1. Adds an opt-in (default **OFF**), local, content-addressed `VerdictCache` wired transparently into the CI check orchestrator. Each check's verdict is keyed by a SHA-256 over `(check identity × gate version × config hash × input hash)`; on a hit the stored `CICheckResult` is returned instead of re-running the check, on a miss the check runs and records its verdict. Hit/miss telemetry rides on an optional `CICheckReport.cacheStats`, **absent** on the default cache-off path so existing report output is byte-identical.

Builds cleanly on the `GateMeasurement` work merged in #1673 — the `CheckContribution`/`measurements` plumbing is untouched and round-trips through the cache.

`Refs #1639` — first correct-by-construction slice; remainder deferred (see below).

## How it works

- **Input hash** — one content digest over the project's tracked source/config/docs tree (all languages + `md`/`json`/`yaml`/`toml`, dotfiles included), computed once per run and shared by every memoized check. Reuses `computeSourceHash` (membership + content, path-length-prefixed, sorted, full SHA-256).
- **Config hash** — canonical JSON of the effective (pack-overlaid) config, minus the cache's own subtree.
- **Gate version** — per-check integer; bumping it invalidates that check's cache by construction.
- **Store** — one JSON file per key under `.harness/cache/verdicts`, written atomically (temp + rename); corrupt/missing entries degrade to a miss.

## Correctness — never a stale hit

Only checks whose **full** verdict closure the source-tree hash covers are memoized (`MEMOIZABLE_CHECKS`). Two checks are deliberately excluded because their verdict depends on state **outside** the closure, so a tree hash could serve a stale verdict:

- **`traceability`** reads the derived graph under `.harness`.
- **`arch`** diffs against `.harness/arch/baselines.json` + per-PR allowances and, in a PR context, resolves the baseline from the git **base ref** / `HARNESS_ARCH_BASE_REF` — none of which is a working-tree file.

A non-memoizable check always runs and never appears in `cacheStats`. Additionally, a check that **threw** an internal error is never cached (transient-error guard).

This exclusion was surfaced by an adversarial self-review of the diff (it initially caught `arch` as a stale-hit blocker) and fixed before opening.

## Opt-in

```jsonc
"cache": { "verdicts": { "enabled": true } }   // default false; dir defaults to .harness/cache/verdicts
```

`harness ci check` prints a `Verdict cache: N hits, M misses` line; `--output json` carries the full `cacheStats`.

## Tests

New `packages/core/tests/ci/verdict-cache.test.ts` (25 cases): key determinism/sensitivity, config-hash order-independence + cache-subtree exclusion, input-closure stability + **changed-file → miss** + membership + `.harness` self-reference exclusion, store round-trip + corrupt-entry tolerance + threw-guard, `MEMOIZABLE_CHECKS` exclusions, and an end-to-end `runCIChecks` integration: **miss on first run → hit on unchanged second run**, **miss again after a closure file changes**, non-memoizable checks (`arch`/`traceability`) never recorded, and **no `cacheStats` when disabled**. All 61 `tests/ci/` pass.

Verified behaviorally via the built CLI: two consecutive `harness ci check` runs → run 1 `0 hits, 3 misses`, run 2 `3 hits, 0 misses`, identical verdicts.

## Assumptions made

- Opt-in local content-addressed verdict cache; changed input ⇒ different hash ⇒ miss (no stale hits); remote/distributed backend deferred.
- The input closure is an honest **over-approximation** (whole tracked source/config/docs tree) shared across the memoized checks; it may over-miss but never returns a stale hit.
- Checks whose verdict depends on `.harness` baseline/graph state or git base-ref (`arch`, `traceability`) are excluded from memoization rather than risk a stale hit.
- `cacheStats` is emission-only telemetry — never influences `exitCode` or any check status; absent on the default cache-off path for byte-stable reports.

## Deferred (remainder on #1639)

- Per-gate **input-closure declaration** + runtime **access-recorder / closure audit** (would let `arch`/`traceability` opt in by folding baseline/allowance/base-ref or the graph digest into the key; also lets internal-failure paths be marked uncacheable).
- **Shareable / distributed** cache backend (artifact store) — local dir only here.
- Per-gate-class savings telemetry feeding **basal-metabolism** accounting.
- `harness cache stats` / `harness cache explain` CLI surface.

## Provenance

- Plan: `docs/changes/content-addressed-gate-memoization-1639/plans/plan-content-addressed-gate-memoization.md`
- `docs/changes/content-addressed-gate-memoization-1639/provenance.json`

https://claude.ai/code/session_01DHrH6jAfhUaVhkhjw2P1ga
