### PR TITLE
feat(waypoint): opt-in sdlc.* event emission and repo-local spool

### DIFF
--- a/.changeset/waypoint-sdlc-emission.md
+++ b/.changeset/waypoint-sdlc-emission.md
@@ -1,0 +1,28 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+'@harness-engineering/orchestrator': minor
+---
+
+feat(waypoint): opt-in `sdlc.*` event emission and repo-local spool
+(pnyon/pnyon#124).
+
+Adds an additive, OPT-IN Waypoint emission layer: with `waypoint.sink`
+configured in `harness.config.json`, the sanctioned roadmap mutators
+(`setStatus`/`claim`/`release`), skill phase transitions (`emit_interaction`),
+persisted eval/UAT verdicts, and fleet artifact writes each append exactly one
+CloudEvents-1.0-profile `sdlc.*.v1` event to a bounded, per-process JSONL
+spool under `.harness/spool/` (drop-oldest at cap with a persistent
+`droppedEvents` counter; client-side best-effort secret scrub; ULID
+idempotency keys). The pinned 19-type `sdlc.*.v1` vocabulary is registered on
+the gateway webhook bus, delivered through the existing `GatewayEvent`
+envelope and `WebhookQueue` retry machinery via a new orchestrator-side
+bridge. A new `harness waypoint` command records fleet
+provenance/handoff artifacts and reports spool health.
+
+THE HARD INVARIANT: with no `waypoint.sink` configured, nothing changes —
+no new files, no new I/O, no behavior change to any existing command, mode,
+or test (verified by dedicated non-adopter invariance tests). Shipping
+spooled events to a hosted ingest is explicitly out of scope (pnyon owns
+ingest).

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ temp/
 **/.harness/proposals/
 **/.harness/workspaces/
 **/.harness/black-box/
+# spool/: repo-local Waypoint sdlc.* event segments (opt-in; pnyon/pnyon#124)
+**/.harness/spool/
 # metrics/: track the holiday-confidence trend ledger, ignore everything else
 **/.harness/metrics/*
 !**/.harness/metrics/holiday-confidence.jsonl

--- a/.harness/arch/allowances/feat-waypoint-sdlc-emission.json
+++ b/.harness/arch/allowances/feat-waypoint-sdlc-emission.json
@@ -1,0 +1,9 @@
+{
+  "reason": "Additive opt-in Waypoint sdlc.* emission layer (pnyon/pnyon#124): new packages/core/src/waypoint module, harness waypoint CLI command, and orchestrator sdlc bridge account for the module-size and dependency-depth growth",
+  "categories": {
+    "module-size": 262891,
+    "dependency-depth": 666
+  },
+  "violationIds": [],
+  "createdFrom": "32a3b8cde"
+}

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,11 +1,127 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/commands"
-sourceHash: "5acc5633675f3411761f3f3f9f0411d3f503184e3829e7d0d2d595b56cf9685f"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/cli/src/commands'
+sourceHash: '68d9c0e9a8612a60f1bb2774f14da06765026dd4e5ec0f501b7469b18b4eaff6'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["_registry.ts", "add.ts", "adoption.ts", "advise-skills.test.ts", "advise-skills.ts", "align-design-system.ts", "api-craft.ts", "audit-protected.ts", "backfill-skill-provenance.ts", "blueprint.ts", "check-arch.ts", "check-deployment.ts", "check-deps.ts", "check-design.ts", "check-docs.ts", "check-harness-strength.ts", "check-operational-drift.test.ts", "check-operational-drift.ts", "check-perf.ts", "check-phase-gate.ts", "check-security.ts", "check-vocabulary.ts", "cleanup-sessions.ts", "cleanup.ts", "cli-ergonomics-craft.ts", "code-craft.ts", "comprehend.ts", "comprehension-merge-driver.ts", "copy-craft.ts", "create-skill.ts", "cross-check.ts", "dashboard.ts", "design-pipeline.ts", "docs-craft.ts", "doctor.ts", "fix-drift.ts", "generate-agent-definitions.ts", "generate-slash-commands.ts", "generate.ts", "holiday-confidence.ts", "impact-preview.ts", "init-minimal.ts", "init.ts", "insights.ts", "install-constraints.ts", "install.ts", "knowledge-craft.ts", "knowledge-pipeline.test.ts", "knowledge-pipeline.ts", "maintenance-config.test.ts", "maintenance-config.ts", "maintenance-run.ts", "maintenance.ts", "mcp-guard.ts", "mcp.ts", "migrate-backends.ts", "migrate.ts", "models.ts", "naming-craft.ts", "operational-drift.test.ts", "operational-drift.ts", "orchestrator-black-box.test.ts", "orchestrator-black-box.ts", "orchestrator.ts", "outcome-eval-ci.ts", "perf.ts", "pre-merge-brief.ts", "predict.ts", "proposals.ts", "publish-analyses.ts", "recommend.ts", "rehearse.ts", "review-ci-local-adapter.ts", "review-ci.ts", "rework.test.ts", "rework.ts", "rollback.ts", "scan-config.ts", "search.ts", "security-craft.ts", "setup-mcp.ts", "setup-types.ts", "setup.ts", "share.ts", "skill-regression.test.ts", "skill-regression.ts", "snapshot.ts", "spec-craft.ts", "stale-constraints.ts", "sync-analyses.ts", "sync-main.ts", "taint.ts", "telemetry-wizard.ts", "test-craft.ts", "traceability.ts", "uninstall-constraints.ts", "uninstall.ts", "update.ts", "usage.ts", "validate-cross-check.ts", "validate-scope.ts", "validate.ts", "verify.test.ts", "verify.ts"]
+members:
+  [
+    '_registry.ts',
+    'add.ts',
+    'adoption.ts',
+    'advise-skills.test.ts',
+    'advise-skills.ts',
+    'align-design-system.ts',
+    'api-craft.ts',
+    'audit-protected.ts',
+    'backfill-skill-provenance.ts',
+    'blueprint.ts',
+    'check-arch.ts',
+    'check-deployment.ts',
+    'check-deps.ts',
+    'check-design.test.ts',
+    'check-design.ts',
+    'check-docs.ts',
+    'check-harness-strength.ts',
+    'check-operational-drift-action.test.ts',
+    'check-operational-drift.test.ts',
+    'check-operational-drift.ts',
+    'check-perf.ts',
+    'check-phase-gate.ts',
+    'check-security.ts',
+    'check-vocabulary.ts',
+    'cleanup-sessions.ts',
+    'cleanup.ts',
+    'cli-ergonomics-craft.ts',
+    'code-craft.ts',
+    'comprehend.test.ts',
+    'comprehend.ts',
+    'comprehension-merge-driver.ts',
+    'copy-craft.ts',
+    'create-skill.ts',
+    'cross-check.ts',
+    'dashboard.ts',
+    'design-pipeline.ts',
+    'distortion.ts',
+    'docs-craft.ts',
+    'doctor.ts',
+    'fix-drift.ts',
+    'generate-agent-definitions.ts',
+    'generate-slash-commands.ts',
+    'generate.ts',
+    'holiday-confidence.ts',
+    'impact-preview.ts',
+    'init-minimal.ts',
+    'init.ts',
+    'insights.ts',
+    'install-constraints.ts',
+    'install.ts',
+    'knowledge-craft.ts',
+    'knowledge-pipeline.test.ts',
+    'knowledge-pipeline.ts',
+    'maintenance-config.test.ts',
+    'maintenance-config.ts',
+    'maintenance-run.ts',
+    'maintenance.test.ts',
+    'maintenance.ts',
+    'mcp-guard.ts',
+    'mcp.ts',
+    'migrate-backends.ts',
+    'migrate.ts',
+    'models-drift.test.ts',
+    'models.ts',
+    'naming-craft.ts',
+    'operational-drift.test.ts',
+    'operational-drift.ts',
+    'orchestrator-black-box.test.ts',
+    'orchestrator-black-box.ts',
+    'orchestrator.ts',
+    'outcome-eval-ci.ts',
+    'perf.ts',
+    'pre-merge-brief.ts',
+    'predict.ts',
+    'proposals.ts',
+    'publish-analyses.ts',
+    'recommend.ts',
+    'rehearse.test.ts',
+    'rehearse.ts',
+    'release-inventory.test.ts',
+    'release-inventory.ts',
+    'review-ci-local-adapter.ts',
+    'review-ci.ts',
+    'rework.test.ts',
+    'rework.ts',
+    'rollback.ts',
+    'scan-config.ts',
+    'search.ts',
+    'security-craft.ts',
+    'setup-mcp.ts',
+    'setup-types.ts',
+    'setup.ts',
+    'share.ts',
+    'skill-regression.test.ts',
+    'skill-regression.ts',
+    'snapshot.ts',
+    'spec-craft.ts',
+    'stale-constraints.ts',
+    'sync-analyses.ts',
+    'sync-main.ts',
+    'taint.ts',
+    'telemetry-wizard.ts',
+    'test-craft.ts',
+    'traceability.ts',
+    'uninstall-constraints.ts',
+    'uninstall.ts',
+    'update.ts',
+    'usage.ts',
+    'validate-cross-check.ts',
+    'validate-scope.ts',
+    'validate.ts',
+    'verify.test.ts',
+    'verify.ts',
+    'waypoint.ts',
+  ]
 ---
 
 ## Interface Contract
@@ -79,14 +195,17 @@ export createCreateSkillCommand
 export createCrossCheckCommand
 export createDashboardCommand
 export createDesignPipelineCommand
+export createDistortionCommand
 export createDocsCraftCommand
 export createDoctorCommand
 export createFixDispatcher
 export createFixDriftCommand
+export createFsPort
 export createGenerateAgentDefinitionsCommand
 export createGenerateCommand
 export createGenerateSlashCommandsCommand
 export createGhSeam
+export createGitPort
 export createHolidayConfidenceCommand
 export createImpactPreviewCommand
 export createInitCommand
@@ -114,6 +233,7 @@ export createProposalsCommand
 export createPublishAnalysesCommand
 export createRecommendCommand
 export createRehearseCommand
+export createReleaseInventoryCommand
 export createReviewCiCommand
 export createReworkCommand
 export createRollbackCommand
@@ -138,6 +258,7 @@ export createUpdateCommand
 export createUsageCommand
 export createValidateCommand
 export createVerifyCommand
+export createWaypointCommand
 export deepEqual
 export defaultPostBrief
 export defaultRunGit
@@ -239,6 +360,7 @@ export runMigrate
 export runMigrateBackends
 export runMinimalInit
 export runModelsApprove
+export runModelsDrift
 export runModelsProbe
 export runModelsProposals
 export runModelsRefresh
@@ -251,6 +373,7 @@ export runProposalsReject
 export runProposalsShow
 export runProposalsStatus
 export runRecommend
+export runReleaseInventory
 export runReviewCi
 export runReworkCommand
 export runRollbackEvaluate
@@ -391,10 +514,10 @@ import { createBurnCommand } from './burn'
 import { createCheckArchCommand } from './check-arch'
 import { createCheckDeploymentCommand } from './check-deployment'
 import { createCheckDepsCommand } from './check-deps'
-import { createCheckDesignCommand } from './check-design'
+import { createCheckDesignCommand, runCheckDesign } from './check-design'
 import { createCheckDocsCommand } from './check-docs'
 import { createCheckHarnessStrengthCommand } from './check-harness-strength'
-import { RunGit, collectChangedFiles, createCheckOperationalDriftCommand, resolveBaseRef } from './check-operational-drift'
+import { RunGit, collectChangedFiles, createCheckOperationalDriftCommand, resolveBaseRef, runCheckOperationalDrift } from './check-operational-drift'
 import { createCheckPerfCommand } from './check-perf'
 import { createCheckPhaseGateCommand } from './check-phase-gate'
 import { createCheckSecurityCommand } from './check-security'
@@ -406,13 +529,15 @@ import { createCleanupSessionsCommand } from './cleanup-sessions'
 import { createCliErgonomicsCraftCommand } from './cli-ergonomics-craft'
 import { createCodeCraftCommand } from './code-craft'
 import { createCompoundCommand } from './compound'
-import { createComprehendCommand } from './comprehend'
+import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
 import { createComprehensionMergeDriverCommand } from './comprehension-merge-driver'
+import { createContextDictionaryCommand } from './context-dictionary'
 import { createCopyCraftCommand } from './copy-craft'
 import { createCreateSkillCommand } from './create-skill'
 import { createCrossCheckCommand } from './cross-check'
 import { createDashboardCommand } from './dashboard'
 import { createDesignPipelineCommand } from './design-pipeline'
+import { createDistortionCommand } from './distortion'
 import { createDocsCraftCommand } from './docs-craft'
 import { createDocsPublishCommand } from './docs-publish'
 import { createDoctorCommand } from './doctor'
@@ -436,6 +561,7 @@ import { createInstallCommand, resolveCommunityBase } from './install'
 import { createInstallConstraintsCommand } from './install-constraints'
 import { createIntegrationsCommand } from './integrations'
 import { readConfiguredServers } from './integrations/sync'
+import { createKnowledgeCommand } from './knowledge'
 import { createKnowledgeCraftCommand } from './knowledge-craft'
 import { createKnowledgePipelineCommand } from './knowledge-pipeline'
 import { createLearningsCommand } from './learnings'
@@ -447,7 +573,7 @@ import { createMcpCommand, createMcpContextReportCommand, createMcpListCapabilit
 import { createMcpGuardCommand } from './mcp-guard'
 import { createMigrateCommand, detectLegacyArtifacts } from './migrate'
 import { createBackendsSubcommand } from './migrate-backends'
-import { createModelsCommand } from './models'
+import { createModelsCommand, runModelsDrift } from './models'
 import { createNamingCraftCommand } from './naming-craft'
 import { createNotificationsCommand } from './notifications'
 import { DEFAULT_OPERATIONAL_DRIFT_POLICY, OperationalDriftFinding, OperationalDriftPolicy, OperationalDriftSeverity, changedThresholdPaths, deepEqual, detectOperationalDrift, getByPath, normalizeRel } from './operational-drift'
@@ -463,6 +589,7 @@ import { createPublishAnalysesCommand } from './publish-analyses'
 import { createPulseCommand } from './pulse'
 import { createRecommendCommand } from './recommend'
 import { createRehearseCommand } from './rehearse'
+import { RunGit, createFsPort, createGitPort, createReleaseInventoryCommand, runReleaseInventory } from './release-inventory'
 import { RunGit, buildDiffInfo, createReviewCiCommand, resolveDiffRange } from './review-ci'
 import { createLocalInvoke } from './review-ci-local-adapter'
 import { createReworkCommand, runReworkCommand } from './rework'
@@ -499,8 +626,9 @@ import { createValidateCommand } from './validate'
 import { runCrossCheck } from './validate-cross-check'
 import { ChangedSurface, SCOPED_WALKERS, deriveChangedSurface, filterToDesignSurface } from './validate-scope'
 import { createVerifyCommand, runVerify } from './verify'
+import { createWaypointCommand } from './waypoint'
 import * as clack from '@clack/prompts'
-import { AdjustedForecast, AgentConfigValidation, AllowanceFilteredDiff, AnnotationIssue, ArchAllowance, ArchAllowanceSchema, ArchBaseline, ArchBaselineManager, ArchConfig, ArchConfigSchema, ArchDiffResult, ArchMetricCategory, AuditResult, BaselineManager, BlueprintGenerator, BranchingConfig, Bundle, BundleSchema, CI_ASSESSMENTS, COMPREHENSION_ROOT, CiBlockOn, CiReviewResult, ComprehensionStore, ConflictReport, ConstraintNodeStore, Contributions, CriticalPathResolver, DeploymentExitCode, DeploymentFsPort, DeploymentGateConfig, DeploymentGateResult, DetectStaleResult, DiffInfo, DriftConfig, EntropyAnalyzer, EntropyConfig, Err, HarnessStrengthAuditor, InjectionFinding, LayerConfig, ListProposalsOptions, LocalEndpointInvoke, Lockfile, LockfilePackage, MetricResult, Ok, OsvAdvisory, OsvCheckResult, PatternConfig, PredictionEngine, PredictionResult, PredictionWarning, ProjectScanner, Proposal, ProposalStatus, ProtectedRegion, RUNNER_PRESETS, RecoveryRecordSchema, RehearsalManifest, RehearsalScore, Result, ReworkReport, RoadmapMeta, RollbackDecision, RollbackIO, RunCiReviewOptions, RunnerId, SECURITY_SCAN_DEFAULT_IGNORE, SECURITY_SCAN_GLOB, ScanConfigFileResult, ScanConfigFinding, ScanConfigResult, SecurityFinding, SecurityScanner, SecuritySeverity, SecurityTimelineManager, Severity, SpecImpactEstimator, StrengthFinding, TimelineManager, TimelineSnapshot, TrendLine, TrendResult, TypeScriptParser, Violation, addProvenance, applyFixes, archAllowanceSlug, archAllowancesDir, buildCiReviewVerdict, buildSnapshot, checkDocCoverage, checkRoadmapAggregateDrift, checkRoadmapHealth, checkTaint, classifyRevert, clearTaint, computeOverallSeverity, computeRework, computeScanExitCode, createFixes, createNodeComprehensionIO, createNodeModuleSourceReader, createNodeRoadmapIO, createOsvClient, createTrackerClient, deepMergeConstraints, defineLayer, deriveDeploymentExitCode, detectCircularDepsInFiles, detectDeadCode, detectDeploymentSurface, detectDocDrift, detectRoadmapStorageMode, detectStaleConstraints, diff, evaluateDeploymentGate, extractBundle, filterDiffByAllowances, findFixture, generateAgentsMap, generateSuggestions, getProposal, invalidateCheckState, isWholeSnapshotContext, listProposals, listTaintedSessions, loadArchAllowances, loadCatalog, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, mapInjectionFindings, mapSecurityFindings, needsMergeOursDriverWarning, parseDiff, parseFileRegions, parseManifest, parseRoadmap, parseSecurityConfig, plannedIssuesFromExternalIds, readLockfile, regenerate, removeContributions, removeProvenance, resolveArchBaseline, resolveRoadmapStore, roadmapSourceExists, runAll, runCiReview, scanForInjection, scoreRecovery, serializeMeta, updateProposal, validateAgentConfigs, validateAgentsMap, validateBranchName, validateDecisionNumbers, validateDependencies, validateKnowledgeMap, validatePulseConfig, validateRoadmapMode, validateSolutionsDir, validateStrategy, writeArchAllowance, writeConfig, writeLockfile } from '@harness-engineering/core'
+import { AdjustedForecast, AgentConfigValidation, AllowanceFilteredDiff, AnnotationIssue, ArchAllowance, ArchAllowanceSchema, ArchBaseline, ArchBaselineManager, ArchConfig, ArchConfigSchema, ArchDiffResult, ArchMetricCategory, AuditResult, BaselineManager, BlueprintGenerator, BranchingConfig, Bundle, BundleSchema, CI_ASSESSMENTS, COMPREHENSION_ROOT, CiBlockOn, CiReviewResult, ComprehensionStore, ConflictReport, ConstraintNodeStore, Contributions, CriticalPathResolver, DEFAULT_RELEASE_INVENTORY_THRESHOLDS, DeploymentExitCode, DeploymentFsPort, DeploymentGateConfig, DeploymentGateResult, DetectStaleResult, DiffInfo, DriftConfig, EntropyAnalyzer, EntropyConfig, Err, HarnessStrengthAuditor, InjectionFinding, LayerConfig, ListProposalsOptions, LocalEndpointInvoke, Lockfile, LockfilePackage, MetricResult, ModelDriftResult, Ok, OsvAdvisory, OsvCheckResult, PatternConfig, PredictionEngine, PredictionResult, PredictionWarning, ProjectScanner, Proposal, ProposalStatus, ProtectedRegion, RUNNER_PRESETS, RawBackendsMap, RecoveryRecordSchema, RehearsalManifest, RehearsalScore, ReleaseChannel, ReleaseInventoryFsPort, ReleaseInventoryGitPort, ReleaseInventoryResult, ReleaseInventoryThresholds, ReleaseTag, Result, ReworkReport, RoadmapMeta, RollbackDecision, RollbackIO, RunCiReviewOptions, RunnerId, SECURITY_SCAN_DEFAULT_IGNORE, SECURITY_SCAN_GLOB, ScanConfigFileResult, ScanConfigFinding, ScanConfigResult, SecurityFinding, SecurityScanner, SecuritySeverity, SecurityTimelineManager, SentinelRecord, Severity, SpecImpactEstimator, StrengthFinding, TimelineManager, TimelineSnapshot, TrendLine, TrendResult, TypeScriptParser, UnreleasedCommit, Violation, acknowledgeModelDrift, addProvenance, applyFixes, archAllowanceSlug, archAllowancesDir, buildCiReviewVerdict, buildSnapshot, checkDocCoverage, checkRoadmapAggregateDrift, checkRoadmapHealth, checkTaint, classifyRevert, clearTaint, computeOverallSeverity, computeReleaseInventory, computeRework, computeScanExitCode, createFixes, createNodeComprehensionIO, createNodeModuleSourceReader, createNodeRoadmapIO, createOsvClient, createTrackerClient, deepMergeConstraints, defineLayer, deriveDeploymentExitCode, detectCircularDepsInFiles, detectDeadCode, detectDeploymentSurface, detectDocDrift, detectRoadmapStorageMode, detectStaleConstraints, diff, evaluateDeploymentGate, evaluateModelSentinel, evaluateReleaseInventory, extractBundle, filterDiffByAllowances, findFixture, generateAgentsMap, generateSuggestions, getProposal, hasUnacknowledgedMaterialDrift, invalidateCheckState, isWholeSnapshotContext, listProposals, listTaintedSessions, loadArchAllowances, loadCatalog, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, mapInjectionFindings, mapSecurityFindings, needsMergeOursDriverWarning, parseDiff, parseFileRegions, parseManifest, parseRoadmap, parseSecurityConfig, plannedIssuesFromExternalIds, readLockfile, readSentinelHistory, regenerate, removeContributions, removeProvenance, resolveArchBaseline, resolveRoadmapStore, roadmapSourceExists, runAll, runCiReview, scanForInjection, scoreRecovery, serializeMeta, updateProposal, validateAgentConfigs, validateAgentsMap, validateBranchName, validateDecisionNumbers, validateDependencies, validateKnowledgeMap, validatePulseConfig, validateRoadmapMode, validateSolutionsDir, validateStrategy, writeArchAllowance, writeConfig, writeLockfile } from '@harness-engineering/core'
 import { CraftFindingRecord, DEFAULT_SKIP_DIRS, DesignConstraintAdapter, GraphStore, KnowledgePipelineResult, NodeType, skipDirGlobs } from '@harness-engineering/graph'
 import { AbandonedSkill, AnalysisProvider, FailingSkill, GuardianAnalysis, OpenAICompatibleAnalysisProvider, OutcomeVerdict, SkillEffectivenessScore, SkillRegressionFixture, SkillRegressionVerdict, guardianFileLines, guardianFlags, readGuardianAnalyses, summarizeGuardian } from '@harness-engineering/intelligence'
 import { AgentDispatcher, AnalysisRecord, BUILT_IN_TASKS, CheckCommandRunner, CheckScriptRunner, CommandExecutor, FlightRecorder, MAINTENANCE_CHECK_MAX_BUFFER, MAINTENANCE_CHECK_TIMEOUT_MS, MaintenanceReporter, Orchestrator, PersistedOutputEntry, RunMode, RunRecord, RunResult, SyncMainResult, TaskDefinition, TaskOutputStore, TaskRunner, TaskSelectionFilter, UnitVerdict, WorkflowLoader, createAgentDispatcher, defaultFetchModels, defaultSyncMain, discoverCandidates, launchTUI, loadPublishedIndex, makeBackendResolver, migrateAgentConfig, renderAnalysisComment, runHarnessCheck, savePublishedIndex, selectTasks } from '@harness-engineering/orchestrator'

--- a/.harness/comprehension/packages/cli/src/config/_module.md
+++ b/.harness/comprehension/packages/cli/src/config/_module.md
@@ -1,11 +1,20 @@
 ---
 schemaVersion: 1
-module: "packages/cli/src/config"
-sourceHash: "ecbb6da964bc2ed54f0614dd8a512abd6292c6c5c07e8269fe288e5458245926"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/cli/src/config'
+sourceHash: '0d9545aed122a99b14012ee05f355ee7b442c3e7aad7f500390103a9b1c9d2ab'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["analysis-schema.ts", "ingest-schema.ts", "loader.ts", "schema.amr.test.ts", "schema.ts", "stripped-keys.test.ts", "stripped-keys.ts"]
+members:
+  [
+    'analysis-schema.ts',
+    'ingest-schema.ts',
+    'loader.ts',
+    'schema.amr.test.ts',
+    'schema.ts',
+    'stripped-keys.test.ts',
+    'stripped-keys.ts',
+  ]
 ---
 
 ## Interface Contract

--- a/.harness/comprehension/packages/cli/src/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/_module.md
@@ -1,12 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp'
-sourceHash: 'ada544265cbc76d6829af439139846fb8174698e37cb2798870a66e8f537fe66'
+sourceHash: '370e54ef5012320aa02a5d84bbfe3110cb08f9702e90ac89d28eced455c5587c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
+    'context-surface.test.ts',
     'context-surface.ts',
     'index.ts',
     'server.ts',
@@ -33,6 +34,7 @@ export startServer
 ```
 import { ensureComprehensionSearchIgnore, ensureHarnessGitignore } from '../templates/post-write.js'
 import from '../version.js'
+import { agentsMdEntry, gatherContextSurface, hooksEntry, mcpToolEntries, skillTreeEntries, toolDefinitionText } from './context-surface'
 import { getToolDefinitions } from './index.js'
 import { applyCompaction } from './middleware/compaction.js'
 import { applyContextBudget } from './middleware/context-budget.js'
@@ -46,7 +48,9 @@ import { getRulesResource } from './resources/rules.js'
 import { getSkillsResource } from './resources/skills.js'
 import { getStateResource } from './resources/state.js'
 import { TOOL_CAPABILITY_DECLARATIONS } from './tool-capability-declarations.js'
+import { CORE_TOOL_NAMES, STANDARD_TOOL_NAMES } from './tool-tiers'
 import { CORE_TOOL_NAMES, McpToolTier, STANDARD_TOOL_NAMES } from './tool-tiers.js'
+import { ToolDefinition } from './tool-types'
 import { ToolCapabilityDeclaration, ToolDefinition, ToolScope } from './tool-types.js'
 import { acceptanceEvalDefinition, handleAcceptanceEval } from './tools/acceptance-eval.js'
 import { handleManageAdr, manageAdrDefinition } from './tools/adr.js'
@@ -127,6 +131,8 @@ import { ContextSurfaceEntry } from '@harness-engineering/core'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListResourcesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ```

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: 'bb0dfbe27977fbfc7b286484e26ba5eb9142fe41083c699904ed167a834db92f'
+sourceHash: '57422efebd66dd15f9fa1583c97ad3f6d94378bfeff384146d864ca65ff76a00'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -42,6 +42,7 @@ members:
     'detect-drift.ts',
     'dispatch-skills.ts',
     'docs-craft.ts',
+    'docs-publish.test.ts',
     'docs-publish.ts',
     'docs.ts',
     'edit-file.test.ts',
@@ -526,6 +527,7 @@ import { loadGraphStore } from '../utils/graph-loader.js'
 import { McpToolResponse, bigIntSafeReplacer, resultToMcpResponse } from '../utils/result-adapter.js'
 import { sanitizePath } from '../utils/sanitize-path.js'
 import { sortFindingsBySeverity } from '../utils/severity.js'
+import { emitAcceptanceVerdictEvent, emitOutcomeVerdictEvent, emitUatSignoffEvent } from '../utils/waypoint-emission.js'
 import { AdrStoreError, CreateAdrInput, UpdateAdrInput, createAdr, listAdrs, readAdr, resolveWorktreeRoot, updateAdr } from './adr-store.js'
 import { adviseSkillsDefinition, handleAdviseSkills } from './advise-skills.js'
 import from './architecture.js'
@@ -533,6 +535,7 @@ import { generateBlueprintDefinition, handleGenerateBlueprint } from './blueprin
 import { handleCanaryDiscoverTestCommand, handleCanaryProbe, handleCanaryRecommendFramework, handleCanaryRunHistory } from './canary.js'
 import { _resetCompoundLockHandlesForTests, acquireCompoundLockDefinition, handleAcquireCompoundLock, handleReleaseCompoundLock, releaseCompoundLockDefinition } from './compound'
 import { handleValidateCrossCheck, validateCrossCheckDefinition } from './cross-check.js'
+import { docsPublishDefinition, handleDocsPublish } from './docs-publish'
 import from './docs.js'
 import { editFileDefinition, handleEditFile } from './edit-file.js'
 import from './entropy.js'

--- a/.harness/comprehension/packages/cli/src/mcp/utils/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/utils/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/utils'
-sourceHash: '58925d821827489f057aa88ce2f82c399c1b22eae6bfe32953df0fb736f5ad2e'
+sourceHash: 'c6a93793aeaaf86e9400e5599fcf827c272aa980b5b293e8bf19d32d27c50027'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -15,6 +15,8 @@ members:
     'sanitize-path.test.ts',
     'sanitize-path.ts',
     'severity.ts',
+    'waypoint-emission.test.ts',
+    'waypoint-emission.ts',
   ]
 ---
 
@@ -24,6 +26,9 @@ members:
 export SEVERITY_ORDER
 export bigIntSafeReplacer
 export clearGraphStoreCache
+export emitAcceptanceVerdictEvent
+export emitOutcomeVerdictEvent
+export emitUatSignoffEvent
 export globFiles
 export isClaudeCliAvailable
 export isCliAvailable
@@ -34,20 +39,24 @@ export resolveProviderKind
 export resultToMcpResponse
 export sanitizePath
 export sortFindingsBySeverity
+export specSlug
 ```
 
 ## Dependency Slice
 
 ```
 import { sanitizePath } from './sanitize-path'
-import { Err, Ok, Result } from '@harness-engineering/core'
+import { emitAcceptanceVerdictEvent, emitOutcomeVerdictEvent, emitUatSignoffEvent, specSlug } from './waypoint-emission.js'
+import { Err, Ok, Result, resetWaypointEmitterForTests } from '@harness-engineering/core'
 import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph'
 import from '@harness-engineering/intelligence'
+import { SdlcEvent } from '@harness-engineering/types'
 import * as fs from 'fs'
 import { stat } from 'fs/promises'
-import { existsSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import * as fs from 'node:fs/promises'
-import * as path, path from 'node:path'
+import { tmpdir } from 'node:os'
+import * as path, path, { join } from 'node:path'
 import * as path from 'path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ```

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,11 +1,137 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/commands"
-sourceHash: "9b1e903578dc90415bba7e91ff87edaa5dfd3045350184a1b2be73d40b43af04"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/cli/tests/commands'
+sourceHash: '5b3a75277aeb5bbb3949d3786514b93a3b7accda8991c47281cb7d17e350481e'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["add-extra.test.ts", "add.test.ts", "adoption-retrospective.test.ts", "adoption.test.ts", "agent-review.test.ts", "agent-run-persona.test.ts", "agent-run.test.ts", "agent.test.ts", "audit-protected.test.ts", "backfill-skill-provenance.test.ts", "check-arch.test.ts", "check-deployment.test.ts", "check-deps.test.ts", "check-design.test.ts", "check-docs.test.ts", "check-harness-strength.test.ts", "check-perf.test.ts", "check-phase-gate.test.ts", "check-security.test.ts", "check-vocabulary.test.ts", "cleanup-sessions.test.ts", "cleanup.test.ts", "compound-scan-candidates.test.ts", "create-skill.test.ts", "cross-check.test.ts", "dashboard.test.ts", "deprecated-graph-aliases.test.ts", "distortion.test.ts", "doctor-hardening.test.ts", "doctor.test.ts", "fix-drift.test.ts", "generate-agent-definitions.test.ts", "generate-slash-commands.test.ts", "generate.test.ts", "golden-build.test.ts", "graph-ingest-decisions.integration.test.ts", "graph-ingest.test.ts", "graph-integrity.test.ts", "graph.test.ts", "hooks.test.ts", "impact-preview.test.ts", "ingest-options.test.ts", "init-extra.test.ts", "init-minimal.test.ts", "init.test.ts", "insights.test.ts", "install-constraints.test.ts", "install.test.ts", "integrations-sync.test.ts", "integrations.test.ts", "learnings-prune.test.ts", "linter-generate.test.ts", "maintenance-command-shape.test.ts", "maintenance-run-check-runner.test.ts", "maintenance-run-integration.test.ts", "maintenance-run-selection.test.ts", "mcp-guard.test.ts", "mcp-list-capabilities.test.ts", "mcp-refinement-demand.test.ts", "migrate-backends.test.ts", "migrate.test.ts", "models-probe.test.ts", "models.test.ts", "outcome-eval-ci.test.ts", "perf.test.ts", "persona-list.test.ts", "persona.test.ts", "pre-merge-brief-guardian.test.ts", "pre-merge-brief.test.ts", "predict.test.ts", "proposals-status.test.ts", "proposals.test.ts", "publish-analyses.test.ts", "pulse-run.test.ts", "recommend.test.ts", "resolve-skill-sources.test.ts", "review-ci-local-adapter.test.ts", "review-ci.test.ts", "rollback.test.ts", "scan-config.test.ts", "search.test.ts", "setup-mcp.picker-message.test.ts", "setup-mcp.test.ts", "setup.test.ts", "share.test.ts", "skill-create.test.ts", "skill-info.test.ts", "skill-list.test.ts", "skill-local-resolution.test.ts", "skill-publish.test.ts", "skill-run.test.ts", "skill-search.test.ts", "skill-update.test.ts", "skill-validate.test.ts", "skill.test.ts", "snapshot.test.ts", "stale-constraints.test.ts", "state-show.test.ts", "state-streams.test.ts", "state.test.ts", "sync-analyses-action.test.ts", "sync-analyses.test.ts", "sync-main.test.ts", "taint.test.ts", "telemetry-synthesize.test.ts", "telemetry-wizard.test.ts", "telemetry.test.ts", "traceability.test.ts", "uninstall-constraints.test.ts", "uninstall.test.ts", "update-integrations-sync.test.ts", "update-skill-providers.test.ts", "update.test.ts", "usage-pipeline.test.ts", "usage.test.ts", "validate-cross-check.test.ts", "validate-scope.test.ts", "validate.changed.test.ts", "validate.merge-driver.test.ts", "validate.roadmap-abstention.test.ts", "validate.roadmap-health.test.ts", "validate.roadmap-mode.test.ts", "validate.test.ts"]
+members:
+  [
+    'add-extra.test.ts',
+    'add.test.ts',
+    'adoption-retrospective.test.ts',
+    'adoption.test.ts',
+    'agent-review.test.ts',
+    'agent-run-persona.test.ts',
+    'agent-run.test.ts',
+    'agent.test.ts',
+    'audit-protected.test.ts',
+    'backfill-skill-provenance.test.ts',
+    'check-arch.test.ts',
+    'check-deployment.test.ts',
+    'check-deps.test.ts',
+    'check-design.test.ts',
+    'check-docs.test.ts',
+    'check-harness-strength.test.ts',
+    'check-perf.test.ts',
+    'check-phase-gate.test.ts',
+    'check-security.test.ts',
+    'check-vocabulary.test.ts',
+    'cleanup-sessions.test.ts',
+    'cleanup.test.ts',
+    'compound-scan-candidates.test.ts',
+    'create-skill.test.ts',
+    'cross-check.test.ts',
+    'dashboard.test.ts',
+    'deprecated-graph-aliases.test.ts',
+    'distortion.test.ts',
+    'doctor-hardening.test.ts',
+    'doctor.test.ts',
+    'fix-drift.test.ts',
+    'generate-agent-definitions.test.ts',
+    'generate-slash-commands.test.ts',
+    'generate.test.ts',
+    'golden-build.test.ts',
+    'graph-ingest-decisions.integration.test.ts',
+    'graph-ingest.test.ts',
+    'graph-integrity.test.ts',
+    'graph.test.ts',
+    'hooks.test.ts',
+    'impact-preview.test.ts',
+    'ingest-options.test.ts',
+    'init-extra.test.ts',
+    'init-minimal.test.ts',
+    'init.test.ts',
+    'insights.test.ts',
+    'install-constraints.test.ts',
+    'install.test.ts',
+    'integrations-sync.test.ts',
+    'integrations.test.ts',
+    'learnings-prune.test.ts',
+    'linter-generate.test.ts',
+    'maintenance-command-shape.test.ts',
+    'maintenance-run-check-runner.test.ts',
+    'maintenance-run-integration.test.ts',
+    'maintenance-run-selection.test.ts',
+    'mcp-guard.test.ts',
+    'mcp-list-capabilities.test.ts',
+    'mcp-refinement-demand.test.ts',
+    'migrate-backends.test.ts',
+    'migrate.test.ts',
+    'models-probe.test.ts',
+    'models.test.ts',
+    'outcome-eval-ci.test.ts',
+    'perf.test.ts',
+    'persona-list.test.ts',
+    'persona.test.ts',
+    'pre-merge-brief-guardian.test.ts',
+    'pre-merge-brief.test.ts',
+    'predict.test.ts',
+    'proposals-status.test.ts',
+    'proposals.test.ts',
+    'publish-analyses.test.ts',
+    'pulse-run.test.ts',
+    'recommend.test.ts',
+    'resolve-skill-sources.test.ts',
+    'review-ci-local-adapter.test.ts',
+    'review-ci.test.ts',
+    'rollback.test.ts',
+    'scan-config.test.ts',
+    'search.test.ts',
+    'setup-mcp.picker-message.test.ts',
+    'setup-mcp.test.ts',
+    'setup.test.ts',
+    'share.test.ts',
+    'skill-create.test.ts',
+    'skill-info.test.ts',
+    'skill-list.test.ts',
+    'skill-local-resolution.test.ts',
+    'skill-publish.test.ts',
+    'skill-run.test.ts',
+    'skill-search.test.ts',
+    'skill-update.test.ts',
+    'skill-validate.test.ts',
+    'skill.test.ts',
+    'snapshot.test.ts',
+    'stale-constraints.test.ts',
+    'state-show.test.ts',
+    'state-streams.test.ts',
+    'state.test.ts',
+    'sync-analyses-action.test.ts',
+    'sync-analyses.test.ts',
+    'sync-main.test.ts',
+    'taint.test.ts',
+    'telemetry-synthesize.test.ts',
+    'telemetry-wizard.test.ts',
+    'telemetry.test.ts',
+    'traceability.test.ts',
+    'uninstall-constraints.test.ts',
+    'uninstall.test.ts',
+    'update-integrations-sync.test.ts',
+    'update-skill-providers.test.ts',
+    'update.test.ts',
+    'usage-pipeline.test.ts',
+    'usage.test.ts',
+    'validate-cross-check.test.ts',
+    'validate-scope.test.ts',
+    'validate.changed.test.ts',
+    'validate.merge-driver.test.ts',
+    'validate.roadmap-abstention.test.ts',
+    'validate.roadmap-health.test.ts',
+    'validate.roadmap-mode.test.ts',
+    'validate.test.ts',
+    'waypoint.test.ts',
+  ]
 ---
 
 ## Interface Contract
@@ -127,6 +253,7 @@ import { createUsageCommand } from '../../src/commands/usage'
 import { createValidateCommand, runValidate } from '../../src/commands/validate'
 import { runCrossCheck } from '../../src/commands/validate-cross-check'
 import { SCOPED_WALKERS, deriveChangedSurface, filterToDesignSurface } from '../../src/commands/validate-scope'
+import { createWaypointCommand } from '../../src/commands/waypoint'
 import { resolveConfig } from '../../src/config/loader'
 import { HarnessConfig } from '../../src/config/schema'
 import { createProgram } from '../../src/index'
@@ -164,12 +291,12 @@ import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
 import * as clack from '@clack/prompts'
-import { CiReviewResult, DiffInfo, Err, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
+import { CiReviewResult, DiffInfo, Err, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
 import from '@harness-engineering/graph'
 import { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION, GuardianAnalysis, OutcomeVerdict } from '@harness-engineering/intelligence'
 import { AnalysisRecord, MockBackend, RunMode, RunResult, SyncMainResult, TaskDefinition, renderAnalysisComment } from '@harness-engineering/orchestrator'
 import { SignalResult, SignalsResult } from '@harness-engineering/signals'
-import { TrackerComment } from '@harness-engineering/types'
+import { SdlcEvent, TrackerComment } from '@harness-engineering/types'
 import { execFileSync, execSync } from 'child_process'
 import { Command } from 'commander'
 import * as fs from 'fs'

--- a/.harness/comprehension/packages/core/src/_module.md
+++ b/.harness/comprehension/packages/core/src/_module.md
@@ -1,11 +1,11 @@
 ---
 schemaVersion: 1
-module: "packages/core/src"
-sourceHash: "31756866d08e4b1872c881a10c56b98043c05abd4e444a3105a4b1ae6068d994"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/core/src'
+sourceHash: '2aa32b1b71900aded05a907425b00ad7c6788b9e705d29760cf42958e73e6615'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["index.ts", "update-checker.ts", "version.ts"]
+members: ['index.ts', 'update-checker.ts', 'version.ts']
 ---
 
 ## Interface Contract

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: 'bd2857a9a116227e1acf98f7888236b5ed209bd2e7a0a213b2f7b46568facdd7'
+sourceHash: 'fdb81d49ee25b5aae30bd38ba050ba7d2c250d7316126c58ed34cf3c7ec2a78f'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -128,6 +128,7 @@ export syncToExternal
 
 ```
 import * as eventSourcing from '../state/event-sourcing'
+import { emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange } from '../waypoint/events'
 import { assigneeInvariantHolds, isMachineAssignee, setStatus } from './assignee-lifecycle'
 import { deriveRepoFromGitRemote } from './derive-repo'
 import { GROUP_PREFIX, matchFeatureHeadings, serializeFeatureHeading } from './heading'

--- a/.harness/comprehension/packages/core/src/waypoint/_module.md
+++ b/.harness/comprehension/packages/core/src/waypoint/_module.md
@@ -1,0 +1,87 @@
+---
+schemaVersion: 1
+module: 'packages/core/src/waypoint'
+sourceHash: '3e72231c4277b4ab1dcdd15633f15f0954ec6fa4659228a77ee56635a43b0784'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'config-loader.test.ts',
+    'config-loader.ts',
+    'emitter.test.ts',
+    'emitter.ts',
+    'events.test.ts',
+    'events.ts',
+    'index.ts',
+    'scrub.test.ts',
+    'scrub.ts',
+    'spool.test.ts',
+    'spool.ts',
+    'ulid.test.ts',
+    'ulid.ts',
+    'validate.test.ts',
+    'validate.ts',
+  ]
+---
+
+## Interface Contract
+
+```ts
+export DEFAULT_MAX_EVENTS
+export EmissionFailure
+export EmitSdlcOptions
+export FileSpool
+export FileSpoolOptions
+export FleetProvenanceArtifact
+export PersistedVerdict
+export REDACTED
+export ScrubOutcome
+export SkillPhaseTransition
+export SkillTransitionQualityGate
+export ULID_LENGTH
+export UlidFactoryOptions
+export VerdictKind
+export WaypointEmitter
+export WaypointEmitterOptions
+export WaypointEmitterPorts
+export bestEffortScrub
+export configureWaypointEmitter
+export createUlidFactory
+export emitFleetHandoffWritten
+export emitFleetProvenanceWritten
+export emitRoadmapClaim
+export emitRoadmapRelease
+export emitRoadmapStatusChange
+export emitSdlc
+export emitSkillPhaseTransition
+export emitVerdictPersisted
+export ensureWaypointEmitter
+export getWaypointEmitter
+export initWaypointEmitter
+export isUlid
+export loadWaypointConfig
+export mergeSegments
+export readSpoolSegments
+export resetWaypointEmitterForTests
+export validateSdlcEvent
+export verdictGrade
+```
+
+## Dependency Slice
+
+```
+import { Err, Ok, Result, isErr, isOk } from '../shared/result'
+import { loadWaypointConfig } from './config-loader'
+import { WaypointEmitter, configureWaypointEmitter, emitSdlc, ensureWaypointEmitter, getWaypointEmitter, initWaypointEmitter, resetWaypointEmitterForTests } from './emitter'
+import { emitFleetHandoffWritten, emitFleetProvenanceWritten, emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange, emitSkillPhaseTransition, emitVerdictPersisted, verdictGrade } from './events'
+import { REDACTED, bestEffortScrub } from './scrub'
+import { FileSpool, mergeSegments, readSpoolSegments } from './spool'
+import { ULID_LENGTH, createUlidFactory, isUlid } from './ulid'
+import { validateSdlcEvent } from './validate'
+import { FeatureStatus, FleetHandoffRecord, SDLC_EVENT_TYPES_V1, SDLC_SPECVERSION, SDLC_VERIFICATION_GRADES, SdlcActor, SdlcAppendResult, SdlcEvent, SdlcEventTypeV1, SdlcSpoolSegmentSnapshot, SdlcValidationIssue, SdlcValidationResult, SdlcVerificationGrade, WaypointConfig, WaypointConfigSchema } from '@harness-engineering/types'
+import * as fs, { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir, userInfo } from 'node:os'
+import * as path, { basename, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+```

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,12 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '0774acae016cddbadd9a652344de3c23338b36112f5befadafea23e77e1e4851'
+sourceHash: '2ab7ac3467a6761da3e8782abc57d646e0e78df3a2084e1318fc8d6055b44629'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
+    'assignee-lifecycle-waypoint.test.ts',
     'assignee-lifecycle.test.ts',
     'derive-repo.test.ts',
     'fixtures.ts',
@@ -95,13 +96,14 @@ import { TrackedFeature } from '../../src/roadmap/tracker'
 import { loadTrackerSyncConfig } from '../../src/roadmap/tracker-config'
 import { ExternalSyncOptions, TrackerSyncAdapter, resolveReverseStatus } from '../../src/roadmap/tracker-sync'
 import { emitEvent } from '../../src/state/event-sourcing'
+import { initWaypointEmitter, resetWaypointEmitterForTests } from '../../src/waypoint/emitter'
 import { EMPTY_BACKLOG, EMPTY_BACKLOG_MD, EXTENDED_FIELDS_MD, EXTENDED_FIELDS_ROADMAP, GROUPED_ROADMAP, GROUPED_ROADMAP_MD, HISTORY_MD, HISTORY_ROADMAP, INVALID_STATUS_MD, MARKER_NAMES, NO_FRONTMATTER_MD, VALID_ROADMAP, VALID_ROADMAP_MD } from './fixtures'
 import { MIGRATION_ROADMAP, MONOLITH_ROADMAP, OLD_ROADMAP_MD } from './store/fixtures'
 import { getRoadmapMode } from '@harness-engineering/core'
-import { AssignmentRecord, Err, ExternalTicket, ExternalTicketState, FeatureStatus, Ok, Result, Roadmap, RoadmapFeature, RoadmapMilestone, TrackerSyncConfig } from '@harness-engineering/types'
+import { AssignmentRecord, Err, ExternalTicket, ExternalTicketState, FeatureStatus, Ok, Result, Roadmap, RoadmapFeature, RoadmapMilestone, SdlcEvent, TrackerSyncConfig } from '@harness-engineering/types'
 import * as fs from 'fs'
 import { execFileSync } from 'node:child_process'
-import * as fs, { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import * as fs, { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import * as os, { tmpdir } from 'node:os'
 import * as path, { join } from 'node:path'
 import * as os from 'os'

--- a/.harness/comprehension/packages/orchestrator/src/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src'
-sourceHash: 'fe26846001c876f35aa425fac3ec741cade6d4281792d7d01a8a28a61787fcf1'
+sourceHash: '1105d712efd37079818bebcb2bc908a43d709d29f3caa21f183c1a5f76e7871a'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -240,6 +240,7 @@ import { WebhookDelivery } from './gateway/webhooks/delivery'
 import { wireWebhookFanout } from './gateway/webhooks/events'
 import { WebhookQueue } from './gateway/webhooks/queue'
 import { WebhookStore } from './gateway/webhooks/store'
+import { wireWaypointSdlcBridge } from './gateway/webhooks/waypoint-bridge'
 import { IntelligencePipelineRunner } from './intelligence/pipeline-runner'
 import { StructuredLogger } from './logging/logger'
 import { createAgentDispatcher } from './maintenance/agent-dispatcher'

--- a/.harness/comprehension/packages/orchestrator/src/gateway/webhooks/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/gateway/webhooks/_module.md
@@ -1,27 +1,26 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/gateway/webhooks"
-sourceHash: "998f0fcbbf0e253a0e563e33e2bbbda7d9ede13ee4d34e217a6f58fb9f992941"
-compiledAt: "2026-08-28T01:22:12.239Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["delivery.test.ts", "delivery.ts", "events.test.ts", "events.ts", "queue.test.ts", "queue.ts", "signer.test.ts", "signer.ts", "store.test.ts", "store.ts"]
+module: 'packages/orchestrator/src/gateway/webhooks'
+sourceHash: '9237d4931c236454e9efb9dffd6b7b7331c70dbce7d708c0505090b9ba328600'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'delivery.test.ts',
+    'delivery.ts',
+    'events.test.ts',
+    'events.ts',
+    'queue.test.ts',
+    'queue.ts',
+    'signer.test.ts',
+    'signer.ts',
+    'store.test.ts',
+    'store.ts',
+    'waypoint-bridge.test.ts',
+    'waypoint-bridge.ts',
+  ]
 ---
-
-## Summary
-
-The webhooks gateway module implements outbound event delivery for the orchestrator. It separates concerns across WebhookStore (subscription persistence), WebhookQueue (SQLite-backed delivery queue), and WebhookDelivery (event-driven worker). When events fire, matching subscriptions enqueue delivery tasks; the worker polls the queue on a tick interval, signs payloads with HMAC-SHA256, POSTs to subscribed URLs, and tracks delivery status. Failed attempts escalate to dead-letter status after MAX_ATTEMPTS. The module hardens against SSRF by validating host literals and DNS resolution at registration and again at delivery time, refusing redirect following, and escalating deleted subscriptions to dead-letter. Graceful shutdown drains in-flight work or aborts after timeout, leaving rows in_flight for recovery on restart.
-
-## Invariants
-
-- Signature integrity: every delivery includes x-harness-signature: sha256=<hex> computed via the shared subscription token; subscribers verify before accepting
-- Delivery idempotency: each row gets a unique dlv_* ID and is marked delivered before yielding; retries carry the same ID for deduplication
-- Private-host double-check: route-level validation at registration + delivery-time re-validation (literal URL + DNS resolution) catch both malicious and corrupted subscriptions
-- No redirect following: delivery enforces redirect-refuse (3xx → dead letter) to prevent SSRF bypass via injected Location headers
-- Dead-letter on missing subscription: if a subscription is deleted after enqueue, the row transitions to dead with subscription deleted error rather than retry
-- Concurrency cap per subscription: maxConcurrentPerSub (default 1) ensures a misbehaving endpoint cannot starve other subscriptions
-- Graceful drain: stop() waits up to drainTimeoutMs for in-flight POSTs; rows aborted mid-delivery stay in_flight so recovery logic recoverInFlight re-queues them on restart
 
 ## Interface Contract
 
@@ -34,6 +33,7 @@ export WebhookStore
 export eventMatches
 export sign
 export verify
+export wireWaypointSdlcBridge
 export wireWebhookFanout
 ```
 
@@ -49,11 +49,13 @@ import { eventMatches, sign, verify } from './signer'
 import { sign } from './signer.js'
 import { WebhookStore } from './store'
 import { WebhookStore } from './store.js'
-import { GatewayEvent, WebhookSubscription, WebhookSubscriptionSchema } from '@harness-engineering/types'
+import { wireWaypointSdlcBridge } from './waypoint-bridge'
+import { emitSdlc, ensureWaypointEmitter, resetWaypointEmitterForTests } from '@harness-engineering/core'
+import { GatewayEvent, SDLC_EVENT_TYPES_V1, WebhookSubscription, WebhookSubscriptionSchema } from '@harness-engineering/types'
 import Database from 'better-sqlite3'
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 import { EventEmitter } from 'node:events'
-import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'

--- a/.harness/comprehension/packages/types/src/_module.md
+++ b/.harness/comprehension/packages/types/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/types/src'
-sourceHash: 'ffb7f71106c83f7c89cd308ae46b7a269a4b8a0942d2ceb9a09e3544c55cf694'
+sourceHash: 'ff173a9df45279219fe3642e1eb5aa3beca77b312184567f4513d7413216a48c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -39,6 +39,7 @@ members:
     'telemetry.ts',
     'tracker-sync.ts',
     'usage.ts',
+    'waypoint.ts',
     'webhooks.ts',
     'workflow.ts',
   ]
@@ -310,12 +311,27 @@ export RoutingTelemetryDecision
 export RoutingUseCase
 export RoutingValue
 export RowSyncResult
+export SDLC_CATEGORIES
+export SDLC_EVENT_TYPES_V1
+export SDLC_SPECVERSION
+export SDLC_VERIFICATION_GRADES
 export SESSIONS_DEFAULTS
 export SESSION_SECTION_NAMES
 export STANDARD_COGNITIVE_MODES
 export SanitizeFn
 export SanitizedResult
 export ScopeTier
+export SdlcActor
+export SdlcAgentActor
+export SdlcAppendResult
+export SdlcCategory
+export SdlcEvent
+export SdlcEventTypeV1
+export SdlcHumanActor
+export SdlcSpoolSegmentSnapshot
+export SdlcValidationIssue
+export SdlcValidationResult
+export SdlcVerificationGrade
 export SecretBackend
 export SecretConfig
 export SecretError
@@ -397,6 +413,10 @@ export UsageRecord
 export UsageSection
 export VerdictCacheEntry
 export VerdictCacheStats
+export WaypointConfig
+export WaypointConfigSchema
+export WaypointSinkConfig
+export WaypointSinkConfigSchema
 export WebhookDelivery
 export WebhookDeliverySchema
 export WebhookDeliveryStatus

--- a/docs/changes/waypoint-sdlc-emission/plans/2026-09-04-waypoint-sdlc-emission-plan.md
+++ b/docs/changes/waypoint-sdlc-emission/plans/2026-09-04-waypoint-sdlc-emission-plan.md
@@ -1,0 +1,120 @@
+# Plan: Waypoint sdlc.\* event emission and spool (opt-in)
+
+Spec: `docs/changes/waypoint-sdlc-emission/proposal.md` · Upstream item:
+pnyon/pnyon#124 · Contract: pnyon `docs/architecture/waypoint/sdlc-event-schema.md`.
+
+## Goal
+
+Land the additive, opt-in `sdlc.*` emission layer end-to-end: contract types,
+bounded JSONL spool, config-gated emitter, hooks at all four emission-point
+families, `sdlc.*` gateway topics, and the fleet-artifact/observability CLI —
+with the non-adopter invariance contract proven by tests.
+
+## Scope Boundary
+
+IN: emission + spool + topics + tests + docs. OUT: shipper-to-cloud (pnyon
+owns ingest), `RoadmapTrackerClient` kind `pnyon` and any tracker
+adapter/registry file (parallel lane), file-less-mode tracker-path emission,
+fleet SKILL.md prose changes (plugin regen blast radius), dashboard signoff
+route emission (same event is already emitted on the MCP path; follow-up).
+
+## Observable Truths (Acceptance Criteria)
+
+- SC1–SC6 as enumerated in the proposal's Success Criteria section.
+- `pnpm --filter` typecheck/test green for types, core, cli, orchestrator;
+  lint + format green; changeset present; barrels regenerated.
+
+## File Map
+
+| File                                                                                           | Change                                        |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `packages/types/src/waypoint.ts`                                                               | NEW — contract types + `WaypointConfigSchema` |
+| `packages/types/src/index.ts`                                                                  | export block                                  |
+| `packages/core/src/waypoint/{ulid,validate,scrub,spool,config-loader,emitter,events,index}.ts` | NEW — emission layer                          |
+| `packages/core/src/roadmap/assignee-lifecycle.ts`                                              | hook 3 mutators                               |
+| `packages/core/src/index.ts`                                                                   | regenerated barrel                            |
+| `packages/cli/src/mcp/utils/waypoint-emission.ts`                                              | NEW — verdict emission                        |
+| `packages/cli/src/mcp/tools/{interaction,outcome-eval,acceptance-eval,uat-signoff,roadmap}.ts` | hooks                                         |
+| `packages/cli/src/config/schema.ts`                                                            | `waypoint` passthrough key                    |
+| `packages/cli/src/commands/waypoint.ts` (+ `_registry.ts` regen)                               | NEW — CLI                                     |
+| `packages/orchestrator/src/gateway/webhooks/events.ts`                                         | +19 `sdlc.*.v1` topics                        |
+| `packages/orchestrator/src/gateway/webhooks/waypoint-bridge.ts`                                | NEW — bus bridge                              |
+| `packages/orchestrator/src/orchestrator.ts`                                                    | wire + teardown                               |
+| `.gitignore`                                                                                   | `**/.harness/spool/`                          |
+| `.changeset/waypoint-sdlc-emission.md`                                                         | minor ×4                                      |
+| `docs/knowledge/orchestrator/webhook-fanout.md`                                                | topic-family note                             |
+
+## Tasks
+
+### Task 1 (TDD): Contract types + pure lib (SC6 groundwork)
+
+`waypoint.ts` types; ULID factory (monotonic, injected ports); per-field
+validator over the closed vocabulary; best-effort scrub. Tests:
+`ulid.test.ts`, `validate.test.ts`, `scrub.test.ts`.
+
+### Task 2 (TDD): FileSpool + segment readers (SC6)
+
+Bounded JSONL segment with drop-oldest + sidecar `droppedEvents`;
+`readSpoolSegments`; ULID-ordered `mergeSegments`; I/O failures returned,
+never thrown. Tests: `spool.test.ts`.
+
+### Task 3 (TDD): Config loader + emitter + singleton (SC1)
+
+`loadWaypointConfig` (absent → `Ok({})`); `WaypointEmitter` (envelope
+stamping, listener fan-out, failure ledger); `initWaypointEmitter`
+(absent sink → null, no filesystem effect); memoized
+`ensureWaypointEmitter`; `emitSdlc` null-object no-op. Tests:
+`config-loader.test.ts`, `emitter.test.ts` (invariance block first).
+
+### Task 4 (TDD): Mapping helpers + mutator hooks (SC2, D4/D5)
+
+`events.ts` helpers; hook `claim`/`release`/`setStatus` on committed
+mutations only. Tests: `events.test.ts`,
+`tests/roadmap/assignee-lifecycle-waypoint.test.ts`; pre-existing
+`assignee-lifecycle.test.ts` must pass unmodified.
+
+### Task 5 (TDD): CLI hooks (SC3)
+
+`waypoint-emission.ts` (+`specSlug`); wire `handleTransition`,
+`handleOutcomeEval`, `handleAcceptanceEval`, `handleUatSignoff`,
+`handleManageRoadmap`; `waypoint` config key. Tests:
+`waypoint-emission.test.ts`.
+
+### Task 6 (TDD): `harness waypoint` command (SC4)
+
+`record-provenance` / `record-handoff` (via `validateFleetHandoffRecord`) /
+`status`; `_registry.ts` regen. Tests: `tests/commands/waypoint.test.ts`.
+
+### Task 7 (TDD): Gateway topics + bridge (SC5)
+
+Spread `SDLC_EVENT_TYPES_V1` into `WEBHOOK_TOPICS`; `waypoint-bridge.ts`;
+orchestrator wire + stop() teardown. Tests: `waypoint-bridge.test.ts`;
+pre-existing `events.test.ts` unmodified.
+
+### Task 8: Docs + gates
+
+Changeset, `.gitignore`, knowledge-doc note, proposal/plan/provenance
+artifacts; run typecheck/tests/lint/format/generators.
+
+## Sequencing Notes
+
+1→2→3 strictly ordered (each consumes the prior); 4/5/6 parallel after 3;
+7 after 3; 8 last.
+
+## Integration Tier
+
+Medium: cross-package (types→core→cli/orchestrator) with regenerated barrels
+and a changeset.
+
+## Checkpoints
+
+`[checkpoint:human-verify]` — the PR itself: upstream maintainer review is
+the gate (additive posture, vocabulary mapping D5, and the D6 topic-list
+decision are the judgment calls to confirm).
+
+## Traceability
+
+PRD stories (pnyon `docs/product-requirements/waypoint-harness-adaptation-sdlc-event-emission-and-spool/prd.md`):
+S1→SC1/Task 3; S2→SC2/Task 4; S3→SC3/Task 5; S4→SC4/Task 6; S5→SC5/Task 7;
+S7 (Could)→`harness waypoint status` (Task 6). S6 (upstream coordination) is
+the filed issue + this PR.

--- a/docs/changes/waypoint-sdlc-emission/proposal.md
+++ b/docs/changes/waypoint-sdlc-emission/proposal.md
@@ -1,0 +1,222 @@
+---
+title: Waypoint sdlc.* event emission and repo-local spool (opt-in)
+status: draft
+keywords: waypoint, sdlc-events, cloudevents, spool, roadmap-mutators, emit-interaction, verdicts, fleet-artifacts, gateway-webhooks, opt-in
+---
+
+# Waypoint `sdlc.*` event emission and repo-local spool (opt-in)
+
+Upstream implementation of pnyon roadmap item _"Waypoint harness adaptation —
+sdlc event emission and spool"_ (pnyon/pnyon#124; pnyon ADR-0047). Waypoint is
+a pnyon-hosted, event-sourced SDLC ledger: every board, lane, and digest is a
+deterministic reduction over an append-only stream of `sdlc.*` events. Its
+hard precondition is that harness emits those events — today the webhook bus
+carries only `interaction.*`, `maintenance.*`, `proposal.*`, and
+`webhook.subscription.*` topics, and roadmap mutations emit nothing anywhere.
+
+## Overview & Goals
+
+Add an **additive, opt-in** emission layer: when (and only when)
+`harness.config.json` declares a `waypoint.sink`, the four existing evidence
+feeds each append one pinned `sdlc.*.v1` event to a repo-local spool:
+
+1. **Sanctioned roadmap mutators** — `setStatus` / `claim` / `release`
+   (`packages/core/src/roadmap/assignee-lifecycle.ts`, the status-change
+   chokepoint).
+2. **Skill phase transitions** — the `emit_interaction` transition path
+   (`packages/cli/src/mcp/tools/interaction.ts` `handleTransition`), carrying
+   its `qualityGate` payload verbatim.
+3. **Eval/UAT verdict persistence** — `outcome_eval`, `acceptance_eval`, and
+   `uat_signoff` MCP handlers, surfacing the existing verdicts (emission, not
+   new judgment).
+4. **Fleet artifact writes** — `provenance.json` / `FleetHandoffRecord`,
+   which are authored by fleet skill agents (no TS writer exists), via a new
+   sanctioned `harness waypoint record-provenance|record-handoff` CLI seam.
+
+Plus: the closed 19-type `sdlc.*.v1` vocabulary registered on the gateway
+webhook bus (existing `GatewayEvent` envelope + `WebhookQueue` retry
+machinery), and `harness waypoint status` for spool observability.
+
+**The hard invariant (Unwanted-EARS, PRD Story 1):** _if no Waypoint sink is
+configured, then the system shall not change any existing harness behavior_ —
+no new files under the working tree, no new network calls, no new required
+config keys, no change to any command's output or exit code, and every
+pre-existing test suite passes unmodified.
+
+**Non-goals:** the shipper-to-cloud (pnyon owns ingest; spooled events are the
+contract boundary), the `RoadmapTrackerClient` kind `pnyon` (sibling
+adaptation item — tracker adapter/registry files deliberately untouched),
+file-less-mode tracker-path emission (follow-up; see Decisions), new
+statuses/judgment, and any erosion of the human PR gate.
+
+## Contract (normative, external)
+
+The event schema, vocabulary, and spool format are pinned by pnyon's
+`docs/architecture/waypoint/sdlc-event-schema.md` (shipped in pnyon PR #136)
+and re-pinned in code here as `SDLC_EVENT_TYPES_V1` in
+`packages/types/src/waypoint.ts`:
+
+- **Envelope:** CloudEvents 1.0 JSON binding + Waypoint extensions
+  (`actor` duality — agent events MUST carry `onBehalfOf`; optional `grade`
+  V0–V3; optional `causes` ULID links).
+- **Identity:** client-minted ULID per event — the idempotency/dedup key;
+  monotonic per process, lexicographic order = creation order.
+- **Vocabulary:** closed set of 19 `sdlc.<category>.<predicate>.v1` types
+  across 10 categories; validation rejects anything else. Incompatible
+  changes mint `.v2` alongside; `.v1` is never mutated.
+- **Spool:** UTF-8 JSONL, one envelope per line; one segment per writing
+  process (`.harness/spool/sdlc-<ulid>.jsonl`, no locks); bounded at 10 000
+  events/segment default with **drop-oldest** and a persistent
+  `droppedEvents` counter (sidecar `sdlc-<ulid>.meta.json`); appending never
+  throws and never fails the originating operation; client-side best-effort
+  secret scrub before the line is written (authoritative scrub is
+  ingest-side).
+
+## Decisions made
+
+- **D1 — Placement: core module + types contract, not a plugin.** The types
+  live in `packages/types/src/waypoint.ts` (imports only zod, like
+  `fleet-handoff.ts`); the pure lib + file spool + emitter live in
+  `packages/core/src/waypoint/`. Mutator-level hook points favor core (the
+  PRD's open question 2); the opt-in posture is preserved by config gating,
+  not packaging.
+- **D2 — Config: `waypoint` key, `pulse` pattern.** Real schema
+  (`WaypointConfigSchema`) in types; core-side `loadWaypointConfig`
+  mirroring `loadNotificationsConfig` (absent file/key → `Ok({})` → layer
+  disabled); CLI `HarnessConfigSchema` declares `waypoint` as a tolerant
+  passthrough so the stripped-key warning (#862) never fires.
+- **D3 — Installable process-wide emitter, lazy `ensure` at handler seams.**
+  The mutators are pure functions without a project root, so emission routes
+  through a module singleton (`emitSdlc`, null → guaranteed no-op).
+  Handler-shaped call sites that know the root (`manage_roadmap`,
+  `emit_interaction`, the eval/UAT tools, `harness waypoint`, the
+  orchestrator server block) call the memoized `ensureWaypointEmitter(root)`
+  — one config read per process, only on those paths.
+- **D4 — Emit on committed mutations only.** A first-claim-wins rejection, a
+  same-owner idempotent re-claim, and a same-status `setStatus` commit
+  nothing and emit nothing — "exactly one event per committed mutation".
+- **D5 — Vocabulary mapping** (documented projection, no new judgment):
+  `setStatus`→`intent.updated` (`done`→`intent.closed`); `claim`→
+  `claim.opened`; `release`→`claim.released`; phase transition→
+  `build.finished` (subject `phase/<completedPhase>`, `qualityGate` in
+  `data`); verdicts→`verify.graded` with grade projection acceptance
+  MEASURABLE→V1, outcome SATISFIED→V2, UAT ACCEPTED→V3, else V0 (UAT events
+  carry a human actor); provenance write→`build.finished`; handoff `done`→
+  `review.requested` (the item now awaits the human PR gate), other
+  dispositions→`intent.updated` with the blocker.
+- **D6 — Gateway topics: register the closed v1 list verbatim.**
+  `WEBHOOK_TOPICS` gains all 19 concrete types (spread from
+  `SDLC_EVENT_TYPES_V1`, so the lists cannot drift). Types are 4 segments;
+  the segment-glob matcher means subscribers use exact types or
+  `sdlc.*.*.*`. No wildcard-exclusion (unlike `telemetry.*`): the events
+  only exist on opted-in repos, so legacy `*.*` subscribers are structurally
+  unaffected (segment counts differ).
+- **D7 — Bus bridge lives in the orchestrator.** Core cannot import the
+  orchestrator (layer rules); the emitter exposes `onEvent`, and
+  `wireWaypointSdlcBridge` republishes spooled events onto the orchestrator
+  bus (spool-first: the durable append happens before any listener runs).
+  `NOTIFICATION_TOPICS` / `SSE_TOPICS` / telemetry fan-out are deliberately
+  NOT extended (per-destination opt-in is their documented design; webhooks
+  are the PRD's named destination).
+- **D8 — Fleet artifacts get a CLI seam, not a file watcher.** No TS code
+  writes `provenance.json` or handoff records (fleet skill agents author
+  them), so `harness waypoint record-provenance/record-handoff` is the
+  sanctioned call — validation via the existing
+  `validateFleetHandoffRecord`; a no-sink invocation exits 0 with an
+  explanatory note so fleets may call it unconditionally. Wiring the fleet
+  SKILL.md prose to invoke it is a follow-up (plugin regeneration blast
+  radius).
+- **D9 — Emission failures are recorded, never thrown.** Invalid events and
+  I/O failures land on the emitter's `emissionFailures` (and the append
+  result); the originating harness operation always completes (PRD Story 1
+  criterion 3).
+
+## Technical design
+
+New modules:
+
+- `packages/types/src/waypoint.ts` — `SDLC_EVENT_TYPES_V1`, `SdlcEvent`,
+  `SdlcActor`, grades, validation/append/segment result types,
+  `WaypointConfigSchema` (zod).
+- `packages/core/src/waypoint/` — `ulid.ts` (monotonic factory, injected
+  ports), `validate.ts` (per-field diagnostics, closed vocabulary),
+  `scrub.ts` (best-effort secret redaction of `data` strings), `spool.ts`
+  (`FileSpool` bounded JSONL writer + `readSpoolSegments` + `mergeSegments`),
+  `config-loader.ts`, `emitter.ts` (`WaypointEmitter`, singleton install,
+  `ensureWaypointEmitter`, `emitSdlc`), `events.ts` (one mapping helper per
+  emission family).
+- `packages/cli/src/mcp/utils/waypoint-emission.ts` — verdict emission for
+  the three eval/UAT handlers (+ `specSlug`).
+- `packages/cli/src/commands/waypoint.ts` — `record-provenance`,
+  `record-handoff`, `status`.
+- `packages/orchestrator/src/gateway/webhooks/waypoint-bridge.ts` —
+  `wireWaypointSdlcBridge`.
+
+Hooked existing files (all additive):
+`packages/core/src/roadmap/assignee-lifecycle.ts` (3 mutators),
+`packages/cli/src/mcp/tools/interaction.ts` (`handleTransition`),
+`packages/cli/src/mcp/tools/{outcome-eval,acceptance-eval,uat-signoff}.ts`,
+`packages/cli/src/mcp/tools/roadmap.ts` (`ensureWaypointEmitter` before
+dispatch), `packages/cli/src/config/schema.ts` (`waypoint` passthrough key),
+`packages/orchestrator/src/gateway/webhooks/events.ts` (topic list),
+`packages/orchestrator/src/orchestrator.ts` (bridge wire + teardown),
+`.gitignore` (`**/.harness/spool/`).
+
+## Integration Points
+
+- **Webhook fan-out** — `wireWebhookFanout` picks up the new topics
+  unchanged; delivery keeps `WebhookQueue` retry semantics
+  (`RETRY_DELAYS_MS`, `MAX_ATTEMPTS=5`) and HMAC signing.
+- **`subscribe_webhook` MCP tool** — accepts `sdlc.*.*.*` and exact-type
+  patterns with zero changes (glob matching is store-side).
+- **Fleet pipelines** — call `harness waypoint record-provenance
+docs/changes/<slug>/provenance.json` and `… record-handoff <file>` after
+  writing artifacts (unconditionally safe).
+- **pnyon ingest (external)** — consumes the spool per the schema doc §7.3;
+  merge order is ULID; `id` is the dedup key.
+
+## Success Criteria
+
+1. **SC1 — Non-adopter invariance:** with no `waypoint.sink`, no
+   `.harness/spool/` is ever created, `emitSdlc` returns null, mutators are
+   byte-identical to prior behavior, and the pre-existing
+   assignee-lifecycle, gateway webhook, interaction, and roadmap suites pass
+   unmodified. (Tests: `emitter.test.ts` invariance describe-block,
+   `assignee-lifecycle-waypoint.test.ts` no-sink block,
+   `waypoint-bridge.test.ts` no-op case, `waypoint.test.ts` no-sink case.)
+2. **SC2 — Mutator emission:** each committed `setStatus`/`claim`/`release`
+   spools exactly one correctly-typed, schema-valid event; no-op calls spool
+   nothing. (Test: `assignee-lifecycle-waypoint.test.ts`.)
+3. **SC3 — Transition + verdict emission:** a transition through
+   `emit_interaction` spools one `build.finished` preserving `qualityGate`;
+   each persisted outcome/acceptance/UAT verdict spools one `verify.graded`
+   with the documented grade projection and (for UAT) a human actor.
+   (Tests: `events.test.ts`, `waypoint-emission.test.ts`.)
+4. **SC4 — Fleet artifact emission:** `record-provenance` and
+   `record-handoff` spool exactly one event per artifact with
+   reconstruction-sufficient `data`; invalid records are rejected with exit
+   code 1 and spool nothing. (Test: `tests/commands/waypoint.test.ts`.)
+5. **SC5 — Gateway topics:** an `sdlc.*.*.*` (or exact-type) subscription
+   receives bridged events in the `GatewayEvent` envelope through the
+   existing fan-out; existing topics behave identically (existing
+   `events.test.ts` passes unmodified). (Test: `waypoint-bridge.test.ts`.)
+6. **SC6 — Spool format:** segments are plain JSONL parseable by any
+   standard parser; the bound drops oldest and persists `droppedEvents`;
+   appends never throw. (Test: `spool.test.ts`.)
+
+## Implementation Order
+
+### Phase 1: Contract + spool + emitter (types, core) <!-- complexity: medium -->
+
+Types, ULID/validate/scrub ports, `FileSpool`, config loader, emitter +
+singleton, mapping helpers, full unit coverage.
+
+### Phase 2: Emission hooks (core, cli) <!-- complexity: medium -->
+
+Mutator hooks, `emit_interaction` transition hook, verdict-handler hooks,
+`manage_roadmap` ensure, config schema key, `harness waypoint` command.
+
+### Phase 3: Gateway topics + bridge (orchestrator) <!-- complexity: small -->
+
+`WEBHOOK_TOPICS` extension, `wireWaypointSdlcBridge`, orchestrator wire +
+teardown, fan-out tests.

--- a/docs/changes/waypoint-sdlc-emission/provenance.json
+++ b/docs/changes/waypoint-sdlc-emission/provenance.json
@@ -1,0 +1,51 @@
+{
+  "item": "waypoint-harness-adaptation-sdlc-event-emission-and-spool",
+  "issues": ["pnyon/pnyon#124"],
+  "slug": "waypoint-sdlc-emission",
+  "route": "feature",
+  "branch": "feat/waypoint-sdlc-emission",
+  "stages": ["brainstorming", "planning", "execution", "verification"],
+  "specArtifact": "docs/changes/waypoint-sdlc-emission/proposal.md",
+  "planArtifact": "docs/changes/waypoint-sdlc-emission/plans/2026-09-04-waypoint-sdlc-emission-plan.md",
+  "sourceFiles": [
+    "packages/types/src/waypoint.ts",
+    "packages/core/src/waypoint/ulid.ts",
+    "packages/core/src/waypoint/validate.ts",
+    "packages/core/src/waypoint/scrub.ts",
+    "packages/core/src/waypoint/spool.ts",
+    "packages/core/src/waypoint/config-loader.ts",
+    "packages/core/src/waypoint/emitter.ts",
+    "packages/core/src/waypoint/events.ts",
+    "packages/core/src/roadmap/assignee-lifecycle.ts",
+    "packages/cli/src/mcp/utils/waypoint-emission.ts",
+    "packages/cli/src/mcp/tools/interaction.ts",
+    "packages/cli/src/mcp/tools/outcome-eval.ts",
+    "packages/cli/src/mcp/tools/acceptance-eval.ts",
+    "packages/cli/src/mcp/tools/uat-signoff.ts",
+    "packages/cli/src/mcp/tools/roadmap.ts",
+    "packages/cli/src/config/schema.ts",
+    "packages/cli/src/commands/waypoint.ts",
+    "packages/orchestrator/src/gateway/webhooks/events.ts",
+    "packages/orchestrator/src/gateway/webhooks/waypoint-bridge.ts",
+    "packages/orchestrator/src/orchestrator.ts"
+  ],
+  "registrationSites": [
+    "packages/types/src/index.ts",
+    "packages/core/src/index.ts (generate:barrels)",
+    "packages/core/src/waypoint/index.ts",
+    "packages/cli/src/commands/_registry.ts (generate:barrels)",
+    "packages/orchestrator/src/orchestrator.ts (wire + teardown)",
+    ".changeset/waypoint-sdlc-emission.md"
+  ],
+  "assumptions": [
+    "Vocabulary mapping D5 (mutators/transitions/verdicts/fleet artifacts to the closed sdlc.*.v1 set) and the V1/V2/V3 grade projection are documented projections pending pnyon field-level payload schemas.",
+    "Emission covers the file-backed roadmap mode's sanctioned mutators; file-less tracker-path emission is a follow-up (tracker adapter files untouched to avoid the parallel RoadmapTrackerClient lane).",
+    "Fleet artifact emission is invoked via the new `harness waypoint record-*` CLI seam because no TypeScript writer for provenance.json/FleetHandoffRecord exists; wiring fleet SKILL.md prose to call it is a follow-up.",
+    "acceptance_eval has no `path` input, so its emission uses process.cwd() as the project root.",
+    "Only WEBHOOK_TOPICS gains the sdlc.* family; NOTIFICATION_TOPICS/SSE_TOPICS stay per-destination opt-in per their documented design.",
+    "UAT dashboard signoff route not hooked (MCP path emits the same verdict event); follow-up if dashboard-only signoffs need coverage."
+  ],
+  "route_detail": "harness-brainstorming (proposal) -> harness-autopilot-style autonomous execution (plan -> TDD execution -> verification), adapted to this repo's docs/changes conventions",
+  "generatedBy": "roadmap-fleet build lane (pnyon), Claude",
+  "date": "2026-09-04"
+}

--- a/docs/knowledge/orchestrator/webhook-fanout.md
+++ b/docs/knowledge/orchestrator/webhook-fanout.md
@@ -95,6 +95,8 @@ The fan-out subscribes to a fixed set of orchestrator event-bus topics, declared
 
 The colon-to-dot normalization (`events.ts:47`) is a transitional layer — orchestrator topics with colon separators predate the webhook surface and live in older callsites. New topics added in Phase 3+ should be dotted at the source so the normalization layer can be retired once the colon-form topics fade.
 
+**Waypoint `sdlc.*` family (opt-in, pnyon/pnyon#124).** `WEBHOOK_TOPICS` also registers the pinned, closed 19-type `sdlc.*.v1` vocabulary (spread verbatim from `SDLC_EVENT_TYPES_V1` in `@harness-engineering/types`, so the lists cannot drift). These events reach the bus only through `wireWaypointSdlcBridge` (`gateway/webhooks/waypoint-bridge.ts`), which republishes events the core Waypoint emitter has already spooled to `.harness/spool/` — and that emitter only exists when `harness.config.json` declares `waypoint.sink`. The types are four dotted segments (`sdlc.claim.opened.v1`), so subscriptions match exact types or the `sdlc.*.*.*` glob; legacy `*.*` subscriptions are structurally unaffected (segment counts differ). See `docs/changes/waypoint-sdlc-emission/proposal.md`.
+
 The two **subscription-lifecycle** topics emitted BY the fan-out (`webhook.subscription.created`, `webhook.subscription.deleted`) are not in `WEBHOOK_TOPICS` — they are observed on the SSE event channel (so dashboards see new subscriptions live) but the fan-out itself does NOT re-fan them out to webhooks (that would create a delivery loop where every subscription is notified of every other subscription's lifecycle).
 
 ## Segment-glob matching

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -2066,3 +2066,19 @@ List recent sessions with token usage and cost
 **Options:**
 
 - `--limit` — Number of sessions to show (default: 10, max: 100) (default: "10")
+
+## Waypoint Commands
+
+Opt-in Waypoint sdlc.\* emission: record fleet artifacts, inspect the spool
+
+### `harness waypoint record-handoff <file>`
+
+Spool one sdlc.\* event for a written fleet handoff record
+
+### `harness waypoint record-provenance <file>`
+
+Spool one sdlc.\* event for a written fleet provenance.json
+
+### `harness waypoint status`
+
+Show spool health: segments, event counts, drops, oldest event age

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -115,6 +115,7 @@ import { createUpdateCommand } from './update';
 import { createUsageCommand } from './usage';
 import { createValidateCommand } from './validate';
 import { createVerifyCommand } from './verify';
+import { createWaypointCommand } from './waypoint';
 
 /**
  * All discovered command creators, sorted alphabetically.
@@ -234,4 +235,5 @@ export const commandCreators: Array<() => Command> = [
   createUsageCommand,
   createValidateCommand,
   createVerifyCommand,
+  createWaypointCommand,
 ];

--- a/packages/cli/src/commands/waypoint.ts
+++ b/packages/cli/src/commands/waypoint.ts
@@ -1,0 +1,201 @@
+/**
+ * `harness waypoint` — the fleet-artifact emission surface and spool
+ * observability for the opt-in Waypoint sdlc.* layer (pnyon/pnyon#124).
+ *
+ * Fleet provenance.json and handoff records are written by fleet workers
+ * (skill-driven agents), not by TypeScript code — so this command is the
+ * sanctioned code seam those pipelines invoke at artifact-write time:
+ *
+ *   harness waypoint record-provenance docs/changes/<slug>/provenance.json
+ *   harness waypoint record-handoff <handoff.json>
+ *   harness waypoint status [--json]
+ *
+ * Every subcommand is a no-op (exit 0, explanatory note) when no
+ * `waypoint.sink` is configured in `harness.config.json`, so fleets can call
+ * it unconditionally without changing non-adopter behavior (PRD Story 1).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Command } from 'commander';
+import { logger } from '../output/logger';
+
+const NO_SINK_NOTE =
+  'Waypoint sink not configured (harness.config.json `waypoint.sink`); nothing recorded.';
+
+/** Loose shape of a fleet provenance.json (deliberately permissive, like burn). */
+interface ProvenanceFile {
+  slug?: string;
+  item?: string;
+  issues?: unknown[];
+  issue?: unknown;
+  stages?: unknown[];
+}
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+/** Derives the item id from a provenance file, preferring slug over path. */
+function provenanceItem(parsed: ProvenanceFile, filePath: string): string {
+  if (typeof parsed.slug === 'string' && parsed.slug.length > 0) return parsed.slug;
+  if (typeof parsed.item === 'string' && parsed.item.length > 0) return parsed.item;
+  return path.basename(path.dirname(path.resolve(filePath)));
+}
+
+function registerRecordProvenance(waypoint: Command): void {
+  waypoint
+    .command('record-provenance <file>')
+    .description('Spool one sdlc.* event for a written fleet provenance.json')
+    .action(async (file: string, _opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const cwd = process.cwd();
+      const { ensureWaypointEmitter, emitFleetProvenanceWritten } =
+        await import('@harness-engineering/core');
+      if (ensureWaypointEmitter(cwd) === null) {
+        emitResult(globalOpts.json === true, { recorded: false, note: NO_SINK_NOTE });
+        return;
+      }
+      let parsed: ProvenanceFile;
+      try {
+        parsed = readJsonFile(file) as ProvenanceFile;
+      } catch (error) {
+        logger.error(
+          `Could not read provenance file: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const eventId = emitFleetProvenanceWritten({
+        item: provenanceItem(parsed, file),
+        stages: Array.isArray(parsed.stages) ? parsed.stages.map(String) : [],
+        artifactPath: path.relative(cwd, path.resolve(file)).replaceAll('\\', '/'),
+      });
+      emitResult(globalOpts.json === true, { recorded: eventId !== null, eventId });
+    });
+}
+
+function registerRecordHandoff(waypoint: Command): void {
+  waypoint
+    .command('record-handoff <file>')
+    .description('Spool one sdlc.* event for a written fleet handoff record')
+    .action(async (file: string, _opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const cwd = process.cwd();
+      const { ensureWaypointEmitter, emitFleetHandoffWritten } =
+        await import('@harness-engineering/core');
+      const { validateFleetHandoffRecord } = await import('@harness-engineering/types');
+      if (ensureWaypointEmitter(cwd) === null) {
+        emitResult(globalOpts.json === true, { recorded: false, note: NO_SINK_NOTE });
+        return;
+      }
+      let raw: unknown;
+      try {
+        raw = readJsonFile(file);
+      } catch (error) {
+        logger.error(
+          `Could not read handoff file: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const validated = validateFleetHandoffRecord(raw);
+      if (!validated.ok) {
+        logger.error(`Invalid fleet handoff record: ${validated.error.message}`);
+        process.exitCode = 1;
+        return;
+      }
+      const eventId = emitFleetHandoffWritten(validated.record);
+      emitResult(globalOpts.json === true, { recorded: eventId !== null, eventId });
+    });
+}
+
+function registerStatus(waypoint: Command): void {
+  waypoint
+    .command('status')
+    .description('Show spool health: segments, event counts, drops, oldest event age')
+    .action(async (_opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const cwd = process.cwd();
+      const { readSpoolSegments } = await import('@harness-engineering/core');
+      const spoolDir = path.join(cwd, '.harness', 'spool');
+      const segments = readSpoolSegments(spoolDir);
+      const status: SpoolStatus = {
+        spoolDir: path.relative(cwd, spoolDir).replaceAll('\\', '/'),
+        segments: segments.length,
+        events: segments.reduce((sum, s) => sum + s.lines.length, 0),
+        droppedEvents: segments.reduce((sum, s) => sum + s.droppedEvents, 0),
+        oldestEventTime: oldestEventTime(segments),
+      };
+      if (globalOpts.json === true) {
+        console.log(JSON.stringify(status, null, 2));
+        return;
+      }
+      renderStatus(status);
+    });
+}
+
+interface SpoolStatus {
+  spoolDir: string;
+  segments: number;
+  events: number;
+  droppedEvents: number;
+  oldestEventTime: string | null;
+}
+
+/** Oldest `time` across segment heads (segments are append-ordered). */
+function oldestEventTime(segments: readonly { lines: readonly string[] }[]): string | null {
+  let oldestIso: string | null = null;
+  for (const segment of segments) {
+    const first = segment.lines[0];
+    if (first === undefined) continue;
+    try {
+      const time = (JSON.parse(first) as { time?: string }).time;
+      if (typeof time === 'string' && (oldestIso === null || time < oldestIso)) {
+        oldestIso = time;
+      }
+    } catch {
+      /* unparseable line: skip */
+    }
+  }
+  return oldestIso;
+}
+
+function renderStatus(status: SpoolStatus): void {
+  if (status.segments === 0) {
+    logger.info('No spool segments found (no Waypoint sink configured, or nothing emitted).');
+    return;
+  }
+  logger.info(`Spool: ${status.spoolDir}`);
+  logger.info(`Segments: ${status.segments} · Events: ${status.events}`);
+  if (status.droppedEvents > 0) {
+    logger.warn(`Dropped events (drop-oldest at cap): ${status.droppedEvents}`);
+  }
+  if (status.oldestEventTime !== null) {
+    logger.info(`Oldest spooled event: ${status.oldestEventTime}`);
+  }
+}
+
+function emitResult(json: boolean, body: Record<string, unknown>): void {
+  if (json) {
+    console.log(JSON.stringify(body, null, 2));
+    return;
+  }
+  if (body.recorded === true) {
+    logger.info(`Spooled sdlc.* event ${String(body.eventId)}`);
+  } else {
+    logger.info(typeof body.note === 'string' ? body.note : 'Nothing recorded.');
+  }
+}
+
+export function createWaypointCommand(): Command {
+  const waypoint = new Command('waypoint')
+    .description('Opt-in Waypoint sdlc.* emission: record fleet artifacts, inspect the spool')
+    .option('--json', 'Output in JSON format');
+
+  registerRecordProvenance(waypoint);
+  registerRecordHandoff(waypoint);
+  registerStatus(waypoint);
+
+  return waypoint;
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1428,6 +1428,16 @@ export const HarnessConfigSchema = z.object({
    * also trip the stripped-key warning added for issue #862).
    */
   pulse: z.object({}).passthrough().optional(),
+  /**
+   * Waypoint sdlc.* emission configuration (opt-in, pnyon/pnyon#124),
+   * validated by the dedicated `WaypointConfigSchema` in
+   * `@harness-engineering/types` and consumed by the core emission layer
+   * (`loadWaypointConfig` / `ensureWaypointEmitter`). Declared here as a
+   * tolerant passthrough — like `pulse` — so the shared loader recognizes it
+   * as a legitimate top-level key instead of tripping the stripped-key
+   * warning. Absent key = emission fully disabled (non-adopter invariance).
+   */
+  waypoint: z.object({}).passthrough().optional(),
 });
 
 /**

--- a/packages/cli/src/mcp/context-surface.ts
+++ b/packages/cli/src/mcp/context-surface.ts
@@ -62,7 +62,7 @@ function collectSkillFiles(dir: string): string[] {
 }
 
 /** One invoked-only entry per platform skill tree (aggregated bodies). */
-function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
+export function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
   const entries: ContextSurfaceEntry[] = [];
   for (const platform of PLATFORM_SKILL_DIRS) {
     const dir = join(projectRoot, 'agents', 'skills', platform);
@@ -88,7 +88,7 @@ function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
 }
 
 /** AGENTS.md entry (always-loaded), when present. */
-function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
+export function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
   const path = join(projectRoot, 'AGENTS.md');
   if (!existsSync(path)) return null;
   try {
@@ -104,7 +104,7 @@ function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
 }
 
 /** Hook-configuration entry from .claude/settings.json (always-loaded). */
-function hooksEntry(projectRoot: string): ContextSurfaceEntry | null {
+export function hooksEntry(projectRoot: string): ContextSurfaceEntry | null {
   const path = join(projectRoot, '.claude', 'settings.json');
   if (!existsSync(path)) return null;
   try {

--- a/packages/cli/src/mcp/tools/acceptance-eval.ts
+++ b/packages/cli/src/mcp/tools/acceptance-eval.ts
@@ -24,6 +24,7 @@
 import { readFile } from 'node:fs/promises';
 import { findFiles } from '../../utils/files.js';
 import { resolveAnalysisProvider } from '../utils/analysis-provider.js';
+import { emitAcceptanceVerdictEvent } from '../utils/waypoint-emission.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -154,6 +155,12 @@ export async function handleAcceptanceEval(input: AcceptanceEvalToolInput): Prom
       specPath: input.specPath,
       ...(testContent !== undefined && { testContent }),
     });
+
+    // Waypoint sdlc.* emission (opt-in): surfaces the returned verdict as a
+    // spooled sdlc.verify.graded.v1 event. This tool has no `path?` input
+    // (see persistence-seam note above), so cwd stands in for the project
+    // root. No-op without a configured sink; never affects the response.
+    await emitAcceptanceVerdictEvent(process.cwd(), verdict, input.specPath);
 
     // Return the verdict EXACTLY as produced — authority is TS-derived
     // (deriveAcceptanceAuthority); the handler never recomputes or overrides it.

--- a/packages/cli/src/mcp/tools/interaction.ts
+++ b/packages/cli/src/mcp/tools/interaction.ts
@@ -301,6 +301,25 @@ async function handleTransition(
     data: { fromSkill: skillName, toSkill: transition.suggestedNext },
   });
 
+  // Waypoint sdlc.* emission (opt-in, pnyon/pnyon#124): spools one
+  // sdlc.build.finished.v1 event preserving the transition's qualityGate
+  // payload. Guaranteed no-op when no waypoint.sink is configured; a failed
+  // emission never fails the interaction.
+  try {
+    const { ensureWaypointEmitter, emitSkillPhaseTransition } =
+      await import('@harness-engineering/core');
+    ensureWaypointEmitter(projectPath);
+    emitSkillPhaseTransition({
+      completedPhase: transition.completedPhase,
+      suggestedNext: transition.suggestedNext,
+      reason: transition.reason,
+      artifacts: transition.artifacts,
+      ...(transition.qualityGate !== undefined ? { qualityGate: transition.qualityGate } : {}),
+    });
+  } catch {
+    /* Waypoint emission failure is non-fatal */
+  }
+
   const metadata: Record<string, unknown> = { id, handoffWritten: true };
   if (!transition.requiresConfirmation) {
     metadata.autoTransition = true;

--- a/packages/cli/src/mcp/tools/outcome-eval.ts
+++ b/packages/cli/src/mcp/tools/outcome-eval.ts
@@ -25,6 +25,7 @@ import type { GuardianAnalysis } from '@harness-engineering/intelligence';
 import { sanitizePath } from '../utils/sanitize-path.js';
 import { loadGraphStore } from '../utils/graph-loader.js';
 import { resolveAnalysisProvider } from '../utils/analysis-provider.js';
+import { emitOutcomeVerdictEvent } from '../utils/waypoint-emission.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -177,6 +178,15 @@ export async function handleOutcomeEval(input: OutcomeEvalToolInput): Promise<To
       ...(typeof input.commit === 'string' && input.commit !== '' ? { commit: input.commit } : {}),
       ...(guardian.length > 0 ? { guardian } : {}),
     });
+
+    // Waypoint sdlc.* emission (opt-in): surfaces the persisted verdict as a
+    // spooled sdlc.verify.graded.v1 event. No-op without a configured sink;
+    // never affects the verdict or the response.
+    await emitOutcomeVerdictEvent(
+      sanitizePath(input.path ?? process.cwd()),
+      verdict,
+      input.specPath
+    );
 
     // Return the verdict EXACTLY as the evaluator produced it — authority is
     // TS-derived (deriveAuthority); the handler never recomputes it.

--- a/packages/cli/src/mcp/tools/roadmap.ts
+++ b/packages/cli/src/mcp/tools/roadmap.ts
@@ -882,7 +882,18 @@ export async function handleManageRoadmap(input: ManageRoadmapInput): Promise<Mc
       release,
       promoteFeature,
       groomRoadmap,
+      ensureWaypointEmitter,
     } = await import('@harness-engineering/core');
+
+    // Waypoint sdlc.* emission (opt-in, pnyon/pnyon#124): lazily install the
+    // emitter so the sanctioned mutators (setStatus/claim/release) spool
+    // events. Memoized; a guaranteed no-op unless harness.config.json
+    // declares waypoint.sink, and never fatal to the roadmap operation.
+    try {
+      ensureWaypointEmitter(projectPathPre);
+    } catch {
+      /* Waypoint emitter init failure is non-fatal */
+    }
     const { Ok } = await import('@harness-engineering/types');
 
     const projectPath = projectPathPre;

--- a/packages/cli/src/mcp/tools/uat-signoff.ts
+++ b/packages/cli/src/mcp/tools/uat-signoff.ts
@@ -24,6 +24,7 @@
 import * as path from 'node:path';
 import { mkdir } from 'node:fs/promises';
 import { sanitizePath } from '../utils/sanitize-path.js';
+import { emitUatSignoffEvent } from '../utils/waypoint-emission.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -189,6 +190,15 @@ export async function handleUatSignoff(input: UatSignoffToolInput): Promise<Tool
 
     const { outcomeId, ingest } = new UatSignoffRecorder(store).record(toRecorderInput(input));
     await store.save(graphDir);
+
+    // Waypoint sdlc.* emission (opt-in): surfaces the recorded human sign-off
+    // as a spooled sdlc.verify.graded.v1 event with a human actor. No-op
+    // without a configured sink; never affects the recorded node or response.
+    await emitUatSignoffEvent(projectRoot, {
+      slug: input.slug,
+      decision: input.decision,
+      signedOffBy: input.signedOffBy,
+    });
 
     return successResponse({
       outcomeId,

--- a/packages/cli/src/mcp/utils/waypoint-emission.test.ts
+++ b/packages/cli/src/mcp/utils/waypoint-emission.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resetWaypointEmitterForTests } from '@harness-engineering/core';
+import type { SdlcEvent } from '@harness-engineering/types';
+import {
+  emitAcceptanceVerdictEvent,
+  emitOutcomeVerdictEvent,
+  emitUatSignoffEvent,
+  specSlug,
+} from './waypoint-emission.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-cli-'));
+  resetWaypointEmitterForTests();
+});
+
+afterEach(() => {
+  resetWaypointEmitterForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function configureSink(): void {
+  writeFileSync(
+    join(dir, 'harness.config.json'),
+    JSON.stringify({ waypoint: { sink: { transport: 'spool' } } }),
+    'utf8'
+  );
+}
+
+function spooledEvents(): SdlcEvent[] {
+  const spoolDir = join(dir, '.harness', 'spool');
+  if (!existsSync(spoolDir)) return [];
+  const events: SdlcEvent[] = [];
+  for (const entry of readdirSync(spoolDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    for (const line of readFileSync(join(spoolDir, entry), 'utf8').split('\n')) {
+      if (line.length > 0) events.push(JSON.parse(line) as SdlcEvent);
+    }
+  }
+  return events;
+}
+
+describe('specSlug', () => {
+  it('extracts the docs/changes slug', () => {
+    expect(specSlug('docs/changes/my-change/proposal.md')).toBe('my-change');
+    expect(specSlug('/abs/repo/docs/changes/my-change/proposal.md')).toBe('my-change');
+    expect(specSlug('docs\\changes\\win-change\\proposal.md')).toBe('win-change');
+  });
+
+  it('falls back to the basename without extension', () => {
+    expect(specSlug('specs/feature-spec.md')).toBe('feature-spec');
+  });
+});
+
+describe('verdict emission helpers', () => {
+  it('are no-ops without a configured sink (no files created)', async () => {
+    await emitOutcomeVerdictEvent(dir, { verdict: 'SATISFIED', confidence: 'high' }, 'x.md');
+    await emitAcceptanceVerdictEvent(dir, { measurability: 'MEASURABLE' }, 'x.md');
+    await emitUatSignoffEvent(dir, { slug: 's', decision: 'ACCEPTED', signedOffBy: 'chad' });
+    expect(existsSync(join(dir, '.harness'))).toBe(false);
+  });
+
+  it('spool outcome verdicts as sdlc.verify.graded.v1 (SATISFIED => V2)', async () => {
+    configureSink();
+    await emitOutcomeVerdictEvent(
+      dir,
+      { verdict: 'SATISFIED', confidence: 'high' },
+      'docs/changes/my-change/proposal.md'
+    );
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.verify.graded.v1');
+    expect(event?.grade).toBe('V2');
+    expect(event?.subject).toBe('item/my-change');
+    expect(event?.data).toMatchObject({ kind: 'outcome', verdict: 'SATISFIED' });
+  });
+
+  it('spool acceptance verdicts using measurability (MEASURABLE => V1)', async () => {
+    configureSink();
+    await emitAcceptanceVerdictEvent(
+      dir,
+      { measurability: 'MEASURABLE', confidence: 'medium' },
+      'docs/changes/my-change/proposal.md'
+    );
+    const [event] = spooledEvents();
+    expect(event?.grade).toBe('V1');
+    expect(event?.data).toMatchObject({ kind: 'acceptance', verdict: 'MEASURABLE' });
+  });
+
+  it('skip malformed verdicts without spooling or throwing', async () => {
+    configureSink();
+    await emitOutcomeVerdictEvent(dir, { not: 'a verdict' }, 'x.md');
+    await emitOutcomeVerdictEvent(dir, undefined, 'x.md');
+    expect(spooledEvents()).toEqual([]);
+  });
+
+  it('spool UAT sign-offs with a human actor (ACCEPTED => V3)', async () => {
+    configureSink();
+    await emitUatSignoffEvent(dir, {
+      slug: 'my-change',
+      decision: 'ACCEPTED',
+      signedOffBy: 'chad',
+    });
+    const [event] = spooledEvents();
+    expect(event?.grade).toBe('V3');
+    expect(event?.actor).toEqual({ kind: 'human', id: 'user://chad' });
+    expect(event?.data).toMatchObject({ kind: 'uat', verdict: 'ACCEPTED' });
+  });
+});

--- a/packages/cli/src/mcp/utils/waypoint-emission.ts
+++ b/packages/cli/src/mcp/utils/waypoint-emission.ts
@@ -1,0 +1,94 @@
+/**
+ * Waypoint `sdlc.*` verdict emission for MCP tool handlers (opt-in,
+ * pnyon/pnyon#124).
+ *
+ * Each helper lazily initializes the core Waypoint emitter for the project
+ * (a memoized no-op unless `harness.config.json` declares `waypoint.sink`)
+ * and spools one `sdlc.verify.graded.v1` event surfacing an EXISTING
+ * persisted verdict — emission, never new judgment. Every helper is
+ * fire-and-forget: it never throws and never alters the handler's response
+ * (PRD Story 1: emission failure must not fail the operation).
+ */
+
+import * as path from 'node:path';
+
+/**
+ * Derives the work-item identifier a verdict grades from its spec path:
+ * `docs/changes/<slug>/…` yields the slug; anything else falls back to the
+ * spec file's basename without extension.
+ */
+export function specSlug(specPath: string): string {
+  const normalized = specPath.replaceAll('\\', '/');
+  const match = /docs\/changes\/([^/]+)\//.exec(normalized);
+  if (match) return match[1] as string;
+  return path.basename(normalized).replace(/\.md$/, '');
+}
+
+interface VerdictShape {
+  verdict?: string;
+  measurability?: string;
+  confidence?: string;
+}
+
+/** Spools an outcome_eval verdict (`SATISFIED` asserts V2). */
+export async function emitOutcomeVerdictEvent(
+  projectRoot: string,
+  verdict: unknown,
+  specPath: string
+): Promise<void> {
+  await emitEvalVerdict(projectRoot, 'outcome', verdict, specPath);
+}
+
+/** Spools an acceptance_eval verdict (`MEASURABLE` asserts V1). */
+export async function emitAcceptanceVerdictEvent(
+  projectRoot: string,
+  verdict: unknown,
+  specPath: string
+): Promise<void> {
+  await emitEvalVerdict(projectRoot, 'acceptance', verdict, specPath);
+}
+
+async function emitEvalVerdict(
+  projectRoot: string,
+  kind: 'outcome' | 'acceptance',
+  verdict: unknown,
+  specPath: string
+): Promise<void> {
+  try {
+    const { ensureWaypointEmitter, emitVerdictPersisted } =
+      await import('@harness-engineering/core');
+    if (ensureWaypointEmitter(projectRoot) === null) return;
+    const shape = (verdict ?? {}) as VerdictShape;
+    const verdictText = kind === 'acceptance' ? shape.measurability : shape.verdict;
+    if (typeof verdictText !== 'string' || verdictText.length === 0) return;
+    emitVerdictPersisted({
+      kind,
+      verdict: verdictText,
+      ...(typeof shape.confidence === 'string' ? { confidence: shape.confidence } : {}),
+      item: specSlug(specPath),
+      detail: { specPath },
+    });
+  } catch {
+    /* Waypoint emission failure is non-fatal */
+  }
+}
+
+/** Spools a human UAT sign-off (`ACCEPTED` asserts V3; human actor). */
+export async function emitUatSignoffEvent(
+  projectRoot: string,
+  signoff: { slug: string; decision: string; signedOffBy: string }
+): Promise<void> {
+  try {
+    const { ensureWaypointEmitter, emitVerdictPersisted } =
+      await import('@harness-engineering/core');
+    if (ensureWaypointEmitter(projectRoot) === null) return;
+    emitVerdictPersisted({
+      kind: 'uat',
+      verdict: signoff.decision,
+      item: signoff.slug,
+      actor: { kind: 'human', id: `user://${signoff.signedOffBy}` },
+    });
+  } catch {
+    /* Waypoint emission failure is non-fatal */
+  }
+}

--- a/packages/cli/tests/commands/waypoint.test.ts
+++ b/packages/cli/tests/commands/waypoint.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Command } from 'commander';
+import { resetWaypointEmitterForTests } from '@harness-engineering/core';
+import type { SdlcEvent } from '@harness-engineering/types';
+import { createWaypointCommand } from '../../src/commands/waypoint';
+
+async function runCommand(args: string[]): Promise<void> {
+  const parent = new Command();
+  parent.option('--json', 'JSON output');
+  parent.addCommand(createWaypointCommand());
+  parent.exitOverride();
+  await parent.parseAsync(['node', 'test', '--json', 'waypoint', ...args]);
+}
+
+let tmpDir: string;
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-waypoint-cmd-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir) as ReturnType<typeof vi.spyOn>;
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}) as ReturnType<typeof vi.spyOn>;
+  resetWaypointEmitterForTests();
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  resetWaypointEmitterForTests();
+  cwdSpy.mockRestore();
+  logSpy.mockRestore();
+  process.exitCode = undefined;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function configureSink(): void {
+  fs.writeFileSync(
+    path.join(tmpDir, 'harness.config.json'),
+    JSON.stringify({ waypoint: { sink: { transport: 'spool' } } }),
+    'utf8'
+  );
+}
+
+function lastJsonOutput(): Record<string, unknown> {
+  const call = logSpy.mock.calls.at(-1);
+  return JSON.parse(String(call?.[0])) as Record<string, unknown>;
+}
+
+function spooledEvents(): SdlcEvent[] {
+  const spoolDir = path.join(tmpDir, '.harness', 'spool');
+  if (!fs.existsSync(spoolDir)) return [];
+  const events: SdlcEvent[] = [];
+  for (const entry of fs.readdirSync(spoolDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    for (const line of fs.readFileSync(path.join(spoolDir, entry), 'utf8').split('\n')) {
+      if (line.length > 0) events.push(JSON.parse(line) as SdlcEvent);
+    }
+  }
+  return events;
+}
+
+describe('harness waypoint record-provenance', () => {
+  it('is a no-op without a configured sink', async () => {
+    const file = path.join(tmpDir, 'provenance.json');
+    fs.writeFileSync(file, JSON.stringify({ slug: 's', stages: [] }), 'utf8');
+    await runCommand(['record-provenance', file]);
+    expect(lastJsonOutput()).toMatchObject({ recorded: false });
+    expect(fs.existsSync(path.join(tmpDir, '.harness'))).toBe(false);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it('spools one sdlc.build.finished.v1 for a provenance artifact', async () => {
+    configureSink();
+    const artifactDir = path.join(tmpDir, 'docs', 'changes', 'my-slug');
+    fs.mkdirSync(artifactDir, { recursive: true });
+    const file = path.join(artifactDir, 'provenance.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ slug: 'my-slug', issues: [1], stages: ['plan', 'execute'] }),
+      'utf8'
+    );
+    await runCommand(['record-provenance', file]);
+    expect(lastJsonOutput()).toMatchObject({ recorded: true });
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.build.finished.v1');
+    expect(event?.subject).toBe('item/my-slug');
+    expect(event?.data).toMatchObject({ artifact: 'provenance', stages: ['plan', 'execute'] });
+  });
+
+  it('derives the item from the directory name when slug is absent', async () => {
+    configureSink();
+    const artifactDir = path.join(tmpDir, 'docs', 'changes', 'dir-slug');
+    fs.mkdirSync(artifactDir, { recursive: true });
+    const file = path.join(artifactDir, 'provenance.json');
+    fs.writeFileSync(file, JSON.stringify({ stages: [] }), 'utf8');
+    await runCommand(['record-provenance', file]);
+    expect(spooledEvents()[0]?.subject).toBe('item/dir-slug');
+  });
+
+  it('fails with exit code 1 on an unreadable file', async () => {
+    configureSink();
+    await runCommand(['record-provenance', path.join(tmpDir, 'missing.json')]);
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe('harness waypoint record-handoff', () => {
+  it('spools review.requested for a done handoff record', async () => {
+    configureSink();
+    const file = path.join(tmpDir, 'handoff.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        status: 'done',
+        fleet: 'roadmap-fleet',
+        item: 'my-slug',
+        summary: 'shipped',
+        evidence: [{ kind: 'pr', ref: 'https://example.test/pr/9' }],
+        next_steps: [],
+      }),
+      'utf8'
+    );
+    await runCommand(['record-handoff', file]);
+    expect(lastJsonOutput()).toMatchObject({ recorded: true });
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.review.requested.v1');
+    expect(event?.data).toMatchObject({ artifact: 'handoff', status: 'done' });
+  });
+
+  it('rejects an invalid handoff record with exit code 1', async () => {
+    configureSink();
+    const file = path.join(tmpDir, 'handoff.json');
+    fs.writeFileSync(file, JSON.stringify({ status: 'parked' }), 'utf8');
+    await runCommand(['record-handoff', file]);
+    expect(process.exitCode).toBe(1);
+    expect(spooledEvents()).toEqual([]);
+  });
+});
+
+describe('harness waypoint status', () => {
+  it('reports an empty spool', async () => {
+    await runCommand(['status']);
+    expect(lastJsonOutput()).toMatchObject({ segments: 0, events: 0, droppedEvents: 0 });
+  });
+
+  it('reports segment, event, and drop counts', async () => {
+    configureSink();
+    const file = path.join(tmpDir, 'handoff.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        status: 'done',
+        fleet: 'roadmap-fleet',
+        item: 'x',
+        summary: 's',
+        evidence: [],
+        next_steps: [],
+      }),
+      'utf8'
+    );
+    await runCommand(['record-handoff', file]);
+    await runCommand(['status']);
+    const status = lastJsonOutput();
+    expect(status.segments).toBe(1);
+    expect(status.events).toBe(1);
+    expect(typeof status.oldestEventTime).toBe('string');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -390,6 +390,11 @@ export * from './solutions';
 export * from './strategy';
 
 /**
+ * Waypoint module.
+ */
+export * from './waypoint';
+
+/**
  * The current version of the Harness Engineering core library.
  *
  * @deprecated Read the CLI version from `@harness-engineering/cli/package.json`

--- a/packages/core/src/roadmap/assignee-lifecycle.ts
+++ b/packages/core/src/roadmap/assignee-lifecycle.ts
@@ -1,4 +1,5 @@
 import type { Roadmap, RoadmapFeature, FeatureStatus } from '@harness-engineering/types';
+import { emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange } from '../waypoint/events';
 
 /**
  * The assignee lifecycle authority.
@@ -15,11 +16,19 @@ import type { Roadmap, RoadmapFeature, FeatureStatus } from '@harness-engineerin
  * orchestrator tracker adapter can never drift apart again — the original bug
  * was born from two adapters disagreeing about how to treat machine ids.
  *
- * Pure functions, no IO. Transition helpers mutate the passed `roadmap` /
- * `feature` in place and append assignment-history records, matching the
- * existing `assignFeature` convention.
+ * Pure functions, no IO of their own. Transition helpers mutate the passed
+ * `roadmap` / `feature` in place and append assignment-history records,
+ * matching the existing `assignFeature` convention.
+ *
+ * Waypoint emission (opt-in, pnyon/pnyon#124): each committed transition also
+ * calls the corresponding `emitRoadmap*` helper. Those helpers are guaranteed
+ * no-ops — no I/O, no behavior change — unless a `waypoint.sink` is
+ * configured in `harness.config.json`, and they never throw, so the mutators
+ * stay deterministic for every non-adopter. A no-op call (first-claim-wins
+ * rejection, same-status `setStatus`) commits nothing and emits nothing.
  *
  * @see docs/changes/assignee-execution-lifecycle/proposal.md
+ * @see docs/changes/waypoint-sdlc-emission/proposal.md
  */
 
 /**
@@ -123,8 +132,13 @@ export function claim(
     return;
   }
 
+  const statusChanged = feature.status !== 'in-progress';
   feature.status = 'in-progress';
-  if (feature.assignee === assignee) return;
+  if (feature.assignee === assignee) {
+    // Idempotent re-claim by the same owner: only a status flip is a commit.
+    if (statusChanged) emitRoadmapClaim(feature.name, assignee);
+    return;
+  }
 
   if (feature.assignee !== null) {
     pushUnassigned(roadmap, feature, feature.assignee, date);
@@ -136,6 +150,7 @@ export function claim(
     action: 'assigned',
     date,
   });
+  emitRoadmapClaim(feature.name, assignee);
 }
 
 /**
@@ -147,14 +162,19 @@ export function claim(
  * Mutates `roadmap` / `feature` in place.
  */
 export function release(roadmap: Roadmap, feature: RoadmapFeature, date: string): void {
-  if (feature.status === 'in-progress') {
+  const wasInProgress = feature.status === 'in-progress';
+  if (wasInProgress) {
     feature.status = 'planned';
   }
-  if (feature.assignee === null) return;
+  if (feature.assignee === null) {
+    if (wasInProgress) emitRoadmapRelease(feature.name, null);
+    return;
+  }
 
   const prev = feature.assignee;
   feature.assignee = null;
   pushUnassigned(roadmap, feature, prev, date);
+  emitRoadmapRelease(feature.name, prev);
 }
 
 /**
@@ -172,10 +192,14 @@ export function setStatus(
   status: FeatureStatus,
   date: string
 ): void {
+  const previousStatus = feature.status;
   feature.status = status;
   if (status !== 'in-progress' && feature.assignee !== null) {
     const prev = feature.assignee;
     feature.assignee = null;
     pushUnassigned(roadmap, feature, prev, date);
+  }
+  if (previousStatus !== status) {
+    emitRoadmapStatusChange(feature.name, status, previousStatus);
   }
 }

--- a/packages/core/src/waypoint/config-loader.test.ts
+++ b/packages/core/src/waypoint/config-loader.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isErr, isOk } from '../shared/result';
+import { loadWaypointConfig } from './config-loader';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-config-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function write(config: unknown): void {
+  writeFileSync(join(dir, 'harness.config.json'), JSON.stringify(config), 'utf8');
+}
+
+describe('waypoint/config-loader', () => {
+  it('returns Ok({}) when harness.config.json is absent', () => {
+    const result = loadWaypointConfig(dir);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.value).toEqual({});
+  });
+
+  it('returns Ok({}) when the waypoint key is absent (non-adopter default)', () => {
+    write({ version: 1, name: 'p' });
+    const result = loadWaypointConfig(dir);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.value).toEqual({});
+  });
+
+  it('parses a valid waypoint.sink block', () => {
+    write({
+      waypoint: {
+        sink: {
+          transport: 'spool',
+          source: 'harness://outpost/u1/repo/p',
+          maxEventsPerSegment: 500,
+          onBehalfOf: 'user://chad',
+        },
+      },
+    });
+    const result = loadWaypointConfig(dir);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value.sink?.transport).toBe('spool');
+      expect(result.value.sink?.maxEventsPerSegment).toBe(500);
+    }
+  });
+
+  it('rejects an invalid waypoint block with named issues', () => {
+    write({ waypoint: { sink: { transport: 'carrier-pigeon' } } });
+    const result = loadWaypointConfig(dir);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) expect(result.error.message).toContain('waypoint.sink.transport');
+  });
+
+  it('rejects unparseable JSON with a clear error', () => {
+    writeFileSync(join(dir, 'harness.config.json'), '{nope', 'utf8');
+    const result = loadWaypointConfig(dir);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) expect(result.error.message).toContain('Failed to parse');
+  });
+});

--- a/packages/core/src/waypoint/config-loader.ts
+++ b/packages/core/src/waypoint/config-loader.ts
@@ -1,0 +1,47 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { WaypointConfigSchema, type WaypointConfig } from '@harness-engineering/types';
+import type { Result } from '../shared/result';
+import { Ok, Err } from '../shared/result';
+
+/**
+ * Result wrapper around the parsed `waypoint` section of
+ * `harness.config.json` (same pattern as `loadNotificationsConfig`).
+ *
+ * Returns Ok with `{}` (no sink → emission disabled) when the config file or
+ * the `waypoint` key is absent — the non-adopter invariance contract (PRD
+ * Story 1): a repo that never opted in never grows Waypoint behavior.
+ */
+export function loadWaypointConfig(projectRoot: string): Result<WaypointConfig, Error> {
+  const configPath = path.join(projectRoot, 'harness.config.json');
+  if (!fs.existsSync(configPath)) {
+    return Ok({});
+  }
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf-8');
+  } catch (err) {
+    return Err(err instanceof Error ? err : new Error(String(err)));
+  }
+  let parsed: { waypoint?: unknown };
+  try {
+    parsed = JSON.parse(raw) as { waypoint?: unknown };
+  } catch (err) {
+    return Err(
+      new Error(
+        `Failed to parse harness.config.json: ${err instanceof Error ? err.message : String(err)}`
+      )
+    );
+  }
+  if (parsed.waypoint === undefined) {
+    return Ok({});
+  }
+  const result = WaypointConfigSchema.safeParse(parsed.waypoint);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - waypoint.${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    return Err(new Error(`Invalid waypoint config:\n${issues}`));
+  }
+  return Ok(result.data);
+}

--- a/packages/core/src/waypoint/emitter.test.ts
+++ b/packages/core/src/waypoint/emitter.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import type { SdlcEvent } from '@harness-engineering/types';
+import {
+  configureWaypointEmitter,
+  emitSdlc,
+  ensureWaypointEmitter,
+  getWaypointEmitter,
+  initWaypointEmitter,
+  resetWaypointEmitterForTests,
+  WaypointEmitter,
+} from './emitter';
+import { FileSpool } from './spool';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-emitter-'));
+  resetWaypointEmitterForTests();
+});
+
+afterEach(() => {
+  resetWaypointEmitterForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeConfig(config: unknown): void {
+  writeFileSync(join(dir, 'harness.config.json'), JSON.stringify(config), 'utf8');
+}
+
+function spooledEvents(): SdlcEvent[] {
+  const spoolDir = join(dir, '.harness', 'spool');
+  if (!existsSync(spoolDir)) return [];
+  const events: SdlcEvent[] = [];
+  for (const entry of readdirSync(spoolDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    for (const line of readFileSync(join(spoolDir, entry), 'utf8').split('\n')) {
+      if (line.length > 0) events.push(JSON.parse(line) as SdlcEvent);
+    }
+  }
+  return events;
+}
+
+describe('waypoint/emitter — non-adopter invariance (PRD Story 1)', () => {
+  it('installs nothing without a waypoint config and emits nothing', () => {
+    expect(initWaypointEmitter(undefined, dir)).toBeNull();
+    expect(initWaypointEmitter({}, dir)).toBeNull();
+    expect(getWaypointEmitter()).toBeNull();
+    expect(emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/x' })).toBeNull();
+    // THE hard invariant: no sink => no new files anywhere under the repo.
+    expect(existsSync(join(dir, '.harness'))).toBe(false);
+  });
+
+  it('ensureWaypointEmitter is a memoized no-op without config', () => {
+    expect(ensureWaypointEmitter(dir)).toBeNull();
+    expect(ensureWaypointEmitter(dir)).toBeNull();
+    expect(existsSync(join(dir, '.harness'))).toBe(false);
+  });
+
+  it('ensureWaypointEmitter survives a malformed harness.config.json', () => {
+    writeFileSync(join(dir, 'harness.config.json'), '{not json', 'utf8');
+    expect(ensureWaypointEmitter(dir)).toBeNull();
+  });
+});
+
+describe('waypoint/emitter — configured sink', () => {
+  it('ensureWaypointEmitter installs from harness.config.json waypoint.sink', () => {
+    writeConfig({ waypoint: { sink: { transport: 'spool' } } });
+    const emitter = ensureWaypointEmitter(dir);
+    expect(emitter).toBeInstanceOf(WaypointEmitter);
+    // Second call returns the installed singleton.
+    expect(ensureWaypointEmitter(dir)).toBe(emitter);
+  });
+
+  it('emitSdlc spools exactly one valid enveloped event per call', () => {
+    initWaypointEmitter({ sink: { transport: 'spool', source: 'harness://repo/custom' } }, dir);
+    const id = emitSdlc({
+      type: 'sdlc.claim.opened.v1',
+      subject: 'item/example',
+      component: 'roadmap',
+      data: { assignee: 'chad' },
+    });
+    expect(id).not.toBeNull();
+    const events = spooledEvents();
+    expect(events).toHaveLength(1);
+    const event = events[0] as SdlcEvent;
+    expect(event.id).toBe(id);
+    expect(event.source).toBe('harness://repo/custom');
+    expect(event.type).toBe('sdlc.claim.opened.v1');
+    expect(event.actor.kind).toBe('agent');
+    expect(event.actor.id).toBe('agent://harness/roadmap');
+    expect((event.actor as { onBehalfOf?: string }).onBehalfOf).toBeDefined();
+    expect(event.data).toEqual({ assignee: 'chad' });
+  });
+
+  it('defaults source to harness://repo/<basename> and honors explicit actors', () => {
+    initWaypointEmitter({ sink: { transport: 'spool', onBehalfOf: 'user://someone' } }, dir);
+    emitSdlc({
+      type: 'sdlc.verify.graded.v1',
+      subject: 'item/x',
+      grade: 'V3',
+      actor: { kind: 'human', id: 'user://approver' },
+    });
+    const [event] = spooledEvents();
+    expect(event?.source).toBe(`harness://repo/${basename(dir)}`);
+    expect(event?.actor).toEqual({ kind: 'human', id: 'user://approver' });
+    expect(event?.grade).toBe('V3');
+  });
+
+  it('records failures without throwing and reports them on the emitter', () => {
+    const emitter = initWaypointEmitter({ sink: { transport: 'spool' } }, dir);
+    expect(emitter).not.toBeNull();
+    // An invalid subject fails validation inside the spool append.
+    const id = emitSdlc({ type: 'sdlc.claim.opened.v1', subject: '' });
+    expect(id).toBeNull();
+    expect(emitter?.emissionFailures).toHaveLength(1);
+    expect(emitter?.emissionFailures[0]?.type).toBe('sdlc.claim.opened.v1');
+  });
+
+  it('notifies onEvent listeners for spooled events and isolates listener errors', () => {
+    initWaypointEmitter({ sink: { transport: 'spool' } }, dir);
+    const seen: string[] = [];
+    const emitter = getWaypointEmitter() as WaypointEmitter;
+    emitter.onEvent(() => {
+      throw new Error('bad bridge');
+    });
+    const off = emitter.onEvent((event) => seen.push(event.type));
+    const id = emitSdlc({ type: 'sdlc.build.finished.v1', subject: 'phase/execute' });
+    expect(id).not.toBeNull();
+    expect(seen).toEqual(['sdlc.build.finished.v1']);
+    off();
+    emitSdlc({ type: 'sdlc.build.finished.v1', subject: 'phase/verify' });
+    expect(seen).toHaveLength(1);
+  });
+
+  it('respects maxEventsPerSegment from the sink config', () => {
+    initWaypointEmitter({ sink: { transport: 'spool', maxEventsPerSegment: 1 } }, dir);
+    emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/a' });
+    emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/b' });
+    expect(spooledEvents()).toHaveLength(1);
+    expect(getWaypointEmitter()?.spoolSegment.droppedEvents).toBe(1);
+  });
+
+  it('never propagates spool exceptions to the caller (second seatbelt)', () => {
+    const throwingSpool = new FileSpool({ spoolDir: join(dir, 's'), segmentId: 'X' });
+    throwingSpool.append = () => {
+      throw new Error('disk on fire');
+    };
+    const emitter = new WaypointEmitter({
+      source: 'harness://repo/test',
+      onBehalfOf: 'user://x',
+      spool: throwingSpool,
+    });
+    configureWaypointEmitter(emitter);
+    expect(() => emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/x' })).not.toThrow();
+    expect(emitter.emissionFailures).toHaveLength(1);
+  });
+});

--- a/packages/core/src/waypoint/emitter.ts
+++ b/packages/core/src/waypoint/emitter.ts
@@ -1,0 +1,289 @@
+/**
+ * Waypoint emitter — the opt-in seam between harness operations and the
+ * repo-local `sdlc.*` spool (pnyon/pnyon#124; pnyon ADR-0047).
+ *
+ * THE HARD INVARIANT (PRD Story 1 — non-adopter invariance): when
+ * `harness.config.json` carries no `waypoint.sink`, `initWaypointEmitter`
+ * installs nothing and every `emitSdlc*` helper is a guaranteed no-op — no
+ * new files, no new I/O, no behavior change for any existing operation.
+ * Emission failures while a sink IS configured are recorded on the emitter
+ * and never propagate to the calling operation.
+ *
+ * The emitter is a module-level installable singleton: process entry points
+ * that already load `harness.config.json` (CLI, orchestrator) call
+ * `initWaypointEmitter(config.waypoint, projectRoot)` once; sanctioned
+ * mutators and other emission points call the exported `emitSdlc` helper,
+ * which routes through the active emitter or does nothing.
+ */
+
+import { userInfo } from 'node:os';
+import { basename, join } from 'node:path';
+import type {
+  SdlcActor,
+  SdlcAppendResult,
+  SdlcEvent,
+  SdlcEventTypeV1,
+  SdlcVerificationGrade,
+  WaypointConfig,
+} from '@harness-engineering/types';
+import { SDLC_SPECVERSION } from '@harness-engineering/types';
+import { isOk } from '../shared/result';
+import { loadWaypointConfig } from './config-loader';
+import { FileSpool } from './spool';
+import { createUlidFactory } from './ulid';
+
+/** Everything an emission point supplies; the emitter stamps the envelope. */
+export interface EmitSdlcOptions {
+  /** Pinned vocabulary member, e.g. `sdlc.claim.opened.v1`. */
+  readonly type: SdlcEventTypeV1;
+  /** Stable subject id, e.g. `item/<feature name>`. */
+  readonly subject: string;
+  /** Event-type-specific payload. */
+  readonly data?: Readonly<Record<string, unknown>>;
+  /** Verification grade for grade-asserting events. */
+  readonly grade?: SdlcVerificationGrade;
+  /** ULIDs of causing events (causal links). */
+  readonly causes?: readonly string[];
+  /** Explicit actor; defaults to this emitter's agent actor. */
+  readonly actor?: SdlcActor;
+  /**
+   * Emitting harness component, e.g. `roadmap`, `skills`, `fleet`; becomes
+   * the default agent actor id `agent://harness/<component>`.
+   */
+  readonly component?: string;
+}
+
+/** One recorded emission failure (observable, never thrown). */
+export interface EmissionFailure {
+  readonly type: string;
+  readonly subject: string;
+  readonly issues: readonly { readonly field: string; readonly message: string }[];
+}
+
+/** Injectable ports for deterministic tests. */
+export interface WaypointEmitterPorts {
+  /** ISO timestamp factory. Default: `() => new Date().toISOString()`. */
+  readonly nowIso?: () => string;
+  /** ULID mint. Default: a per-process monotonic factory. */
+  readonly ulid?: () => string;
+}
+
+/** Construction options resolved from `WaypointSinkConfig`. */
+export interface WaypointEmitterOptions {
+  /** Emitting scope URI stamped on every event's `source`. */
+  readonly source: string;
+  /** Accountable human principal for agent-authored events. */
+  readonly onBehalfOf: string;
+  /** The spool this emitter appends to. */
+  readonly spool: FileSpool;
+  readonly ports?: WaypointEmitterPorts;
+}
+
+/**
+ * Appends one spooled `sdlc.*` event per emission point call. Spool-first:
+ * the append lands locally before any (out-of-scope) shipping would be
+ * attempted, so harness operations never block on a sink.
+ */
+export class WaypointEmitter {
+  private readonly source: string;
+  private readonly onBehalfOf: string;
+  private readonly spool: FileSpool;
+  private readonly nowIso: () => string;
+  private readonly ulid: () => string;
+  private readonly listeners = new Set<(event: SdlcEvent) => void>();
+  private readonly failures: EmissionFailure[] = [];
+
+  constructor(options: WaypointEmitterOptions) {
+    this.source = options.source;
+    this.onBehalfOf = options.onBehalfOf;
+    this.spool = options.spool;
+    this.nowIso = options.ports?.nowIso ?? ((): string => new Date().toISOString());
+    this.ulid = options.ports?.ulid ?? createUlidFactory();
+  }
+
+  /** Stamps the full v1 envelope for one emission-point call. */
+  private buildEnvelope(id: string, options: EmitSdlcOptions): SdlcEvent {
+    const actor: SdlcActor = options.actor ?? {
+      kind: 'agent',
+      id: `agent://harness/${options.component ?? 'core'}`,
+      onBehalfOf: this.onBehalfOf,
+    };
+    return {
+      specversion: SDLC_SPECVERSION,
+      id,
+      source: this.source,
+      type: options.type,
+      time: this.nowIso(),
+      subject: options.subject,
+      ...(options.data !== undefined ? { datacontenttype: 'application/json' as const } : {}),
+      actor,
+      ...(options.grade !== undefined ? { grade: options.grade } : {}),
+      ...(options.causes !== undefined && options.causes.length > 0
+        ? { causes: options.causes }
+        : {}),
+      ...(options.data !== undefined ? { data: options.data } : {}),
+    };
+  }
+
+  /**
+   * Appends via the spool's never-throw contract, with a second seatbelt so
+   * no emission path can ever fail the caller's operation.
+   */
+  private safeAppend(candidate: SdlcEvent): SdlcAppendResult {
+    try {
+      return this.spool.append(candidate);
+    } catch (error) {
+      return {
+        ok: false,
+        issues: [
+          { field: 'spool', message: error instanceof Error ? error.message : String(error) },
+        ],
+      };
+    }
+  }
+
+  /**
+   * Builds the envelope, appends it to the spool, and notifies listeners.
+   * Never throws; a failed append is recorded and reported in the result.
+   * Returns the event ULID on success (for causal chaining), null otherwise.
+   */
+  emit(options: EmitSdlcOptions): string | null {
+    const candidate = this.buildEnvelope(this.ulid(), options);
+    const result = this.safeAppend(candidate);
+    if (!result.ok) {
+      this.failures.push({ type: options.type, subject: options.subject, issues: result.issues });
+      return null;
+    }
+    for (const listener of this.listeners) {
+      try {
+        listener(candidate);
+      } catch {
+        // A misbehaving bridge (e.g. gateway bus fan-out) must not fail the
+        // originating operation either.
+      }
+    }
+    return candidate.id;
+  }
+
+  /**
+   * Registers a bridge that observes every successfully spooled event —
+   * how the orchestrator fans `sdlc.*` events onto its gateway webhook bus
+   * without core depending on the orchestrator. Returns an unsubscribe.
+   */
+  onEvent(listener: (event: SdlcEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Recorded emission failures (PRD Story 1: observable, never thrown). */
+  get emissionFailures(): readonly EmissionFailure[] {
+    return this.failures;
+  }
+
+  /** The spool this emitter appends to (spool-health observability). */
+  get spoolSegment(): FileSpool {
+    return this.spool;
+  }
+}
+
+let activeEmitter: WaypointEmitter | null = null;
+
+/**
+ * Installs (or clears, with null) the process-wide emitter. Exposed for
+ * entry points and tests; most callers use {@link initWaypointEmitter}.
+ */
+export function configureWaypointEmitter(emitter: WaypointEmitter | null): void {
+  activeEmitter = emitter;
+}
+
+/** The active emitter, or null when no Waypoint sink is configured. */
+export function getWaypointEmitter(): WaypointEmitter | null {
+  return activeEmitter;
+}
+
+function defaultOnBehalfOf(): string {
+  try {
+    return `user://${userInfo().username}`;
+  } catch {
+    return 'user://unknown';
+  }
+}
+
+/**
+ * Resolves the `waypoint` block of `harness.config.json` into an installed
+ * emitter. ABSENT CONFIG = ABSENT FEATURE: without `waypoint.sink` this
+ * installs nothing, returns null, touches no file, and creates no directory.
+ */
+export function initWaypointEmitter(
+  config: WaypointConfig | undefined,
+  projectRoot: string,
+  ports?: WaypointEmitterPorts
+): WaypointEmitter | null {
+  const sink = config?.sink;
+  if (sink === undefined || sink.transport !== 'spool') {
+    configureWaypointEmitter(null);
+    return null;
+  }
+  const segmentId = (ports?.ulid ?? createUlidFactory())();
+  const spool = new FileSpool({
+    spoolDir: join(projectRoot, '.harness', 'spool'),
+    segmentId,
+    ...(sink.maxEventsPerSegment !== undefined ? { maxEvents: sink.maxEventsPerSegment } : {}),
+  });
+  const emitter = new WaypointEmitter({
+    source: sink.source ?? `harness://repo/${basename(projectRoot)}`,
+    onBehalfOf: sink.onBehalfOf ?? defaultOnBehalfOf(),
+    spool,
+    ...(ports !== undefined ? { ports } : {}),
+  });
+  configureWaypointEmitter(emitter);
+  return emitter;
+}
+
+/**
+ * The one call every emission point makes: emits through the active emitter,
+ * or does nothing at all when none is installed. Never throws. Returns the
+ * event ULID when an event was spooled, null otherwise.
+ */
+export function emitSdlc(options: EmitSdlcOptions): string | null {
+  const emitter = activeEmitter;
+  if (emitter === null) {
+    return null;
+  }
+  return emitter.emit(options);
+}
+
+/** Project roots for which lazy init already ran (memoized per process). */
+const ensuredRoots = new Set<string>();
+
+/**
+ * Lazy, memoized emitter init for handler-shaped call sites (MCP tools, CLI
+ * commands) that know the project root but run without an entry-point hook.
+ * Reads the `waypoint` key of `harness.config.json` at most once per root
+ * per process; absent or invalid config installs nothing. Never throws
+ * (PRD Story 1: a malformed config records nothing and fails nothing).
+ */
+export function ensureWaypointEmitter(projectRoot: string): WaypointEmitter | null {
+  if (activeEmitter !== null) {
+    return activeEmitter;
+  }
+  if (ensuredRoots.has(projectRoot)) {
+    return null;
+  }
+  ensuredRoots.add(projectRoot);
+  try {
+    const loaded = loadWaypointConfig(projectRoot);
+    if (!isOk(loaded)) {
+      return null;
+    }
+    return initWaypointEmitter(loaded.value, projectRoot);
+  } catch {
+    return null;
+  }
+}
+
+/** Test-only: clears the installed emitter and the lazy-init memo. */
+export function resetWaypointEmitterForTests(): void {
+  activeEmitter = null;
+  ensuredRoots.clear();
+}

--- a/packages/core/src/waypoint/events.test.ts
+++ b/packages/core/src/waypoint/events.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FleetHandoffRecord, SdlcEvent } from '@harness-engineering/types';
+import { initWaypointEmitter, resetWaypointEmitterForTests } from './emitter';
+import {
+  emitFleetHandoffWritten,
+  emitFleetProvenanceWritten,
+  emitRoadmapClaim,
+  emitRoadmapRelease,
+  emitRoadmapStatusChange,
+  emitSkillPhaseTransition,
+  emitVerdictPersisted,
+  verdictGrade,
+} from './events';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-events-'));
+  resetWaypointEmitterForTests();
+  initWaypointEmitter({ sink: { transport: 'spool', onBehalfOf: 'user://tester' } }, dir);
+});
+
+afterEach(() => {
+  resetWaypointEmitterForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function spooledEvents(): SdlcEvent[] {
+  const spoolDir = join(dir, '.harness', 'spool');
+  if (!existsSync(spoolDir)) return [];
+  const events: SdlcEvent[] = [];
+  for (const entry of readdirSync(spoolDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    for (const line of readFileSync(join(spoolDir, entry), 'utf8').split('\n')) {
+      if (line.length > 0) events.push(JSON.parse(line) as SdlcEvent);
+    }
+  }
+  return events;
+}
+
+describe('waypoint/events — roadmap mutator mapping', () => {
+  it('setStatus maps to intent.updated (and intent.closed for done)', () => {
+    emitRoadmapStatusChange('My Feature', 'planned', 'backlog');
+    emitRoadmapStatusChange('My Feature', 'done', 'in-progress');
+    const [updated, closed] = spooledEvents();
+    expect(updated?.type).toBe('sdlc.intent.updated.v1');
+    expect(updated?.subject).toBe('item/My Feature');
+    expect(updated?.data).toEqual({
+      mutator: 'setStatus',
+      status: 'planned',
+      previousStatus: 'backlog',
+    });
+    expect(closed?.type).toBe('sdlc.intent.closed.v1');
+  });
+
+  it('claim maps to claim.opened with the assignee', () => {
+    emitRoadmapClaim('My Feature', 'orchestrator-abcd1234');
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.claim.opened.v1');
+    expect(event?.data).toEqual({ mutator: 'claim', assignee: 'orchestrator-abcd1234' });
+  });
+
+  it('release maps to claim.released, omitting a null previous assignee', () => {
+    emitRoadmapRelease('My Feature', 'chad');
+    emitRoadmapRelease('My Feature', null);
+    const [withPrev, withoutPrev] = spooledEvents();
+    expect(withPrev?.type).toBe('sdlc.claim.released.v1');
+    expect(withPrev?.data).toEqual({ mutator: 'release', previousAssignee: 'chad' });
+    expect(withoutPrev?.data).toEqual({ mutator: 'release' });
+  });
+});
+
+describe('waypoint/events — skill phase transitions', () => {
+  it('preserves the qualityGate payload on build.finished', () => {
+    emitSkillPhaseTransition({
+      completedPhase: 'execution',
+      suggestedNext: 'verification',
+      reason: 'all tasks complete',
+      artifacts: ['src/a.ts'],
+      qualityGate: { checks: [{ name: 'tests', passed: true }], allPassed: true },
+    });
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.build.finished.v1');
+    expect(event?.subject).toBe('phase/execution');
+    expect(event?.data).toEqual({
+      completedPhase: 'execution',
+      suggestedNext: 'verification',
+      reason: 'all tasks complete',
+      artifacts: ['src/a.ts'],
+      qualityGate: { checks: [{ name: 'tests', passed: true }], allPassed: true },
+    });
+  });
+});
+
+describe('waypoint/events — verdict grading', () => {
+  it('maps passing verdicts to their asserted grades', () => {
+    expect(verdictGrade('acceptance', 'MEASURABLE')).toBe('V1');
+    expect(verdictGrade('outcome', 'SATISFIED')).toBe('V2');
+    expect(verdictGrade('uat', 'ACCEPTED')).toBe('V3');
+  });
+
+  it('maps every non-passing verdict to V0', () => {
+    expect(verdictGrade('acceptance', 'NOT_MEASURABLE')).toBe('V0');
+    expect(verdictGrade('outcome', 'INCONCLUSIVE')).toBe('V0');
+    expect(verdictGrade('uat', 'REJECTED')).toBe('V0');
+  });
+
+  it('emits verify.graded carrying the persisted verdict verbatim', () => {
+    emitVerdictPersisted({
+      kind: 'outcome',
+      verdict: 'SATISFIED',
+      confidence: 'high',
+      item: 'my-change',
+      detail: { specPath: 'docs/changes/my-change/proposal.md' },
+    });
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.verify.graded.v1');
+    expect(event?.grade).toBe('V2');
+    expect(event?.subject).toBe('item/my-change');
+    expect(event?.data).toMatchObject({
+      kind: 'outcome',
+      verdict: 'SATISFIED',
+      confidence: 'high',
+    });
+  });
+
+  it('carries an explicit human actor for UAT sign-offs', () => {
+    emitVerdictPersisted({
+      kind: 'uat',
+      verdict: 'ACCEPTED',
+      item: 'my-change',
+      actor: { kind: 'human', id: 'user://chad' },
+    });
+    const [event] = spooledEvents();
+    expect(event?.actor).toEqual({ kind: 'human', id: 'user://chad' });
+    expect(event?.grade).toBe('V3');
+  });
+});
+
+describe('waypoint/events — fleet artifacts', () => {
+  it('provenance write maps to build.finished with stages and path', () => {
+    emitFleetProvenanceWritten({
+      item: 'my-slug',
+      stages: ['brainstorm', 'plan', 'execute'],
+      artifactPath: 'docs/changes/my-slug/provenance.json',
+    });
+    const [event] = spooledEvents();
+    expect(event?.type).toBe('sdlc.build.finished.v1');
+    expect(event?.data).toEqual({
+      artifact: 'provenance',
+      artifactPath: 'docs/changes/my-slug/provenance.json',
+      stages: ['brainstorm', 'plan', 'execute'],
+    });
+  });
+
+  it('done handoff maps to review.requested; non-done to intent.updated', () => {
+    const done: FleetHandoffRecord = {
+      status: 'done',
+      fleet: 'roadmap-fleet',
+      item: 'my-slug',
+      summary: 'shipped',
+      evidence: [{ kind: 'pr', ref: 'https://example.test/pr/1' }],
+      next_steps: [],
+    };
+    emitFleetHandoffWritten(done);
+    emitFleetHandoffWritten({
+      ...done,
+      status: 'parked',
+      blocker: 'unforeseen fork',
+    });
+    const [reviewRequested, parked] = spooledEvents();
+    expect(reviewRequested?.type).toBe('sdlc.review.requested.v1');
+    expect(reviewRequested?.data).toMatchObject({
+      artifact: 'handoff',
+      status: 'done',
+      fleet: 'roadmap-fleet',
+      evidence: [{ kind: 'pr', ref: 'https://example.test/pr/1' }],
+    });
+    expect(parked?.type).toBe('sdlc.intent.updated.v1');
+    expect(parked?.data).toMatchObject({ status: 'parked', blocker: 'unforeseen fork' });
+  });
+});

--- a/packages/core/src/waypoint/events.ts
+++ b/packages/core/src/waypoint/events.ts
@@ -1,0 +1,217 @@
+/**
+ * Emission-point mapping helpers — one tiny function per sanctioned harness
+ * emission family, each translating an already-committed harness fact into
+ * one pinned `sdlc.*.v1` event and routing it through {@link emitSdlc}.
+ *
+ * Every helper is a guaranteed no-op when no Waypoint sink is configured
+ * (PRD Story 1), never throws, and emits at most one event per committed
+ * fact. This is emission, not new judgment: helpers carry existing payloads
+ * (statuses, verdicts, quality gates, fleet records) and never compute new
+ * ones.
+ *
+ * Vocabulary mapping (documented in the change proposal):
+ * - roadmap `setStatus` → `sdlc.intent.updated.v1` (`sdlc.intent.closed.v1`
+ *   when the new status is `done`)
+ * - roadmap `claim` → `sdlc.claim.opened.v1`
+ * - roadmap `release` → `sdlc.claim.released.v1`
+ * - skill phase transition (`emit_interaction`) → `sdlc.build.finished.v1`
+ *   (the completed phase is the finished run; `qualityGate` rides in `data`)
+ * - outcome/acceptance/UAT verdict persistence → `sdlc.verify.graded.v1`
+ * - fleet `provenance.json` write → `sdlc.build.finished.v1`
+ * - fleet handoff record: `done` → `sdlc.review.requested.v1` (the item now
+ *   awaits the human PR gate); otherwise → `sdlc.intent.updated.v1`
+ */
+
+import type {
+  FeatureStatus,
+  FleetHandoffRecord,
+  SdlcActor,
+  SdlcVerificationGrade,
+} from '@harness-engineering/types';
+import { emitSdlc } from './emitter';
+
+/** Stable subject for a roadmap feature. */
+function itemSubject(featureName: string): string {
+  return `item/${featureName}`;
+}
+
+/**
+ * A committed `setStatus` mutation. `done` closes the intent; every other
+ * status is an intent update.
+ */
+export function emitRoadmapStatusChange(
+  featureName: string,
+  status: FeatureStatus,
+  previousStatus: FeatureStatus
+): string | null {
+  return emitSdlc({
+    type: status === 'done' ? 'sdlc.intent.closed.v1' : 'sdlc.intent.updated.v1',
+    subject: itemSubject(featureName),
+    component: 'roadmap',
+    data: { mutator: 'setStatus', status, previousStatus },
+  });
+}
+
+/** A committed `claim` mutation (execution start; first claim wins). */
+export function emitRoadmapClaim(featureName: string, assignee: string): string | null {
+  return emitSdlc({
+    type: 'sdlc.claim.opened.v1',
+    subject: itemSubject(featureName),
+    component: 'roadmap',
+    data: { mutator: 'claim', assignee },
+  });
+}
+
+/** A committed `release` mutation (claim released without completion). */
+export function emitRoadmapRelease(
+  featureName: string,
+  previousAssignee: string | null
+): string | null {
+  return emitSdlc({
+    type: 'sdlc.claim.released.v1',
+    subject: itemSubject(featureName),
+    component: 'roadmap',
+    data: { mutator: 'release', ...(previousAssignee !== null ? { previousAssignee } : {}) },
+  });
+}
+
+/** The `qualityGate` payload shape carried by `emit_interaction` transitions. */
+export interface SkillTransitionQualityGate {
+  readonly checks: readonly {
+    readonly name: string;
+    readonly passed: boolean;
+    readonly detail?: string | undefined;
+  }[];
+  readonly allPassed: boolean;
+}
+
+/** One skill phase transition surfaced through the `emit_interaction` path. */
+export interface SkillPhaseTransition {
+  readonly completedPhase: string;
+  readonly suggestedNext: string;
+  readonly reason: string;
+  readonly artifacts: readonly string[];
+  readonly qualityGate?: SkillTransitionQualityGate;
+}
+
+/**
+ * A skill phase transition: the completed phase is a finished execution run;
+ * the transition's `qualityGate` fields are preserved verbatim in `data`.
+ */
+export function emitSkillPhaseTransition(transition: SkillPhaseTransition): string | null {
+  return emitSdlc({
+    type: 'sdlc.build.finished.v1',
+    subject: `phase/${transition.completedPhase}`,
+    component: 'skills',
+    data: {
+      completedPhase: transition.completedPhase,
+      suggestedNext: transition.suggestedNext,
+      reason: transition.reason,
+      artifacts: transition.artifacts,
+      ...(transition.qualityGate !== undefined ? { qualityGate: transition.qualityGate } : {}),
+    },
+  });
+}
+
+/** Which existing judgment artifact a verdict event surfaces. */
+export type VerdictKind = 'outcome' | 'acceptance' | 'uat';
+
+/** A persisted eval/UAT verdict (existing judgment — never recomputed here). */
+export interface PersistedVerdict {
+  readonly kind: VerdictKind;
+  /** The verdict string exactly as persisted (e.g. `SATISFIED`, `MEASURABLE`, `ACCEPTED`). */
+  readonly verdict: string;
+  /** Verdict confidence when the source artifact carries one. */
+  readonly confidence?: string;
+  /** The work item the verdict grades (feature name, spec slug, PR ref). */
+  readonly item: string;
+  /** Extra source-artifact fields worth carrying (rationale refs, spec path). */
+  readonly detail?: Readonly<Record<string, unknown>>;
+  /**
+   * Explicit actor — a UAT sign-off is a HUMAN verdict and carries the human
+   * principal; eval verdicts default to the emitter's agent actor.
+   */
+  readonly actor?: SdlcActor;
+}
+
+const PASSING_VERDICTS: Readonly<
+  Record<VerdictKind, { pass: string; grade: SdlcVerificationGrade }>
+> = {
+  acceptance: { pass: 'MEASURABLE', grade: 'V1' },
+  outcome: { pass: 'SATISFIED', grade: 'V2' },
+  uat: { pass: 'ACCEPTED', grade: 'V3' },
+};
+
+/**
+ * Verification-grade mapping (an explicit, documented projection of existing
+ * verdicts — not new judgment): a passing acceptance verdict asserts V1, a
+ * passing outcome verdict V2, a UAT approval V3; anything else asserts V0.
+ */
+export function verdictGrade(kind: VerdictKind, verdict: string): SdlcVerificationGrade {
+  return PASSING_VERDICTS[kind].pass === verdict ? PASSING_VERDICTS[kind].grade : 'V0';
+}
+
+/** A persisted OutcomeVerdict / AcceptanceVerdict / UAT sign-off. */
+export function emitVerdictPersisted(persisted: PersistedVerdict): string | null {
+  return emitSdlc({
+    type: 'sdlc.verify.graded.v1',
+    subject: itemSubject(persisted.item),
+    component: 'eval',
+    grade: verdictGrade(persisted.kind, persisted.verdict),
+    ...(persisted.actor !== undefined ? { actor: persisted.actor } : {}),
+    data: {
+      kind: persisted.kind,
+      verdict: persisted.verdict,
+      ...(persisted.confidence !== undefined ? { confidence: persisted.confidence } : {}),
+      ...(persisted.detail !== undefined ? { detail: persisted.detail } : {}),
+    },
+  });
+}
+
+/** A written per-item fleet `provenance.json` artifact. */
+export interface FleetProvenanceArtifact {
+  /** The item the provenance belongs to (slug / issue ref). */
+  readonly item: string;
+  /** Pipeline stages the artifact records. */
+  readonly stages: readonly string[];
+  /** Repo-relative path of the written artifact. */
+  readonly artifactPath: string;
+}
+
+/** A fleet pipeline wrote a `provenance.json` for an item. */
+export function emitFleetProvenanceWritten(artifact: FleetProvenanceArtifact): string | null {
+  return emitSdlc({
+    type: 'sdlc.build.finished.v1',
+    subject: itemSubject(artifact.item),
+    component: 'fleet',
+    data: {
+      artifact: 'provenance',
+      artifactPath: artifact.artifactPath,
+      stages: artifact.stages,
+    },
+  });
+}
+
+/**
+ * A fleet worker's handoff record was written. A `done` handoff means the
+ * item now awaits the human PR gate (`sdlc.review.requested.v1`); every
+ * other disposition is an intent update carrying the blocker. The full
+ * record rides in `data` so an ingest can reconstruct the handoff without
+ * reading the repo (PRD Story 4).
+ */
+export function emitFleetHandoffWritten(record: FleetHandoffRecord): string | null {
+  return emitSdlc({
+    type: record.status === 'done' ? 'sdlc.review.requested.v1' : 'sdlc.intent.updated.v1',
+    subject: itemSubject(record.item),
+    component: 'fleet',
+    data: {
+      artifact: 'handoff',
+      status: record.status,
+      fleet: record.fleet,
+      summary: record.summary,
+      evidence: record.evidence,
+      next_steps: record.next_steps,
+      ...(record.blocker !== undefined ? { blocker: record.blocker } : {}),
+    },
+  });
+}

--- a/packages/core/src/waypoint/index.ts
+++ b/packages/core/src/waypoint/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Waypoint `sdlc.*` emission layer — opt-in via the `waypoint.sink` key in
+ * `harness.config.json`; a guaranteed no-op (no files, no I/O, no behavior
+ * change) when that key is absent. See pnyon/pnyon#124 and the change
+ * proposal at `docs/changes/waypoint-sdlc-emission/proposal.md`.
+ */
+
+export { createUlidFactory, isUlid, ULID_LENGTH, type UlidFactoryOptions } from './ulid';
+export { validateSdlcEvent } from './validate';
+export { bestEffortScrub, REDACTED, type ScrubOutcome } from './scrub';
+export {
+  DEFAULT_MAX_EVENTS,
+  FileSpool,
+  mergeSegments,
+  readSpoolSegments,
+  type FileSpoolOptions,
+} from './spool';
+export { loadWaypointConfig } from './config-loader';
+export {
+  configureWaypointEmitter,
+  emitSdlc,
+  ensureWaypointEmitter,
+  getWaypointEmitter,
+  initWaypointEmitter,
+  resetWaypointEmitterForTests,
+  WaypointEmitter,
+  type EmissionFailure,
+  type EmitSdlcOptions,
+  type WaypointEmitterOptions,
+  type WaypointEmitterPorts,
+} from './emitter';
+export {
+  emitFleetHandoffWritten,
+  emitFleetProvenanceWritten,
+  emitRoadmapClaim,
+  emitRoadmapRelease,
+  emitRoadmapStatusChange,
+  emitSkillPhaseTransition,
+  emitVerdictPersisted,
+  verdictGrade,
+  type FleetProvenanceArtifact,
+  type PersistedVerdict,
+  type SkillPhaseTransition,
+  type SkillTransitionQualityGate,
+  type VerdictKind,
+} from './events';

--- a/packages/core/src/waypoint/scrub.test.ts
+++ b/packages/core/src/waypoint/scrub.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { SdlcEvent } from '@harness-engineering/types';
+import { bestEffortScrub, REDACTED } from './scrub';
+
+function eventWith(data?: Readonly<Record<string, unknown>>): SdlcEvent {
+  return {
+    specversion: '1.0',
+    id: '01J9F3ZK7QW5X8M2N4P6R8T0AB',
+    source: 'harness://repo/test',
+    type: 'sdlc.build.finished.v1',
+    time: '2026-09-04T18:21:07.000Z',
+    subject: 'item/example',
+    actor: { kind: 'human', id: 'user://chad' },
+    ...(data !== undefined ? { data } : {}),
+  };
+}
+
+describe('waypoint/scrub', () => {
+  it('passes through events without data untouched', () => {
+    const event = eventWith();
+    const outcome = bestEffortScrub(event);
+    expect(outcome.event).toBe(event);
+    expect(outcome.redactions).toBe(0);
+  });
+
+  it('passes through clean data untouched (same reference)', () => {
+    const event = eventWith({ note: 'all clear' });
+    const outcome = bestEffortScrub(event);
+    expect(outcome.event).toBe(event);
+    expect(outcome.redactions).toBe(0);
+  });
+
+  it('redacts secret-shaped strings anywhere in data', () => {
+    const event = eventWith({
+      aws: 'key AKIAABCDEFGHIJKLMNOP trailing',
+      nested: { gh: 'ghp_' + 'a'.repeat(24) },
+      list: ['Bearer abcdefghijklmnopqrstuv'],
+      kv: 'password=hunter2hunter2',
+    });
+    const outcome = bestEffortScrub(event);
+    expect(outcome.redactions).toBe(4);
+    const data = outcome.event.data as Record<string, unknown>;
+    expect(data.aws).toContain(REDACTED);
+    expect((data.nested as Record<string, unknown>).gh).toBe(REDACTED);
+    expect((data.list as string[])[0]).toBe(REDACTED);
+    expect(data.kv).toBe(REDACTED);
+  });
+
+  it('does not mutate the original event', () => {
+    const original = eventWith({ token: 'api_key: sk-' + 'x'.repeat(24) });
+    const outcome = bestEffortScrub(original);
+    expect(outcome.redactions).toBeGreaterThan(0);
+    expect((original.data as Record<string, unknown>).token).toContain('sk-');
+  });
+
+  it('preserves non-string values', () => {
+    const event = eventWith({ count: 3, flag: true, nothing: null });
+    const outcome = bestEffortScrub(event);
+    expect(outcome.event.data).toEqual({ count: 3, flag: true, nothing: null });
+  });
+});

--- a/packages/core/src/waypoint/scrub.ts
+++ b/packages/core/src/waypoint/scrub.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-side best-effort scrub — pure logic, no I/O.
+ *
+ * Runs before an event is spooled so the repo-local copy is already mostly
+ * clean. This pass is ADVISORY: the authoritative, fail-closed scrub happens
+ * at the (out-of-scope) ingest side, and an event failing it is never
+ * persisted to a hosted ledger.
+ *
+ * Only string values inside `data` are scrubbed. Envelope attributes are
+ * schema-shaped (ids, URIs, timestamps) and are not rewritten client-side —
+ * quasi-identifying principals like `actor.onBehalfOf` are required by the
+ * schema and handled by ingest policy, not redaction.
+ */
+
+import type { SdlcEvent } from '@harness-engineering/types';
+
+/** Replacement marker for every redacted secret-shaped substring. */
+export const REDACTED = '[REDACTED]';
+
+/** Common secret shapes (best-effort; not a scanner, a seatbelt). */
+const SECRET_PATTERNS: readonly RegExp[] = [
+  /AKIA[0-9A-Z]{16}/g, // AWS access key id
+  /gh[pousr]_[A-Za-z0-9]{20,}/g, // GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+  /sk-[A-Za-z0-9_-]{20,}/g, // generic sk- API keys
+  /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}/g, // JWTs
+  /[Bb]earer\s+[A-Za-z0-9._~+/=-]{16,}/g, // bearer tokens
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, // PEM
+  /\b(password|passwd|secret|token|api[_-]?key)\s*[=:]\s*\S+/gi, // k=v pairs
+];
+
+interface ScrubState {
+  redactions: number;
+}
+
+function scrubString(value: string, state: ScrubState): string {
+  let out = value;
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, () => {
+      state.redactions += 1;
+      return REDACTED;
+    });
+  }
+  return out;
+}
+
+function scrubValue(value: unknown, state: ScrubState): unknown {
+  if (typeof value === 'string') {
+    return scrubString(value, state);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubValue(entry, state));
+  }
+  if (typeof value === 'object' && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = scrubValue(entry, state);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Result of a best-effort scrub: the (possibly copied) event + count. */
+export interface ScrubOutcome {
+  readonly event: SdlcEvent;
+  /** Number of secret-shaped substrings redacted from `data`. */
+  readonly redactions: number;
+}
+
+/** Returns a copy of `event` with secret-shaped `data` strings redacted. */
+export function bestEffortScrub(event: SdlcEvent): ScrubOutcome {
+  if (event.data === undefined) {
+    return { event, redactions: 0 };
+  }
+  const state: ScrubState = { redactions: 0 };
+  const data = scrubValue(event.data, state) as Readonly<Record<string, unknown>>;
+  if (state.redactions === 0) {
+    return { event, redactions: 0 };
+  }
+  return { event: { ...event, data }, redactions: state.redactions };
+}

--- a/packages/core/src/waypoint/spool.test.ts
+++ b/packages/core/src/waypoint/spool.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { SdlcEvent } from '@harness-engineering/types';
+import { FileSpool, mergeSegments, readSpoolSegments } from './spool';
+import { createUlidFactory } from './ulid';
+
+const mint = createUlidFactory();
+
+function event(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    specversion: '1.0',
+    id: mint(),
+    source: 'harness://repo/test',
+    type: 'sdlc.claim.opened.v1',
+    time: new Date().toISOString(),
+    subject: 'item/example',
+    actor: { kind: 'human', id: 'user://chad' },
+    ...overrides,
+  };
+}
+
+describe('waypoint/spool FileSpool', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-spool-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('appends one JSONL line per event to sdlc-<id>.jsonl', () => {
+    const spool = new FileSpool({ spoolDir: join(dir, 'spool'), segmentId: 'SEG1' });
+    expect(spool.append(event()).ok).toBe(true);
+    expect(spool.append(event()).ok).toBe(true);
+    const raw = readFileSync(join(dir, 'spool', 'sdlc-SEG1.jsonl'), 'utf8');
+    const lines = raw.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    // Every line is a complete envelope any standard JSONL parser consumes.
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as SdlcEvent;
+      expect(parsed.specversion).toBe('1.0');
+    }
+  });
+
+  it('rejects invalid events with diagnostics and writes nothing', () => {
+    const spoolDir = join(dir, 'spool');
+    const spool = new FileSpool({ spoolDir, segmentId: 'SEG1' });
+    const result = spool.append({ nope: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.issues.length).toBeGreaterThan(0);
+    expect(existsSync(spoolDir)).toBe(false);
+  });
+
+  it('drops the oldest line at the cap and persists the counter', () => {
+    const spoolDir = join(dir, 'spool');
+    const spool = new FileSpool({ spoolDir, segmentId: 'SEG1', maxEvents: 2 });
+    const first = event();
+    spool.append(first);
+    spool.append(event());
+    const third = spool.append(event());
+    expect(third).toEqual({ ok: true, dropped: 1, redactions: 0 });
+    expect(spool.droppedEvents).toBe(1);
+    expect(spool.lines).toHaveLength(2);
+    // On-disk window matches the bounded in-memory window.
+    const raw = readFileSync(join(spoolDir, 'sdlc-SEG1.jsonl'), 'utf8');
+    expect(raw.split('\n').filter((l) => l.length > 0)).toHaveLength(2);
+    expect(raw).not.toContain(first.id as string);
+    // Sidecar meta carries the persistent droppedEvents counter.
+    const meta = JSON.parse(readFileSync(join(spoolDir, 'sdlc-SEG1.meta.json'), 'utf8')) as {
+      droppedEvents: number;
+    };
+    expect(meta.droppedEvents).toBe(1);
+  });
+
+  it('reports I/O failures in the result instead of throwing', () => {
+    // Occupy the spool-dir path with a plain FILE so mkdir fails.
+    const fileAsDir = join(dir, 'occupied');
+    writeFileSync(fileAsDir, 'not a directory\n', 'utf8');
+    const spool = new FileSpool({ spoolDir: join(fileAsDir, 'nested'), segmentId: 'SEG1' });
+    const result = spool.append(event());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.issues[0]?.field).toBe('spool');
+  });
+
+  it('snapshot() exposes segmentId, lines, and droppedEvents', () => {
+    const spool = new FileSpool({ spoolDir: join(dir, 'spool'), segmentId: 'SEG9', maxEvents: 1 });
+    spool.append(event());
+    spool.append(event());
+    const snapshot = spool.snapshot();
+    expect(snapshot.segmentId).toBe('SEG9');
+    expect(snapshot.lines).toHaveLength(1);
+    expect(snapshot.droppedEvents).toBe(1);
+  });
+});
+
+describe('waypoint/spool readSpoolSegments + mergeSegments', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-spool-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns [] for an absent spool directory', () => {
+    expect(readSpoolSegments(join(dir, 'missing'))).toEqual([]);
+  });
+
+  it('round-trips segments written by concurrent writers and merges on ULID order', () => {
+    const spoolDir = join(dir, 'spool');
+    const a = new FileSpool({ spoolDir, segmentId: 'AAA', maxEvents: 1 });
+    const b = new FileSpool({ spoolDir, segmentId: 'BBB' });
+    const e1 = event();
+    const e2 = event();
+    const e3 = event();
+    a.append(e1);
+    a.append(e2); // drops e1 (cap 1) -> meta droppedEvents: 1
+    b.append(e3);
+
+    const segments = readSpoolSegments(spoolDir);
+    expect(segments).toHaveLength(2);
+    const byId = new Map(segments.map((s) => [s.segmentId, s]));
+    expect(byId.get('AAA')?.droppedEvents).toBe(1);
+    expect(byId.get('BBB')?.droppedEvents).toBe(0);
+
+    const merged = mergeSegments(segments);
+    expect(merged.map((e) => e.id)).toEqual([e2.id, e3.id].sort());
+  });
+});

--- a/packages/core/src/waypoint/spool.ts
+++ b/packages/core/src/waypoint/spool.ts
@@ -1,0 +1,191 @@
+/**
+ * Repo-local `sdlc.*` spool — the file-backed binding of the normative spool
+ * contract (pnyon `docs/architecture/waypoint/sdlc-event-schema.md` §7):
+ *
+ * - JSON Lines: one complete event envelope per `\n`-terminated line, UTF-8.
+ * - One segment file per writing process: `.harness/spool/sdlc-<id>.jsonl`
+ *   where `<id>` is a ULID minted at process start. No lock files;
+ *   concurrent writers never share a segment.
+ * - Bounded: at the cap (default 10 000 events) the segment drops its OLDEST
+ *   line and increments a persistent `droppedEvents` counter kept in a
+ *   sidecar `sdlc-<id>.meta.json`.
+ * - Appending never throws and never fails the originating harness
+ *   operation: invalid events return diagnostics, I/O failures are recorded
+ *   and reported in the result — the caller's own work always completes.
+ *
+ * The spool directory is only ever created by an append, and appends only
+ * happen when a Waypoint sink is configured — so a repo without `waypoint`
+ * config never grows a `.harness/spool/` directory (PRD Story 1).
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import type {
+  SdlcAppendResult,
+  SdlcEvent,
+  SdlcSpoolSegmentSnapshot,
+} from '@harness-engineering/types';
+import { bestEffortScrub } from './scrub';
+import { validateSdlcEvent } from './validate';
+
+/** Default segment bound (events per segment; schema doc §7.1). */
+export const DEFAULT_MAX_EVENTS = 10_000;
+
+/** Construction options for one per-process file-backed spool segment. */
+export interface FileSpoolOptions {
+  /** Directory holding the segment files, e.g. `<repo>/.harness/spool`. */
+  readonly spoolDir: string;
+  /** Unique per-writer id (file: `sdlc-<segmentId>.jsonl`). */
+  readonly segmentId: string;
+  /** Segment bound; drop-oldest beyond it. Default: DEFAULT_MAX_EVENTS. */
+  readonly maxEvents?: number;
+}
+
+/**
+ * One per-process spool segment bound to disk. Append is validate →
+ * best-effort scrub → one JSONL line; it never throws: invalid input returns
+ * diagnostics, a full segment drops its oldest line and counts it in the
+ * sidecar meta file, and an I/O failure is reported in the result without
+ * interrupting the caller.
+ */
+export class FileSpool {
+  readonly segmentId: string;
+  private readonly spoolDir: string;
+  private readonly maxEvents: number;
+  private readonly storedLines: string[] = [];
+  private dropped = 0;
+  private dirReady = false;
+
+  constructor(options: FileSpoolOptions) {
+    this.segmentId = options.segmentId;
+    this.spoolDir = options.spoolDir;
+    this.maxEvents = Math.max(1, options.maxEvents ?? DEFAULT_MAX_EVENTS);
+  }
+
+  private get segmentPath(): string {
+    return join(this.spoolDir, `sdlc-${this.segmentId}.jsonl`);
+  }
+
+  private get metaPath(): string {
+    return join(this.spoolDir, `sdlc-${this.segmentId}.meta.json`);
+  }
+
+  /** Validates, scrubs, and appends one event as a JSONL line. */
+  append(candidate: unknown): SdlcAppendResult {
+    const result = validateSdlcEvent(candidate);
+    if (!result.ok) {
+      return { ok: false, issues: result.issues };
+    }
+    const { event, redactions } = bestEffortScrub(result.event);
+    const line = JSON.stringify(event);
+
+    try {
+      if (!this.dirReady) {
+        mkdirSync(this.spoolDir, { recursive: true });
+        this.dirReady = true;
+      }
+      this.storedLines.push(line);
+      let droppedNow = 0;
+      while (this.storedLines.length > this.maxEvents) {
+        this.storedLines.shift();
+        this.dropped += 1;
+        droppedNow += 1;
+      }
+      if (droppedNow > 0) {
+        // Drop-oldest: rewrite the bounded window and persist the counter.
+        writeFileSync(this.segmentPath, this.storedLines.join('\n') + '\n', 'utf8');
+        writeFileSync(
+          this.metaPath,
+          JSON.stringify({ droppedEvents: this.dropped }) + '\n',
+          'utf8'
+        );
+      } else {
+        appendFileSync(this.segmentPath, line + '\n', 'utf8');
+      }
+      return { ok: true, dropped: droppedNow, redactions };
+    } catch (error) {
+      // Spooling must never fail the originating harness operation
+      // (PRD Story 1): report the I/O failure in the result instead.
+      return {
+        ok: false,
+        issues: [
+          {
+            field: 'spool',
+            message: `append failed: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  }
+
+  /** Events evicted by drop-oldest since this segment was created. */
+  get droppedEvents(): number {
+    return this.dropped;
+  }
+
+  /** JSONL lines currently in the bounded window, oldest first. */
+  get lines(): readonly string[] {
+    return this.storedLines;
+  }
+
+  snapshot(): SdlcSpoolSegmentSnapshot {
+    return {
+      segmentId: this.segmentId,
+      lines: [...this.storedLines],
+      droppedEvents: this.dropped,
+    };
+  }
+}
+
+/**
+ * Reads every `sdlc-*.jsonl` segment in a spool directory into snapshots
+ * (sidecar `droppedEvents` counters included). Returns an empty list when the
+ * directory does not exist — a repo with no configured sink has no spool.
+ */
+export function readSpoolSegments(spoolDir: string): SdlcSpoolSegmentSnapshot[] {
+  if (!existsSync(spoolDir)) {
+    return [];
+  }
+  const snapshots: SdlcSpoolSegmentSnapshot[] = [];
+  for (const entry of readdirSync(spoolDir)) {
+    const match = /^sdlc-(.+)\.jsonl$/.exec(entry);
+    if (!match) continue;
+    const segmentId = match[1] as string;
+    const raw = readFileSync(join(spoolDir, entry), 'utf8');
+    const lines = raw.split('\n').filter((line) => line.length > 0);
+    let droppedEvents = 0;
+    const metaPath = join(spoolDir, `sdlc-${segmentId}.meta.json`);
+    if (existsSync(metaPath)) {
+      try {
+        const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as { droppedEvents?: number };
+        droppedEvents = typeof meta.droppedEvents === 'number' ? meta.droppedEvents : 0;
+      } catch {
+        droppedEvents = 0; // Unreadable sidecar: report the segment, not a crash.
+      }
+    }
+    snapshots.push({ segmentId, lines, droppedEvents });
+  }
+  return snapshots;
+}
+
+/**
+ * Merges per-process segments into one stream ordered by event ULID
+ * (time-prefixed, so lexicographic order is creation order). No locks, no
+ * coordination — the ULID is also the idempotency key downstream, so overlap
+ * between readers is harmless. Ships with the (out-of-scope) shipper; kept
+ * here because it is part of the normative spool contract third parties
+ * consume.
+ */
+export function mergeSegments(segments: readonly SdlcSpoolSegmentSnapshot[]): SdlcEvent[] {
+  const events = segments.flatMap((segment) =>
+    segment.lines.map((line) => JSON.parse(line) as SdlcEvent)
+  );
+  return events.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}

--- a/packages/core/src/waypoint/ulid.test.ts
+++ b/packages/core/src/waypoint/ulid.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { createUlidFactory, isUlid, ULID_LENGTH } from './ulid';
+
+describe('waypoint/ulid', () => {
+  it('mints 26-char Crockford-base32 ULIDs', () => {
+    const ulid = createUlidFactory()();
+    expect(ulid).toHaveLength(ULID_LENGTH);
+    expect(isUlid(ulid)).toBe(true);
+  });
+
+  it('rejects non-ULID values', () => {
+    expect(isUlid(undefined)).toBe(false);
+    expect(isUlid('')).toBe(false);
+    expect(isUlid('not-a-ulid')).toBe(false);
+    expect(isUlid('I'.repeat(26))).toBe(false); // I is not in the alphabet
+  });
+
+  it('is monotonic within one millisecond (same clock reading)', () => {
+    const mint = createUlidFactory({ now: () => 1_700_000_000_000 });
+    const a = mint();
+    const b = mint();
+    const c = mint();
+    expect(a < b).toBe(true);
+    expect(b < c).toBe(true);
+  });
+
+  it('orders lexicographically by creation time across milliseconds', () => {
+    let t = 1_700_000_000_000;
+    const mint = createUlidFactory({ now: () => t });
+    const first = mint();
+    t += 5;
+    const second = mint();
+    expect(first < second).toBe(true);
+  });
+
+  it('is deterministic under injected randomness', () => {
+    const mint = createUlidFactory({
+      now: () => 0,
+      random: (bytes) => bytes.fill(0),
+    });
+    expect(mint()).toBe('0000000000' + '0'.repeat(16));
+  });
+
+  it('recovers from random-suffix overflow inside one millisecond', () => {
+    const mint = createUlidFactory({
+      now: () => 42,
+      // All-0xff randomness maps to the top alphabet char, so the first id's
+      // suffix is ZZZZ… and the same-ms increment overflows.
+      random: (bytes) => bytes.fill(0xff),
+    });
+    const first = mint();
+    const second = mint();
+    expect(isUlid(first)).toBe(true);
+    expect(isUlid(second)).toBe(true);
+  });
+});

--- a/packages/core/src/waypoint/ulid.ts
+++ b/packages/core/src/waypoint/ulid.ts
@@ -1,0 +1,103 @@
+/**
+ * ULID generation and validation — pure logic, no I/O.
+ *
+ * ULIDs are the `sdlc.*` event identity and idempotency/dedup key (pnyon
+ * `docs/architecture/waypoint/sdlc-event-schema.md` §3): 26 chars of Crockford
+ * base32 — a 48-bit millisecond timestamp (10 chars) followed by 80 bits of
+ * randomness (16 chars). Lexicographic order equals creation-time order, which
+ * is what gives spool-segment merge a coordination-free total order.
+ *
+ * Time and randomness are injected ports with safe defaults, so the factory
+ * is deterministic under test.
+ */
+
+/** Crockford base32 alphabet (no I, L, O, U). */
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+const TIME_CHARS = 10;
+const RANDOM_CHARS = 16;
+/** Canonical ULID length: 10 time chars + 16 random chars. */
+export const ULID_LENGTH = TIME_CHARS + RANDOM_CHARS;
+
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+/** True when `value` is a well-formed 26-char Crockford-base32 ULID. */
+export function isUlid(value: unknown): value is string {
+  return typeof value === 'string' && ULID_PATTERN.test(value);
+}
+
+/** Ports for deterministic ULID minting. */
+export interface UlidFactoryOptions {
+  /** Millisecond clock. Default: `Date.now`. */
+  readonly now?: () => number;
+  /** Fills `bytes` with randomness. Default: `crypto.getRandomValues`. */
+  readonly random?: (bytes: Uint8Array) => void;
+}
+
+function defaultRandom(bytes: Uint8Array): void {
+  globalThis.crypto.getRandomValues(bytes);
+}
+
+function encodeTime(timeMs: number): string {
+  let remaining = timeMs;
+  const chars = new Array<string>(TIME_CHARS);
+  for (let i = TIME_CHARS - 1; i >= 0; i -= 1) {
+    chars[i] = ALPHABET[remaining % 32] as string;
+    remaining = Math.floor(remaining / 32);
+  }
+  return chars.join('');
+}
+
+function encodeRandom(random: (bytes: Uint8Array) => void): string {
+  // 80 bits = 16 base32 chars. Draw one byte per char (5 bits used); the
+  // entropy budget is preserved by masking each char to 5 independent
+  // random bits.
+  const bytes = new Uint8Array(RANDOM_CHARS);
+  random(bytes);
+  let out = '';
+  for (const byte of bytes) {
+    out += ALPHABET[byte % 32] as string;
+  }
+  return out;
+}
+
+/** Increments a base32 string by one; returns null on overflow. */
+function incrementBase32(value: string): string | null {
+  const chars = value.split('');
+  for (let i = chars.length - 1; i >= 0; i -= 1) {
+    const index = ALPHABET.indexOf(chars[i] as string);
+    if (index < ALPHABET.length - 1) {
+      chars[i] = ALPHABET[index + 1] as string;
+      return chars.join('');
+    }
+    chars[i] = ALPHABET[0] as string; // carry
+  }
+  return null;
+}
+
+/**
+ * A per-process monotonic ULID mint: ids from one factory strictly increase
+ * even when the clock does not advance between calls (same-ms calls increment
+ * the random suffix — the standard ULID monotonicity rule), so a process's
+ * spool segment is always append-ordered.
+ */
+export function createUlidFactory(options: UlidFactoryOptions = {}): () => string {
+  const now = options.now ?? Date.now;
+  const random = options.random ?? defaultRandom;
+  let lastTime = -1;
+  let lastRandom = '';
+
+  return () => {
+    const time = now();
+    if (time === lastTime) {
+      const bumped = incrementBase32(lastRandom);
+      // Overflow of 80 random bits within one millisecond is not a realistic
+      // event-rate; fall back to fresh randomness rather than throwing.
+      lastRandom = bumped ?? encodeRandom(random);
+    } else {
+      lastTime = time;
+      lastRandom = encodeRandom(random);
+    }
+    return encodeTime(time) + lastRandom;
+  };
+}

--- a/packages/core/src/waypoint/validate.test.ts
+++ b/packages/core/src/waypoint/validate.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { createUlidFactory } from './ulid';
+import { validateSdlcEvent } from './validate';
+
+const mint = createUlidFactory();
+
+function validEvent(): Record<string, unknown> {
+  return {
+    specversion: '1.0',
+    id: mint(),
+    source: 'harness://repo/test',
+    type: 'sdlc.claim.opened.v1',
+    time: '2026-09-04T18:21:07.000Z',
+    subject: 'item/example',
+    actor: { kind: 'agent', id: 'agent://harness/roadmap', onBehalfOf: 'user://chad' },
+  };
+}
+
+function issueFields(candidate: unknown): string[] {
+  const result = validateSdlcEvent(candidate);
+  if (result.ok) return [];
+  return result.issues.map((issue) => issue.field);
+}
+
+describe('waypoint/validate', () => {
+  it('accepts a minimal valid envelope', () => {
+    const result = validateSdlcEvent(validEvent());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.event.type).toBe('sdlc.claim.opened.v1');
+      expect(result.event.datacontenttype).toBeUndefined();
+    }
+  });
+
+  it('stamps datacontenttype when data is present', () => {
+    const result = validateSdlcEvent({ ...validEvent(), data: { a: 1 } });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.event.datacontenttype).toBe('application/json');
+  });
+
+  it('rejects a non-object candidate with a $ diagnostic', () => {
+    expect(issueFields('nope')).toEqual(['$']);
+  });
+
+  it('names each violated field', () => {
+    const fields = issueFields({
+      ...validEvent(),
+      specversion: '2.0',
+      id: 'bad',
+      type: 'sdlc.made.up.v1',
+      time: 'not-a-time',
+      subject: '',
+      grade: 'V9',
+      data: 'not-an-object',
+    });
+    expect(fields).toEqual(
+      expect.arrayContaining(['specversion', 'id', 'type', 'time', 'subject', 'grade', 'data'])
+    );
+  });
+
+  it('enforces the closed v1 vocabulary', () => {
+    expect(issueFields({ ...validEvent(), type: 'sdlc.intent.reopened.v1' })).toContain('type');
+  });
+
+  it('enforces actor duality: agent actors require onBehalfOf', () => {
+    expect(issueFields({ ...validEvent(), actor: { kind: 'agent', id: 'agent://x' } })).toContain(
+      'actor.onBehalfOf'
+    );
+    const human = validateSdlcEvent({
+      ...validEvent(),
+      actor: { kind: 'human', id: 'user://chad' },
+    });
+    expect(human.ok).toBe(true);
+  });
+
+  it('rejects a missing or malformed actor', () => {
+    expect(issueFields({ ...validEvent(), actor: undefined })).toContain('actor');
+    expect(issueFields({ ...validEvent(), actor: { kind: 'robot', id: '' } })).toEqual(
+      expect.arrayContaining(['actor.kind', 'actor.id'])
+    );
+  });
+
+  it('validates causes as an array of ULIDs', () => {
+    expect(issueFields({ ...validEvent(), causes: 'x' })).toContain('causes');
+    expect(issueFields({ ...validEvent(), causes: ['not-a-ulid'] })).toContain('causes[0]');
+    const ok = validateSdlcEvent({ ...validEvent(), causes: [mint()] });
+    expect(ok.ok).toBe(true);
+  });
+
+  it('accepts every pinned verification grade', () => {
+    for (const grade of ['V0', 'V1', 'V2', 'V3']) {
+      expect(validateSdlcEvent({ ...validEvent(), grade }).ok).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/waypoint/validate.ts
+++ b/packages/core/src/waypoint/validate.ts
@@ -1,0 +1,154 @@
+/**
+ * `sdlc.*` envelope validation — pure logic, no I/O.
+ *
+ * Per-field, diagnostic validation of the v1 CloudEvents profile (pnyon
+ * `docs/architecture/waypoint/sdlc-event-schema.md` §1): every rejection
+ * names the violated field. The vocabulary is CLOSED — types outside the
+ * pinned `SDLC_EVENT_TYPES_V1` list are rejected.
+ */
+
+import {
+  SDLC_EVENT_TYPES_V1,
+  SDLC_SPECVERSION,
+  SDLC_VERIFICATION_GRADES,
+  type SdlcActor,
+  type SdlcEvent,
+  type SdlcEventTypeV1,
+  type SdlcValidationIssue,
+  type SdlcValidationResult,
+  type SdlcVerificationGrade,
+} from '@harness-engineering/types';
+import { isUlid } from './ulid';
+
+const EVENT_TYPES: ReadonlySet<string> = new Set(SDLC_EVENT_TYPES_V1);
+const GRADES: ReadonlySet<string> = new Set(SDLC_VERIFICATION_GRADES);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/** One per-field check: `field`, predicate over the candidate, message. */
+type FieldRule = readonly [
+  field: string,
+  valid: (value: Record<string, unknown>) => boolean,
+  message: string,
+];
+
+const FIELD_RULES: readonly FieldRule[] = [
+  ['specversion', (v) => v['specversion'] === SDLC_SPECVERSION, `must be "${SDLC_SPECVERSION}"`],
+  ['id', (v) => isUlid(v['id']), 'must be a 26-char Crockford-base32 ULID'],
+  ['source', (v) => isNonEmptyString(v['source']), 'must be a non-empty emitting-scope URI'],
+  [
+    'type',
+    (v) => isNonEmptyString(v['type']) && EVENT_TYPES.has(v['type'] as string),
+    'must be a pinned sdlc.*.v1 vocabulary member',
+  ],
+  [
+    'time',
+    (v) => isNonEmptyString(v['time']) && !Number.isNaN(Date.parse(v['time'] as string)),
+    'must be an RFC 3339 / ISO-8601 timestamp',
+  ],
+  ['subject', (v) => isNonEmptyString(v['subject']), 'must be a non-empty subject id'],
+  [
+    'grade',
+    (v) => v['grade'] === undefined || (typeof v['grade'] === 'string' && GRADES.has(v['grade'])),
+    'must be one of V0, V1, V2, V3',
+  ],
+  [
+    'data',
+    (v) => v['data'] === undefined || isRecord(v['data']),
+    'must be a JSON object when present',
+  ],
+];
+
+function validateActor(value: unknown, issues: SdlcValidationIssue[]): void {
+  if (!isRecord(value)) {
+    issues.push({
+      field: 'actor',
+      message: 'required Waypoint extension: { kind, id [, onBehalfOf] }',
+    });
+    return;
+  }
+  const kind = value['kind'];
+  if (kind !== 'human' && kind !== 'agent') {
+    issues.push({ field: 'actor.kind', message: 'must be "human" or "agent"' });
+  }
+  if (!isNonEmptyString(value['id'])) {
+    issues.push({ field: 'actor.id', message: 'must be a non-empty principal id' });
+  }
+  if (kind === 'agent' && !isNonEmptyString(value['onBehalfOf'])) {
+    issues.push({
+      field: 'actor.onBehalfOf',
+      message: 'agent actors must name the accountable human principal (actor duality)',
+    });
+  }
+}
+
+function validateCauses(value: unknown, issues: SdlcValidationIssue[]): void {
+  if (value === undefined) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    issues.push({ field: 'causes', message: 'must be an array of causing-event ULIDs' });
+    return;
+  }
+  value.forEach((cause, index) => {
+    if (!isUlid(cause)) {
+      issues.push({
+        field: `causes[${index}]`,
+        message: 'must be a 26-char Crockford-base32 ULID',
+      });
+    }
+  });
+}
+
+/** Assembles the typed event from an already-validated candidate. */
+function toEvent(value: Record<string, unknown>): SdlcEvent {
+  const withData = value['datacontenttype'] !== undefined || value['data'] !== undefined;
+  return {
+    specversion: SDLC_SPECVERSION,
+    id: value['id'] as string,
+    source: value['source'] as string,
+    type: value['type'] as SdlcEventTypeV1,
+    time: value['time'] as string,
+    subject: value['subject'] as string,
+    ...(withData ? { datacontenttype: 'application/json' as const } : {}),
+    actor: value['actor'] as SdlcActor,
+    ...(value['grade'] !== undefined ? { grade: value['grade'] as SdlcVerificationGrade } : {}),
+    ...(value['causes'] !== undefined ? { causes: value['causes'] as string[] } : {}),
+    ...(value['data'] !== undefined
+      ? { data: value['data'] as Readonly<Record<string, unknown>> }
+      : {}),
+  };
+}
+
+/**
+ * Validates an unknown value against the v1 envelope profile. Returns the
+ * typed event on success, or one named diagnostic per violated field.
+ */
+export function validateSdlcEvent(value: unknown): SdlcValidationResult {
+  if (!isRecord(value)) {
+    return {
+      ok: false,
+      issues: [{ field: '$', message: 'event must be a JSON object' }],
+    };
+  }
+
+  const issues: SdlcValidationIssue[] = [];
+  for (const [field, valid, message] of FIELD_RULES) {
+    if (!valid(value)) {
+      issues.push({ field, message });
+    }
+  }
+  validateActor(value['actor'], issues);
+  validateCauses(value['causes'], issues);
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+  return { ok: true, event: toEvent(value) };
+}

--- a/packages/core/tests/roadmap/assignee-lifecycle-waypoint.test.ts
+++ b/packages/core/tests/roadmap/assignee-lifecycle-waypoint.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Waypoint emission at the sanctioned roadmap mutators (pnyon/pnyon#124).
+ *
+ * Two contracts under test:
+ * 1. NO SINK CONFIGURED (the PRD Story 1 invariant): the mutators behave
+ *    byte-identically to the pre-Waypoint behavior and create no files —
+ *    the entire pre-existing assignee-lifecycle suite doubles as proof, and
+ *    this file adds the file-system half of the assertion.
+ * 2. SINK CONFIGURED: each committed mutation spools exactly one
+ *    corresponding sdlc.* event; no-op calls (first-claim-wins rejection,
+ *    same-status setStatus) spool nothing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Roadmap, RoadmapFeature, SdlcEvent } from '@harness-engineering/types';
+import { claim, release, setStatus } from '../../src/roadmap/assignee-lifecycle';
+import { initWaypointEmitter, resetWaypointEmitterForTests } from '../../src/waypoint/emitter';
+
+function feature(overrides: Partial<RoadmapFeature> & { name: string }): RoadmapFeature {
+  return {
+    status: 'backlog',
+    spec: null,
+    plans: [],
+    blockedBy: [],
+    summary: '',
+    assignee: null,
+    priority: null,
+    externalId: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function roadmap(features: RoadmapFeature[]): Roadmap {
+  return {
+    frontmatter: {
+      project: 'test',
+      version: 1,
+      lastSynced: '2026-01-01T00:00:00Z',
+      lastManualEdit: '2026-01-01T00:00:00Z',
+    },
+    milestones: [{ name: 'M', isBacklog: false, features }],
+    assignmentHistory: [],
+  };
+}
+
+const DATE = '2026-09-04';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-mutators-'));
+  resetWaypointEmitterForTests();
+});
+
+afterEach(() => {
+  resetWaypointEmitterForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function spooledEvents(): SdlcEvent[] {
+  const spoolDir = join(dir, '.harness', 'spool');
+  if (!existsSync(spoolDir)) return [];
+  const events: SdlcEvent[] = [];
+  for (const entry of readdirSync(spoolDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    for (const line of readFileSync(join(spoolDir, entry), 'utf8').split('\n')) {
+      if (line.length > 0) events.push(JSON.parse(line) as SdlcEvent);
+    }
+  }
+  return events;
+}
+
+describe('mutators with NO Waypoint sink (non-adopter invariance)', () => {
+  it('behave exactly as before and create no files', () => {
+    const f = feature({ name: 'A' });
+    const r = roadmap([f]);
+    claim(r, f, 'chad', DATE);
+    expect(f.status).toBe('in-progress');
+    expect(f.assignee).toBe('chad');
+    release(r, f, DATE);
+    expect(f.status).toBe('planned');
+    expect(f.assignee).toBeNull();
+    setStatus(r, f, 'done', DATE);
+    expect(f.status).toBe('done');
+    expect(existsSync(join(dir, '.harness'))).toBe(false);
+    expect(spooledEvents()).toEqual([]);
+  });
+});
+
+describe('mutators with a configured Waypoint sink', () => {
+  beforeEach(() => {
+    initWaypointEmitter({ sink: { transport: 'spool' } }, dir);
+  });
+
+  it('claim spools exactly one sdlc.claim.opened.v1', () => {
+    const f = feature({ name: 'A' });
+    claim(roadmap([f]), f, 'chad', DATE);
+    const events = spooledEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('sdlc.claim.opened.v1');
+    expect(events[0]?.subject).toBe('item/A');
+    expect(events[0]?.data).toMatchObject({ mutator: 'claim', assignee: 'chad' });
+  });
+
+  it('a rejected steal (first claim wins) commits nothing and spools nothing', () => {
+    const f = feature({ name: 'A', status: 'in-progress', assignee: 'someone-else' });
+    claim(roadmap([f]), f, 'chad', DATE);
+    expect(f.assignee).toBe('someone-else');
+    expect(spooledEvents()).toEqual([]);
+  });
+
+  it('an idempotent same-owner re-claim spools nothing', () => {
+    const f = feature({ name: 'A', status: 'in-progress', assignee: 'chad' });
+    claim(roadmap([f]), f, 'chad', DATE);
+    expect(spooledEvents()).toEqual([]);
+  });
+
+  it('release spools exactly one sdlc.claim.released.v1 with the prior owner', () => {
+    const f = feature({ name: 'A', status: 'in-progress', assignee: 'chad' });
+    release(roadmap([f]), f, DATE);
+    const events = spooledEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('sdlc.claim.released.v1');
+    expect(events[0]?.data).toMatchObject({ mutator: 'release', previousAssignee: 'chad' });
+  });
+
+  it('release of an already-unassigned, non-in-progress row spools nothing', () => {
+    const f = feature({ name: 'A', status: 'planned' });
+    release(roadmap([f]), f, DATE);
+    expect(spooledEvents()).toEqual([]);
+  });
+
+  it('setStatus spools intent.updated, and intent.closed for done', () => {
+    const f = feature({ name: 'A', status: 'planned' });
+    const r = roadmap([f]);
+    setStatus(r, f, 'in-progress', DATE);
+    setStatus(r, f, 'done', DATE);
+    const events = spooledEvents();
+    expect(events.map((e) => e.type)).toEqual(['sdlc.intent.updated.v1', 'sdlc.intent.closed.v1']);
+    expect(events[1]?.data).toMatchObject({ status: 'done', previousStatus: 'in-progress' });
+  });
+
+  it('a same-status setStatus commits no change and spools nothing', () => {
+    const f = feature({ name: 'A', status: 'planned' });
+    setStatus(roadmap([f]), f, 'planned', DATE);
+    expect(spooledEvents()).toEqual([]);
+  });
+
+  it('a full lifecycle spools one event per committed mutation (exactly-one)', () => {
+    const f = feature({ name: 'A' });
+    const r = roadmap([f]);
+    setStatus(r, f, 'planned', DATE); // 1: intent.updated
+    claim(r, f, 'chad', DATE); // 2: claim.opened
+    release(r, f, DATE); // 3: claim.released
+    setStatus(r, f, 'done', DATE); // 4: intent.closed
+    expect(spooledEvents().map((e) => e.type)).toEqual([
+      'sdlc.intent.updated.v1',
+      'sdlc.claim.opened.v1',
+      'sdlc.claim.released.v1',
+      'sdlc.intent.closed.v1',
+    ]);
+  });
+});

--- a/packages/orchestrator/src/gateway/webhooks/events.ts
+++ b/packages/orchestrator/src/gateway/webhooks/events.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import type { EventEmitter } from 'node:events';
-import type { GatewayEvent } from '@harness-engineering/types';
+import { SDLC_EVENT_TYPES_V1, type GatewayEvent } from '@harness-engineering/types';
 import type { WebhookStore } from './store';
 import type { WebhookDelivery } from './delivery';
 
@@ -23,6 +23,12 @@ const WEBHOOK_TOPICS = [
   'proposal.created',
   'proposal.approved',
   'proposal.rejected',
+  // Waypoint sdlc.* family (pnyon/pnyon#124): the pinned, closed v1
+  // vocabulary, published only when a `waypoint.sink` is configured (the
+  // bridge in waypoint-bridge.ts). Types are 4 segments (`sdlc.claim.opened.v1`),
+  // so subscriptions match exact types or the `sdlc.*.*.*` glob. Registering
+  // the topics is additive: without the opt-in bridge nothing ever emits them.
+  ...SDLC_EVENT_TYPES_V1,
 ] as const;
 
 interface WireParams {

--- a/packages/orchestrator/src/gateway/webhooks/waypoint-bridge.test.ts
+++ b/packages/orchestrator/src/gateway/webhooks/waypoint-bridge.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { emitSdlc, resetWaypointEmitterForTests } from '@harness-engineering/core';
+import { wireWaypointSdlcBridge } from './waypoint-bridge';
+import { wireWebhookFanout } from './events';
+import { WebhookStore } from './store';
+import { WebhookDelivery } from './delivery';
+import { WebhookQueue } from './queue';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'harness-waypoint-bridge-'));
+  resetWaypointEmitterForTests();
+});
+
+afterEach(() => {
+  resetWaypointEmitterForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function configureSink(): void {
+  writeFileSync(
+    join(dir, 'harness.config.json'),
+    JSON.stringify({ waypoint: { sink: { transport: 'spool' } } }),
+    'utf8'
+  );
+}
+
+describe('wireWaypointSdlcBridge', () => {
+  it('is a no-op without a configured sink (non-adopter invariance)', () => {
+    const bus = new EventEmitter();
+    const off = wireWaypointSdlcBridge({ bus, projectRoot: dir });
+    expect(bus.eventNames()).toEqual([]);
+    emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/x' });
+    expect(existsSync(join(dir, '.harness'))).toBe(false);
+    off(); // teardown of the no-op bridge is safe
+  });
+
+  it('republishes spooled sdlc.* events onto the bus under their own type', () => {
+    configureSink();
+    const bus = new EventEmitter();
+    const seen: Array<{ topic: string; subject: string }> = [];
+    bus.on('sdlc.claim.opened.v1', (event: { subject: string }) =>
+      seen.push({ topic: 'sdlc.claim.opened.v1', subject: event.subject })
+    );
+    const off = wireWaypointSdlcBridge({ bus, projectRoot: dir });
+    const id = emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/x' });
+    expect(id).not.toBeNull();
+    expect(seen).toEqual([{ topic: 'sdlc.claim.opened.v1', subject: 'item/x' }]);
+    off();
+    emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/y' });
+    expect(seen).toHaveLength(1);
+  });
+});
+
+describe('sdlc.* topics on the webhook fan-out', () => {
+  let store: WebhookStore;
+  let queue: WebhookQueue;
+
+  beforeEach(() => {
+    store = new WebhookStore(join(dir, 'webhooks.json'));
+    queue = new WebhookQueue(':memory:');
+  });
+
+  afterEach(() => {
+    queue.close();
+  });
+
+  it('delivers bridged sdlc events to matching subscriptions with the GatewayEvent envelope', async () => {
+    configureSink();
+    const bus = new EventEmitter();
+    const delivery = new WebhookDelivery({ queue, store });
+    const spy = vi.spyOn(delivery, 'enqueue').mockImplementation(() => {});
+    await store.create({ tokenId: 't', url: 'https://a.test/h', events: ['sdlc.*.*.*'] });
+    wireWebhookFanout({ bus, store, delivery });
+    wireWaypointSdlcBridge({ bus, projectRoot: dir });
+
+    emitSdlc({ type: 'sdlc.build.finished.v1', subject: 'phase/execute' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(spy).toHaveBeenCalledTimes(1);
+    const event = spy.mock.calls[0]?.[1];
+    expect(event?.type).toBe('sdlc.build.finished.v1');
+    expect(event?.id).toMatch(/^evt_[a-f0-9]+$/);
+    expect((event?.data as { subject?: string }).subject).toBe('phase/execute');
+  });
+
+  it('exact-type sdlc subscriptions match; unrelated topics are untouched', async () => {
+    configureSink();
+    const bus = new EventEmitter();
+    const delivery = new WebhookDelivery({ queue, store });
+    const spy = vi.spyOn(delivery, 'enqueue').mockImplementation(() => {});
+    await store.create({ tokenId: 't', url: 'https://a.test/h', events: ['sdlc.claim.opened.v1'] });
+    wireWebhookFanout({ bus, store, delivery });
+    wireWaypointSdlcBridge({ bus, projectRoot: dir });
+
+    emitSdlc({ type: 'sdlc.claim.opened.v1', subject: 'item/x' });
+    emitSdlc({ type: 'sdlc.claim.released.v1', subject: 'item/x' });
+    bus.emit('interaction.created', { id: 'int_1' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[1].type).toBe('sdlc.claim.opened.v1');
+  });
+});

--- a/packages/orchestrator/src/gateway/webhooks/waypoint-bridge.ts
+++ b/packages/orchestrator/src/gateway/webhooks/waypoint-bridge.ts
@@ -1,0 +1,41 @@
+import type { EventEmitter } from 'node:events';
+import { ensureWaypointEmitter } from '@harness-engineering/core';
+
+/**
+ * Waypoint → gateway bus bridge (opt-in, pnyon/pnyon#124).
+ *
+ * The core Waypoint emitter spools `sdlc.*` events repo-locally; this bridge
+ * republishes every successfully spooled event onto the orchestrator's
+ * EventEmitter bus under the event's own pinned type (e.g.
+ * `sdlc.claim.opened.v1`), where the existing `wireWebhookFanout` machinery
+ * wraps it in a `GatewayEvent` and delivers it to matching webhook
+ * subscriptions with the standard `WebhookQueue` retry semantics.
+ *
+ * Spool-first ordering is preserved: the emitter appends locally BEFORE
+ * notifying listeners, so a slow or failing subscriber can never block or
+ * lose the durable copy.
+ *
+ * When no `waypoint.sink` is configured in `harness.config.json`,
+ * `ensureWaypointEmitter` installs nothing and this function is a no-op
+ * returning a no-op teardown — the hard non-adopter invariant (PRD Story 1).
+ */
+function resolveEmitter(projectRoot: string): ReturnType<typeof ensureWaypointEmitter> {
+  try {
+    return ensureWaypointEmitter(projectRoot);
+  } catch {
+    return null; // Waypoint init failure never affects the orchestrator.
+  }
+}
+
+export function wireWaypointSdlcBridge(params: {
+  bus: EventEmitter;
+  projectRoot: string;
+}): () => void {
+  const emitter = resolveEmitter(params.projectRoot);
+  if (emitter === null) {
+    return (): void => {};
+  }
+  return emitter.onEvent((event) => {
+    params.bus.emit(event.type, event);
+  });
+}

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -152,6 +152,7 @@ import { WebhookStore } from './gateway/webhooks/store';
 import { WebhookDelivery } from './gateway/webhooks/delivery';
 import { WebhookQueue } from './gateway/webhooks/queue';
 import { wireWebhookFanout } from './gateway/webhooks/events';
+import { wireWaypointSdlcBridge } from './gateway/webhooks/waypoint-bridge';
 import { wireTelemetryFanout } from './gateway/telemetry/fanout';
 import { SinkRegistry } from './notifications/registry';
 import { wireNotificationSinks } from './notifications/events';
@@ -906,6 +907,10 @@ export class Orchestrator extends EventEmitter {
   private webhookFanoutOff?: () => void;
   private webhookQueue?: WebhookQueue;
   private webhookDeliveryWorker?: WebhookDelivery;
+  // Waypoint sdlc.* bridge (opt-in, pnyon/pnyon#124): unsubscribe handle for
+  // the spooled-event → bus republisher; a no-op unless waypoint.sink is
+  // configured in harness.config.json.
+  private waypointBridgeOff?: () => void;
   // Phase 5: prompt-cache metrics + OTLP trace export. Both are constructed
   // unconditionally so non-telemetry call sites can reference them safely; the
   // OTLPExporter is only handed a fanout subscription when config supplies an
@@ -1401,6 +1406,15 @@ export class Orchestrator extends EventEmitter {
         delivery: webhookDelivery,
       });
       webhookDelivery.start();
+
+      // Waypoint sdlc.* bridge (opt-in, pnyon/pnyon#124): republishes
+      // spooled sdlc.* events onto this bus so the fan-out above delivers
+      // them to matching subscriptions. A no-op unless harness.config.json
+      // declares waypoint.sink.
+      this.waypointBridgeOff = wireWaypointSdlcBridge({
+        bus: this,
+        projectRoot: this.projectRoot,
+      });
 
       // Hermes Phase 3: in-process notification sinks. See setupNotifications.
       this.setupNotifications(config.notifications);
@@ -5089,6 +5103,12 @@ export class Orchestrator extends EventEmitter {
     if (this.webhookFanoutOff) {
       this.webhookFanoutOff();
       delete this.webhookFanoutOff;
+    }
+    // Waypoint sdlc.* bridge: drop the spooled-event listener. The spool
+    // itself needs no teardown — appends are synchronous and file-local.
+    if (this.waypointBridgeOff) {
+      this.waypointBridgeOff();
+      delete this.waypointBridgeOff;
     }
     // Hermes Phase 3: detach the notification listeners before the
     // registry disposes so no in-flight emit pulls from a torn-down

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -509,3 +509,28 @@ export type {
   TelemetrySynthesisHeadline,
   TelemetrySynthesis,
 } from './telemetry-synthesis';
+
+// --- Waypoint sdlc.* event contract (opt-in emission layer, pnyon/pnyon#124) ---
+export {
+  SDLC_CATEGORIES,
+  SDLC_EVENT_TYPES_V1,
+  SDLC_SPECVERSION,
+  SDLC_VERIFICATION_GRADES,
+  WaypointConfigSchema,
+  WaypointSinkConfigSchema,
+} from './waypoint';
+export type {
+  SdlcActor,
+  SdlcAgentActor,
+  SdlcAppendResult,
+  SdlcCategory,
+  SdlcEvent,
+  SdlcEventTypeV1,
+  SdlcHumanActor,
+  SdlcSpoolSegmentSnapshot,
+  SdlcValidationIssue,
+  SdlcValidationResult,
+  SdlcVerificationGrade,
+  WaypointConfig,
+  WaypointSinkConfig,
+} from './waypoint';

--- a/packages/types/src/waypoint.ts
+++ b/packages/types/src/waypoint.ts
@@ -1,0 +1,212 @@
+// packages/types/src/waypoint.ts
+//
+// Waypoint `sdlc.*` event contract — cross-layer types for the opt-in SDLC
+// event emission layer (pnyon/pnyon#124; pnyon ADR-0047).
+//
+// The envelope is a CloudEvents 1.0 profile with Waypoint extension
+// attributes and a pinned, versioned `sdlc.*.v1` vocabulary mapped against
+// CDEvents v0.5.1 (mapped and pinned, never a runtime dependency). The
+// normative contract lives in pnyon's
+// `docs/architecture/waypoint/sdlc-event-schema.md`; this module pins the
+// same list so emitter and consumer cannot drift.
+//
+// Nothing in this module performs I/O or changes behavior — it is the shared
+// vocabulary for the opt-in emission layer in
+// `packages/core/src/waypoint/`. When no Waypoint sink is configured in
+// `harness.config.json`, no code path constructs these values.
+
+import { z } from 'zod';
+
+/** The only CloudEvents spec version the v1 profile accepts. */
+export const SDLC_SPECVERSION = '1.0';
+
+/** The ten pinned `sdlc.*` categories (pnyon ADR-0047). */
+export const SDLC_CATEGORIES = [
+  'intent',
+  'claim',
+  'build',
+  'review',
+  'test',
+  'verify',
+  'release',
+  'wave',
+  'override',
+  'approval',
+] as const;
+
+/** One of the ten pinned `sdlc.*` categories. */
+export type SdlcCategory = (typeof SDLC_CATEGORIES)[number];
+
+/**
+ * The pinned, CLOSED v1 vocabulary. Validation rejects any type outside this
+ * list. Incompatible payload changes mint `.v2` types alongside — `.v1` is
+ * never mutated. The CDEvents v0.5.1 mapping table lives in the schema doc,
+ * one row per entry here.
+ */
+export const SDLC_EVENT_TYPES_V1 = [
+  'sdlc.intent.created.v1',
+  'sdlc.intent.updated.v1',
+  'sdlc.intent.closed.v1',
+  'sdlc.claim.opened.v1',
+  'sdlc.claim.released.v1',
+  'sdlc.build.started.v1',
+  'sdlc.build.finished.v1',
+  'sdlc.review.requested.v1',
+  'sdlc.review.verdict.v1',
+  'sdlc.test.started.v1',
+  'sdlc.test.finished.v1',
+  'sdlc.verify.graded.v1',
+  'sdlc.release.published.v1',
+  'sdlc.wave.proposed.v1',
+  'sdlc.wave.approved.v1',
+  'sdlc.wave.completed.v1',
+  'sdlc.override.applied.v1',
+  'sdlc.approval.granted.v1',
+  'sdlc.approval.denied.v1',
+] as const;
+
+/** A member of the pinned, closed v1 vocabulary. */
+export type SdlcEventTypeV1 = (typeof SDLC_EVENT_TYPES_V1)[number];
+
+/**
+ * Actor duality: a human principal, or an agent principal that MUST name the
+ * human it acts on behalf of. Validation rejects agent actors lacking
+ * `onBehalfOf` — agent work is always attributable to a human.
+ */
+export interface SdlcHumanActor {
+  readonly kind: 'human';
+  /** Human principal URI/id, e.g. `user://chad`. */
+  readonly id: string;
+}
+
+/** An agent principal acting on behalf of an accountable human. */
+export interface SdlcAgentActor {
+  readonly kind: 'agent';
+  /** Agent principal URI/id, e.g. `agent://claude/roadmap-fleet`. */
+  readonly id: string;
+  /** The accountable human principal. Required for every agent actor. */
+  readonly onBehalfOf: string;
+}
+
+/** The accountable-actor union: a human, or an agent `onBehalfOf` a human. */
+export type SdlcActor = SdlcHumanActor | SdlcAgentActor;
+
+/** SLSA-style verification grades, V0 (none) to V3. */
+export const SDLC_VERIFICATION_GRADES = ['V0', 'V1', 'V2', 'V3'] as const;
+
+/** One of the four SLSA-style verification grades. */
+export type SdlcVerificationGrade = (typeof SDLC_VERIFICATION_GRADES)[number];
+
+/**
+ * The v1 envelope — CloudEvents 1.0 required attributes plus Waypoint
+ * extension attributes, in the Waypoint JSON binding (structured `actor` and
+ * `causes`; the strict-transport flattening is documented in the schema doc).
+ */
+export interface SdlcEvent<
+  TData extends Readonly<Record<string, unknown>> = Readonly<Record<string, unknown>>,
+> {
+  /** CloudEvents spec version — always `"1.0"` in the v1 profile. */
+  readonly specversion: typeof SDLC_SPECVERSION;
+  /**
+   * ULID, client-generated at append time; the idempotency/dedup key.
+   * Stable across every retry and replay (at-least-once delivery,
+   * exactly-once effects).
+   */
+  readonly id: string;
+  /** Emitting scope URI, e.g. `harness://repo/harness-engineering`. */
+  readonly source: string;
+  /** Pinned vocabulary member, e.g. `sdlc.review.verdict.v1`. */
+  readonly type: SdlcEventTypeV1;
+  /** RFC 3339 / ISO-8601 timestamp of the occurrence. */
+  readonly time: string;
+  /** Stable subject id, e.g. `item/<feature-name>`. */
+  readonly subject: string;
+  /** Present (as `application/json`) whenever `data` is present. */
+  readonly datacontenttype?: 'application/json';
+  /** Waypoint extension: accountable actor (duality — see SdlcActor). */
+  readonly actor: SdlcActor;
+  /** Waypoint extension: verification grade for grade-asserting events. */
+  readonly grade?: SdlcVerificationGrade;
+  /** Waypoint extension: ULIDs of the events this one was caused by. */
+  readonly causes?: readonly string[];
+  /** Event-type-specific payload. */
+  readonly data?: TData;
+}
+
+/** One named diagnostic from envelope validation (reject-with-field). */
+export interface SdlcValidationIssue {
+  /** Dotted path of the violated field, e.g. `actor.onBehalfOf`. */
+  readonly field: string;
+  readonly message: string;
+}
+
+/** Envelope validation outcome: the typed event, or per-field diagnostics. */
+export type SdlcValidationResult =
+  | { readonly ok: true; readonly event: SdlcEvent }
+  | { readonly ok: false; readonly issues: readonly SdlcValidationIssue[] };
+
+/**
+ * Result of an append attempt. Appending NEVER throws and never blocks the
+ * originating harness operation: invalid events come back with diagnostics,
+ * valid events land (dropping the oldest at the cap).
+ */
+export type SdlcAppendResult =
+  | {
+      readonly ok: true;
+      /** Events evicted from this segment by this append (0 or 1). */
+      readonly dropped: number;
+      /** Redactions applied by the client-side best-effort scrub. */
+      readonly redactions: number;
+    }
+  | { readonly ok: false; readonly issues: readonly SdlcValidationIssue[] };
+
+/** A read-only view of one per-process segment's state. */
+export interface SdlcSpoolSegmentSnapshot {
+  /** Unique per-writer id; the segment file is `sdlc-<segmentId>.jsonl`. */
+  readonly segmentId: string;
+  /** JSONL lines, oldest first — each one complete event envelope. */
+  readonly lines: readonly string[];
+  /** Monotonic count of events evicted by drop-oldest at the cap. */
+  readonly droppedEvents: number;
+}
+
+/**
+ * Waypoint sink configuration — the `waypoint` key in `harness.config.json`
+ * (zod, mirroring `NotificationsConfigSchema`: the runtime schema lives in
+ * types so core, cli, and orchestrator all validate the same shape).
+ *
+ * ABSENT CONFIG MEANS ABSENT FEATURE: when `harness.config.json` has no
+ * `waypoint.sink` entry, the emission layer stays a no-op — no new files, no
+ * new I/O, no behavior change anywhere in harness (PRD Story 1, the
+ * non-adopter invariance contract).
+ */
+export const WaypointSinkConfigSchema = z.object({
+  /**
+   * Spool transport toggle. `spool` appends events to the repo-local
+   * `.harness/spool/` JSONL segments. Shipping spooled events to a hosted
+   * ingest is out of scope for this layer (pnyon owns ingest).
+   */
+  transport: z.literal('spool'),
+  /**
+   * Emitting scope URI stamped on every event's `source`, e.g.
+   * `harness://outpost/<uuid>/repo/<name>`. Defaults to
+   * `harness://repo/<basename of project root>`.
+   */
+  source: z.string().min(1).optional(),
+  /** Segment bound; drop-oldest beyond it. Default 10 000 events/segment. */
+  maxEventsPerSegment: z.number().int().positive().optional(),
+  /**
+   * Accountable human principal stamped as `actor.onBehalfOf` on
+   * agent-authored events, e.g. `user://chad`. Defaults to
+   * `user://<os user name>`.
+   */
+  onBehalfOf: z.string().min(1).optional(),
+});
+export type WaypointSinkConfig = z.infer<typeof WaypointSinkConfigSchema>;
+
+/** The `waypoint` block of `harness.config.json`. */
+export const WaypointConfigSchema = z.object({
+  /** Opt-in sink. Absent (or undefined) disables the emission layer. */
+  sink: WaypointSinkConfigSchema.optional(),
+});
+export type WaypointConfig = z.infer<typeof WaypointConfigSchema>;


### PR DESCRIPTION
Implements the Waypoint harness adaptation — **opt-in `sdlc.*` event emission and repo-local spool** (pnyon ADR-0047).

Closes #1817
Closes pnyon/pnyon#124

## What this adds

With `waypoint.sink` declared in `harness.config.json` (and only then):

- **Contract types** (`packages/types/src/waypoint.ts`) — the CloudEvents-1.0-profile envelope, the pinned, CLOSED 19-type `sdlc.*.v1` vocabulary, actor duality (`agent onBehalfOf human`), V0–V3 verification grades, and `WaypointConfigSchema` (zod).
- **Emission layer** (`packages/core/src/waypoint/`) — monotonic ULID mint, per-field envelope validation, client-side best-effort secret scrub, a bounded per-process JSONL spool (`.harness/spool/sdlc-<ulid>.jsonl`, drop-oldest at 10 000-event cap with a persistent `droppedEvents` sidecar counter), a config-gated installable emitter (`ensureWaypointEmitter` / `emitSdlc`), and one mapping helper per emission family.
- **Emission hooks** —
  - roadmap mutators `setStatus`/`claim`/`release` (the assignee-lifecycle chokepoint): one event per **committed** mutation (`intent.updated`/`intent.closed`, `claim.opened`, `claim.released`);
  - `emit_interaction` phase transitions → `build.finished` preserving the `qualityGate` payload;
  - `outcome_eval` / `acceptance_eval` / `uat_signoff` handlers → `verify.graded` carrying the existing verdict + a documented grade projection (MEASURABLE→V1, SATISFIED→V2, ACCEPTED→V3, else V0; UAT events carry a human actor) — emission, never new judgment;
  - fleet artifacts via a new sanctioned seam: `harness waypoint record-provenance | record-handoff` (validated by the existing `validateFleetHandoffRecord`), plus `harness waypoint status` for spool health.
- **Gateway topics** — `WEBHOOK_TOPICS` gains the 19 `sdlc.*.v1` types (spread from `SDLC_EVENT_TYPES_V1` so the lists cannot drift); `wireWaypointSdlcBridge` republishes spooled events onto the orchestrator bus, where the existing fan-out delivers them in the `GatewayEvent` envelope with `WebhookQueue` retry semantics. Subscriptions match exact types or `sdlc.*.*.*`.

## The hard invariant (tested)

**No `waypoint.sink` ⇒ zero behavior change.** No new files, no new I/O, no change to any command's output or exit code; `emitSdlc` is a guaranteed no-op; the bridge wires nothing. Dedicated non-adopter invariance tests assert this at the emitter, the mutators, the bridge, and the CLI — and every pre-existing suite passes unmodified.

## Explicitly out of scope

- Shipping spooled events to a hosted ingest (the consumer owns ingest; the spool format is the contract boundary — normative in pnyon's `docs/architecture/waypoint/sdlc-event-schema.md`).
- `RoadmapTrackerClient` kind `pnyon` (separate adaptation item; tracker adapter/registry files untouched).

## Artifacts

- Spec: `docs/changes/waypoint-sdlc-emission/proposal.md`
- Plan: `docs/changes/waypoint-sdlc-emission/plans/2026-09-04-waypoint-sdlc-emission-plan.md`
- Provenance: `docs/changes/waypoint-sdlc-emission/provenance.json`
- Changeset: minor for types/core/cli/orchestrator
- Arch allowance: `.harness/arch/allowances/feat-waypoint-sdlc-emission.json` (module-size/dependency-depth growth from the new module, reason recorded)
- Knowledge doc: `docs/knowledge/orchestrator/webhook-fanout.md` topic-family note

Also includes one drive-by main-health fix: `src/mcp/context-surface.test.ts` imports `agentsMdEntry`/`hooksEntry`/`skillTreeEntries`, which the module kept private — breaking cli typecheck and 8 tests on main; the three helpers are now exported (separate commit).

## Assumptions made

1. **Vocabulary mapping is a documented projection** (proposal D5): mutators → `intent.*`/`claim.*`; phase transition → `build.finished`; verdicts → `verify.graded` with the V1/V2/V3 grade projection; provenance → `build.finished`; handoff `done` → `review.requested`, other dispositions → `intent.updated`. Adjustable in review without changing the layer's shape.
2. **File-backed roadmap mode only** for mutator emission; the file-less tracker path is a follow-up so this PR cannot conflict with the parallel `RoadmapTrackerClient` work.
3. **Fleet artifact emission is CLI-invoked** (`harness waypoint record-*`) because no TypeScript code writes those artifacts today; teaching the fleet SKILL.md prose to call it is a follow-up (plugin regeneration blast radius).
4. **`acceptance_eval` uses `process.cwd()`** as project root (the tool has no `path?` input, per its documented deferred-persistence seam).
5. **Only `WEBHOOK_TOPICS` gains the family**; `NOTIFICATION_TOPICS`/`SSE_TOPICS`/telemetry fan-out stay per-destination opt-in per their documented design.
6. **Dashboard UAT signoff route not hooked** — the MCP path emits the verdict event; a dashboard-only signoff is a follow-up.

https://claude.ai/code/session_01P7y8wPNXz6nsU8oWgFdZni
