### PR TITLE
fix(docker): make the cli and mcp container images start

### DIFF
--- a/.changeset/lucky-pandas-smile.md
+++ b/.changeset/lucky-pandas-smile.md
@@ -1,0 +1,24 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix container startup for the published `harness-cli` and `harness-mcp` images.
+
+Both images failed to start, producing no stdout — which the Docker smoke test reported as
+`Expected semver, got: ''` and `Expected serverInfo in response, got: ''`. Three independent
+packaging defects, none of which could surface before the first release-path publish:
+
+- The `cli` stage's `COPY` allowlist had drifted from the CLI's transitive workspace closure,
+  omitting `burn`, `signals` and `local-models`. `pnpm install` symlinks every workspace dependency
+  whether or not its directory was copied, so the miss produced dangling symlinks that were invisible
+  at build time and fatal at startup with `ERR_MODULE_NOT_FOUND`.
+- `typescript` is imported at runtime by the CLI and deliberately kept out of the tsup bundle, but
+  was declared only as a root devDependency, so `--prod` installs excluded it. It is now a real
+  runtime dependency of `packages/cli`. This adds no bytes to the container (it was already present
+  transitively) and makes an existing implicit requirement explicit.
+- The `cli` stage drops to `USER node` while `/app` stays root-owned, so the MCP server died with
+  `EACCES` creating `/app/.harness`. The directory is now pre-created and owned by `node`, matching
+  the pattern the orchestrator stage already uses for its workspaces directory.
+
+Verified against real containers: `--version` prints `12.3.0` and the MCP server answers `initialize`
+with `serverInfo`. Image size grows ~1MB.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,17 @@ RUN pnpm build
 # ==============================================================================
 FROM base AS cli
 
-# CLI bundles its own code via tsup; workspace packages (core, graph, linter-gen, types,
-# orchestrator, dashboard, intelligence) are copied as pre-built dist artifacts.
+# CLI bundles its own code via tsup, but only for the four packages in tsup's
+# `noExternal` list (core, graph, linter-gen, types). Every OTHER workspace package in
+# the CLI's runtime dependency closure stays external and is resolved from node_modules
+# at startup, so it must be present here as a pre-built dist artifact.
+#
+# This COPY list must cover the CLI's FULL TRANSITIVE workspace closure, not just its
+# direct dependencies. `pnpm install` below creates a symlink for every workspace dep
+# whether or not its directory was copied; a missing COPY yields a DANGLING SYMLINK that
+# fails at runtime with ERR_MODULE_NOT_FOUND, not at build time. Omitting burn, signals
+# and local-models is exactly how the smoke test's `--version` check started returning ''.
+#
 # eslint-plugin is referenced by package.json only (no dist needed at runtime).
 COPY --from=build /app/packages/cli/dist /app/packages/cli/dist
 COPY --from=build /app/packages/cli/package.json /app/packages/cli/
@@ -77,7 +86,21 @@ COPY --from=build /app/packages/dashboard/dist /app/packages/dashboard/dist
 COPY --from=build /app/packages/intelligence/package.json /app/packages/intelligence/
 COPY --from=build /app/packages/intelligence/dist /app/packages/intelligence/dist
 COPY --from=build /app/packages/eslint-plugin/package.json /app/packages/eslint-plugin/
+COPY --from=build /app/packages/burn/package.json /app/packages/burn/
+COPY --from=build /app/packages/burn/dist /app/packages/burn/dist
+COPY --from=build /app/packages/signals/package.json /app/packages/signals/
+COPY --from=build /app/packages/signals/dist /app/packages/signals/dist
+COPY --from=build /app/packages/local-models/package.json /app/packages/local-models/
+COPY --from=build /app/packages/local-models/dist /app/packages/local-models/dist
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts
+
+# Everything under /app was created by root during the build, but the container runs as
+# `node`. The CLI and the MCP server both create /app/.harness on startup
+# (ensureHarnessGitignore), which fails with EACCES against a root-owned /app and kills the
+# process before it writes any stdout. Pre-create the directory owned by node so startup can
+# proceed. The orchestrator stage already does this for .harness/workspaces; the cli and
+# mcp-server stages need the parent.
+RUN mkdir -p /app/.harness && chown -R node:node /app/.harness
 
 USER node
 

--- a/docs/changes/docker-container-startup/plans/2026-09-05-docker-container-startup-plan.md
+++ b/docs/changes/docker-container-startup/plans/2026-09-05-docker-container-startup-plan.md
@@ -1,0 +1,134 @@
+# Plan: fix Docker container startup for the CLI and MCP images
+
+**Date:** 2026-09-05 · **Trigger:** Release run `33965602127`, job `101306280873` (`docker / smoke-test`), sha `851a5e4e` · **Tasks:** 4 · **Integration Tier:** medium
+
+Remediation for two of the three assertion failures in the first release-path execution of the
+`docker / smoke-test` job. The third (orchestrator image size) is a separate root cause and ships as
+a separate PR off `main`.
+
+## Goal
+
+Make the published `harness-cli` and `harness-mcp` container images actually start, so that
+`docker run <cli> --version` prints a semver and the MCP server answers a JSON-RPC `initialize` with
+`serverInfo` — verified against real containers, not asserted.
+
+## The failures
+
+```
+FAIL CLI --version — Expected semver, got: ''
+FAIL MCP stdio initialize — Expected serverInfo in response, got: ''
+```
+
+Both report `''` because `scripts/docker-smoke-test.sh:179` and `:192` capture stdout with
+`2>/dev/null || echo ""`. `''` means _the container produced no stdout_, not _it printed an empty
+version_. The diagnostic was on stderr and was discarded. Per decision **F3** this plan does **not**
+fix that stderr swallowing; the observability gap is filed separately. It is, however, the reason
+diagnosis required a full local reproduction.
+
+## Reproduction
+
+The published images could not be pulled: they are private and the available token carries
+`gist, read:org, repo, workflow` — no `read:packages`. Anonymous and authenticated pulls both
+returned `denied`.
+
+Reproduced against a local build after establishing it is faithful:
+`git diff 851a5e4e3..HEAD -- Dockerfile packages/cli/package.json pnpm-lock.yaml` is **empty**, so the
+packaging inputs at HEAD are byte-identical to the failing release. The rebuilt image reports version
+`12.3.0` — the released version — confirming the same artifact.
+
+## Root cause: three independent defects, all first-execution-only
+
+The `docker` job is gated `if: needs.release.outputs.published == 'true'`, so it runs only on a real
+changesets publish. None of these three could surface until it did.
+
+1. **The `cli` stage's `COPY` allowlist drifted from the CLI's workspace closure.**
+   The CLI's transitive workspace closure is ten packages; the stage copied seven. Missing:
+   `burn`, `signals`, `local-models`. `pnpm install` creates a symlink for _every_ workspace
+   dependency regardless of whether its directory was copied, so the miss produces a **dangling
+   symlink** that is invisible at build time and fatal at startup:
+   `ERR_MODULE_NOT_FOUND: Cannot find package '@harness-engineering/burn'`.
+
+2. **`typescript` is imported at runtime but declared nowhere as a runtime dependency.**
+   It is statically imported by several CLI sources (`naming-craft/extract/identifiers.ts:11`,
+   `brand/rules/forbidden-phrases-rule.ts:18`, `security-craft/extract/signals.ts:17`, and others)
+   and is deliberately excluded from the tsup bundle (`tsup.config.ts` `external: ['typescript']`,
+   because bundling breaks its CommonJS `require('fs')` host). It exists only as a **root
+   devDependency**, which `--prod` excludes. The tsup comment claims it is "available transitively
+   via `@typescript-eslint/typescript-estree`" — false under pnpm's strict linking, which links only
+   direct dependencies. It holds for npm consumers (npm auto-installs it as a peer), which is why the
+   published CLI works and only the Docker `--prod` install exposes the gap.
+
+3. **The `cli` stage drops to `USER node` without a node-writable state directory.**
+   `/app` is root-owned from the build. The MCP server's `ensureHarnessGitignore` creates
+   `/app/.harness` on startup and dies with `EACCES: permission denied, mkdir '/app/.harness'`.
+   `--version` exits before reaching that path, which is why one image produced two different
+   failures. The `orchestrator` stage already anticipates this one level down
+   (`Dockerfile:118-119`); `cli` and `mcp-server` never got the equivalent for the parent.
+
+Defects 1 and 3 are in the `Dockerfile`. Defect 2 is a manifest under-declaration; fixing it in the
+Dockerfile would be a workaround, so it is fixed at its source.
+
+## Observable Truths (Acceptance Criteria)
+
+Verified against real containers built from this `Dockerfile`.
+
+1. `docker run --rm <cli-image> --version 2>/dev/null` prints a semver.
+   **Gate:** output matches `^[0-9]+\.[0-9]+\.[0-9]+` — observed `12.3.0`.
+2. Piping a JSON-RPC `initialize` into `docker run --rm -i <mcp-image> 2>/dev/null | head -1` yields a
+   response containing `"serverInfo"`.
+   **Gate:** observed
+   `{"result":{"protocolVersion":"2025-03-26","capabilities":{...},"serverInfo":{"name":"harness-engineering","version":"2.3.1"}},"jsonrpc":"2.0","id":1}`
+3. Every workspace symlink under `packages/cli/node_modules/@harness-engineering/` resolves.
+   **Gate:** no dangling entries; `/app/packages/` contains burn, signals and local-models.
+4. The image does not grow materially.
+   **Gate:** `/app` 544MB -> 545MB.
+5. No smoke-test assertion is weakened, disabled or deleted.
+   **Gate:** `scripts/docker-smoke-test.sh` is untouched by this PR.
+
+## Progressive verification
+
+Each fix element clears exactly one observed failure — none is speculative.
+
+| Image state                       | `CLI --version`                            | `MCP stdio initialize` |
+| --------------------------------- | ------------------------------------------ | ---------------------- |
+| baseline (reproduces the release) | `''` FAIL — no `@harness-engineering/burn` | `''` FAIL              |
+| + workspace COPYs                 | `''` FAIL — no `typescript`                | `''` FAIL              |
+| + `typescript` dependency         | `12.3.0` **PASS**                          | `''` FAIL — EACCES     |
+| + `.harness` chown (final)        | `12.3.0` **PASS**                          | `serverInfo` **PASS**  |
+
+## Tasks
+
+1. Add `burn`, `signals`, `local-models` (package.json + dist) to the `cli` stage COPY list, with a
+   comment recording that the list must track the full transitive closure.
+2. Declare `typescript` as a runtime dependency of `packages/cli`; regenerate the lockfile.
+3. Pre-create `/app/.harness` owned by `node` before `USER node`.
+4. Add a changeset; write the plan and session artifacts.
+
+## Assumptions made
+
+- **Assumption:** a local build from HEAD faithfully reproduces the published image. Justified by the
+  empty diff on all three packaging inputs, and corroborated by the rebuilt CLI reporting `12.3.0`.
+- **Assumption:** the defects are architecture-independent. The local build is `linux/arm64`; CI
+  publishes `linux/amd64`. All three failures are module resolution, manifest declaration and POSIX
+  file ownership — none is arch-sensitive. Image _sizes_ are not comparable across the two, so the
+  size claim is stated as a delta (~1MB), not an absolute.
+- **Assumption:** declaring `typescript` a dependency of `packages/cli` is acceptable for npm
+  consumers. It adds no bytes to the container (already present transitively) and npm consumers
+  already resolve it as a peer of `typescript-estree`; this makes an existing implicit requirement
+  explicit.
+
+## Deferred — NOT fixed here
+
+- **`better-sqlite3` ships with no native binding.** `--ignore-scripts` (`Dockerfile:80`, `:147`)
+  skips its `install` script, which is what fetches the prebuilt `.node`. Confirmed: no
+  `better_sqlite3.node` anywhere in the image, and no `build/` under the package. This was the
+  fleet's leading hypothesis for THIS red and is **refuted as its cause** — the process dies during
+  module resolution and never reaches a native `require` — but the defect is real and latent. It will
+  fire the moment a command touches the webhook queue or session search index
+  (`packages/orchestrator/src/gateway/webhooks/queue.ts:1`,
+  `packages/orchestrator/src/sessions/search-index.ts:13`). Note `--ignore-scripts` is load-bearing:
+  `503fbd819` added it because the root `prepare` runs husky, a devDependency. A fix must keep husky
+  skipped while letting native modules build. Out of scope for a minimal remediation; needs filing.
+- **The smoke test discards stderr** on both runtime assertions (decision F3). Filed separately.
+- **A build-time guard** asserting every workspace symlink resolves would have caught defect 1 in CI
+  rather than in a release. Worth doing; not done here.

--- a/docs/changes/docker-container-startup/sessions/2026-09-05-session-state.md
+++ b/docs/changes/docker-container-startup/sessions/2026-09-05-session-state.md
@@ -1,0 +1,69 @@
+# Session state: Docker container-startup remediation
+
+**Fleet:** cicd-fleet · **Item:** R2b · **Date:** 2026-09-05 · **Pipeline:** harness-debugging
+**Branch:** `fleet/cicd-container-startup` · **Base:** `origin/main` @ `5cd661d74`
+
+## Trigger
+
+Release run `33965602127`, job `101306280873` (`docker / smoke-test`), sha `851a5e4e`.
+Cause classification: **real-failure**, first-execution exposure of a latent packaging defect.
+
+| #   | Assertion                                             | This session        |
+| --- | ----------------------------------------------------- | ------------------- |
+| 1   | `Orchestrator image size — 815MB exceeds 800MB limit` | out of scope (PR-A) |
+| 2   | `CLI --version — Expected semver, got: ''`            | **in scope**        |
+| 3   | `MCP stdio initialize — Expected serverInfo, got: ''` | **in scope**        |
+
+## Phase log
+
+- **INVESTIGATE** — established that `''` means "no stdout", not "empty version"
+  (`scripts/docker-smoke-test.sh:179`, `:192`). Attempted to pull the published artifacts; blocked by
+  a missing `read:packages` scope. Proved a local build is a faithful reproduction via an empty
+  `git diff 851a5e4e3..HEAD` across `Dockerfile`, `packages/cli/package.json` and `pnpm-lock.yaml`,
+  then reproduced and captured the stderr the smoke test had discarded.
+- **ANALYZE** — computed the CLI's transitive workspace closure from the manifests (10 packages) and
+  compared it to the stage's COPY list (7). Enumerated all 52 bare specifiers in `packages/cli/dist`
+  and resolution-tested each root inside the image, rather than discovering gaps one rebuild at a
+  time. Read `tsup.config.ts` to establish which packages are bundled vs external.
+- **HYPOTHESIZE** — four hypotheses, tested one variable per rebuild. H1 (the fleet's supplied
+  `better-sqlite3` hypothesis) **refuted**; H2, H3, H4 confirmed. See the table below.
+- **FIX** — three changes, each clearing exactly one observed failure.
+
+## Hypothesis ledger
+
+| #   | Hypothesis                                                                         | Verdict              | Evidence                                                                                                                                                           |
+| --- | ---------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| H1  | `better-sqlite3` native binding missing (`--ignore-scripts`) kills startup         | **REFUTED as cause** | Process dies during ESM resolution on `@harness-engineering/burn`, never reaching a native require. The missing binding is real but latent — recorded as deferred. |
+| H2  | `cli` stage COPY allowlist drifted from the workspace closure -> dangling symlinks | CONFIRMED            | `burn`, `signals`, `local-models` symlinked but never copied                                                                                                       |
+| H3  | `typescript` imported at runtime but not a declared runtime dep                    | CONFIRMED            | Root devDependency only; `--prod` excludes it; tsup keeps it external                                                                                              |
+| H4  | `USER node` with a root-owned `/app` blocks state-dir creation                     | CONFIRMED            | `EACCES: permission denied, mkdir '/app/.harness'`                                                                                                                 |
+
+## Verification
+
+Real containers, exact CI assertions. `12.3.0` is the released version, confirming artifact identity.
+
+| Image state        | `--version`   | MCP `initialize`  |
+| ------------------ | ------------- | ----------------- |
+| baseline           | `''` FAIL     | `''` FAIL         |
+| + workspace COPYs  | `''` FAIL     | `''` FAIL         |
+| + `typescript` dep | `12.3.0` PASS | `''` FAIL         |
+| final              | `12.3.0` PASS | `serverInfo` PASS |
+
+Size delta: `/app` 544MB -> 545MB.
+
+## Human decisions carried into this session
+
+- **F2 -> (b)** two PRs off `main`, not stacked. This branch is cut from `origin/main` and does not
+  contain PR-A's commit.
+- **F3 -> (b)** the smoke test's `2>/dev/null` stderr swallowing is **not** fixed here. Stderr was
+  read locally for diagnosis only; `scripts/docker-smoke-test.sh` is untouched by this PR.
+
+## Constraints honoured
+
+- No assertion weakened, disabled or deleted — the fix is entirely on the packaging side.
+- No `--no-verify`. No merge.
+
+## Status
+
+`resolved` — session record at `.harness/debug/active/docker-container-startup.md` (gitignored path;
+mirrored here because `.harness/debug/` is excluded by `.gitignore:49`).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "minimatch": "^10.2.5",
     "semver": "^7.7.4",
     "tree-sitter-wasms": "0.1.13",
+    "typescript": "^5.9.3",
     "web-tree-sitter": "^0.24.7",
     "yaml": "^2.8.3",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       tree-sitter-wasms:
         specifier: 0.1.13
         version: 0.1.13
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       web-tree-sitter:
         specifier: ^0.24.7
         version: 0.24.7


### PR DESCRIPTION
Remediation for **2 of 3** assertion failures in Release run [33965602127](https://github.com/Intense-Visions/harness-engineering/actions/runs/33965602127), job `101306280873` (`docker / smoke-test`), sha `851a5e4e`.

```
FAIL CLI --version — Expected semver, got: ''
FAIL MCP stdio initialize — Expected serverInfo in response, got: ''
```

The third failure (orchestrator image size) is a different root cause and ships as #1830. **This PR is based on `main`, not stacked on that one.**

## `''` did not mean "empty version"

Both assertions capture stdout with `2>/dev/null || echo ""` (`scripts/docker-smoke-test.sh:179`, `:192`). `''` means **the container produced no stdout at all**. The actual diagnosis was on stderr and was thrown away. Per the decision on this run, that stderr swallowing is **not** fixed here — it is being filed separately — but it is why this red cost a full reproduction cycle.

## Reproduction

The published images could not be pulled: they are private and the available token carries `gist, read:org, repo, workflow` — **no `read:packages`**. Anonymous and authenticated pulls both returned `denied`.

So I reproduced against a local build, after first proving it faithful: `git diff 851a5e4e3..HEAD -- Dockerfile packages/cli/package.json pnpm-lock.yaml` is **empty**, so the packaging inputs at HEAD are byte-identical to the failing release. Corroborated by the rebuilt CLI reporting **`12.3.0`** — exactly the released version.

The stderr the smoke test discarded:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@harness-engineering/burn' imported from /app/packages/cli/dist/chunk-4FZJQERY.js
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:314:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    ...
  code: 'ERR_MODULE_NOT_FOUND'
}
```

The process dies during ESM link, before `main()` runs — hence zero stdout.

## The fleet's leading hypothesis was refuted

The dispatch proposed that `better-sqlite3` lacks a native binding because the `cli` stage installs with `--ignore-scripts`, killing startup. **Refuted as the cause of this red:** the process dies during module *resolution* and never reaches a native `require`.

The underlying observation is nonetheless **real and confirmed** — there is no `better_sqlite3.node` anywhere in the image and no `build/` under the package. It is a genuine latent defect; it simply is not what fired. Recorded under *Deferred* below.

## Root cause: three independent defects

All three are first-execution-only, which is why a release-gated job was the first thing to see them.

**1. The `cli` stage's `COPY` allowlist drifted from the CLI's workspace closure.**
The transitive closure is 10 packages; the stage copied 7. Missing: `burn`, `signals`, `local-models`. `pnpm install` symlinks *every* workspace dependency whether or not its directory was copied, so the miss produced **dangling symlinks** — invisible at build time, fatal at startup. Same dual-source-of-truth class as the core-barrel allowlist.

**2. `typescript` is imported at runtime but declared nowhere as a runtime dependency.**
Statically imported by several CLI sources (`naming-craft/extract/identifiers.ts:11`, `brand/rules/forbidden-phrases-rule.ts:18`, `security-craft/extract/signals.ts:17`, …) and deliberately excluded from the tsup bundle (`external: ['typescript']`, because bundling breaks its CommonJS `require('fs')` host). It existed only as a **root devDependency**, which `--prod` excludes. The tsup comment asserts it is "available transitively via `@typescript-eslint/typescript-estree`" — false under pnpm's strict linking, which links only direct dependencies. It holds for npm consumers (npm auto-installs it as a peer), which is why the published CLI works and only the Docker `--prod` install exposed it.

**3. The `cli` stage drops to `USER node` without a node-writable state directory.**
`/app` is root-owned from the build; the MCP server's `ensureHarnessGitignore` creates `/app/.harness` on startup and dies with `EACCES`. `--version` exits before reaching that path — which is why one image produced two different failures needing two different fixes. The `orchestrator` stage already anticipates this one level down (`Dockerfile:118-119`); `cli` and `mcp-server` never got the equivalent for the parent.

Defects 1 and 3 are fixed in the `Dockerfile`. Defect 2 is a manifest under-declaration — fixing it in the Dockerfile would be a workaround, so it is fixed at its source (3-line lockfile delta).

## Verification — real containers, exact CI assertions

One variable per rebuild; each fix element clears exactly one observed failure. Nothing speculative.

| Image state | `CLI --version` | `MCP stdio initialize` |
| --- | --- | --- |
| baseline (reproduces the release) | `''` FAIL — no `@harness-engineering/burn` | `''` FAIL |
| + workspace COPYs | `''` FAIL — no `typescript` | `''` FAIL |
| + `typescript` dependency | `12.3.0` **PASS** | `''` FAIL — `EACCES /app/.harness` |
| + `.harness` chown (final) | `12.3.0` **PASS** | `serverInfo` **PASS** |

Final MCP response:

```json
{"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{},"resources":{}},"serverInfo":{"name":"harness-engineering","version":"2.3.1"}},"jsonrpc":"2.0","id":1}
```

**Image size:** `/app` grows 544MB → 545MB (**~1MB**). `typescript@5.9.3` (23MB) was *already* in the baseline image transitively; declaring it direct only adds a symlink. On the CI `linux/amd64` images this puts the orchestrator around 816MB — over the old 800MB limit, comfortably under the 1000MB set by #1830.

## Assumptions made

- **A local build faithfully reproduces the published image.** Justified by the empty diff across all three packaging inputs and corroborated by the `12.3.0` version match.
- **The defects are architecture-independent.** The local build is `linux/arm64`; CI publishes `linux/amd64`. All three failures are module resolution, manifest declaration, and POSIX file ownership — none arch-sensitive. Image *sizes* are not comparable across the two, so the size claim is stated as a **delta**, not an absolute.
- **Declaring `typescript` a dependency of `packages/cli` is acceptable for npm consumers.** It adds no bytes to the container and npm consumers already resolve it as a peer of `typescript-estree`; this makes an existing implicit requirement explicit.

## Deferred — NOT fixed here

- **`better-sqlite3` ships with no native binding.** `--ignore-scripts` (`Dockerfile:80`, `:147`) skips the `install` script that fetches the prebuilt `.node`. Will fire the moment a command touches the webhook queue or session search index (`packages/orchestrator/src/gateway/webhooks/queue.ts:1`, `packages/orchestrator/src/sessions/search-index.ts:13`). Note `--ignore-scripts` is **load-bearing**: `503fbd819` added it because the root `prepare` runs husky, a devDependency — a fix must keep husky skipped while letting native modules build. **Needs filing.**
- **The smoke test discards stderr** on both runtime assertions. Filed separately.
- **A build-time guard** asserting every workspace symlink resolves would have caught defect 1 in CI instead of in a release. Worth doing; not done here.

## Constraints honoured

- `scripts/docker-smoke-test.sh` is **untouched** by this PR — no assertion weakened, disabled, or deleted. The fix is entirely on the packaging side.
- No `--no-verify`.

## Artifacts

- Plan: `docs/changes/docker-container-startup/plans/2026-09-05-docker-container-startup-plan.md`
- Session state: `docs/changes/docker-container-startup/sessions/2026-09-05-session-state.md`

Produced by cicd-fleet via the `harness-debugging` pipeline.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
