### PR TITLE
fix(cleanup): honor entropy.drift.docPaths in cleanup and fix-drift (#1819)

### DIFF
--- a/.changeset/cleanup-honors-docpaths-1819.md
+++ b/.changeset/cleanup-honors-docpaths-1819.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cleanup): honor `entropy.drift.docPaths` in `cleanup` and `fix-drift` (#1819)
+
+`runCleanup` and `runFixDrift` hardcoded the doc denominator to `[join(docsDir, '**/*.md')]`. `runCleanup` did thread the project's drift config into `analyze.drift`, but `buildSnapshot` reads `docPaths` from the **top level** of `EntropyConfig`, so the hardcoded value stayed in force and `entropy.drift.docPaths` did nothing on the CLI path — while the MCP `detect_entropy` tool honored it. The key was live on one code path and dead on the other, which is what made it read as effective config: a project could widen its doc denominator, see the config accepted, and get no change in the gate. Both commands now forward the configured value, falling back to the `docsDir` glob when none is set.

--- a/.harness/arch/allowances/fix-cleanup-honors-docpaths.json
+++ b/.harness/arch/allowances/fix-cleanup-honors-docpaths.json
@@ -1,0 +1,8 @@
+{
+  "reason": "Two stacked fixes (#1819 docPaths threading, #1820 restored context-surface exports) that each fit the tolerance alone and exceed it together — the merge-order shape, not unchecked growth. The +4696 is almost entirely TESTS: 69 of 88 added lines are the three docPaths regression tests (each verified to fail against the unpatched source) plus the comments recording why the restored exports must not be swept again. Source change is 6 lines across two files.",
+  "categories": {
+    "module-size": 261220
+  },
+  "violationIds": [],
+  "createdFrom": "05b83cd76"
+}

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '688682a07f92279f3991e14ca1ee341508fc07ff723df9d16193638c3183aa84'
+sourceHash: '755734b0644e897f6ebae1be8e5446f80f388ab40902af2776707a83e161d382'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'a8fc3d8286a2e064cd7382d6a812e633c07fb33144c071ec1f40c9dd2b104350'
+sourceHash: '222e5fd2d48eb6d1c4590cf26110d212cb7282b3f80882aa5e94fa409d8f0483'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/src/commands/cleanup.ts
+++ b/packages/cli/src/commands/cleanup.ts
@@ -57,7 +57,12 @@ export async function runCleanup(
   // Build entropy config — use configured entry points or let resolveEntryPoints discover them.
   // docPaths must be glob patterns (a bare directory yields zero matches from glob).
   // Thread the project's drift config (entropy.drift) into analyze.drift so
-  // docPaths / ignorePatterns / checkApiSignatures etc. are honored (issue #723).
+  // ignorePatterns / checkApiSignatures etc. are honored (issue #723).
+  //
+  // `docPaths` needs threading separately (#1819): `buildSnapshot` reads it
+  // from the TOP LEVEL of EntropyConfig, not from `analyze.drift`, so the
+  // hard-coded value below stayed in force and the configured one was inert —
+  // while the MCP `detect_entropy` tool honored it.
   const driftEnabled = type === 'all' || type === 'drift';
   const driftConfig = config.entropy?.drift as Partial<DriftConfig> | undefined;
 
@@ -89,7 +94,10 @@ export async function runCleanup(
   const entropyConfig: EntropyConfig = {
     rootDir,
     ...(config.entropy?.entryPoints && { entryPoints: config.entropy.entryPoints }),
-    docPaths: [path.join(docsDir, '**/*.md')],
+    // Fallback stays docsDir-derived (configurable, and #301 made it a glob).
+    // It is narrower than the analyzer default, so an unconfigured project has
+    // no README in the drift denominator — deliberately unchanged here, #1819.
+    docPaths: driftConfig?.docPaths ?? [path.join(docsDir, '**/*.md')],
     analyze: {
       drift: driftEnabled ? (driftConfig ?? true) : false,
       deadCode: type === 'all' || type === 'dead-code',

--- a/packages/cli/src/commands/fix-drift.ts
+++ b/packages/cli/src/commands/fix-drift.ts
@@ -59,10 +59,16 @@ export async function runFixDrift(
 
   // Build entropy config for snapshot — use configured entry points or let resolveEntryPoints discover them.
   // docPaths must be glob patterns (a bare directory yields zero matches from glob).
+  //
+  // Same #1819 defect as `cleanup`, and it matters more here: `fix-drift`
+  // REWRITES docs, so a denominator narrower than the project declared leaves
+  // the files it was told to maintain silently unmaintained.
+  const driftConfig = config.entropy?.drift as { docPaths?: string[] } | undefined;
+
   const entropyConfig: EntropyConfig = {
     rootDir,
     ...(config.entropy?.entryPoints && { entryPoints: config.entropy.entryPoints }),
-    docPaths: [path.join(docsDir, '**/*.md')],
+    docPaths: driftConfig?.docPaths ?? [path.join(docsDir, '**/*.md')],
     analyze: {
       drift: true,
       deadCode: true,

--- a/packages/cli/tests/commands/cleanup.test.ts
+++ b/packages/cli/tests/commands/cleanup.test.ts
@@ -253,6 +253,48 @@ describe('cleanup command', () => {
       expect(capturedConfigs[0]).not.toHaveProperty('entryPoints');
     });
 
+    it('forwards entropy.drift.docPaths to the analyzer (#1819)', async () => {
+      // `buildSnapshot` reads docPaths from the TOP LEVEL, so threading the
+      // drift config through `analyze.drift` alone left this key inert.
+      vi.mocked(resolveConfig).mockReturnValueOnce({
+        ok: true,
+        value: {
+          version: 1,
+          rootDir: '.',
+          docsDir: './docs',
+          entropy: {
+            excludePatterns: [],
+            drift: { docPaths: ['AGENTS.md', '**/SKILL.md', 'docs/**/*.md'] },
+          },
+        },
+      } as never);
+
+      await runCleanup({ cwd: '/tmp/test' });
+
+      const config = capturedConfigs[0] as { docPaths: string[] };
+      expect(config.docPaths).toEqual(['AGENTS.md', '**/SKILL.md', 'docs/**/*.md']);
+    });
+
+    it('does not silently narrow a configured docPaths to the docsDir glob (#1819)', async () => {
+      // The failure mode is a SILENT narrowing: a clean drift check over a
+      // denominator the project did not choose reads exactly like a real pass.
+      vi.mocked(resolveConfig).mockReturnValueOnce({
+        ok: true,
+        value: {
+          version: 1,
+          rootDir: '.',
+          docsDir: './docs',
+          entropy: { excludePatterns: [], drift: { docPaths: ['AGENTS.md'] } },
+        },
+      } as never);
+
+      await runCleanup({ cwd: '/tmp/test' });
+
+      const config = capturedConfigs[0] as { docPaths: string[] };
+      expect(config.docPaths).not.toContainEqual(expect.stringMatching(/\*\*[\\/]\*\.md$/));
+      expect(config.docPaths).toHaveLength(1);
+    });
+
     it('passes docPaths as a glob pattern, not a bare directory (#301 follow-up)', async () => {
       await runCleanup({ cwd: '/tmp/test' });
       expect(capturedConfigs).toHaveLength(1);

--- a/packages/cli/tests/commands/fix-drift.test.ts
+++ b/packages/cli/tests/commands/fix-drift.test.ts
@@ -84,6 +84,28 @@ describe('fix-drift command', () => {
       }
     });
 
+    it('forwards entropy.drift.docPaths to buildSnapshot (#1819)', async () => {
+      // Higher stakes than `cleanup`: fix-drift REWRITES docs, so a narrower
+      // denominator leaves declared files silently unmaintained.
+      vi.mocked(resolveConfig).mockReturnValueOnce({
+        ok: true,
+        value: {
+          version: 1,
+          rootDir: '.',
+          docsDir: './docs',
+          entropy: {
+            excludePatterns: [],
+            drift: { docPaths: ['AGENTS.md', '**/SKILL.md'] },
+          },
+        },
+      } as never);
+
+      await runFixDrift({ cwd: '/tmp/test' });
+
+      const config = vi.mocked(buildSnapshot).mock.calls[0]?.[0] as { docPaths: string[] };
+      expect(config.docPaths).toEqual(['AGENTS.md', '**/SKILL.md']);
+    });
+
     it('passes docPaths as a glob pattern to buildSnapshot (#301 follow-up)', async () => {
       await runFixDrift({ cwd: '/tmp/test' });
       expect(vi.mocked(buildSnapshot)).toHaveBeenCalled();


### PR DESCRIPTION
Fixes #1819.

> **Stacked on #1821** (the red-`main` typecheck fix), because the pre-push
> hook runs typecheck and `main` currently fails it. Base this on `main` once
> #1821 lands — happy to retarget.

## The defect

`runCleanup` and `runFixDrift` hardcode the doc denominator:

```ts
docPaths: [path.join(docsDir, '**/*.md')],
```

`runCleanup` *does* thread the drift config into `analyze.drift`, and the
comment above that line says `docPaths` is honored as a result (#723) — but
`buildSnapshot` reads `docPaths` from the **top level** of `EntropyConfig`
(`packages/core/src/entropy/snapshot.ts:420`), so the hardcoded value stays in
force and the configured one is inert.

Two paths here already get it right — `mcp/tools/entropy.ts:218` and
`core/src/ci/check-orchestrator.ts:276` both spread `driftConfig?.docPaths`. So
`detect_entropy` honors the key and `cleanup` ignores it, which is what makes
it read as effective config: a project widens its doc denominator, sees the
config accepted with no error, and gets no change in the gate, because the run
still reports a clean drift check over the old denominator.

## Verification — paired planted positive

One commit of a real consuming repo, same dead link, control in `docs/`,
treatment in `AGENTS.md` (which that repo lists in `entropy.drift.docPaths`):

| probe | CLI 12.2.0 | patched |
| --- | --- | --- |
| `docs/CANARY_STATE.md` (control) | `findings 1` | `findings 1` |
| `AGENTS.md` (treatment) | `findings 0` | `findings 1` |

The control fires in both, so the tree is not simply clean; only the treatment
moves.

## `fix-drift` matters more than `cleanup`

It had no `driftConfig` binding at all. And it **rewrites** docs — a
denominator narrower than the project declared leaves the files it was told to
maintain silently unmaintained.

## Tests

Three added, each confirmed to **fail against the unpatched source** and pass
with the fix, rather than only asserted green.

## Deliberately NOT changed

The fallback stays `join(docsDir, '**/*.md')`, which is narrower than the
analyzer's own default (`['docs/**/*.md', 'README.md', '**/README.md']`) — so
a project that has *not* configured `docPaths` has **no README anywhere** in
the drift denominator, including the root one.

That is arguably also wrong, but widening it moves the denominator for every
consumer that never set the key: a real backlog, and a risk to an
absolute-total ratchet in repos I cannot see. It felt like a maintainer's call
rather than something to fold in silently, so it is recorded in a code comment
and in #1819. Say the word and I will add it here.

## Arch allowance

`.harness/arch/allowances/fix-cleanup-honors-docpaths.json`, with a reason.
The two stacked fixes each fit the tolerance alone and exceed it together
(+4696) — the merge-order shape rather than unchecked growth. 69 of 88 added
lines are tests and the anti-regression comments; the source change is 6 lines
across two files. `baselines.json` is byte-identical to the base.