### PR TITLE
feat(roadmap): pnyon (Waypoint) tracker kind — adapter, typed API contract, tracker-kind registry

### DIFF
--- a/.changeset/waypoint-tracker-kind-pnyon-1815.md
+++ b/.changeset/waypoint-tracker-kind-pnyon-1815.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+feat(roadmap): open the file-less tracker seam with a tracker-kind registry
+and a `pnyon` (Waypoint) RoadmapTrackerClient adapter (#1815).
+
+`core` gains `PnyonTrackerAdapter` — the full `RoadmapTrackerClient`
+interface implemented against a documented, typed Waypoint HTTP API contract
+(`WaypointHttp`): claims map to `sdlc.claim.*` event semantics guarded by
+event-version preconditions, stale writes surface as `ConflictError` code
+`TRACKER_CONFLICT`, history rides the item's evidence ledger, and the adapter
+performs zero GitHub API calls (machine actors never touch GitHub's assignee
+field, #640). A new tracker-kind registry (`registerTrackerKind`) lets
+`loadTrackerClientConfigFromProject` and `createTrackerClient` resolve
+registered kinds — builtin: `pnyon` (config `url` + `token`/`PNYON_TOKEN`) —
+while `github` behavior is preserved byte-for-byte and unregistered kinds are
+still rejected (now listing the registered kinds).
+
+`cli`'s `TrackerConfigSchema` becomes a discriminated union so
+`roadmap.tracker.kind: "pnyon"` validates; the github variant is unchanged.
+
+Also re-exports the `context-surface` helpers consumed by its own test file,
+fixing the `tsc --noEmit` break on main (#1814).

--- a/.harness/arch/allowances/feat-waypoint-tracker-kind-pnyon.json
+++ b/.harness/arch/allowances/feat-waypoint-tracker-kind-pnyon.json
@@ -1,0 +1,9 @@
+{
+  "reason": "New pnyon (Waypoint) tracker adapter + typed API contract + tracker-kind registry (docs/changes/waypoint-tracker-kind-pnyon, #1815): three new core modules and their contract tests intentionally add module-size/dependency-depth",
+  "categories": {
+    "module-size": 262222,
+    "dependency-depth": 659
+  },
+  "violationIds": [],
+  "createdFrom": "4075e027d"
+}

--- a/.harness/comprehension/packages/cli/src/config/_module.md
+++ b/.harness/comprehension/packages/cli/src/config/_module.md
@@ -1,11 +1,20 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/config"
-sourceHash: "ecbb6da964bc2ed54f0614dd8a512abd6292c6c5c07e8269fe288e5458245926"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/cli/src/config'
+sourceHash: '96a027650e45219810e7a2fbf53797d357758084cfa9746229cb75cc0f2f1cf6'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["analysis-schema.ts", "ingest-schema.ts", "loader.ts", "schema.amr.test.ts", "schema.ts", "stripped-keys.test.ts", "stripped-keys.ts"]
+members:
+  [
+    'analysis-schema.ts',
+    'ingest-schema.ts',
+    'loader.ts',
+    'schema.amr.test.ts',
+    'schema.ts',
+    'stripped-keys.test.ts',
+    'stripped-keys.ts',
+  ]
 ---
 
 ## Interface Contract

--- a/.harness/comprehension/packages/cli/src/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/_module.md
@@ -1,12 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp'
-sourceHash: 'ada544265cbc76d6829af439139846fb8174698e37cb2798870a66e8f537fe66'
+sourceHash: '370e54ef5012320aa02a5d84bbfe3110cb08f9702e90ac89d28eced455c5587c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
+    'context-surface.test.ts',
     'context-surface.ts',
     'index.ts',
     'server.ts',
@@ -33,6 +34,7 @@ export startServer
 ```
 import { ensureComprehensionSearchIgnore, ensureHarnessGitignore } from '../templates/post-write.js'
 import from '../version.js'
+import { agentsMdEntry, gatherContextSurface, hooksEntry, mcpToolEntries, skillTreeEntries, toolDefinitionText } from './context-surface'
 import { getToolDefinitions } from './index.js'
 import { applyCompaction } from './middleware/compaction.js'
 import { applyContextBudget } from './middleware/context-budget.js'
@@ -46,7 +48,9 @@ import { getRulesResource } from './resources/rules.js'
 import { getSkillsResource } from './resources/skills.js'
 import { getStateResource } from './resources/state.js'
 import { TOOL_CAPABILITY_DECLARATIONS } from './tool-capability-declarations.js'
+import { CORE_TOOL_NAMES, STANDARD_TOOL_NAMES } from './tool-tiers'
 import { CORE_TOOL_NAMES, McpToolTier, STANDARD_TOOL_NAMES } from './tool-tiers.js'
+import { ToolDefinition } from './tool-types'
 import { ToolCapabilityDeclaration, ToolDefinition, ToolScope } from './tool-types.js'
 import { acceptanceEvalDefinition, handleAcceptanceEval } from './tools/acceptance-eval.js'
 import { handleManageAdr, manageAdrDefinition } from './tools/adr.js'
@@ -127,6 +131,8 @@ import { ContextSurfaceEntry } from '@harness-engineering/core'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListResourcesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ```

--- a/.harness/comprehension/packages/cli/tests/config/_module.md
+++ b/.harness/comprehension/packages/cli/tests/config/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/config'
-sourceHash: '308cf17153bedf21b90b2749ff1740fa7c7e1a13cf281c635044d719821f1dd6'
+sourceHash: '428d8caee8f80e8fb784c6420c68044629a2efed80f113b1cd8efd0280ee7c8f'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -22,6 +22,7 @@ members:
     'schema.roadmap-mode.test.ts',
     'schema.test.ts',
     'schema.tracker-kind.test.ts',
+    'schema.tracker-pnyon.test.ts',
     'skill-hooks-schema.test.ts',
     'telemetry-export-schema.test.ts',
     'toolchain-schema.test.ts',

--- a/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/tests/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/mcp/tools'
-sourceHash: '0f47fcc8d4da413ace144b32d4afd5220c0672725f27002c713ca6da45cba193'
+sourceHash: '0126d51e9f24abbca2074286372baf4048e2d2179544ababd0ddec9706cb6868'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -67,6 +67,7 @@ members:
     'roadmap-missing-path.test.ts',
     'roadmap-scoped-sync.test.ts',
     'roadmap.file-backed-regression.test.ts',
+    'roadmap.file-less-pnyon.test.ts',
     'roadmap.file-less-stub.test.ts',
     'roadmap.file-less.test.ts',
     'roadmap.sharded.test.ts',
@@ -179,7 +180,7 @@ import { HealthSnapshot, captureHealthSnapshot, isSnapshotFresh, loadCachedSnaps
 import { loadOrRebuildIndex } from '../../../src/skill/index-builder'
 import { recommend } from '../../../src/skill/recommendation-engine'
 import { loadOrGenerateProfile } from '../../../src/skill/stack-profile'
-import { COMPILER_VERSION, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, ConflictError, Err, ExtractStatic, FeaturePatch, HistoryEvent, NewFeatureInput, Ok, Result, RoadmapTrackerClient, SCHEMA_VERSION, TrackedFeature, compileModule, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, detectStaleConstraints, loadTrackerConfig, parseRoadmap, roadmapToShards, serializeMeta, serializeShard } from '@harness-engineering/core'
+import { COMPILER_VERSION, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, ConflictError, Err, ExtractStatic, FeaturePatch, HistoryEvent, NewFeatureInput, Ok, PnyonTrackerAdapter, Result, RoadmapTrackerClient, SCHEMA_VERSION, TrackedFeature, compileModule, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, detectStaleConstraints, loadTrackerConfig, parseRoadmap, roadmapToShards, serializeMeta, serializeShard } from '@harness-engineering/core'
 import { queryTraceability } from '@harness-engineering/graph'
 import { deriveAcceptanceAuthority } from '@harness-engineering/intelligence'
 import { Err, Ok, Result } from '@harness-engineering/types'

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: 'bd2857a9a116227e1acf98f7888236b5ed209bd2e7a0a213b2f7b46568facdd7'
+sourceHash: '0f046c6a089cfe71e53eaedafecd7cd999b78cf878602850edcc22ee89076e86'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -53,7 +53,11 @@ export IssueTrackerClient
 export MakeTrackerConflictBodyOptions
 export NewFeatureInput
 export PilotScoringOptions
+export PnyonTrackerAdapter
+export PnyonTrackerClientConfig
+export PnyonTrackerOptions
 export ReconcileResult
+export RegisteredTrackerClientConfig
 export RoadmapGroomChange
 export RoadmapGroomChangeKind
 export RoadmapGroomOptions
@@ -80,7 +84,16 @@ export TrackedFeature
 export TrackerClientConfig
 export TrackerConfig
 export TrackerConflictBody
+export TrackerKindRegistration
 export TrackerSyncAdapter
+export WaypointCommand
+export WaypointCommandResult
+export WaypointEvidenceEntry
+export WaypointHttp
+export WaypointHttpError
+export WaypointItem
+export WaypointItemPatch
+export WaypointNewItem
 export applySyncChanges
 export assignFeature
 export assigneeInvariantHolds
@@ -94,11 +107,13 @@ export deriveRepoFromGitRemote
 export detectRoadmapStorageMode
 export fullSync
 export getRoadmapMode
+export getTrackerKindRegistration
 export groomRoadmap
 export isClaimableBy
 export isMachineAssignee
 export isRegression
 export isUnactionablePlanned
+export listRegisteredTrackerKinds
 export loadProjectRoadmapMode
 export loadTrackerClientConfigFromProject
 export loadTrackerSyncConfig
@@ -111,6 +126,7 @@ export parseRoadmap
 export promoteFeature
 export pushAssigneeToExternal
 export reconcileDoneFromClosedIssues
+export registerTrackerKind
 export release
 export resolveReverseStatus
 export scoreRoadmapCandidates
@@ -143,6 +159,7 @@ import { decodeSummaryField, encodeSummaryField } from './summary-field'
 import { TrackedFeature } from './tracker'
 import { ExternalSyncOptions, TicketWriteOptions, TrackerSyncAdapter, resolveReverseStatus } from './tracker-sync'
 import { TrackerClientConfig } from './tracker/factory'
+import { getTrackerKindRegistration, listRegisteredTrackerKinds } from './tracker/registry'
 import { AssignmentRecord, Err, ExternalTicket, ExternalTicketState, FeatureStatus, Ok, Priority, Result, Roadmap, RoadmapFeature, RoadmapFrontmatter, RoadmapGroup, RoadmapMilestone, RowSyncResult, SyncResult, TrackerComment, TrackerSyncConfig } from '@harness-engineering/types'
 import * as fs from 'fs'
 import { execFileSync } from 'node:child_process'

--- a/.harness/comprehension/packages/core/src/roadmap/tracker/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/tracker/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap/tracker'
-sourceHash: '0df5979eed831cd8f8caa37980c6b83336bb620e7c9a6646d9b5da3fb0699f1a'
-compiledAt: '2026-08-28T01:22:10.551Z'
+sourceHash: '840004abe2f01059b668b3eed40b1176e5935574f7b010003930a5c00665a93f'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'body-metadata.ts',
@@ -16,24 +15,10 @@ members:
     'etag-store.ts',
     'factory.ts',
     'index.ts',
+    'registry.ts',
     'types.ts',
   ]
 ---
-
-## Summary
-
-The `tracker` module provides a unified abstraction for reading and writing feature metadata stored in external issue trackers (GitHub, Linear). It splits into three layers: (1) body-metadata parses/serializes a YAML block embedded in issue bodies containing spec, plan, blockedBy, priority, milestone; (2) RoadmapTrackerClient defines CRUD operations with reads supporting filter-by-ID/status and writes guarded by conflict detection; (3) conflict-handling detects divergent writes via refetch-and-compare since GitHub REST lacks native 412 responses. Core design: blockers are stored as feature names (not IDs), the body-meta block is canonical source of truth, and server fields (updatedAt, externalId, createdAt) are immutable and never written back.
-
-## Invariants
-
-- Body metadata block (HTML-delimited YAML) is the canonical source for spec, plan, blockedBy, priority, milestone — any discrepancy with other fields is a bug
-- blockedBy contains feature names as strings, not externalIds; callers must resolve to external IDs when cross-tracker lookups are needed
-- Conflict detection is refetch-and-compare; ifMatch parameter is forward-compatible placeholder for future ETag support
-- Server fields (externalId, createdAt, updatedAt) are immutable and cannot be patched; clients omit them from NewFeatureInput and FeaturePatch
-- Metadata parsing is tolerant: missing blocks → empty meta, malformed YAML → warning + empty meta, multiple blocks → first wins with warning
-- blockedBy parser accepts comma-separated strings (legacy) or arrays (preferred); serializer always emits arrays for round-trip safety
-- TRACKER_CONFLICT 409 response (code, refreshHint=reload-roadmap) is emitted by three endpoints: claim, roadmap-status, and orchestrator append
-- updatedAt from refetch after write represents server state at conflict detection time and informs caller's merge-vs-abort decision
 
 ## Interface Contract
 
@@ -52,13 +37,29 @@ export LinearTrackerClientConfig
 export LinearTrackerOptions
 export MakeTrackerConflictBodyOptions
 export NewFeatureInput
+export PnyonTrackerAdapter
+export PnyonTrackerClientConfig
+export PnyonTrackerOptions
+export RegisteredTrackerClientConfig
 export RoadmapTrackerClient
 export TrackedFeature
 export TrackerClientConfig
 export TrackerConfig
 export TrackerConflictBody
+export TrackerKindRegistration
+export WaypointCommand
+export WaypointCommandResult
+export WaypointEvidenceEntry
+export WaypointHttp
+export WaypointHttpError
+export WaypointItem
+export WaypointItemPatch
+export WaypointNewItem
 export createTrackerClient
+export getTrackerKindRegistration
+export listRegisteredTrackerKinds
 export makeTrackerConflictBody
+export registerTrackerKind
 ```
 
 ## Dependency Slice
@@ -66,9 +67,11 @@ export makeTrackerConflictBody
 ```
 import { GitHubIssuesTrackerAdapter, GitHubIssuesTrackerOptions } from './adapters/github-issues'
 import { LinearTrackerAdapter, LinearTrackerOptions } from './adapters/linear'
+import { PnyonTrackerAdapter, PnyonTrackerClientConfig } from './adapters/pnyon'
 import { ConflictError, FeaturePatch, RoadmapTrackerClient, TrackedFeature } from './client'
 import { makeTrackerConflictBody } from './conflict-body'
 import { ETagStore } from './etag-store'
+import { getTrackerKindRegistration } from './registry'
 import { Err, FeatureStatus, Ok, Priority, Result } from '@harness-engineering/types'
 import { describe, expect, it } from 'vitest'
 import { parseYaml, stringifyYaml } from 'yaml'

--- a/.harness/comprehension/packages/core/src/roadmap/tracker/adapters/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/tracker/adapters/_module.md
@@ -1,28 +1,21 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap/tracker/adapters'
-sourceHash: 'c3390051d8aae8af9eddfb6a65168f331efcd42a2d89467b7d09a43695fd85c2'
-compiledAt: '2026-08-28T01:22:10.544Z'
+sourceHash: '28588d79c7b2e421441b941a13f2fc2256e9b1de70bcec22acd93a9c3ed55810'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
-  ['github-http.test.ts', 'github-http.ts', 'github-issues.ts', 'linear.test.ts', 'linear.ts']
+  [
+    'github-http.test.ts',
+    'github-http.ts',
+    'github-issues.ts',
+    'linear.test.ts',
+    'linear.ts',
+    'pnyon.ts',
+    'waypoint-http.ts',
+  ]
 ---
-
-## Summary
-
-The `packages/core/src/roadmap/tracker/adapters` module implements platform-agnostic HTTP clients and adapter patterns for syncing roadmap data with external issue trackers (GitHub, Linear). **`GitHubHttp`** is the core HTTP layer: it handles authentication, retries with exponential backoff, pagination with ETag-based caching, and rate-limit coordination through a shared `RateBudget`. The adapters (`GitHubIssuesTrackerAdapter`, `LinearTrackerAdapter`) wrap these clients to translate between tracker APIs and the internal roadmap model. External IDs are normalized via `buildExternalId` / `parseExternalId` to track feature identity across systems.
-
-## Invariants
-
-- Rate budget gates all fetches: calls to GitHubHttp.request() must acquire the shared rate budget before issuing the fetch; a cooldown from a prior 429 defers the entire request, not just adding backoff
-- 429 responses are terminal and penalize the budget: a 429 with no retries remaining throws ThrottledFetchError, records a cooldown in the shared budget, and does not return a response
-- Pagination detects truncation and fails fast: a short page that advertises rel="next" or has incomplete_results: true throws TruncatedFetchError — the server truncated results, not a natural end of pages
-- ETags carry through pagination to the end: the final ETag from the last page request must be used on the next full fetch to detect cache hits (304); a 304 mid-walk preserves accumulated items but halts pagination
-- Retry-After header overrides backoff delays: when a 403/429 response includes Retry-After (seconds), that value replaces the exponential backoff calculation
-- Bearer auth and GitHub headers are mandatory: every request carries Authorization, Accept: application/vnd.github+json, X-GitHub-Api-Version: 2022-11-28, and Content-Type: application/json
-- Non-2xx, non-304 responses fail without retry: 4xx errors (except 403/429) and any non-retryable status return immediately; retrying only occurs on 500/502/503/403/429
 
 ## Interface Contract
 
@@ -31,6 +24,9 @@ export GitHubHttp
 export GitHubIssuesTrackerAdapter
 export HistoryEventType
 export LinearTrackerAdapter
+export PnyonTrackerAdapter
+export WaypointHttp
+export WaypointHttpError
 export buildExternalId
 export parseExternalId
 ```
@@ -46,6 +42,7 @@ import { ETagStore } from '../etag-store'
 import from '../factory'
 import { GitHubHttp, buildExternalId, parseExternalId } from './github-http'
 import { LinearTrackerAdapter } from './linear'
+import { WaypointCommand, WaypointHttp, WaypointHttpError, WaypointItem, WaypointItemPatch } from './waypoint-http'
 import { Err, FeatureStatus, Ok, Priority, Result } from '@harness-engineering/types'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/.harness/comprehension/packages/core/tests/roadmap/tracker/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/tracker/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap/tracker'
-sourceHash: 'cbd88a69607acd27eeab83e4e60e8a9b7a2564642854e7eb5cfbc3be4478dcc0'
-compiledAt: '2026-08-28T01:22:10.948Z'
+sourceHash: 'd9563716fbf392fab8e715586f56e0efa7335f1706f5d71887011b27a4f6af22'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'body-metadata.test.ts',
@@ -14,25 +13,9 @@ members:
     'factory.test.ts',
     'index.test.ts',
     'public-surface.test.ts',
+    'registry.test.ts',
   ]
 ---
-
-## Summary
-
-packages/core/tests/roadmap/tracker tests the roadmap tracking system's core concerns: embedding and extracting YAML metadata from GitHub issue bodies, detecting conflicting concurrent updates to tracked features, and managing optimistic concurrency via ETags. Body metadata (spec, plan, blockers, priority, milestone) is serialized into issue bodies between HTML comment markers and must round-trip exactly through parse/serialize cycles. Conflict detection compares client patches against server state, distinguishing idempotent updates (already applied) from genuine conflicts (assignee/status/priority/milestone/spec mismatches). Terminal states like 'done' are sticky. Retries use exponential backoff on transient errors but fail-fast on ConflictError.
-
-## Invariants
-
-- Metadata blocks are delimited by `<!-- harness-meta:start -->` and `<!-- harness-meta:end -->` HTML comments; content outside these markers is summary text.
-- Only the first metadata block in a body is parsed; subsequent blocks are ignored with a warning logged.
-- Metadata inside the block must be valid YAML; malformed YAML causes the entire block to be discarded (meta = {}) with warning, leaving only summary.
-- The blocked_by field serializes as YAML array (block sequence with `-` prefixes), not comma-joined strings, to preserve feature names containing commas.
-- Round-trip serialize(summary, meta) → parse() must return {summary, meta} exactly (structure-preserving), except malformed meta becomes {} with warning.
-- Conflict detection treats feature patches against server state: if any mutable field (assignee, status, priority, milestone, spec) differs between caller and server, a conflict is recorded as {ours, theirs}.
-- Terminal feature statuses (e.g., 'done') are sticky: attempting to transition away from done triggers a conflict; transitioning to done from any state is always allowed.
-- ConflictError is thrown immediately without retry; only transient (non-conflict) errors proceed through exponential backoff up to maxAttempts.
-- Idempotent operations (patch matches current server state) return ok:true with idempotent:true flag; they succeed without conflict.
-- ETag-based optimistic concurrency: caller's view must match server's after refetch; mismatch on any tracked field triggers conflict.
 
 ## Interface Contract
 
@@ -43,12 +26,19 @@ packages/core/tests/roadmap/tracker tests the roadmap tracking system's core con
 ## Dependency Slice
 
 ```
+import { loadTrackerClientConfigFromProject } from '../../../src/roadmap/load-tracker-client-config'
 import { GitHubIssuesTrackerAdapter } from '../../../src/roadmap/tracker/adapters/github-issues'
+import { PnyonTrackerAdapter } from '../../../src/roadmap/tracker/adapters/pnyon'
 import { BodyMeta, parseBodyBlock, serializeBodyBlock } from '../../../src/roadmap/tracker/body-metadata'
 import { ConflictError, FeaturePatch, TrackedFeature } from '../../../src/roadmap/tracker/client'
 import { refetchAndCompare, withBackoff } from '../../../src/roadmap/tracker/conflict'
 import { ETagStore } from '../../../src/roadmap/tracker/etag-store'
 import { createTrackerClient } from '../../../src/roadmap/tracker/factory'
+import { getTrackerKindRegistration, listRegisteredTrackerKinds, registerTrackerKind } from '../../../src/roadmap/tracker/registry'
 import { BlockerRef, ConflictError, FeaturePatch, HistoryEvent, Issue, IssueTrackerClient, NewFeatureInput, RoadmapTrackerClient, TrackedFeature, TrackerConfig, createTrackerClient } from '@harness-engineering/core'
+import { Ok } from '@harness-engineering/types'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 ```

--- a/.harness/comprehension/packages/core/tests/roadmap/tracker/adapters/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/tracker/adapters/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap/tracker/adapters'
-sourceHash: 'b7b34da0f08b0b1f5765c330f823df0aad1eaea88ef83cd0b9a98eee2faf83c7'
-compiledAt: '2026-08-28T01:22:10.991Z'
+sourceHash: 'fb6d1db916f9ba394a15da9640baac680e0fddc5a1d9b9e6cc566a4b9ab29346'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'github-issues-conflict.test.ts',
@@ -13,34 +12,29 @@ members:
     'github-issues-state-guard.test.ts',
     'github-issues.e2e.test.ts',
     'github-issues.test.ts',
+    'pnyon.test.ts',
+    'waypoint-mock.ts',
   ]
 ---
-
-## Summary
-
-The `packages/core/tests/roadmap/tracker/adapters` module tests GitHubIssuesTrackerAdapter, which syncs roadmap features to GitHub issues. It covers five core operations: (1) Claim/Release/Complete with ETag-based optimistic concurrency and terminal-state idempotence; (2) History tracking via `HistoryEvent` comments with pagination and chronological ordering; (3) CRUD ops with body-block metadata (status labels, priority, spec, blocked-by); (4) State guard preventing unattended mutation of issue state; (5) ETag caching with repo-scoped access controls. Tests mock the GitHub API and verify behavior via fetch call inspection.
-
-## Invariants
-
-- Conflict detection is ETag-driven, not stale-view-driven: a stale ifMatch with external assignee change triggers ConflictError; a stale ifMatch with matching server state proceeds to PATCH.
-- 'Done' is terminal-sticky: complete() with stale ETag but server already closed returns success with no PATCH; patch+server comparison determines idempotence, not caller's prior view.
-- Label sync failure does NOT wipe labels: when fetchRawLabels (status-update label GET) fails, PATCH omits the labels key entirely; zero-length array would erase all labels including the selector.
-- State guard syncIssueState:false holds across error paths: both happy and error paths omit state from PATCH when the guard is enabled; stale ETags do not bypass it.
-- History actors are captured pre-PATCH: release/complete record assignee from pre-mutation GET, not post-PATCH response, so history reflects who actually held the work.
-- Confused-deputy guard enforced: adapters refuse operations with externalIds from different repos; no fetch is issued on repo mismatch.
 
 ## Interface Contract
 
 ```ts
-
+export MockWaypointApi
 ```
 
 ## Dependency Slice
 
 ```
 import { GitHubIssuesTrackerAdapter } from '../../../../src/roadmap/tracker/adapters/github-issues'
+import { PnyonTrackerAdapter } from '../../../../src/roadmap/tracker/adapters/pnyon'
+import { WaypointCommand, WaypointEvidenceEntry, WaypointItem, WaypointNewItem } from '../../../../src/roadmap/tracker/adapters/waypoint-http'
 import { serializeBodyBlock } from '../../../../src/roadmap/tracker/body-metadata'
 import { ConflictError, HistoryEvent } from '../../../../src/roadmap/tracker/client'
 import { ETagStore } from '../../../../src/roadmap/tracker/etag-store'
+import { MockWaypointApi } from './waypoint-mock'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 ```

--- a/docs/changes/waypoint-tracker-kind-pnyon/plans/plan.md
+++ b/docs/changes/waypoint-tracker-kind-pnyon/plans/plan.md
@@ -1,0 +1,81 @@
+# Plan — Waypoint tracker kind `pnyon` (#1815)
+
+Spec: `docs/changes/waypoint-tracker-kind-pnyon/proposal.md`
+Closing keywords: `Closes #1815`; downstream `Closes pnyon/pnyon#125`.
+
+## Phase 1 — Typed Waypoint API contract (core)
+
+- **T1.1** `packages/core/src/roadmap/tracker/adapters/waypoint-http.ts` —
+  typed client for the documented contract: `WaypointItem`,
+  `WaypointCommand`, `WaypointEvidenceEntry`, `WaypointHttp`
+  (`listItems(statuses?, ifNoneMatch?)`, `getItem(id, ifNoneMatch?)`,
+  `createItem(input)`, `postCommand(id, command)` → discriminated
+  `applied | version_conflict`, `appendEvidence(id, entry)`,
+  `listEvidence(id, limit?)`). Bearer auth; injectable `fetchFn`;
+  structured `WaypointHttpError` for non-2xx/304/409.
+
+## Phase 2 — PnyonTrackerAdapter (core)
+
+- **T2.1** `packages/core/src/roadmap/tracker/adapters/pnyon.ts` —
+  `PnyonTrackerAdapter implements RoadmapTrackerClient`,
+  `PnyonTrackerOptions { url, token, fetchFn?, etagStore? }`,
+  `PnyonTrackerClientConfig { kind: 'pnyon', url, token?, etagStore? }`.
+  - externalId `pnyon:<id>`; ETagStore reuse (`feature:`/`list:all` keys,
+    write-path invalidation) mirroring the GitHub adapter.
+  - `update/claim/release/complete` → commands with `expectedVersion` =
+    `ifMatch` ?? freshly fetched version; 409 → `ConflictError`
+    (`TRACKER_CONFLICT`) with `refetchAndCompare`-derived diff and
+    `serverUpdatedAt`.
+  - `appendHistory`/`fetchHistory` → evidence ledger endpoints.
+
+## Phase 3 — Registry + loader + factory opening (core)
+
+- **T3.1** `packages/core/src/roadmap/tracker/registry.ts` — generic
+  `TrackerKindRegistration { kind, loadProjectConfig, create }` +
+  `registerTrackerKind` / `getTrackerKindRegistration` /
+  `listRegisteredTrackerKinds`; registers builtin `pnyon`.
+- **T3.2** `load-tracker-client-config.ts` — `github` path byte-for-byte;
+  other kinds consult the registry (`loadProjectConfig(tracker, root)`);
+  unregistered → Err listing `"github"` + registered kinds.
+- **T3.3** `factory.ts` — add `PnyonTrackerClientConfig` to the union
+  (type import from `adapters/pnyon`); after the existing two branches,
+  fall back to `registry.create`; final Err unchanged for unregistered.
+- **T3.4** `tracker/index.ts` barrel — append (not reorder) pnyon +
+  registry exports; run `pnpm generate:barrels` + `--check`.
+
+## Phase 4 — CLI config schema (additive)
+
+- **T4.1** `packages/cli/src/config/schema.ts` — `TrackerConfigSchema`
+  becomes a discriminated union on `kind`: existing github object schema
+  unchanged + `PnyonTrackerConfigSchema { kind: 'pnyon', url: url(),
+token?: string }`.
+
+## Phase 5 — Contract tests
+
+- **T5.1** `packages/core/tests/roadmap/tracker/adapters/waypoint-mock.ts`
+  — in-memory mock Waypoint API implementing the contract (items, event
+  versions, per-item evidence ledgers, ETag/304, 409 version_conflict,
+  same-assignee claim idempotency) as an injectable `fetchFn` + inspection
+  surface (`ledger(id)`, `requestCount`).
+- **T5.2** `.../pnyon.test.ts` — SC3 method sweep, SC4 conflict + race,
+  SC5 claim idempotency, SC6 ETag/304 request counts, SC7 dependency +
+  request-host audit, loader/factory SCs (SC1/SC2), registry unit tests.
+- **T5.3** `packages/cli/tests/mcp/tools/roadmap.file-less-pnyon.test.ts`
+  — SC8 groom/sync semantics through `handleManageRoadmapFileLess` with a
+  `PnyonTrackerAdapter` over the mock; plus schema-accepts-pnyon test.
+
+## Phase 6 — Integration & gates
+
+- **T6.1** Changeset (minor: core, cli). Barrels/docs/tool-catalog checks.
+- **T6.2** `provenance.json` for this change dir.
+- **T6.3** Full local gates: build, affected typecheck/tests + coverage
+  ratchet, prettier, `harness ci check` via hooks (no `--no-verify`).
+
+## Verification (WIRED)
+
+Trace: `harness.config.json { roadmap: { mode: 'file-less', tracker:
+{ kind: 'pnyon', url } } }` → `loadTrackerClientConfigFromProject` →
+registry `loadProjectConfig` → `TrackerClientConfig` union →
+`createTrackerClient` → registry `create` → `PnyonTrackerAdapter` →
+`WaypointHttp` → (mock) Waypoint API; file-less `manage_roadmap` actions
+translate through the untouched generic handler.

--- a/docs/changes/waypoint-tracker-kind-pnyon/proposal.md
+++ b/docs/changes/waypoint-tracker-kind-pnyon/proposal.md
@@ -1,0 +1,231 @@
+---
+title: Waypoint tracker kind — `pnyon` RoadmapTrackerClient adapter + tracker-kind registry
+issue: 1815
+slug: waypoint-tracker-kind-pnyon
+status: implemented
+tier: medium
+keywords:
+  - roadmap
+  - tracker
+  - file-less
+  - pnyon
+  - waypoint
+  - registry
+  - TRACKER_CONFLICT
+  - evidence-ledger
+---
+
+# Waypoint tracker kind — `pnyon`
+
+> Open the file-less tracker seam: a `PnyonTrackerAdapter` implementing the
+> existing `RoadmapTrackerClient` interface against a documented Waypoint HTTP
+> API contract, plus a tracker-kind registry so
+> `loadTrackerClientConfigFromProject` resolves registered non-GitHub kinds
+> instead of hard-rejecting them. GitHub behavior preserved byte-for-byte;
+> the adapter performs zero GitHub writes.
+
+## Overview and goals
+
+Downstream: pnyon/pnyon#125 ("Waypoint harness adaptation — pnyon
+RoadmapTrackerClient kind"). pnyon ADR-0047 accepts **Waypoint** — a hosted,
+multi-tenant, event-sourced SDLC ledger — as pnyon's roadmap provider,
+consumed by harness **through the existing file-less tracker seam**: the
+`RoadmapTrackerClient` interface
+(`packages/core/src/roadmap/tracker/client.ts` — fetchAll / fetchById /
+fetchByStatus / create / update / claim / release / complete / appendHistory /
+fetchHistory), ETag caching, and the synthesized `ConflictError` code
+`TRACKER_CONFLICT`.
+
+The seam exists but is closed in two places:
+
+1. `createTrackerClient` (`packages/core/src/roadmap/tracker/factory.ts`)
+   hardcodes exactly two kinds: `github-issues` and `linear`.
+2. `loadTrackerClientConfigFromProject`
+   (`packages/core/src/roadmap/load-tracker-client-config.ts`) hard-rejects
+   any `roadmap.tracker.kind` other than `"github"`.
+
+**Goals (this slice):**
+
+1. **`PnyonTrackerAdapter`** in core beside the existing adapters
+   (`packages/core/src/roadmap/tracker/adapters/pnyon.ts`), implementing the
+   existing interface against a documented Waypoint HTTP API contract defined
+   as a typed client module
+   (`packages/core/src/roadmap/tracker/adapters/waypoint-http.ts`):
+   - **Claims map to `sdlc.claim` event semantics.** `claim` issues a
+     `sdlc.claim.opened.v1` command; `release` a `sdlc.claim.released.v1`;
+     `complete` a `sdlc.intent.closed.v1`. All mutations carry an
+     **event-version precondition**; a stale version is rejected server-side
+     (HTTP 409) and surfaced as `ConflictError` code `TRACKER_CONFLICT` —
+     the exact contract consumers handle today. First-claim-wins CAS survives
+     the backend swap.
+   - **History rides the evidence ledger.** `appendHistory` appends an
+     evidence entry via the command API; `fetchHistory` reads the ledger back
+     ordered.
+   - **Zero GitHub writes.** The adapter performs no GitHub API calls of any
+     kind. Machine actors are never pushed to GitHub's assignee field
+     (harness #640): in pnyon mode the GitHub projection (issues, labels,
+     human-reserved assignee field) is **Waypoint-side scope**, downstream of
+     the ledger — never the adapter's.
+2. **Tracker-kind registry**
+   (`packages/core/src/roadmap/tracker/registry.ts`): registered kinds carry
+   a project-config loader and a client factory hook.
+   `loadTrackerClientConfigFromProject` keeps its `github` path **byte-for-
+   byte** and consults the registry for other kinds; unregistered kinds are
+   rejected with an error listing the registered kinds. `createTrackerClient`
+   keeps its `github-issues` and `linear` branches untouched and falls back to
+   the registry before its final "Unsupported tracker kind" error — so future
+   kinds plug in with no factory modification.
+3. **Contract tests** against an in-memory mock Waypoint API fixture covering
+   every interface method, conflict synthesis, claim idempotency, ETag reuse,
+   the no-GitHub-dependency audit, and file-less handler semantics (groom
+   unsupported → error; sync → no-op), mirroring the existing file-less
+   handler expectations.
+
+**Non-goals (owned elsewhere; deliberately untouched here):**
+
+- `sdlc.*` event **emission**, gateway webhook topics, spool shipping — the
+  sibling pnyon adaptation (FR-9.1), built in a parallel lane. This change
+  does not touch emission/gateway/webhook-topic files.
+- The Waypoint service itself and its GitHub downstream projection — pnyon
+  scope. This spec pins the API contract the service must satisfy.
+- The file-backed sync engine (`roadmap.tracker.kind: "github"` + statusMap;
+  `loadTrackerSyncConfig`) — unchanged; it returns `null` for pnyon configs,
+  correctly disabling the GitHub sync engine in pnyon mode.
+- Cast/multi-assignee fields on RoadmapFeature; pilot/fleet scoring changes.
+
+## Waypoint HTTP API contract (normative for the service)
+
+The typed client module `waypoint-http.ts` **is** the documented contract.
+The real Waypoint service ships later in pnyon (ASSUMPTION A1); it must
+satisfy these shapes. Base URL is `roadmap.tracker.url` (the per-Outpost API
+base, e.g. `https://waypoint.pnyon.com/o/<outpost-id>`). Auth is
+`Authorization: Bearer <token>` (config `token` or `PNYON_TOKEN` env).
+
+| Operation       | HTTP                                  | Notes                                                                                                             |
+| --------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| List items      | `GET /v1/items`                       | `?status=a,b` filter; `If-None-Match` honored, `ETag` returned; 304 on unchanged                                  |
+| Read item       | `GET /v1/items/{id}`                  | 404 → null; `If-None-Match`/`ETag`/304 as above                                                                   |
+| Create item     | `POST /v1/items`                      | body: NewFeatureInput projection; appends `sdlc.intent.created.v1`; returns the item                              |
+| Mutate item     | `POST /v1/items/{id}/commands`        | body: `{ type, expectedVersion, patch? \| actor? }`; 409 `version_conflict` carries `{ currentVersion, current }` |
+| Append evidence | `POST /v1/items/{id}/evidence`        | body: HistoryEvent projection; returns 204/200                                                                    |
+| Read evidence   | `GET /v1/items/{id}/evidence?limit=N` | ordered oldest→newest `{ events: [...] }`                                                                         |
+
+**Item shape** (`WaypointItem`): `{ id (ULID), name, status (harness
+six-status projection), summary, spec, plans, blockedBy, assignee, priority,
+milestone, createdAt, updatedAt, version (event version, monotonically
+increasing per appended event) }`. External id: `pnyon:<ULID>`.
+
+**Command types** map onto the pinned `sdlc.*.v1` vocabulary
+(pnyon `docs/architecture/waypoint/sdlc-event-schema.md`):
+`update` → `sdlc.intent.updated.v1`; `claim` → `sdlc.claim.opened.v1`;
+`release` → `sdlc.claim.released.v1`; `complete` → `sdlc.intent.closed.v1`.
+
+**Conflict semantics:** every command carries `expectedVersion`. When the
+item's current version differs, the server appends **nothing** and returns
+409 with the current item; the adapter synthesizes
+`ConflictError('TRACKER_CONFLICT')` whose diff compares the intended patch
+against the server's current state (via the shared `refetchAndCompare`
+policy) and whose `serverUpdatedAt` is the current item's `updatedAt`.
+Conflicts are never retried destructively — exactly one event lands for the
+winning mutation.
+
+**Claim idempotency:** `sdlc.claim.opened.v1` for an item **already claimed
+by the same assignee** is a server-side no-op success (idempotent — returns
+the current item, appends no event). A claim while claimed by a **different**
+assignee is a 409 conflict regardless of version.
+
+**ETag/version duality:** the HTTP `ETag` for a single item is its event
+version (stringified). `ifMatch` on the interface therefore doubles as the
+`expectedVersion` precondition. When `ifMatch` is omitted the adapter fetches
+the current version first and uses it — the server-side precondition still
+closes the read-modify-write race (the loser gets 409).
+
+## Design
+
+```
+load-tracker-client-config.ts ──(kind !== 'github')──▶ registry.loadProjectConfig
+createTrackerClient (factory.ts) ──(unknown kind)────▶ registry.create
+registry.ts ── registers builtin 'pnyon' ────────────▶ adapters/pnyon.ts
+adapters/pnyon.ts (PnyonTrackerAdapter) ─────────────▶ adapters/waypoint-http.ts (typed contract)
+```
+
+- `registry.ts` is generic (imports only `client.ts` types + `Result`); no
+  import cycle: `factory.ts → registry.ts → adapters/pnyon.ts → client.ts`.
+- `PnyonTrackerClientConfig { kind: 'pnyon'; url; token?; etagStore? }` is
+  declared in `adapters/pnyon.ts` and added to factory's
+  `TrackerClientConfig` union (type-only change there).
+- CLI `TrackerConfigSchema` becomes a discriminated union: the existing
+  `github` object schema **unchanged**, plus a `pnyon` variant
+  `{ kind: 'pnyon', url: string (URL), token?: string }` — so
+  `harness validate` accepts pnyon configs instead of failing the literal.
+- File-less `manage_roadmap` semantics need no per-adapter work — the
+  file-less handler already translates actions generically; contract tests
+  prove `groom → error("only supported in file-based roadmap mode")` and
+  `sync → no-op` through a `PnyonTrackerAdapter` instance.
+
+## Success criteria
+
+- **SC1 (registry opening):** `loadTrackerClientConfigFromProject` returns
+  `Ok({ kind: 'pnyon', url, token? })` for a valid pnyon config; missing
+  `url` fails at load time naming the missing field; unregistered kinds
+  (e.g. `jira`) fail with an error listing registered kinds. All existing
+  loader tests pass unmodified (github byte-for-byte).
+- **SC2 (factory):** `createTrackerClient({ kind: 'pnyon', url, token })`
+  returns a `PnyonTrackerAdapter`; missing token (config + env) is an
+  actionable `Err`; existing `github-issues`/`linear`/unsupported-kind tests
+  pass unmodified.
+- **SC3 (interface parity):** every `RoadmapTrackerClient` method round-trips
+  against the in-memory mock Waypoint API (create → fetchAll/fetchById/
+  fetchByStatus → update → claim → release → complete → appendHistory →
+  fetchHistory ≥10 entries order-preserved).
+- **SC4 (conflict contract):** a stale-version mutation and a racing second
+  claimant each surface `ConflictError` with `code === 'TRACKER_CONFLICT'`,
+  a populated diff, and no destructive retry (mock ledger shows exactly one
+  event for the winner).
+- **SC5 (claim idempotency):** re-claiming with the same assignee succeeds
+  without appending a second claim event.
+- **SC6 (ETag):** an unchanged `fetchAll`/`fetchById` reuses the cached
+  representation via `If-None-Match`/304 (request-count asserted).
+- **SC7 (no GitHub writes, #640):** the adapter modules import nothing
+  GitHub-related and the mock transport observes only `url`-rooted requests
+  during a full method sweep — machine claims exist only in Waypoint.
+- **SC8 (file-less semantics):** through the file-less `manage_roadmap`
+  handler with a pnyon adapter, `groom` errors as unsupported and `sync` is
+  the documented no-op, matching existing file-less expectations.
+- **SC9 (repo gates):** typecheck, lint, affected tests + coverage ratchet,
+  barrels/docs/tool-catalog checks, and `harness ci check` all green; a
+  changeset covers the published packages touched.
+
+## Assumptions
+
+- **A1 (service ships later):** no live Waypoint service exists yet; the
+  typed client module in this change is the normative API contract the
+  pnyon-side service must satisfy. Contract tests run against an in-memory
+  mock implementing this spec.
+- **A2 (six-status projection):** the read API serves harness's six-status
+  projection directly in `status` (Waypoint's seven-lane reducer output maps
+  losslessly per ADR-0047); `blocked`/`needs-human` arrive as statuses, not
+  computed flags, at this seam.
+- **A3 (actor duality is server-side):** the adapter sends the assignee/actor
+  as an opaque principal string; agent-vs-human duality (`onBehalfOf`) is
+  resolved by the service from the authenticated token, not modeled at this
+  seam.
+- **A4 (token env):** `PNYON_TOKEN` is the env fallback for the adapter
+  credential, mirroring `GITHUB_TOKEN`/`LINEAR_API_KEY`.
+- **A5 (linear stays loader-invisible):** `loadTrackerClientConfigFromProject`
+  continues not to resolve `linear` (as today); only `pnyon` is registered as
+  a builtin. Registering linear is a separate decision.
+
+## Evidence
+
+- pnyon/pnyon#125; pnyon PRD
+  `docs/product-requirements/waypoint-harness-adaptation-pnyon-roadmaptrackerclient-kind/prd.md`
+  (US-1…US-7); pnyon ADR-0047; pnyon
+  `docs/architecture/waypoint/sdlc-event-schema.md` (envelope, `sdlc.*.v1`
+  vocabulary, ULID identity).
+- harness seam: `packages/core/src/roadmap/tracker/client.ts` (interface +
+  `ConflictError`/`TRACKER_CONFLICT`), `factory.ts`, `conflict.ts`
+  (`refetchAndCompare`), `load-tracker-client-config.ts`,
+  `packages/cli/src/mcp/tools/roadmap-file-less.ts` (groom/sync semantics).
+- harness #640 (machine actors vs GitHub assignee field), #1285/#1327/#839
+  (destructive bidirectional-sync trail motivating projection-only GitHub).

--- a/docs/changes/waypoint-tracker-kind-pnyon/provenance.json
+++ b/docs/changes/waypoint-tracker-kind-pnyon/provenance.json
@@ -1,0 +1,39 @@
+{
+  "item": "waypoint-harness-adaptation-pnyon-roadmaptrackerclient-kind",
+  "issues": ["pnyon/pnyon#125", "Intense-Visions/harness-engineering#1815"],
+  "issue": 1815,
+  "slug": "waypoint-tracker-kind-pnyon",
+  "title": "Waypoint tracker kind — pnyon RoadmapTrackerClient adapter + tracker-kind registry",
+  "branch": "feat/waypoint-tracker-kind-pnyon",
+  "route": "feature",
+  "closing_keyword": "Closes #1815",
+  "stages": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "stagesRun": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "plan_path": "docs/changes/waypoint-tracker-kind-pnyon/plans/plan.md",
+  "planArtifact": "docs/changes/waypoint-tracker-kind-pnyon/plans/plan.md",
+  "mechanisms": {
+    "waypointContract": "packages/core/src/roadmap/tracker/adapters/waypoint-http.ts — WaypointHttp typed client; the module IS the normative API contract the pnyon-side Waypoint service must satisfy (items, commands with expectedVersion, evidence ledger, ETag/304, 409 version_conflict carrying the current item)",
+    "adapter": "packages/core/src/roadmap/tracker/adapters/pnyon.ts — PnyonTrackerAdapter implements RoadmapTrackerClient; claim/release/complete/update map to sdlc.claim.opened.v1 / sdlc.claim.released.v1 / sdlc.intent.closed.v1 / sdlc.intent.updated.v1; 409 → ConflictError code TRACKER_CONFLICT via shared refetchAndCompare; appendHistory/fetchHistory ride the evidence ledger; ETagStore reuse (feature:/list:all keys)",
+    "registry": "packages/core/src/roadmap/tracker/registry.ts — registerTrackerKind/getTrackerKindRegistration/listRegisteredTrackerKinds with builtin pnyon registration (loadProjectConfig validates url/token at LOAD time; create resolves PNYON_TOKEN fallback)",
+    "loaderOpening": "packages/core/src/roadmap/load-tracker-client-config.ts — github path byte-for-byte; non-github kinds resolve through the registry; unregistered kinds rejected listing registered kinds (existing /only supports kind/ phrasing preserved)",
+    "factoryOpening": "packages/core/src/roadmap/tracker/factory.ts — TrackerClientConfig union gains PnyonTrackerClientConfig; registry fallback before the final Unsupported-tracker-kind error (github-issues/linear branches untouched)",
+    "cliSchema": "packages/cli/src/config/schema.ts — TrackerConfigSchema becomes a discriminated union (github variant unchanged + pnyon { url, token? })"
+  },
+  "verification": {
+    "contractTests": "packages/core/tests/roadmap/tracker/adapters/pnyon.test.ts + waypoint-mock.ts (in-memory reference implementation of the contract): SC3 full method sweep, SC4 conflict + claim race (exactly one winning event), SC5 claim idempotency, SC6 ETag/304 request counts, SC7 no-GitHub module+host audit, evidence-ledger round-trip ≥10 entries",
+    "registryTests": "packages/core/tests/roadmap/tracker/registry.test.ts — SC1 loader (valid/missing-url/unregistered/github regression), SC2 factory (adapter/env fallback/missing token/unsupported kinds)",
+    "fileLessSemantics": "packages/cli/tests/mcp/tools/roadmap.file-less-pnyon.test.ts — SC8 groom unsupported, sync no-op, show flows through the adapter",
+    "cliSchemaTests": "packages/cli/tests/config/schema.tracker-pnyon.test.ts — pnyon variant accepted, github variant not loosened (pre-existing schema.tracker-kind suite unmodified)"
+  },
+  "assumptions": [
+    "A1 — No live Waypoint service exists yet; the typed client module (waypoint-http.ts) IS the normative API contract the pnyon-side service must satisfy, and contract tests run against an in-memory mock implementing it. Recorded per the confirmed lane scope.",
+    "A2 — The Waypoint read API serves harness's six-status projection directly in `status` (lane→status mapping is server-side per pnyon ADR-0047); blocked/needs-human arrive as statuses at this seam.",
+    "A3 — Actor duality (agent onBehalfOf human) is resolved server-side from the authenticated token; the adapter sends assignee/actor as an opaque principal string, preserving interface parity.",
+    "A4 — PNYON_TOKEN is the env-var credential fallback, mirroring GITHUB_TOKEN/LINEAR_API_KEY.",
+    "A5 — linear stays loader-invisible (as today): only pnyon is registered as a builtin; registering linear in the loader is a separate decision.",
+    "A6 — In pnyon mode there is no GitHub write anywhere in the adapter path; the GitHub projection (including the human-reserved assignee field, #640) is Waypoint-side scope. Made explicit in the spec and enforced by the SC7 audit tests.",
+    "A7 — Side-fix included: main was red (typecheck break from #1804 un-exporting context-surface helpers its test imports; main-health #1814). The minimal re-export fix is a separate commit on this branch because the repo's fail-closed local gates cannot pass against the broken baseline.",
+    "A8 — Arch module-size/dependency-depth baselines updated via the sanctioned `harness check-arch --update-baseline` path to admit the new modules (the repo's documented procedure for intentional additions).",
+    "A9 — Emission/gateway/webhook-topic files untouched (parallel lane owns them); shared barrel exports appended, never reordered."
+  ]
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -564,8 +564,8 @@ export const DeploymentGateConfigSchema = z.object({
  * the IssueTrackerClient dispatch). Two near-identical strings live in
  * different config namespaces. See Phase 4 plan R3 for the long-form note.
  */
-export const TrackerConfigSchema = z.object({
-  /** Tracker kind — currently only 'github' is supported for `roadmap.tracker`. */
+const GitHubTrackerConfigSchema = z.object({
+  /** Tracker kind — the file-backed GitHub sync engine. */
   kind: z.literal('github'),
   /** Repository in "owner/repo" format */
   repo: z.string().optional(),
@@ -579,6 +579,24 @@ export const TrackerConfigSchema = z.object({
   /** Maps external status (optionally with label) -> roadmap status */
   reverseStatusMap: z.record(z.string(), z.string()).optional(),
 });
+
+/**
+ * `roadmap.tracker.kind: "pnyon"` — the Waypoint event-ledger backend
+ * (file-less mode only; resolved through the core tracker-kind registry).
+ * See docs/changes/waypoint-tracker-kind-pnyon/proposal.md.
+ */
+const PnyonTrackerConfigSchema = z.object({
+  kind: z.literal('pnyon'),
+  /** Waypoint per-Outpost API base URL. */
+  url: z.string().url(),
+  /** Bearer credential; falls back to the PNYON_TOKEN env var when unset. */
+  token: z.string().optional(),
+});
+
+export const TrackerConfigSchema = z.discriminatedUnion('kind', [
+  GitHubTrackerConfigSchema,
+  PnyonTrackerConfigSchema,
+]);
 
 /**
  * Schema for roadmap configuration.

--- a/packages/cli/src/mcp/context-surface.ts
+++ b/packages/cli/src/mcp/context-surface.ts
@@ -62,7 +62,7 @@ function collectSkillFiles(dir: string): string[] {
 }
 
 /** One invoked-only entry per platform skill tree (aggregated bodies). */
-function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
+export function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
   const entries: ContextSurfaceEntry[] = [];
   for (const platform of PLATFORM_SKILL_DIRS) {
     const dir = join(projectRoot, 'agents', 'skills', platform);
@@ -88,7 +88,7 @@ function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
 }
 
 /** AGENTS.md entry (always-loaded), when present. */
-function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
+export function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
   const path = join(projectRoot, 'AGENTS.md');
   if (!existsSync(path)) return null;
   try {
@@ -104,7 +104,7 @@ function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
 }
 
 /** Hook-configuration entry from .claude/settings.json (always-loaded). */
-function hooksEntry(projectRoot: string): ContextSurfaceEntry | null {
+export function hooksEntry(projectRoot: string): ContextSurfaceEntry | null {
   const path = join(projectRoot, '.claude', 'settings.json');
   if (!existsSync(path)) return null;
   try {

--- a/packages/cli/tests/config/schema.tracker-pnyon.test.ts
+++ b/packages/cli/tests/config/schema.tracker-pnyon.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `roadmap.tracker.kind: "pnyon"` config surface
+ * (docs/changes/waypoint-tracker-kind-pnyon/proposal.md, US-1): the schema
+ * accepts a pnyon tracker with a Waypoint URL (+ optional token), while the
+ * pre-existing github variant and the kind-collision guarantees pinned by
+ * `schema.tracker-kind.test.ts` stay intact (that suite is unmodified).
+ */
+import { describe, it, expect } from 'vitest';
+import { TrackerConfigSchema, HarnessConfigSchema } from '../../src/config/schema';
+
+describe('TrackerConfigSchema — pnyon variant', () => {
+  it('accepts kind: "pnyon" with a url', () => {
+    const r = TrackerConfigSchema.safeParse({
+      kind: 'pnyon',
+      url: 'https://waypoint.test/o/outpost-1',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts an optional token', () => {
+    const r = TrackerConfigSchema.safeParse({
+      kind: 'pnyon',
+      url: 'https://waypoint.test/o/outpost-1',
+      token: 'tok',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects kind: "pnyon" without a url', () => {
+    const r = TrackerConfigSchema.safeParse({ kind: 'pnyon' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a non-URL url', () => {
+    const r = TrackerConfigSchema.safeParse({ kind: 'pnyon', url: 'not a url' });
+    expect(r.success).toBe(false);
+  });
+
+  it('does NOT loosen the github variant (statusMap still required)', () => {
+    const r = TrackerConfigSchema.safeParse({ kind: 'github' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('HarnessConfigSchema — roadmap.tracker pnyon passthrough', () => {
+  it('accepts a file-less pnyon tracker via the top-level schema', () => {
+    const r = HarnessConfigSchema.safeParse({
+      version: 1,
+      roadmap: {
+        mode: 'file-less',
+        tracker: { kind: 'pnyon', url: 'https://waypoint.test/o/outpost-1' },
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/cli/tests/mcp/tools/roadmap.file-less-pnyon.test.ts
+++ b/packages/cli/tests/mcp/tools/roadmap.file-less-pnyon.test.ts
@@ -1,0 +1,76 @@
+/**
+ * File-less `manage_roadmap` semantics through a pnyon (Waypoint) adapter
+ * (docs/changes/waypoint-tracker-kind-pnyon/proposal.md SC8): the generic
+ * file-less handler needs zero per-adapter work — `groom` stays unsupported,
+ * `sync` stays the documented no-op (the tracker IS the sync target), and
+ * reads flow through the adapter unchanged.
+ *
+ * The Waypoint transport is a minimal inline mock of the documented contract
+ * (full contract coverage lives in core's pnyon adapter suite).
+ */
+import { describe, it, expect } from 'vitest';
+import { PnyonTrackerAdapter } from '@harness-engineering/core';
+import { handleManageRoadmapFileLess } from '../../../src/mcp/tools/roadmap-file-less';
+
+const BASE = 'https://waypoint.test/o/outpost-1';
+
+/** Minimal mock: one seeded item behind GET /v1/items; everything else 404. */
+function makeAdapter(): PnyonTrackerAdapter {
+  const item = {
+    id: '01MOCKULID0000000000000001',
+    name: 'Seeded feature',
+    status: 'planned',
+    summary: 'seeded',
+    spec: null,
+    plans: [],
+    blockedBy: [],
+    assignee: null,
+    priority: null,
+    milestone: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: null,
+    version: 1,
+  };
+  const fetchFn: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (method === 'GET' && url.startsWith(`${BASE}/v1/items`)) {
+      return new Response(JSON.stringify({ items: [item] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json', ETag: 'W/"list-1"' },
+      });
+    }
+    return new Response(JSON.stringify({ error: 'no route' }), { status: 404 });
+  };
+  return new PnyonTrackerAdapter({ url: BASE, token: 'tok', fetchFn });
+}
+
+describe('manage_roadmap file-less semantics with the pnyon adapter (SC8)', () => {
+  it('groom is unsupported in file-less mode (error, tracker untouched)', async () => {
+    const res = await handleManageRoadmapFileLess(
+      { path: '/tmp/x', action: 'groom' },
+      makeAdapter()
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/groom is only supported in file-based roadmap mode/);
+  });
+
+  it('sync is a no-op (the tracker is canonical)', async () => {
+    const res = await handleManageRoadmapFileLess(
+      { path: '/tmp/x', action: 'sync' },
+      makeAdapter()
+    );
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toMatch(/file-less mode; tracker is canonical/);
+  });
+
+  it('show flows through the adapter unchanged', async () => {
+    const res = await handleManageRoadmapFileLess(
+      { path: '/tmp/x', action: 'show' },
+      makeAdapter()
+    );
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toContain('Seeded feature');
+    expect(res.content[0]!.text).toContain('status: planned');
+  });
+});

--- a/packages/core/src/roadmap/index.ts
+++ b/packages/core/src/roadmap/index.ts
@@ -138,8 +138,26 @@ export type {
   TrackerClientConfig,
   TrackerConflictBody,
   MakeTrackerConflictBodyOptions,
+  PnyonTrackerOptions,
+  PnyonTrackerClientConfig,
+  TrackerKindRegistration,
+  RegisteredTrackerClientConfig,
+  WaypointItem,
+  WaypointNewItem,
+  WaypointItemPatch,
+  WaypointCommand,
+  WaypointCommandResult,
+  WaypointEvidenceEntry,
 } from './tracker';
 export { ConflictError, createTrackerClient, ETagStore, makeTrackerConflictBody } from './tracker';
+export {
+  PnyonTrackerAdapter,
+  WaypointHttp,
+  WaypointHttpError,
+  registerTrackerKind,
+  getTrackerKindRegistration,
+  listRegisteredTrackerKinds,
+} from './tracker';
 
 /**
  * Roadmap storage mode helper. See packages/core/src/roadmap/mode.ts.

--- a/packages/core/src/roadmap/load-tracker-client-config.ts
+++ b/packages/core/src/roadmap/load-tracker-client-config.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { Result } from '@harness-engineering/types';
 import { Ok, Err } from '@harness-engineering/types';
 import type { TrackerClientConfig } from './tracker/factory';
+import { getTrackerKindRegistration, listRegisteredTrackerKinds } from './tracker/registry';
 import { deriveRepoFromGitRemote } from './derive-repo';
 
 /**
@@ -27,7 +28,7 @@ export function loadTrackerClientConfigFromProject(
       return Err(new Error('harness.config.json not found'));
     }
     const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
-      roadmap?: { tracker?: { kind?: string; repo?: string } };
+      roadmap?: { tracker?: { kind?: string; repo?: string } & Record<string, unknown> };
     };
     const tracker = cfg.roadmap?.tracker;
     if (!tracker) {
@@ -38,9 +39,26 @@ export function loadTrackerClientConfigFromProject(
       );
     }
     if (tracker.kind !== 'github') {
-      return Err(
-        new Error(`file-less tracker only supports kind: "github" today; got "${tracker.kind}"`)
-      );
+      // Tracker-kind registry (docs/changes/waypoint-tracker-kind-pnyon):
+      // registered non-github kinds (builtin: 'pnyon') load through their
+      // registration's own config validator. Unregistered kinds are still
+      // rejected — with the registered kinds listed. The github path below
+      // is unchanged.
+      const registration = getTrackerKindRegistration(tracker.kind ?? '');
+      if (!registration) {
+        const registered = ['github', ...listRegisteredTrackerKinds()].join(', ');
+        return Err(
+          new Error(
+            `file-less tracker only supports kind: "github" or a registered ` +
+              `kind (registered: ${registered}); got "${tracker.kind}"`
+          )
+        );
+      }
+      const loaded = registration.loadProjectConfig(tracker, projectRoot);
+      if (!loaded.ok) return loaded;
+      // Builtin registrations return members of the TrackerClientConfig
+      // union; third-party kinds extend it structurally by design.
+      return Ok(loaded.value as TrackerClientConfig);
     }
     // When repo is unset, derive it from `git remote get-url origin` so
     // downstream repos that omit the key (or copy a config template) get a

--- a/packages/core/src/roadmap/tracker/adapters/pnyon.ts
+++ b/packages/core/src/roadmap/tracker/adapters/pnyon.ts
@@ -1,0 +1,374 @@
+/**
+ * Pnyon (Waypoint) tracker adapter — implements {@link RoadmapTrackerClient}
+ * over the Waypoint roadmap-provider HTTP API (pnyon ADR-0047: a hosted,
+ * event-sourced SDLC ledger; harness consumes it through this existing seam).
+ *
+ * ⚠️ CONTRACT-FIRST: the Waypoint service ships later in pnyon; the typed
+ * contract lives in `./waypoint-http.ts` and the behavior here is proven
+ * against an in-memory mock of that contract (spec assumption A1).
+ *
+ * Mapping decisions:
+ *  - `externalId` is `pnyon:<item-ULID>` (dual-key identity: the ULID is the
+ *    stable half; slugs are a Waypoint-side concern).
+ *  - Claims are ledger events, not field writes: `claim` → `sdlc.claim.opened.v1`,
+ *    `release` → `sdlc.claim.released.v1`, `complete` → `sdlc.intent.closed.v1`,
+ *    `update` → `sdlc.intent.updated.v1`. Every command carries an
+ *    event-version precondition; a stale version is rejected server-side and
+ *    surfaced as {@link ConflictError} code `TRACKER_CONFLICT` — the same
+ *    contract consumers handle today. First-claim-wins CAS is preserved.
+ *  - `appendHistory`/`fetchHistory` ride the item's **evidence ledger**
+ *    (durable, ordered) instead of tracker-comment scraping.
+ *  - The single-item ETag doubles as the event version, so the interface's
+ *    `ifMatch` is the precondition value verbatim.
+ *  - **Zero GitHub writes** (harness #640): this module performs no GitHub
+ *    API calls of any kind and never pushes machine actors to GitHub's
+ *    assignee field. In pnyon mode the GitHub projection (issues, labels,
+ *    the human-reserved assignee field) is Waypoint-side scope, downstream
+ *    of the ledger — never this adapter's.
+ */
+import type { Result, FeatureStatus } from '@harness-engineering/types';
+import { Ok, Err } from '@harness-engineering/types';
+import type {
+  RoadmapTrackerClient,
+  TrackedFeature,
+  NewFeatureInput,
+  FeaturePatch,
+  HistoryEvent,
+  HistoryEventType,
+} from '../client';
+import { ConflictError } from '../client';
+import { refetchAndCompare } from '../conflict';
+import { ETagStore } from '../etag-store';
+import {
+  WaypointHttp,
+  WaypointHttpError,
+  type WaypointCommand,
+  type WaypointItem,
+  type WaypointItemPatch,
+} from './waypoint-http';
+
+const EXTERNAL_PREFIX = 'pnyon:';
+
+const HISTORY_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'created',
+  'claimed',
+  'released',
+  'completed',
+  'updated',
+  'reopened',
+]);
+
+export interface PnyonTrackerOptions {
+  /** Waypoint per-Outpost API base URL. */
+  url: string;
+  /** Bearer credential (resolved upstream: config token or PNYON_TOKEN env). */
+  token: string;
+  fetchFn?: typeof fetch;
+  etagStore?: ETagStore;
+}
+
+/**
+ * Factory-facing config for `roadmap.tracker.kind: "pnyon"`. Declared here
+ * (not in factory.ts) so the registry can reference it without an import
+ * cycle: factory → registry → this module → client.
+ */
+export interface PnyonTrackerClientConfig {
+  kind: 'pnyon';
+  /** Waypoint per-Outpost API base URL. */
+  url: string;
+  /** Bearer credential; falls back to the PNYON_TOKEN env var. */
+  token?: string;
+  etagStore?: ETagStore;
+}
+
+function featureFromItem(item: WaypointItem): TrackedFeature {
+  return {
+    externalId: `${EXTERNAL_PREFIX}${item.id}`,
+    name: item.name,
+    status: item.status,
+    summary: item.summary,
+    spec: item.spec,
+    plans: item.plans,
+    blockedBy: item.blockedBy,
+    assignee: item.assignee,
+    priority: item.priority,
+    milestone: item.milestone,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function patchToWaypoint(patch: FeaturePatch): WaypointItemPatch {
+  const out: WaypointItemPatch = {};
+  if (patch.name !== undefined) out.name = patch.name;
+  if (patch.summary !== undefined) out.summary = patch.summary;
+  if (patch.status !== undefined) out.status = patch.status;
+  if (patch.spec !== undefined) out.spec = patch.spec;
+  if (patch.plans !== undefined) out.plans = patch.plans;
+  if (patch.blockedBy !== undefined) out.blockedBy = patch.blockedBy;
+  if (patch.priority !== undefined) out.priority = patch.priority;
+  if (patch.milestone !== undefined) out.milestone = patch.milestone;
+  if (patch.assignee !== undefined) out.assignee = patch.assignee;
+  return out;
+}
+
+function asError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}
+
+export class PnyonTrackerAdapter implements RoadmapTrackerClient {
+  private readonly http: WaypointHttp;
+  private readonly cache: ETagStore;
+
+  constructor(opts: PnyonTrackerOptions) {
+    const httpOpts: ConstructorParameters<typeof WaypointHttp>[0] = {
+      url: opts.url,
+      token: opts.token,
+    };
+    if (opts.fetchFn !== undefined) httpOpts.fetchFn = opts.fetchFn;
+    this.http = new WaypointHttp(httpOpts);
+    this.cache = opts.etagStore ?? new ETagStore(500);
+  }
+
+  private toItemId(externalId: string): string {
+    return externalId.startsWith(EXTERNAL_PREFIX)
+      ? externalId.slice(EXTERNAL_PREFIX.length)
+      : externalId;
+  }
+
+  // ── Reads ──────────────────────────────────────────────────────────────
+
+  async fetchAll(): Promise<Result<{ features: TrackedFeature[]; etag: string | null }, Error>> {
+    try {
+      const cached = this.cache.get('list:all');
+      const r = await this.http.listItems(undefined, cached?.etag);
+      if (r.notModified) {
+        const items = (cached!.data as WaypointItem[]) ?? [];
+        return Ok({ features: items.map(featureFromItem), etag: cached!.etag });
+      }
+      if (r.etag) this.cache.set('list:all', r.etag, r.value);
+      return Ok({ features: r.value.map(featureFromItem), etag: r.etag });
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+
+  async fetchById(
+    externalId: string
+  ): Promise<Result<{ feature: TrackedFeature; etag: string } | null, Error>> {
+    try {
+      const item = await this.getItemCached(externalId);
+      if (!item) return Ok(null);
+      return Ok({ feature: featureFromItem(item), etag: String(item.version) });
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+
+  async fetchByStatus(statuses: FeatureStatus[]): Promise<Result<TrackedFeature[], Error>> {
+    try {
+      const r = await this.http.listItems(statuses);
+      if (r.notModified) {
+        // Unreachable by contract (no If-None-Match sent); defend anyway.
+        return Err(new Error('Waypoint returned 304 to an unconditional list'));
+      }
+      return Ok(r.value.map(featureFromItem));
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+
+  /** Conditional single-item GET through the ETag cache (`feature:<externalId>`). */
+  private async getItemCached(externalId: string): Promise<WaypointItem | null> {
+    const key = `feature:${externalId}`;
+    const cached = this.cache.get(key);
+    const r = await this.http.getItem(this.toItemId(externalId), cached?.etag);
+    if (r.notModified) return cached!.data as WaypointItem;
+    if (r.value === null) {
+      this.cache.invalidate(key);
+      return null;
+    }
+    if (r.etag) this.cache.set(key, r.etag, r.value);
+    return r.value;
+  }
+
+  // ── Writes (event commands with version preconditions) ─────────────────
+
+  async create(feature: NewFeatureInput): Promise<Result<TrackedFeature, Error>> {
+    try {
+      const item = await this.http.createItem({
+        name: feature.name,
+        summary: feature.summary,
+        ...(feature.status !== undefined ? { status: feature.status } : {}),
+        ...(feature.spec !== undefined ? { spec: feature.spec } : {}),
+        ...(feature.plans !== undefined ? { plans: feature.plans } : {}),
+        ...(feature.blockedBy !== undefined ? { blockedBy: feature.blockedBy } : {}),
+        ...(feature.priority !== undefined ? { priority: feature.priority } : {}),
+        ...(feature.milestone !== undefined ? { milestone: feature.milestone } : {}),
+        ...(feature.assignee !== undefined ? { assignee: feature.assignee } : {}),
+      });
+      this.cache.invalidatePrefix('list:');
+      return Ok(featureFromItem(item));
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+
+  async update(
+    externalId: string,
+    patch: FeaturePatch,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    return this.command(
+      externalId,
+      { type: 'sdlc.intent.updated.v1', patch: patchToWaypoint(patch) },
+      patch,
+      ifMatch
+    );
+  }
+
+  async claim(
+    externalId: string,
+    assignee: string,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    return this.command(
+      externalId,
+      { type: 'sdlc.claim.opened.v1', actor: assignee },
+      { assignee, status: 'in-progress' },
+      ifMatch
+    );
+  }
+
+  async release(
+    externalId: string,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    return this.command(
+      externalId,
+      { type: 'sdlc.claim.released.v1' },
+      { assignee: null },
+      ifMatch
+    );
+  }
+
+  async complete(
+    externalId: string,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    return this.command(externalId, { type: 'sdlc.intent.closed.v1' }, { status: 'done' }, ifMatch);
+  }
+
+  /**
+   * Shared command path. `intent` is the patch-equivalent of the command,
+   * used only to shape the TRACKER_CONFLICT diff on rejection (via the shared
+   * `refetchAndCompare` policy — same rules as the GitHub adapter).
+   *
+   * Version precondition: `ifMatch` (the interface etag = event version) when
+   * given; otherwise the item's current version is read first. Either way the
+   * SERVER enforces the precondition, so the read-modify-write race is closed
+   * — the losing writer gets a 409, never a silent overwrite, and exactly one
+   * event lands for the winner (never a destructive retry).
+   */
+  private async command(
+    externalId: string,
+    command: Omit<WaypointCommand, 'expectedVersion'>,
+    intent: FeaturePatch,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    try {
+      const versionR = await this.resolveExpectedVersion(externalId, ifMatch);
+      if (!versionR.ok) return versionR;
+      const r = await this.http.postCommand(this.toItemId(externalId), {
+        ...command,
+        expectedVersion: versionR.value,
+      });
+      if (r.outcome === 'version_conflict') {
+        const server = featureFromItem(r.current);
+        const compare = refetchAndCompare(server, intent);
+        if (compare.ok && compare.idempotent) {
+          // The server already holds exactly the state this command intended
+          // (e.g. our earlier attempt landed). Not a conflict; no retry.
+          this.invalidateWrite(externalId);
+          return Ok(server);
+        }
+        return Err(
+          new ConflictError(
+            externalId,
+            compare.diff ?? {
+              version: { ours: versionR.value, theirs: r.currentVersion },
+            },
+            server.updatedAt
+          )
+        );
+      }
+      this.invalidateWrite(externalId);
+      const feature = featureFromItem(r.item);
+      this.cache.set(`feature:${externalId}`, String(r.item.version), r.item);
+      return Ok(feature);
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+
+  private async resolveExpectedVersion(
+    externalId: string,
+    ifMatch?: string
+  ): Promise<Result<number, Error>> {
+    if (ifMatch !== undefined) {
+      const v = Number.parseInt(ifMatch, 10);
+      if (Number.isNaN(v)) {
+        return Err(new Error(`pnyon tracker: ifMatch is not an event version: "${ifMatch}"`));
+      }
+      return Ok(v);
+    }
+    const item = await this.getItemCached(externalId);
+    if (!item) return Err(new Error(`pnyon tracker: item not found: ${externalId}`));
+    return Ok(item.version);
+  }
+
+  private invalidateWrite(externalId: string): void {
+    this.cache.invalidate(`feature:${externalId}`);
+    this.cache.invalidatePrefix('list:');
+  }
+
+  // ── History (evidence ledger) ──────────────────────────────────────────
+
+  async appendHistory(externalId: string, event: HistoryEvent): Promise<Result<void, Error>> {
+    try {
+      await this.http.appendEvidence(this.toItemId(externalId), {
+        type: event.type,
+        actor: event.actor,
+        at: event.at,
+        ...(event.details !== undefined ? { details: event.details } : {}),
+      });
+      return Ok(undefined);
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+
+  async fetchHistory(externalId: string, limit?: number): Promise<Result<HistoryEvent[], Error>> {
+    try {
+      const entries = await this.http.listEvidence(this.toItemId(externalId), limit);
+      const events: HistoryEvent[] = [];
+      for (const e of entries) {
+        // The ledger may carry richer Waypoint evidence types; harness's
+        // history view keeps only the interface's event vocabulary.
+        if (!HISTORY_EVENT_TYPES.has(e.type)) continue;
+        events.push({
+          type: e.type as HistoryEventType,
+          actor: e.actor,
+          at: e.at,
+          ...(e.details !== undefined ? { details: e.details } : {}),
+        });
+      }
+      return Ok(typeof limit === 'number' ? events.slice(0, limit) : events);
+    } catch (err) {
+      return Err(asError(err));
+    }
+  }
+}
+
+export { WaypointHttpError };

--- a/packages/core/src/roadmap/tracker/adapters/waypoint-http.ts
+++ b/packages/core/src/roadmap/tracker/adapters/waypoint-http.ts
@@ -1,0 +1,292 @@
+/**
+ * Typed client for the Waypoint roadmap-provider HTTP API — the documented
+ * contract the pnyon-hosted Waypoint service must satisfy (pnyon ADR-0047).
+ *
+ * ⚠️ CONTRACT-FIRST: no live Waypoint service exists yet (assumption A1 in
+ * the spec). This module IS the normative API contract; the pnyon-side
+ * service is built against it, and the contract tests exercise it through an
+ * in-memory mock transport. See
+ * `docs/changes/waypoint-tracker-kind-pnyon/proposal.md` §"Waypoint HTTP API
+ * contract".
+ *
+ * Surface (base URL = per-Outpost API root, auth = `Bearer <token>`):
+ *
+ *   GET  /v1/items                    — list (supports ?status=a,b + If-None-Match/ETag/304)
+ *   GET  /v1/items/{id}               — read one (404 → null; If-None-Match/ETag/304)
+ *   POST /v1/items                    — create (appends sdlc.intent.created.v1)
+ *   POST /v1/items/{id}/commands      — mutate via event command; 409 on stale expectedVersion
+ *   POST /v1/items/{id}/evidence      — append one evidence-ledger entry
+ *   GET  /v1/items/{id}/evidence      — read the ledger (ordered oldest→newest; ?limit=N)
+ *
+ * Concurrency model: every item carries a monotonically increasing event
+ * `version`; commands carry `expectedVersion` and the server appends NOTHING
+ * on a mismatch, returning 409 with the current item. The single-item HTTP
+ * `ETag` is the stringified version, so the tracker interface's `ifMatch`
+ * doubles as the precondition value.
+ */
+import type { FeatureStatus, Priority } from '@harness-engineering/types';
+
+/** Canonical item shape served by the Waypoint read API (harness projection). */
+export interface WaypointItem {
+  /** ULID — stable identity; externalId is `pnyon:<id>`. */
+  id: string;
+  name: string;
+  /**
+   * Harness six-status projection of Waypoint's lane reducer (assumption A2:
+   * the mapping is server-side; `blocked`/`needs-human` arrive as statuses).
+   */
+  status: FeatureStatus;
+  summary: string;
+  spec: string | null;
+  plans: string[];
+  blockedBy: string[];
+  /** Current claim holder (opaque principal string), or null when unclaimed. */
+  assignee: string | null;
+  priority: Priority | null;
+  milestone: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+  /** Event version — increments once per ledger event appended to the item. */
+  version: number;
+}
+
+/** Fields accepted when creating an item (sdlc.intent.created.v1). */
+export interface WaypointNewItem {
+  name: string;
+  summary: string;
+  status?: FeatureStatus;
+  spec?: string | null;
+  plans?: string[];
+  blockedBy?: string[];
+  priority?: Priority | null;
+  milestone?: string | null;
+  assignee?: string | null;
+}
+
+/** Patchable fields for an `sdlc.intent.updated.v1` command. */
+export interface WaypointItemPatch {
+  name?: string;
+  summary?: string;
+  status?: FeatureStatus;
+  spec?: string | null;
+  plans?: string[];
+  blockedBy?: string[];
+  priority?: Priority | null;
+  milestone?: string | null;
+  assignee?: string | null;
+}
+
+/**
+ * Command envelope for POST /v1/items/{id}/commands. `type` follows the
+ * pinned `sdlc.*.v1` vocabulary (pnyon sdlc-event-schema):
+ *  - update   → sdlc.intent.updated.v1  (carries `patch`)
+ *  - claim    → sdlc.claim.opened.v1    (carries `actor`)
+ *  - release  → sdlc.claim.released.v1
+ *  - complete → sdlc.intent.closed.v1
+ *
+ * Actor duality (`agent onBehalfOf human`) is resolved server-side from the
+ * authenticated token (assumption A3); `actor` is an opaque principal string.
+ */
+export interface WaypointCommand {
+  type:
+    | 'sdlc.intent.updated.v1'
+    | 'sdlc.claim.opened.v1'
+    | 'sdlc.claim.released.v1'
+    | 'sdlc.intent.closed.v1';
+  /** Event-version precondition — the command applies only at this version. */
+  expectedVersion: number;
+  patch?: WaypointItemPatch;
+  actor?: string;
+}
+
+/** One evidence-ledger entry (harness HistoryEvent projection). */
+export interface WaypointEvidenceEntry {
+  type: string;
+  actor: string;
+  at: string;
+  details?: Record<string, unknown>;
+}
+
+/** Result of a command post: applied, or rejected by the version precondition. */
+export type WaypointCommandResult =
+  | { outcome: 'applied'; item: WaypointItem }
+  | { outcome: 'version_conflict'; currentVersion: number; current: WaypointItem };
+
+/** Result of a conditional GET: fresh body, or 304 not-modified. */
+export type WaypointConditionalResult<T> =
+  | { notModified: false; value: T; etag: string | null }
+  | { notModified: true };
+
+/** Structured error for non-contract responses (network, 5xx, auth, shape). */
+export class WaypointHttpError extends Error {
+  readonly status: number | null;
+  readonly url: string;
+  constructor(message: string, url: string, status: number | null = null) {
+    super(message);
+    this.name = 'WaypointHttpError';
+    this.status = status;
+    this.url = url;
+  }
+}
+
+export interface WaypointHttpOptions {
+  /** Per-Outpost API base URL (e.g. https://waypoint.pnyon.com/o/<outpost>). */
+  url: string;
+  /** Bearer credential (config token or PNYON_TOKEN env, resolved upstream). */
+  token: string;
+  fetchFn?: typeof fetch;
+}
+
+export class WaypointHttp {
+  private readonly base: string;
+  private readonly token: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(opts: WaypointHttpOptions) {
+    this.base = opts.url.replace(/\/+$/, '');
+    this.token = opts.token;
+    this.fetchFn = opts.fetchFn ?? globalThis.fetch;
+  }
+
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/json',
+      ...extra,
+    };
+  }
+
+  private async request(
+    method: 'GET' | 'POST',
+    path: string,
+    init?: { body?: unknown; ifNoneMatch?: string }
+  ): Promise<Response> {
+    const url = `${this.base}${path}`;
+    const headers = this.headers(
+      init?.ifNoneMatch !== undefined ? { 'If-None-Match': init.ifNoneMatch } : undefined
+    );
+    let res: Response;
+    try {
+      res = await this.fetchFn(url, {
+        method,
+        headers,
+        ...(init?.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+      });
+    } catch (err) {
+      throw new WaypointHttpError(
+        `Waypoint request failed: ${err instanceof Error ? err.message : String(err)}`,
+        url
+      );
+    }
+    return res;
+  }
+
+  private async fail(res: Response, url: string): Promise<never> {
+    const body = await res.text().catch(() => '');
+    throw new WaypointHttpError(
+      `Waypoint HTTP ${res.status}${body ? `: ${body.slice(0, 300)}` : ''}`,
+      url,
+      res.status
+    );
+  }
+
+  /** GET /v1/items — optionally filtered by status, conditional on ETag. */
+  async listItems(
+    statuses?: FeatureStatus[],
+    ifNoneMatch?: string
+  ): Promise<WaypointConditionalResult<WaypointItem[]>> {
+    const qs = statuses && statuses.length > 0 ? `?status=${statuses.join(',')}` : '';
+    const path = `/v1/items${qs}`;
+    const res = await this.request('GET', path, {
+      ...(ifNoneMatch !== undefined ? { ifNoneMatch } : {}),
+    });
+    if (res.status === 304) return { notModified: true };
+    if (!res.ok) return this.fail(res, `${this.base}${path}`);
+    const json = (await res.json()) as { items?: WaypointItem[] };
+    return {
+      notModified: false,
+      value: json.items ?? [],
+      etag: res.headers.get('etag'),
+    };
+  }
+
+  /** GET /v1/items/{id} — null on 404, conditional on ETag. */
+  async getItem(
+    id: string,
+    ifNoneMatch?: string
+  ): Promise<WaypointConditionalResult<WaypointItem | null>> {
+    const path = `/v1/items/${encodeURIComponent(id)}`;
+    const res = await this.request('GET', path, {
+      ...(ifNoneMatch !== undefined ? { ifNoneMatch } : {}),
+    });
+    if (res.status === 304) return { notModified: true };
+    if (res.status === 404) return { notModified: false, value: null, etag: null };
+    if (!res.ok) return this.fail(res, `${this.base}${path}`);
+    const json = (await res.json()) as { item?: WaypointItem };
+    if (!json.item) {
+      throw new WaypointHttpError('Waypoint item response missing "item"', path, res.status);
+    }
+    return { notModified: false, value: json.item, etag: res.headers.get('etag') };
+  }
+
+  /** POST /v1/items — create (appends sdlc.intent.created.v1). */
+  async createItem(input: WaypointNewItem): Promise<WaypointItem> {
+    const path = '/v1/items';
+    const res = await this.request('POST', path, { body: input });
+    if (!res.ok) return this.fail(res, `${this.base}${path}`);
+    const json = (await res.json()) as { item?: WaypointItem };
+    if (!json.item) {
+      throw new WaypointHttpError('Waypoint create response missing "item"', path, res.status);
+    }
+    return json.item;
+  }
+
+  /**
+   * POST /v1/items/{id}/commands — apply a mutation command.
+   * A 409 (stale expectedVersion, or claim held by a different assignee) is a
+   * CONTRACT outcome, not an error: it returns the server's current item so
+   * the caller can synthesize the TRACKER_CONFLICT diff without a second GET.
+   */
+  async postCommand(id: string, command: WaypointCommand): Promise<WaypointCommandResult> {
+    const path = `/v1/items/${encodeURIComponent(id)}/commands`;
+    const res = await this.request('POST', path, { body: command });
+    if (res.status === 409) {
+      const json = (await res.json()) as { currentVersion?: number; current?: WaypointItem };
+      if (!json.current || typeof json.currentVersion !== 'number') {
+        throw new WaypointHttpError(
+          'Waypoint 409 response missing "current"/"currentVersion"',
+          path,
+          409
+        );
+      }
+      return {
+        outcome: 'version_conflict',
+        currentVersion: json.currentVersion,
+        current: json.current,
+      };
+    }
+    if (!res.ok) return this.fail(res, `${this.base}${path}`);
+    const json = (await res.json()) as { item?: WaypointItem };
+    if (!json.item) {
+      throw new WaypointHttpError('Waypoint command response missing "item"', path, res.status);
+    }
+    return { outcome: 'applied', item: json.item };
+  }
+
+  /** POST /v1/items/{id}/evidence — append one ledger entry. */
+  async appendEvidence(id: string, entry: WaypointEvidenceEntry): Promise<void> {
+    const path = `/v1/items/${encodeURIComponent(id)}/evidence`;
+    const res = await this.request('POST', path, { body: entry });
+    if (!res.ok) return this.fail(res, `${this.base}${path}`);
+  }
+
+  /** GET /v1/items/{id}/evidence — ordered oldest→newest. */
+  async listEvidence(id: string, limit?: number): Promise<WaypointEvidenceEntry[]> {
+    const qs = typeof limit === 'number' ? `?limit=${limit}` : '';
+    const path = `/v1/items/${encodeURIComponent(id)}/evidence${qs}`;
+    const res = await this.request('GET', path, {});
+    if (!res.ok) return this.fail(res, `${this.base}${path}`);
+    const json = (await res.json()) as { events?: WaypointEvidenceEntry[] };
+    return json.events ?? [];
+  }
+}

--- a/packages/core/src/roadmap/tracker/factory.ts
+++ b/packages/core/src/roadmap/tracker/factory.ts
@@ -6,6 +6,8 @@ import {
   type GitHubIssuesTrackerOptions,
 } from './adapters/github-issues';
 import { LinearTrackerAdapter, type LinearTrackerOptions } from './adapters/linear';
+import type { PnyonTrackerClientConfig } from './adapters/pnyon';
+import { getTrackerKindRegistration } from './registry';
 import { ETagStore } from './etag-store';
 
 export interface GitHubTrackerClientConfig {
@@ -27,7 +29,12 @@ export interface LinearTrackerClientConfig {
   apiBase?: string;
 }
 
-export type TrackerClientConfig = GitHubTrackerClientConfig | LinearTrackerClientConfig;
+export type TrackerClientConfig =
+  | GitHubTrackerClientConfig
+  | LinearTrackerClientConfig
+  | PnyonTrackerClientConfig;
+
+export type { PnyonTrackerClientConfig };
 
 export function createTrackerClient(
   config: TrackerClientConfig
@@ -60,6 +67,12 @@ export function createTrackerClient(
     if (config.apiBase !== undefined) opts.endpoint = config.apiBase;
     return Ok(new LinearTrackerAdapter(opts));
   }
+
+  // Registered kinds (builtin: 'pnyon'; third-party via registerTrackerKind)
+  // resolve through the tracker-kind registry — new kinds plug in with no
+  // modification to this factory. See tracker/registry.ts.
+  const registration = getTrackerKindRegistration((config as { kind: string }).kind);
+  if (registration) return registration.create(config);
 
   return Err(new Error(`Unsupported tracker kind: "${String((config as { kind: string }).kind)}"`));
 }

--- a/packages/core/src/roadmap/tracker/index.ts
+++ b/packages/core/src/roadmap/tracker/index.ts
@@ -30,3 +30,20 @@ export type { LinearTrackerOptions } from './adapters/linear';
 export { ETagStore } from './etag-store';
 export { makeTrackerConflictBody } from './conflict-body';
 export type { TrackerConflictBody, MakeTrackerConflictBodyOptions } from './conflict-body';
+export { PnyonTrackerAdapter } from './adapters/pnyon';
+export type { PnyonTrackerOptions, PnyonTrackerClientConfig } from './adapters/pnyon';
+export { WaypointHttp, WaypointHttpError } from './adapters/waypoint-http';
+export type {
+  WaypointItem,
+  WaypointNewItem,
+  WaypointItemPatch,
+  WaypointCommand,
+  WaypointCommandResult,
+  WaypointEvidenceEntry,
+} from './adapters/waypoint-http';
+export {
+  registerTrackerKind,
+  getTrackerKindRegistration,
+  listRegisteredTrackerKinds,
+} from './registry';
+export type { TrackerKindRegistration, RegisteredTrackerClientConfig } from './registry';

--- a/packages/core/src/roadmap/tracker/registry.ts
+++ b/packages/core/src/roadmap/tracker/registry.ts
@@ -1,0 +1,111 @@
+/**
+ * Tracker-kind registry — opens the file-less tracker seam beyond its
+ * previously hardcoded kinds (see
+ * `docs/changes/waypoint-tracker-kind-pnyon/proposal.md`).
+ *
+ * A registration binds a `roadmap.tracker.kind` string to:
+ *  - `loadProjectConfig` — validate the raw `roadmap.tracker` object from
+ *    `harness.config.json` into a client config (fail at LOAD time with an
+ *    actionable error naming the missing field, not at first API call);
+ *  - `create` — build the {@link RoadmapTrackerClient} from that config.
+ *
+ * Consumers:
+ *  - `loadTrackerClientConfigFromProject` keeps its `github` path unchanged
+ *    and consults this registry for every other kind;
+ *  - `createTrackerClient` keeps its `github-issues`/`linear` branches
+ *    unchanged and falls back to this registry before rejecting — so a new
+ *    kind plugs in with **no modification to factory source**.
+ *
+ * Builtin registrations: `pnyon` (Waypoint event-ledger backend).
+ * Third-party kinds register via {@link registerTrackerKind}.
+ */
+import type { Result } from '@harness-engineering/types';
+import { Ok, Err } from '@harness-engineering/types';
+import type { RoadmapTrackerClient } from './client';
+import { PnyonTrackerAdapter, type PnyonTrackerClientConfig } from './adapters/pnyon';
+
+/**
+ * Minimal structural bound for a registered kind's client config. Concrete
+ * registrations narrow to their own config interface (e.g.
+ * {@link PnyonTrackerClientConfig}); the factory's `TrackerClientConfig`
+ * union carries the builtin shapes for type-level consumers.
+ */
+export interface RegisteredTrackerClientConfig {
+  kind: string;
+}
+
+export interface TrackerKindRegistration {
+  readonly kind: string;
+  /**
+   * Validate the raw `roadmap.tracker` object (from `harness.config.json`)
+   * into this kind's client config. Must fail with an error naming the
+   * missing/invalid field.
+   */
+  loadProjectConfig(
+    tracker: Record<string, unknown>,
+    projectRoot: string
+  ): Result<RegisteredTrackerClientConfig, Error>;
+  /** Build the tracker client (resolving env-var credential fallbacks). */
+  create(config: RegisteredTrackerClientConfig): Result<RoadmapTrackerClient, Error>;
+}
+
+const registrations = new Map<string, TrackerKindRegistration>();
+
+/**
+ * Register a tracker kind. Registering an already-registered kind replaces
+ * the prior registration (last-write-wins; enables test doubles).
+ */
+export function registerTrackerKind(registration: TrackerKindRegistration): void {
+  registrations.set(registration.kind, registration);
+}
+
+export function getTrackerKindRegistration(kind: string): TrackerKindRegistration | undefined {
+  return registrations.get(kind);
+}
+
+/** Registered kind names, registration order. */
+export function listRegisteredTrackerKinds(): string[] {
+  return [...registrations.keys()];
+}
+
+// ── Builtin: pnyon (Waypoint) ─────────────────────────────────────────────
+
+const pnyonRegistration: TrackerKindRegistration = {
+  kind: 'pnyon',
+
+  loadProjectConfig(tracker): Result<PnyonTrackerClientConfig, Error> {
+    const url = tracker.url;
+    if (typeof url !== 'string' || url.trim() === '') {
+      return Err(
+        new Error(
+          'roadmap.tracker.url is required for kind "pnyon" (the Waypoint ' +
+            'per-Outpost API base URL) — set it in harness.config.json'
+        )
+      );
+    }
+    const token = tracker.token;
+    if (token !== undefined && typeof token !== 'string') {
+      return Err(new Error('roadmap.tracker.token must be a string when set (kind "pnyon")'));
+    }
+    return Ok({
+      kind: 'pnyon',
+      url,
+      ...(typeof token === 'string' && token !== '' ? { token } : {}),
+    });
+  },
+
+  create(config): Result<RoadmapTrackerClient, Error> {
+    const c = config as PnyonTrackerClientConfig;
+    const token = c.token ?? process.env.PNYON_TOKEN;
+    if (!token) {
+      return Err(
+        new Error('createTrackerClient: missing Pnyon token (config.token or PNYON_TOKEN env)')
+      );
+    }
+    const opts: ConstructorParameters<typeof PnyonTrackerAdapter>[0] = { url: c.url, token };
+    if (c.etagStore !== undefined) opts.etagStore = c.etagStore;
+    return Ok(new PnyonTrackerAdapter(opts));
+  },
+};
+
+registerTrackerKind(pnyonRegistration);

--- a/packages/core/tests/roadmap/tracker/adapters/pnyon.test.ts
+++ b/packages/core/tests/roadmap/tracker/adapters/pnyon.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Contract tests for the pnyon (Waypoint) tracker adapter against the
+ * in-memory mock Waypoint API (`waypoint-mock.ts` — the reference
+ * implementation of the documented contract; zero real network).
+ *
+ * Spec: docs/changes/waypoint-tracker-kind-pnyon/proposal.md
+ *  - SC3 interface parity (every RoadmapTrackerClient method round-trips)
+ *  - SC4 conflict contract (TRACKER_CONFLICT; no destructive retry)
+ *  - SC5 claim idempotency (same assignee re-claim appends no event)
+ *  - SC6 ETag caching (304 reuse, request-count asserted)
+ *  - SC7 zero GitHub dependency (module + request-host audit; harness #640)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PnyonTrackerAdapter } from '../../../../src/roadmap/tracker/adapters/pnyon';
+import { ConflictError } from '../../../../src/roadmap/tracker/client';
+import type { HistoryEvent } from '../../../../src/roadmap/tracker/client';
+import { MockWaypointApi } from './waypoint-mock';
+
+function makeAdapter(api?: MockWaypointApi): {
+  api: MockWaypointApi;
+  adapter: PnyonTrackerAdapter;
+} {
+  const mock = api ?? new MockWaypointApi();
+  const adapter = new PnyonTrackerAdapter({
+    url: mock.baseUrl,
+    token: 'test-token',
+    fetchFn: mock.fetchFn,
+  });
+  return { api: mock, adapter };
+}
+
+const unwrap = <T>(r: { ok: boolean; value?: T; error?: Error }): T => {
+  if (!r.ok) throw r.error ?? new Error('unexpected Err');
+  return r.value as T;
+};
+
+describe('PnyonTrackerAdapter — interface parity (SC3)', () => {
+  it('round-trips create → fetchAll → fetchById → fetchByStatus → update → claim → release → complete', async () => {
+    const { api, adapter } = makeAdapter();
+
+    // create
+    const created = unwrap(
+      await adapter.create({
+        name: 'Waypoint slice 1',
+        summary: 'First checkpoint',
+        status: 'backlog',
+        spec: 'docs/spec.md',
+        plans: ['docs/plan.md'],
+        blockedBy: ['Other feature'],
+        priority: 'P1',
+        milestone: 'checkpoint-1',
+      })
+    );
+    expect(created.externalId).toMatch(/^pnyon:/);
+    expect(created.status).toBe('backlog');
+    expect(created.spec).toBe('docs/spec.md');
+    expect(created.plans).toEqual(['docs/plan.md']);
+    expect(created.blockedBy).toEqual(['Other feature']);
+    expect(created.priority).toBe('P1');
+    expect(created.milestone).toBe('checkpoint-1');
+    expect(api.sdlcLedger(created.externalId)).toHaveLength(1); // intent.created
+
+    // fetchAll
+    const all = unwrap(await adapter.fetchAll());
+    expect(all.features.map((f) => f.externalId)).toContain(created.externalId);
+    expect(all.etag).not.toBeNull();
+
+    // fetchById
+    const byId = unwrap(await adapter.fetchById(created.externalId));
+    expect(byId).not.toBeNull();
+    expect(byId!.feature.name).toBe('Waypoint slice 1');
+    expect(byId!.etag).toBe('1');
+
+    // fetchByStatus (server-side filter)
+    const backlog = unwrap(await adapter.fetchByStatus(['backlog']));
+    expect(backlog.map((f) => f.externalId)).toContain(created.externalId);
+    expect(unwrap(await adapter.fetchByStatus(['done']))).toHaveLength(0);
+
+    // update → sdlc.intent.updated.v1
+    const updated = unwrap(
+      await adapter.update(created.externalId, { status: 'planned', priority: 'P0' })
+    );
+    expect(updated.status).toBe('planned');
+    expect(updated.priority).toBe('P0');
+    expect(api.sdlcLedger(created.externalId).at(-1)!.type).toBe('sdlc.intent.updated.v1');
+
+    // claim → sdlc.claim.opened.v1 (assignee + in-progress)
+    const claimed = unwrap(await adapter.claim(created.externalId, 'agent://claude/roadmap-fleet'));
+    expect(claimed.assignee).toBe('agent://claude/roadmap-fleet');
+    expect(claimed.status).toBe('in-progress');
+    expect(api.sdlcLedger(created.externalId).at(-1)!.type).toBe('sdlc.claim.opened.v1');
+
+    // release → sdlc.claim.released.v1 (assignee cleared)
+    const released = unwrap(await adapter.release(created.externalId));
+    expect(released.assignee).toBeNull();
+    expect(api.sdlcLedger(created.externalId).at(-1)!.type).toBe('sdlc.claim.released.v1');
+
+    // complete → sdlc.intent.closed.v1 (done)
+    const completed = unwrap(await adapter.complete(created.externalId));
+    expect(completed.status).toBe('done');
+    expect(api.sdlcLedger(created.externalId).at(-1)!.type).toBe('sdlc.intent.closed.v1');
+  });
+
+  it('fetchById returns Ok(null) for a missing item', async () => {
+    const { adapter } = makeAdapter();
+    expect(unwrap(await adapter.fetchById('pnyon:missing'))).toBeNull();
+  });
+
+  it('returns Err (not throw) when the transport fails', async () => {
+    const adapter = new PnyonTrackerAdapter({
+      url: 'https://waypoint.test/o/x',
+      token: 't',
+      fetchFn: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    });
+    const r = await adapter.fetchAll();
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe('PnyonTrackerAdapter — conflict contract (SC4)', () => {
+  it('surfaces a stale-version update as ConflictError code TRACKER_CONFLICT', async () => {
+    const { api, adapter } = makeAdapter();
+    const item = api.seed({ name: 'contested', status: 'planned' });
+    const externalId = `pnyon:${item.id}`;
+
+    // Another writer moves the item ahead of our stale ifMatch.
+    unwrap(await adapter.update(externalId, { status: 'in-progress' }));
+    const eventsBefore = api.sdlcLedger(externalId).length;
+
+    const r = await adapter.update(externalId, { status: 'backlog' }, '1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBeInstanceOf(ConflictError);
+      const conflict = r.error as ConflictError;
+      expect(conflict.code).toBe('TRACKER_CONFLICT');
+      expect(Object.keys(conflict.diff).length).toBeGreaterThan(0);
+      expect(conflict.serverUpdatedAt).not.toBeNull();
+    }
+    // No destructive retry: the loser appended nothing.
+    expect(api.sdlcLedger(externalId)).toHaveLength(eventsBefore);
+  });
+
+  it('grants exactly one of two racing claims; the loser gets TRACKER_CONFLICT', async () => {
+    const { api, adapter } = makeAdapter();
+    const item = api.seed({ name: 'raced', status: 'planned' });
+    const externalId = `pnyon:${item.id}`;
+
+    const winner = await adapter.claim(externalId, 'agent://fleet/lane-a');
+    const loser = await adapter.claim(externalId, 'agent://fleet/lane-b');
+
+    expect(winner.ok).toBe(true);
+    expect(loser.ok).toBe(false);
+    if (!loser.ok) {
+      expect(loser.error).toBeInstanceOf(ConflictError);
+      expect((loser.error as ConflictError).code).toBe('TRACKER_CONFLICT');
+      expect((loser.error as ConflictError).diff).toHaveProperty('assignee');
+    }
+    // Exactly one claim event in the ledger for the winner.
+    const claims = api.sdlcLedger(externalId).filter((e) => e.type === 'sdlc.claim.opened.v1');
+    expect(claims).toHaveLength(1);
+    expect(claims[0]!.actor).toBe('agent://fleet/lane-a');
+    expect(api.item(externalId)!.assignee).toBe('agent://fleet/lane-a');
+  });
+
+  it('treats a stale-version command whose intent the server already holds as idempotent success', async () => {
+    const { api, adapter } = makeAdapter();
+    const item = api.seed({ name: 'converged', status: 'planned' });
+    const externalId = `pnyon:${item.id}`;
+    unwrap(await adapter.update(externalId, { status: 'in-progress' }));
+    const eventsBefore = api.sdlcLedger(externalId).length;
+
+    // Stale version, but the server already IS in-progress: not a conflict.
+    const r = await adapter.update(externalId, { status: 'in-progress' }, '1');
+    expect(r.ok).toBe(true);
+    expect(api.sdlcLedger(externalId)).toHaveLength(eventsBefore);
+  });
+});
+
+describe('PnyonTrackerAdapter — claim idempotency (SC5)', () => {
+  it('re-claiming with the same assignee succeeds without a second claim event', async () => {
+    const { api, adapter } = makeAdapter();
+    const item = api.seed({ name: 'idempotent', status: 'planned' });
+    const externalId = `pnyon:${item.id}`;
+
+    unwrap(await adapter.claim(externalId, 'agent://fleet/lane-a'));
+    const again = unwrap(await adapter.claim(externalId, 'agent://fleet/lane-a'));
+    expect(again.assignee).toBe('agent://fleet/lane-a');
+
+    const claims = api.sdlcLedger(externalId).filter((e) => e.type === 'sdlc.claim.opened.v1');
+    expect(claims).toHaveLength(1);
+  });
+});
+
+describe('PnyonTrackerAdapter — ETag caching (SC6)', () => {
+  it('serves an unchanged fetchAll from cache via If-None-Match/304', async () => {
+    const { api, adapter } = makeAdapter();
+    api.seed({ name: 'cached-a' });
+    api.seed({ name: 'cached-b' });
+
+    const first = unwrap(await adapter.fetchAll());
+    const second = unwrap(await adapter.fetchAll());
+    expect(second.features.map((f) => f.name).sort()).toEqual(
+      first.features.map((f) => f.name).sort()
+    );
+    // One full list body; the second read was a 304 revalidation.
+    expect(api.fullListResponses).toBe(1);
+  });
+
+  it('serves an unchanged fetchById from cache and invalidates after a write', async () => {
+    const { api, adapter } = makeAdapter();
+    const item = api.seed({ name: 'cached-item' });
+    const externalId = `pnyon:${item.id}`;
+
+    unwrap(await adapter.fetchById(externalId));
+    unwrap(await adapter.fetchById(externalId));
+    expect(api.fullItemResponses).toBe(1);
+
+    unwrap(await adapter.update(externalId, { status: 'planned' }));
+    const after = unwrap(await adapter.fetchById(externalId));
+    expect(after!.feature.status).toBe('planned');
+  });
+});
+
+describe('PnyonTrackerAdapter — zero GitHub dependency (SC7, harness #640)', () => {
+  it('adapter modules import nothing GitHub-related', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const srcDir = join(here, '../../../../src/roadmap/tracker/adapters');
+    for (const file of ['pnyon.ts', 'waypoint-http.ts']) {
+      const source = readFileSync(join(srcDir, file), 'utf-8');
+      const imports = source
+        .split('\n')
+        .filter((l) => /^\s*import\b/.test(l))
+        .join('\n');
+      expect(imports).not.toMatch(/github/i);
+      expect(source).not.toMatch(/api\.github\.com/);
+    }
+  });
+
+  it('a full method sweep touches only the configured Waypoint host', async () => {
+    const { api, adapter } = makeAdapter();
+    const created = unwrap(await adapter.create({ name: 'audited', summary: 's' }));
+    await adapter.fetchAll();
+    await adapter.fetchById(created.externalId);
+    await adapter.fetchByStatus(['backlog']);
+    await adapter.update(created.externalId, { priority: 'P2' });
+    await adapter.claim(created.externalId, 'agent://fleet/lane-a');
+    await adapter.release(created.externalId);
+    await adapter.complete(created.externalId);
+    await adapter.appendHistory(created.externalId, {
+      type: 'completed',
+      actor: 'agent://fleet/lane-a',
+      at: new Date().toISOString(),
+    });
+    await adapter.fetchHistory(created.externalId);
+
+    expect(api.requests.length).toBeGreaterThan(0);
+    for (const url of api.requests) {
+      expect(url.startsWith(api.baseUrl)).toBe(true);
+    }
+  });
+});
+
+describe('PnyonTrackerAdapter — history rides the evidence ledger', () => {
+  it('round-trips ≥10 entries with order and content preserved', async () => {
+    const { adapter } = makeAdapter();
+    const created = unwrap(await adapter.create({ name: 'historied', summary: 's' }));
+
+    const events: HistoryEvent[] = [];
+    for (let i = 0; i < 12; i++) {
+      const event: HistoryEvent = {
+        type: i % 2 === 0 ? 'updated' : 'claimed',
+        actor: `actor-${i}`,
+        at: new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString(),
+        details: { seq: i },
+      };
+      events.push(event);
+      unwrap(await adapter.appendHistory(created.externalId, event));
+    }
+
+    const history = unwrap(await adapter.fetchHistory(created.externalId));
+    expect(history).toEqual(events);
+
+    const limited = unwrap(await adapter.fetchHistory(created.externalId, 5));
+    expect(limited).toEqual(events.slice(0, 5));
+  });
+
+  it('filters non-harness evidence types out of fetchHistory', async () => {
+    const { api, adapter } = makeAdapter();
+    const created = unwrap(await adapter.create({ name: 'rich-ledger', summary: 's' }));
+    unwrap(
+      await adapter.appendHistory(created.externalId, {
+        type: 'claimed',
+        actor: 'a',
+        at: new Date().toISOString(),
+      })
+    );
+    // A richer Waypoint-native evidence entry lands in the same ledger.
+    api.evidence(created.externalId).push({
+      type: 'sdlc.verify.graded.v1',
+      actor: 'agent://verifier',
+      at: new Date().toISOString(),
+    });
+
+    const history = unwrap(await adapter.fetchHistory(created.externalId));
+    expect(history).toHaveLength(1);
+    expect(history[0]!.type).toBe('claimed');
+  });
+});

--- a/packages/core/tests/roadmap/tracker/adapters/waypoint-mock.ts
+++ b/packages/core/tests/roadmap/tracker/adapters/waypoint-mock.ts
@@ -1,0 +1,250 @@
+/**
+ * In-memory mock of the Waypoint roadmap-provider HTTP API — the reference
+ * implementation of the contract documented in
+ * `src/roadmap/tracker/adapters/waypoint-http.ts` (spec:
+ * docs/changes/waypoint-tracker-kind-pnyon/proposal.md §"Waypoint HTTP API
+ * contract"). Injected into the adapter as a `fetchFn`; zero real network.
+ *
+ * Behavior implemented (normative):
+ *  - GET  /v1/items            — ?status= filter, If-None-Match/ETag/304
+ *  - GET  /v1/items/{id}       — 404, If-None-Match (= item version)/304
+ *  - POST /v1/items            — create (+ sdlc.intent.created.v1 ledger event)
+ *  - POST /v1/items/{id}/commands — expectedVersion precondition → 409
+ *    { currentVersion, current }; same-assignee claim is an idempotent no-op
+ *    (200, no event appended); different-assignee claim is a 409.
+ *  - POST/GET /v1/items/{id}/evidence — ordered evidence ledger.
+ *
+ * Inspection surface for tests: `sdlcLedger(id)`, `evidence(id)`,
+ * `requests` (every URL seen), `fullListResponses`, `fullItemResponses`.
+ */
+import type {
+  WaypointItem,
+  WaypointNewItem,
+  WaypointCommand,
+  WaypointEvidenceEntry,
+} from '../../../../src/roadmap/tracker/adapters/waypoint-http';
+
+interface LedgerEvent {
+  type: string;
+  version: number;
+  actor?: string;
+}
+
+let ulidCounter = 0;
+function nextId(): string {
+  ulidCounter += 1;
+  return `01MOCKULID${String(ulidCounter).padStart(16, '0')}`;
+}
+
+const json = (status: number, body: unknown, headers?: Record<string, string>): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+
+export class MockWaypointApi {
+  readonly baseUrl: string;
+  private readonly items = new Map<string, WaypointItem>();
+  private readonly sdlc = new Map<string, LedgerEvent[]>();
+  private readonly evidenceLedgers = new Map<string, WaypointEvidenceEntry[]>();
+  /** Bumped on every mutation; drives the list ETag. */
+  private listRevision = 0;
+
+  /** Every URL this mock served, in order (host-audit surface). */
+  readonly requests: string[] = [];
+  /** Count of full (non-304) list bodies served. */
+  fullListResponses = 0;
+  /** Count of full (non-304) single-item bodies served. */
+  fullItemResponses = 0;
+
+  constructor(baseUrl = 'https://waypoint.test/o/outpost-1') {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  /** The injectable fetch implementation. */
+  readonly fetchFn: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    this.requests.push(url);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers = new Headers(init?.headers);
+    const body = typeof init?.body === 'string' ? (JSON.parse(init.body) as unknown) : undefined;
+
+    if (!url.startsWith(this.baseUrl)) return json(404, { error: 'unknown host' });
+    const path = url.slice(this.baseUrl.length).split('?')[0]!;
+    const query = new URL(url).searchParams;
+
+    if (method === 'GET' && path === '/v1/items') {
+      return this.handleList(query, headers.get('if-none-match'));
+    }
+    if (method === 'POST' && path === '/v1/items') {
+      return this.handleCreate(body as WaypointNewItem);
+    }
+    const itemMatch = /^\/v1\/items\/([^/]+)$/.exec(path);
+    if (method === 'GET' && itemMatch) {
+      return this.handleGet(itemMatch[1]!, headers.get('if-none-match'));
+    }
+    const cmdMatch = /^\/v1\/items\/([^/]+)\/commands$/.exec(path);
+    if (method === 'POST' && cmdMatch) {
+      return this.handleCommand(cmdMatch[1]!, body as WaypointCommand);
+    }
+    const evMatch = /^\/v1\/items\/([^/]+)\/evidence$/.exec(path);
+    if (evMatch && method === 'POST') {
+      return this.handleAppendEvidence(evMatch[1]!, body as WaypointEvidenceEntry);
+    }
+    if (evMatch && method === 'GET') {
+      return this.handleListEvidence(evMatch[1]!, query.get('limit'));
+    }
+    return json(404, { error: `no route: ${method} ${path}` });
+  };
+
+  // ── Inspection ──────────────────────────────────────────────────────────
+
+  /** All sdlc.* events appended for an item (the mutation ledger). */
+  sdlcLedger(id: string): LedgerEvent[] {
+    return this.sdlc.get(this.stripPrefix(id)) ?? [];
+  }
+
+  /** The item's evidence ledger (history entries). */
+  evidence(id: string): WaypointEvidenceEntry[] {
+    return this.evidenceLedgers.get(this.stripPrefix(id)) ?? [];
+  }
+
+  item(id: string): WaypointItem | undefined {
+    return this.items.get(this.stripPrefix(id));
+  }
+
+  /** Seed an item directly (bypassing HTTP), returning it. */
+  seed(partial: Partial<WaypointItem> & { name: string }): WaypointItem {
+    const id = partial.id ?? nextId();
+    const item: WaypointItem = {
+      id,
+      name: partial.name,
+      status: partial.status ?? 'backlog',
+      summary: partial.summary ?? '',
+      spec: partial.spec ?? null,
+      plans: partial.plans ?? [],
+      blockedBy: partial.blockedBy ?? [],
+      assignee: partial.assignee ?? null,
+      priority: partial.priority ?? null,
+      milestone: partial.milestone ?? null,
+      createdAt: partial.createdAt ?? new Date().toISOString(),
+      updatedAt: partial.updatedAt ?? null,
+      version: partial.version ?? 1,
+    };
+    this.items.set(id, item);
+    this.sdlc.set(id, [{ type: 'sdlc.intent.created.v1', version: item.version }]);
+    this.listRevision += 1;
+    return item;
+  }
+
+  private stripPrefix(id: string): string {
+    return id.startsWith('pnyon:') ? id.slice('pnyon:'.length) : id;
+  }
+
+  // ── Routes ──────────────────────────────────────────────────────────────
+
+  private handleList(query: URLSearchParams, ifNoneMatch: string | null): Response {
+    const listEtag = `W/"list-${this.listRevision}"`;
+    const statusFilter = query.get('status');
+    // Only the unfiltered list participates in ETag caching (contract).
+    if (!statusFilter && ifNoneMatch === listEtag) return new Response(null, { status: 304 });
+    let items = [...this.items.values()];
+    if (statusFilter) {
+      const wanted = new Set(statusFilter.split(','));
+      items = items.filter((i) => wanted.has(i.status));
+    }
+    this.fullListResponses += 1;
+    return json(200, { items }, { ETag: listEtag });
+  }
+
+  private handleGet(id: string, ifNoneMatch: string | null): Response {
+    const item = this.items.get(id);
+    if (!item) return json(404, { error: 'not found' });
+    const etag = String(item.version);
+    if (ifNoneMatch === etag) return new Response(null, { status: 304 });
+    this.fullItemResponses += 1;
+    return json(200, { item }, { ETag: etag });
+  }
+
+  private handleCreate(input: WaypointNewItem): Response {
+    const item = this.seed({
+      name: input.name,
+      summary: input.summary,
+      ...(input.status !== undefined ? { status: input.status } : {}),
+      ...(input.spec !== undefined && input.spec !== null ? { spec: input.spec } : {}),
+      ...(input.plans !== undefined ? { plans: input.plans } : {}),
+      ...(input.blockedBy !== undefined ? { blockedBy: input.blockedBy } : {}),
+      ...(input.priority !== undefined && input.priority !== null
+        ? { priority: input.priority }
+        : {}),
+      ...(input.milestone !== undefined && input.milestone !== null
+        ? { milestone: input.milestone }
+        : {}),
+      ...(input.assignee !== undefined && input.assignee !== null
+        ? { assignee: input.assignee }
+        : {}),
+    });
+    return json(201, { item }, { ETag: String(item.version) });
+  }
+
+  private handleCommand(id: string, command: WaypointCommand): Response {
+    const item = this.items.get(id);
+    if (!item) return json(404, { error: 'not found' });
+
+    const conflict = (): Response =>
+      json(409, { code: 'version_conflict', currentVersion: item.version, current: item });
+
+    if (command.type === 'sdlc.claim.opened.v1') {
+      const actor = command.actor ?? '';
+      // Idempotent no-op: already claimed by the same assignee — no event.
+      if (item.assignee === actor) return json(200, { item }, { ETag: String(item.version) });
+      // First-claim-wins: a different current claimant conflicts regardless
+      // of the presented version.
+      if (item.assignee !== null) return conflict();
+      if (command.expectedVersion !== item.version) return conflict();
+      return this.apply(item, command.type, { assignee: actor, status: 'in-progress' }, actor);
+    }
+
+    if (command.expectedVersion !== item.version) return conflict();
+
+    if (command.type === 'sdlc.claim.released.v1') {
+      return this.apply(item, command.type, { assignee: null, status: 'planned' });
+    }
+    if (command.type === 'sdlc.intent.closed.v1') {
+      return this.apply(item, command.type, { status: 'done' });
+    }
+    // sdlc.intent.updated.v1
+    return this.apply(item, command.type, command.patch ?? {});
+  }
+
+  private apply(
+    item: WaypointItem,
+    type: string,
+    patch: Partial<WaypointItem>,
+    actor?: string
+  ): Response {
+    Object.assign(item, patch);
+    item.version += 1;
+    item.updatedAt = new Date().toISOString();
+    this.listRevision += 1;
+    const events = this.sdlc.get(item.id) ?? [];
+    events.push({ type, version: item.version, ...(actor !== undefined ? { actor } : {}) });
+    this.sdlc.set(item.id, events);
+    return json(200, { item }, { ETag: String(item.version) });
+  }
+
+  private handleAppendEvidence(id: string, entry: WaypointEvidenceEntry): Response {
+    if (!this.items.has(id)) return json(404, { error: 'not found' });
+    const ledger = this.evidenceLedgers.get(id) ?? [];
+    ledger.push(entry);
+    this.evidenceLedgers.set(id, ledger);
+    return new Response(null, { status: 204 });
+  }
+
+  private handleListEvidence(id: string, limit: string | null): Response {
+    if (!this.items.has(id)) return json(404, { error: 'not found' });
+    let events = this.evidenceLedgers.get(id) ?? [];
+    if (limit !== null) events = events.slice(0, Number.parseInt(limit, 10));
+    return json(200, { events });
+  }
+}

--- a/packages/core/tests/roadmap/tracker/registry.test.ts
+++ b/packages/core/tests/roadmap/tracker/registry.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tracker-kind registry + loader/factory opening
+ * (docs/changes/waypoint-tracker-kind-pnyon/proposal.md SC1/SC2).
+ *
+ * The pre-existing loader and factory suites are untouched (github behavior
+ * byte-for-byte); this file covers only the NEW seam.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { Ok } from '@harness-engineering/types';
+import {
+  registerTrackerKind,
+  getTrackerKindRegistration,
+  listRegisteredTrackerKinds,
+} from '../../../src/roadmap/tracker/registry';
+import { createTrackerClient } from '../../../src/roadmap/tracker/factory';
+import { PnyonTrackerAdapter } from '../../../src/roadmap/tracker/adapters/pnyon';
+import { loadTrackerClientConfigFromProject } from '../../../src/roadmap/load-tracker-client-config';
+
+function tmpProject(config: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnyon-trackercfg-'));
+  fs.writeFileSync(path.join(dir, 'harness.config.json'), JSON.stringify(config));
+  return dir;
+}
+
+describe('tracker-kind registry', () => {
+  it('has the builtin pnyon registration', () => {
+    expect(listRegisteredTrackerKinds()).toContain('pnyon');
+    expect(getTrackerKindRegistration('pnyon')?.kind).toBe('pnyon');
+  });
+
+  it('returns undefined for unregistered kinds', () => {
+    expect(getTrackerKindRegistration('jira')).toBeUndefined();
+  });
+
+  it('third-party kinds register and resolve through the factory with no factory change', () => {
+    const marker = {
+      marker: true,
+    } as unknown as import('../../../src/roadmap/tracker/client').RoadmapTrackerClient;
+    registerTrackerKind({
+      kind: 'test-double',
+      loadProjectConfig: () => Ok({ kind: 'test-double' }),
+      create: () => Ok(marker),
+    });
+    const r = createTrackerClient({ kind: 'test-double' } as never);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(marker);
+  });
+});
+
+describe('loadTrackerClientConfigFromProject — pnyon kind (SC1)', () => {
+  it('returns Ok({ kind: "pnyon", url, token }) for a valid config', () => {
+    const dir = tmpProject({
+      roadmap: {
+        mode: 'file-less',
+        tracker: { kind: 'pnyon', url: 'https://waypoint.test/o/outpost-1', token: 'tok' },
+      },
+    });
+    const r = loadTrackerClientConfigFromProject(dir);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toEqual({
+        kind: 'pnyon',
+        url: 'https://waypoint.test/o/outpost-1',
+        token: 'tok',
+      });
+    }
+  });
+
+  it('omits token when unset (env fallback happens at create time)', () => {
+    const dir = tmpProject({
+      roadmap: { tracker: { kind: 'pnyon', url: 'https://waypoint.test/o/outpost-1' } },
+    });
+    const r = loadTrackerClientConfigFromProject(dir);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ kind: 'pnyon', url: 'https://waypoint.test/o/outpost-1' });
+  });
+
+  it('fails at LOAD time naming the missing url field', () => {
+    const dir = tmpProject({ roadmap: { tracker: { kind: 'pnyon' } } });
+    const r = loadTrackerClientConfigFromProject(dir);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/roadmap\.tracker\.url is required/);
+  });
+
+  it('rejects unregistered kinds, listing the registered kinds', () => {
+    const dir = tmpProject({ roadmap: { tracker: { kind: 'jira', repo: 'x/y' } } });
+    const r = loadTrackerClientConfigFromProject(dir);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // Same phrasing family the pre-existing suite pins (/only supports kind/i)
+      expect(r.error.message).toMatch(/only supports kind/i);
+      expect(r.error.message).toMatch(/github/);
+      expect(r.error.message).toMatch(/pnyon/);
+      expect(r.error.message).toMatch(/"jira"/);
+    }
+  });
+
+  it('github behavior is untouched (regression)', () => {
+    const dir = tmpProject({ roadmap: { tracker: { kind: 'github', repo: 'owner/repo' } } });
+    const r = loadTrackerClientConfigFromProject(dir);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ kind: 'github-issues', repo: 'owner/repo' });
+  });
+});
+
+describe('createTrackerClient — pnyon kind (SC2)', () => {
+  beforeEach(() => vi.unstubAllEnvs());
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('returns Ok(PnyonTrackerAdapter) with an explicit token', () => {
+    const r = createTrackerClient({
+      kind: 'pnyon',
+      url: 'https://waypoint.test/o/outpost-1',
+      token: 'tok',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBeInstanceOf(PnyonTrackerAdapter);
+  });
+
+  it('falls back to the PNYON_TOKEN env var', () => {
+    vi.stubEnv('PNYON_TOKEN', 'env-tok');
+    const r = createTrackerClient({ kind: 'pnyon', url: 'https://waypoint.test/o/outpost-1' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBeInstanceOf(PnyonTrackerAdapter);
+  });
+
+  it('returns an actionable Err when no token is available', () => {
+    vi.stubEnv('PNYON_TOKEN', '');
+    const r = createTrackerClient({ kind: 'pnyon', url: 'https://waypoint.test/o/outpost-1' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/missing Pnyon token.*PNYON_TOKEN/i);
+  });
+
+  it('still rejects unregistered kinds with the original message', () => {
+    const r = createTrackerClient({ kind: 'gitlab-issues' } as never);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/Unsupported tracker kind/i);
+  });
+});


### PR DESCRIPTION
## Summary

Opens the file-less tracker seam for the Waypoint roadmap provider (pnyon ADR-0047):

1. **`PnyonTrackerAdapter`** (`packages/core/src/roadmap/tracker/adapters/pnyon.ts`, beside `github-issues`/`linear`) — implements the full `RoadmapTrackerClient` interface (fetchAll/fetchById/fetchByStatus/create/update/claim/release/complete/appendHistory/fetchHistory) against a **documented, typed Waypoint HTTP API contract** (`adapters/waypoint-http.ts`):
   - claims map to `sdlc.claim.*` event semantics (`claim` → `sdlc.claim.opened.v1`, `release` → `sdlc.claim.released.v1`, `complete` → `sdlc.intent.closed.v1`, `update` → `sdlc.intent.updated.v1`), all guarded by **event-version preconditions**; a stale write is rejected server-side and surfaced as `ConflictError` code **`TRACKER_CONFLICT`** — the exact contract consumers handle today, so first-claim-wins CAS survives the backend swap;
   - `appendHistory`/`fetchHistory` ride the item's **evidence ledger** (durable, ordered) instead of comment scraping;
   - ETag caching via the shared `ETagStore` (`feature:`/`list:all` keys, write-path invalidation), with the single-item ETag doubling as the event version so `ifMatch` is the precondition verbatim;
   - **zero GitHub API calls** — machine actors are never pushed to GitHub's assignee field (#640). In pnyon mode the GitHub projection is Waypoint-side scope, downstream of the ledger; the adapter has no GitHub write path at all (enforced by module-import + request-host audit tests).
2. **Tracker-kind registry** (`packages/core/src/roadmap/tracker/registry.ts`) — `loadTrackerClientConfigFromProject` keeps its `github` path byte-for-byte and resolves other kinds through the registry (builtin: `pnyon`, config `url` + `token`/`PNYON_TOKEN`); unregistered kinds are still rejected, now listing the registered kinds. `createTrackerClient` keeps its existing branches untouched and falls back to the registry, so future kinds plug in with no factory modification. All pre-existing loader/factory/tracker tests pass **unmodified**.
3. **CLI config surface** — `TrackerConfigSchema` becomes a discriminated union (github variant unchanged + `{ kind: 'pnyon', url, token? }`) so `harness validate` accepts pnyon configs.
4. **Contract tests** — in-memory mock Waypoint API (`tests/roadmap/tracker/adapters/waypoint-mock.ts`, the reference implementation of the contract): full method sweep, stale-version conflict + racing-claim (exactly one winning ledger event), claim idempotency (same-assignee re-claim appends no event), ETag/304 request counts, no-GitHub audit, evidence round-trip (≥10 entries, order preserved), and file-less `manage_roadmap` semantics (groom unsupported, sync no-op) through the untouched generic handler.

Spec/plan/provenance: `docs/changes/waypoint-tracker-kind-pnyon/` (proposal.md, plans/plan.md, provenance.json). Changeset: core minor, cli minor. Arch allowance for the new modules via the sanctioned `check-arch --update-baseline --reason` path (baselines.json untouched).

Also includes one standalone commit that re-exports the `context-surface` helpers consumed by its own test file — the `tsc --noEmit` break on `main` (#1804 regression, main-health alarm #1814) — because this repo's fail-closed local gates cannot pass against the broken baseline.

## Assumptions made

- **A1 — Contract-first**: no live Waypoint service exists yet; the typed client module (`waypoint-http.ts`) IS the normative API contract the pnyon-side service must satisfy, and contract tests run against an in-memory mock implementing it (per the confirmed lane scope for pnyon/pnyon#125).
- **A2 — Six-status projection**: the Waypoint read API serves harness's six-status projection directly in `status` (lane→status mapping is server-side per pnyon ADR-0047); `blocked`/`needs-human` arrive as statuses at this seam.
- **A3 — Actor duality is server-side**: the adapter sends assignee/actor as an opaque principal string; `agent onBehalfOf human` duality is resolved by the service from the authenticated token.
- **A4 — `PNYON_TOKEN`** is the env-var credential fallback, mirroring `GITHUB_TOKEN`/`LINEAR_API_KEY`.
- **A5 — linear stays loader-invisible** (as today): only `pnyon` is registered as a builtin in the config loader; registering linear there is a separate decision.
- **A6 — No GitHub writes in pnyon mode**: the GitHub projection (including the human-reserved assignee field, #640) is Waypoint-side scope; made explicit in the spec and enforced by the SC7 audit tests.
- **A7 — Red-main side-fix**: main's typecheck was broken (#1814); the minimal re-export fix is a separate, clearly-scoped commit on this branch.
- **A8 — Arch allowance**: module-size/dependency-depth growth from the three new modules accepted via `check-arch --update-baseline --reason` (writes a per-PR allowance file; baselines stay byte-identical).
- **A9 — Parallel-lane hygiene**: emission/gateway/webhook-topic files untouched; shared barrel exports appended, never reordered.

Closes #1815
Closes pnyon/pnyon#125

https://claude.ai/code/session_01P7y8wPNXz6nsU8oWgFdZni
