### PR TITLE
fix(docker): raise smoke-test image size budget to 1000MB

### DIFF
--- a/.changeset/khaki-moons-repeat.md
+++ b/.changeset/khaki-moons-repeat.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Raise the Docker smoke-test image-size budget from 800MB to 1000MB.
+
+The first release-path execution of the `docker / smoke-test` job measured the orchestrator image at
+815MB against an 800MB limit. The limit was set to 800 in `aeb815856` when the largest image was
+774MB — only 3.4% of headroom — so ordinary dependency growth turned the tripwire into a scheduled
+failure. 1000MB restores ~23% headroom while still catching the structural regressions this check
+exists for (devDependencies or the build stage leaking into a runtime image), each of which costs
+many hundreds of MB.

--- a/docs/changes/docker-smoke-image-budget/plans/2026-09-05-docker-smoke-image-budget-plan.md
+++ b/docs/changes/docker-smoke-image-budget/plans/2026-09-05-docker-smoke-image-budget-plan.md
@@ -1,0 +1,78 @@
+# Plan: raise the Docker smoke-test image-size budget
+
+**Date:** 2026-09-05 · **Trigger:** Release run `33965602127`, job `101306280873` (`docker / smoke-test`), sha `851a5e4e` · **Tasks:** 3 · **Time:** ~10 min · **Integration Tier:** small
+
+Remediation for one of three assertion failures in the first-ever release-path execution of the
+`docker / smoke-test` job. The other two failures (CLI `--version`, MCP stdio) are a distinct root
+cause and ship as a separate PR off `main` — this plan deliberately does not touch them.
+
+## Goal
+
+Give `MAX_IMAGE_SIZE_MB` in `scripts/docker-smoke-test.sh` enough headroom that it functions as a
+tripwire against structural packaging regressions rather than as a scheduled failure, and record why
+the chosen number is the number.
+
+## Context
+
+The failing run measured: CLI 727MB (PASS), MCP 727MB (PASS), Dashboard 482MB (PASS),
+Orchestrator 815MB (**FAIL**, limit 800MB).
+
+The orchestrator stage is `FROM cli` plus an `apt-get install git curl` layer (`Dockerfile:107-112`),
+so its size is structurally `cli + ~88MB`. The CLI image is the growth driver; the orchestrator is
+the image that crosses any budget first.
+
+Commit `aeb815856` ("fix(docker): raise smoke test image size limit to 800MB") already raised this
+constant once, from 400MB, when the observed range was 479-774MB. That set the budget 3.4% above the
+then-largest image. **This is the second raise**, and the reason a second raise was needed so soon is
+that the first one left almost no headroom.
+
+## Decision record
+
+The remediation fork "raise the budget vs. slim the orchestrator image" was put to the human and
+answered **raise the budget**. The tradeoff is stated in full under _Assumptions and tradeoffs_ below.
+
+## Chosen value: 1000MB
+
+- **22.7% headroom** over the observed 815MB orchestrator image, versus the 3.4% that just failed.
+- Still a real tripwire. The failure modes this assertion exists to catch are structural — shipping
+  `devDependencies` into a runtime stage, leaking the `build` stage into a runtime stage, or losing
+  the `--prod` flag on `Dockerfile:80`/`:147`. Each of those adds many hundreds of MB and would blow
+  past 1000MB just as loudly as past 800MB. Nothing that 800 caught is let through by 1000.
+- Absorbs the increment from the companion container-startup fix, which restores a native module
+  binding to the runtime image.
+- 1GB is a round, memorable ceiling, which matters for a constant that is read far more often than
+  it is changed.
+
+## Observable Truths (Acceptance Criteria)
+
+1. `MAX_IMAGE_SIZE_MB` is `1000`.
+   **Gate:** `grep -c '^MAX_IMAGE_SIZE_MB=1000$' scripts/docker-smoke-test.sh` -> `1`.
+2. The constant carries a comment naming the observed sizes the budget was set against, so the next
+   person to hit this does not have to reconstruct the history from `git log`.
+   **Gate:** the lines above `MAX_IMAGE_SIZE_MB` cite run `33965602127` and the 815MB observation.
+3. No assertion is weakened or removed. The size check still runs against all four images.
+   **Gate:** `git diff` touches exactly one assignment line plus comments; `check_image_size` is
+   called four times, unchanged.
+4. `pnpm format:check` is clean and a changeset is present.
+
+## Tasks
+
+1. Raise `MAX_IMAGE_SIZE_MB` from `800` to `1000` and add the explanatory comment block.
+2. Add a `patch` changeset.
+3. Write the plan and session-state artifacts (this file and its sibling under `sessions/`).
+
+## Assumptions and tradeoffs
+
+- **Stated reservation, overruled by decision.** Raising the budget does not make the images smaller.
+  A 815MB orchestrator image is large for what it contains, and the underlying cause — the `cli`
+  stage installing the full production dependency closure of every workspace package it copies — is
+  real and worth addressing. The human's call was that this red is a CI-signal problem and that image
+  slimming is separate, elective work that should not be smuggled into a CI remediation. That call
+  stands and is recorded here rather than re-argued.
+- **Assumption:** the 815MB figure from run `33965602127` is representative. It is a `linux/amd64`
+  image built by `docker/build-push-action@v6` from this exact `Dockerfile`; the image the smoke test
+  measures is pulled from ghcr, not rebuilt, so the number is the shipped artifact's real size.
+- **Deferred:** actual image-size reduction for the `cli`/`orchestrator` stages. Not filed by this
+  plan; the budget comment points at it so the next raise has to confront it.
+- **Deferred:** the smoke test discards stderr (`2>/dev/null`) on its runtime assertions, which is
+  why the companion failures reported `''`. Being filed separately.

--- a/docs/changes/docker-smoke-image-budget/sessions/2026-09-05-session-state.md
+++ b/docs/changes/docker-smoke-image-budget/sessions/2026-09-05-session-state.md
@@ -1,0 +1,51 @@
+# Session state: docker/smoke-test image-size budget remediation
+
+**Fleet:** cicd-fleet · **Item:** R2a · **Date:** 2026-09-05 · **Pipeline:** harness-debugging
+**Branch:** `fleet/cicd-smoke-image-budget` · **Base:** `origin/main` @ `5cd661d74`
+
+## Trigger
+
+Release run `33965602127`, job `101306280873` (`docker / smoke-test`), sha `851a5e4e`.
+Cause classification: **real-failure** (not flake, not infra).
+
+Three deterministic assertion failures. This session addresses **one** of them; the other two are a
+distinct root cause and ship separately as `fleet/cicd-container-startup`.
+
+| #   | Assertion                                             | This session        |
+| --- | ----------------------------------------------------- | ------------------- |
+| 1   | `Orchestrator image size — 815MB exceeds 800MB limit` | **in scope**        |
+| 2   | `CLI --version — Expected semver, got: ''`            | out of scope (PR-B) |
+| 3   | `MCP stdio initialize — Expected serverInfo, got: ''` | out of scope (PR-B) |
+
+## Phase log
+
+- **INVESTIGATE** — located the assertion at `scripts/docker-smoke-test.sh:153-166`; read the
+  observed sizes from the run; established via `Dockerfile:107-112` that the orchestrator stage is
+  `cli` + an apt layer, so the 815/727 split is structurally expected rather than anomalous.
+- **ANALYZE** — `git log` on the constant surfaced `aeb815856`, which raised it 400 -> 800 against a
+  then-max of 774MB. Headroom at that time: 3.4%.
+- **HYPOTHESIZE** — H1 (unintended content in the orchestrator image) rejected: the 88MB
+  orchestrator/cli delta is fully accounted for by `git` + `curl`. H2 (budget set with no headroom,
+  crossed by ordinary growth) confirmed.
+- **FIX** — raised `MAX_IMAGE_SIZE_MB` 800 -> 1000 with an inline comment recording the observation
+  the budget was set against and the escalation rule for any future raise.
+
+## Human decisions carried into this session
+
+- **F1 -> (b)** raise the budget; do **not** slim the image. The reservation (815MB is genuinely
+  large, and the `cli` stage's dependency-closure install is the real lever) is recorded as a stated
+  tradeoff in the plan and in the budget comment, not re-litigated.
+- **F2 -> (b)** split the size-budget change and the container-startup fix into two PRs off `main`.
+- **F3 -> (b)** do **not** fix the smoke test's `2>/dev/null` stderr swallowing here; the
+  observability gap is filed separately.
+
+## Verification
+
+- `grep -c '^MAX_IMAGE_SIZE_MB=1000$' scripts/docker-smoke-test.sh` -> `1`
+- Diff touches one assignment plus comments; `check_image_size` still called for all four images.
+- No assertion weakened or deleted.
+
+## Status
+
+`resolved` — session record at `.harness/debug/active/docker-smoke-image-budget.md` (gitignored path;
+mirrored here because `.harness/debug/` is excluded by `.gitignore:49`).

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -20,7 +20,22 @@ MCP_IMAGE="harness-mcp-smoke"
 ORCH_IMAGE="harness-orchestrator-smoke"
 DASH_IMAGE="harness-dashboard-smoke"
 COMPOSE_PROJECT="harness-smoke"
-MAX_IMAGE_SIZE_MB=800
+# Image-size tripwire. This guards against STRUCTURAL packaging regressions — a runtime
+# stage shipping devDependencies, the `build` stage leaking into a runtime stage, or the
+# `--prod` flag going missing on the Dockerfile's install steps. Each of those adds many
+# hundreds of MB, so the budget only has to be tight enough to catch them.
+#
+# Observed in Release run 33965602127 (the first release-path execution of this job):
+#   CLI 727MB · MCP 727MB · Dashboard 482MB · Orchestrator 815MB
+# The orchestrator is `FROM cli` plus an apt layer for git+curl, so it is always the
+# largest image and is the one that crosses any budget first.
+#
+# 1000MB is ~23% headroom over that 815MB high-water mark. The previous value (800, set in
+# aeb815856, itself a raise from 400) left only 3.4% over the images of the day, which is
+# why ordinary dependency growth turned it into a scheduled failure. If a THIRD raise is
+# ever needed, shrink the images instead — the `cli` stage installs the full production
+# dependency closure of every workspace package it copies, and that is the real lever.
+MAX_IMAGE_SIZE_MB=1000
 HEALTH_TIMEOUT=60
 
 # --- Color output ---


### PR DESCRIPTION
Remediation for **1 of 3** assertion failures in Release run [33965602127](https://github.com/Intense-Visions/harness-engineering/actions/runs/33965602127), job `101306280873` (`docker / smoke-test`), sha `851a5e4e`.

```
FAIL Orchestrator image size — 815MB exceeds 800MB limit
```

The other two failures (`CLI --version`, `MCP stdio`) are a **different root cause** and ship as a separate PR off `main` — not stacked on this one.

## Why this is not a regression

The `docker` job is gated `if: needs.release.outputs.published == 'true'`, so it runs only on a real changesets publish. This was its first execution from the release path (see #1257 / #1258). `build-and-push` succeeded — the images were pushed to ghcr and then failed verification.

## Remediation

Raise `MAX_IMAGE_SIZE_MB` from `800` to `1000` in `scripts/docker-smoke-test.sh`.

Observed in the failing run: CLI 727MB · MCP 727MB · Dashboard 482MB · **Orchestrator 815MB**.

The orchestrator stage is `FROM cli` plus an apt layer for `git`+`curl` (`Dockerfile:107-112`), so the 88MB orchestrator/CLI delta is fully accounted for — nothing anomalous is in the image. It is structurally the largest, and crosses any budget first.

### Why 1000

- **~23% headroom** over the 815MB high-water mark.
- `aeb815856` ("fix(docker): raise smoke test image size limit to 800MB") **already raised this constant once**, from 400, when the largest image was 774MB. That left **3.4%** headroom — which is why a second raise was needed so soon. That context belongs in the record, and the new inline comment carries it.
- Still a real tripwire. What this assertion exists to catch is structural: devDependencies in a runtime stage, the `build` stage leaking into a runtime stage, or `--prod` going missing. Each costs many hundreds of MB and blows past 1000 as loudly as past 800. Nothing 800 caught is let through by 1000.
- Absorbs the ~1MB from the companion container-startup PR.
- The comment sets the escalation rule: **if a third raise is ever needed, shrink the images instead.**

## Assumptions made

- The 815MB figure is representative. The smoke test measures the image **pulled from ghcr**, not a rebuild, so it is the shipped artifact's real size.
- Verified by inspection that no assertion is weakened: the diff touches one assignment plus comments, and `check_image_size` is still called for all four images.

## Stated tradeoff (decision recorded, not re-litigated)

The remediation fork "raise the budget vs. slim the image" was put to the human and answered **raise the budget**. For the record: raising the budget does not make the images smaller, 815MB is genuinely large, and the real lever is that the `cli` stage installs the full production dependency closure of every workspace package it copies. The call was that this red is a CI-signal problem and image slimming is separate, elective work that should not be smuggled into a CI remediation. That call stands; the reservation is captured in the plan and in the code comment so the next person to touch this constant sees it.

## Deferred, filed separately

`scripts/docker-smoke-test.sh:179` and `:192` discard stderr (`2>/dev/null || echo ""`), which is why the other two failures reported `''` rather than a diagnosis. **Deliberately not fixed here** — the observability gap is being filed separately.

## Artifacts

- Plan: `docs/changes/docker-smoke-image-budget/plans/2026-09-05-docker-smoke-image-budget-plan.md`
- Session state: `docs/changes/docker-smoke-image-budget/sessions/2026-09-05-session-state.md`

Produced by cicd-fleet via the `harness-debugging` pipeline.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
