### PR TITLE
fix(dashboard): validate External-ID before interpolating it into the authenticated GitHub API path

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/dashboard': patch
+---
+
+fix(dashboard): validate a roadmap `External-ID` before interpolating it into the authenticated GitHub API path
+
+`assignGithubIssue` parsed `External-ID` with an unconstrained capture and spliced the
+result, unencoded, into the path of a `POST https://api.github.com/...` request carrying
+the operator's `GITHUB_TOKEN`. A crafted External-ID could therefore choose the path of
+that credentialed request (for example `github:x/../../../user/emails?#1` resolved to
+`POST https://api.github.com/user/emails`). The External-ID is now constrained to
+`github:<owner>/<repo>#<number>`, bare dot segments are rejected, and each path segment is
+percent-encoded. Malformed IDs return `false` exactly as before.

--- a/.harness/comprehension/packages/dashboard/src/server/routes/_module.md
+++ b/.harness/comprehension/packages/dashboard/src/server/routes/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/dashboard/src/server/routes'
-sourceHash: 'f1d0d3bbe2025f950e60a8107f05073fe43b1bdb1fc8bb3217f9aa5987ef796c'
-compiledAt: '2026-08-28T01:22:11.403Z'
+sourceHash: '8f244303158a17fbac46ddf1f7b6bee5676a048184ce13a2081c8209d5476daf'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'actions-claim-file-less.ts',
@@ -25,23 +24,6 @@ members:
     'traceability.ts',
   ]
 ---
-
-## Summary
-
-The routes module implements the dashboard server's HTTP endpoint layer via 16 router builders and 2 file-less handlers. Each builder returns a Hono router configured with endpoints split into three categories: data gathering (cache-backed GET endpoints for metrics), mutations (POST endpoints for claim/status/validate with serialized file writes), and signoff (human acceptance recording). The module supports both file-backed and file-less roadmap modes, dispatching at runtime on project config. All file writes serialize via `withFileLock` to prevent concurrent corruption. Status values are closed to 6 options and validated at both code paths. Assignee-status coupling is enforced via `setStatus()` to preserve the invariant that assignee ≠ null ⟺ status = 'in-progress'.
-
-## Invariants
-
-- Assignee-status coupling (RMH005): assignee !== null ⟺ status = 'in-progress'; all transitions route through setStatus() to auto-clear stale assignees
-- Roadmap aggregate immutability (R): never read/write aggregate directly; all mutations via applyRoadmapDiff(store, before, after) which regenerates from shards or rewrites whole file
-- Serialized file writes: all writes to projectPath/chartsPath must acquire withFileLock() first; concurrent mutations queue and serialize fully
-- Single validation gate: only one pnpm harness validate process at a time; validating flag returns 429 during concurrent attempts
-- Closed status set: exactly 6 valid statuses (done, in-progress, planned, blocked, backlog, needs-human); validation at both file-less and file-backed paths rejects unknowns at 400
-- Conflict error standardization (D-P4-B): file-less mode surfaces ConflictError as 409 with { error, code: 'TRACKER_CONFLICT', externalId, refreshHint }
-- GitHub sync timing: assignment persisted to roadmap BEFORE attempting GitHub issue sync; network failure does not lose local change
-- Validation output bounds: stdout/stderr each capped at 512 KB with truncation marker; process kills after 30 seconds; timeout returns dedicated error
-- Cache invalidation scope: roadmap status changes invalidate 'roadmap' + 'overview'; regen-charts also invalidates 'health' + 'graph'; partial invalidation risks stale aggregates
-- Dual roadmap mode dispatch: loadProjectRoadmapMode() determines file-less vs file-backed path at runtime; both must handle identical semantics
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/dashboard/tests/server/routes/_module.md
+++ b/.harness/comprehension/packages/dashboard/tests/server/routes/_module.md
@@ -1,13 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/dashboard/tests/server/routes'
-sourceHash: '2be5491cbd316e94dd312b21b53c08206a127f6ffcf5084a8a77ca2f59d3fdfc'
-compiledAt: '2026-08-28T01:22:11.546Z'
+sourceHash: 'a0a5b05234b3d396d762407973061497c31d860c871d653ccccd4d777e7140c8'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
+    'actions-claim.external-id-path.test.ts',
     'actions-claim.file-less.test.ts',
     'actions-claim.test.ts',
     'actions-refresh.test.ts',
@@ -27,21 +27,6 @@ members:
     'signoff.test.ts',
   ]
 ---
-
-## Summary
-
-`packages/dashboard/tests/server/routes` contains integration and unit tests for the dashboard's HTTP route handlers. It covers endpoints for roadmap claiming, status updates, health checks, roadmap reads, and metadata routes (adoption, signals, graph, impact, CI, signoff). Tests verify correct HTTP status codes, response shapes, cache invalidation, GitHub sync behavior, and persistent state mutations through both file-based (monolith `roadmap.md`) and file-less (tracker client) execution paths. The module uses a dual pattern: file-based tests create real temp projects with actual roadmap files to test the full load→diff→serialize round-trip; file-less tests mock the tracker client to isolate handler logic. Gatherers are mocked globally; GitHub API calls are mocked via fetch stubs.
-
-## Invariants
-
-- 409 TRACKER_CONFLICT response shape must include: code, externalId, error, conflictedWith, refreshHint='reload-roadmap' — clients rely on this to detect and recover from concurrent mutations
-- Only 'planned' features are claimable; attempting to claim 'in-progress' or 'done' returns 409; status must transition to 'in-progress' on successful claim
-- Workflow routing is spec-driven: no spec → brainstorming; spec but no plan → planning; routing decision gates downstream orchestration
-- Real filesystem required for file-based tests — roadmap.md store does async load→applyRoadmapDiff→serialize; static mocks cannot model this, tests must use actual temp files and verify on-disk persistence
-- Cache invalidation is dual-key: both 'roadmap' and 'overview' cache entries must be invalidated on claim/refresh/status-update; partial invalidation leaves stale data
-- GitHub sync is opt-in and non-blocking: syncing only occurs when externalId exists AND GITHUB_TOKEN env var is set; sync failures set githubSynced=false but don't fail the request
-- Input validation is strict: missing feature or assignee returns 400; nonexistent feature returns 404; only one response sent per request
-- Tracker client claim(id, assignee) contract: ConflictError raises 409; network/rate-limit errors raise 502; success returns mutated feature with new status/assignee
 
 ## Interface Contract
 

--- a/packages/dashboard/src/server/routes/actions.ts
+++ b/packages/dashboard/src/server/routes/actions.ts
@@ -293,29 +293,60 @@ function detectWorkflow(spec: string | null, plans: string[]): ClaimWorkflow {
 }
 
 /**
+ * The one shape an External-ID may take before any part of it is spliced into
+ * the authenticated api.github.com path below. `/`, `#`, `?` and whitespace are
+ * excluded so a crafted roadmap row cannot append path segments or truncate the
+ * intended `/issues/<n>/assignees` suffix into a query string.
+ */
+const GITHUB_EXTERNAL_ID_RE = /^github:([^/#?\s]+)\/([^/#?\s]+)#(\d+)$/;
+
+/**
+ * Dot segments have to be rejected separately: `encodeURIComponent` leaves `.`
+ * untouched, so `..` survives the character class above and still collapses
+ * under URL normalization.
+ */
+function isDotSegment(segment: string): boolean {
+  return segment === '.' || segment === '..';
+}
+
+/**
  * Parse a github externalId like "github:owner/repo#42" and assign the issue.
  * Returns true if assignment succeeded, false otherwise.
+ *
+ * The externalId arrives verbatim from roadmap content and is interpolated into
+ * a request that carries the operator's GITHUB_TOKEN, so it is validated and
+ * percent-encoded here rather than trusted (CWE-441, CWE-20).
  */
 async function assignGithubIssue(externalId: string, assignee: string): Promise<boolean> {
   const token = process.env['GITHUB_TOKEN'];
   if (!token) return false;
 
-  const match = externalId.match(/^github:(.+?)#(\d+)$/);
+  const match = externalId.match(GITHUB_EXTERNAL_ID_RE);
   if (!match) return false;
 
-  const [, repo, issueNum] = match;
+  const [, owner, repo, issueNum] = match;
+  if (isDotSegment(owner!) || isDotSegment(repo!)) return false;
+
   const cleanAssignee = assignee.startsWith('@') ? assignee.slice(1) : assignee;
   try {
-    const res = await fetch(`https://api.github.com/repos/${repo}/issues/${issueNum}/assignees`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'harness-dashboard',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ assignees: [cleanAssignee] }),
-    });
+    // Encoding happens inside the try: the character class admits lone
+    // surrogates, on which encodeURIComponent throws URIError. Rejecting that
+    // as a failed sync matches this function's contract; letting it escape
+    // would 500 the request after the claim had already been persisted.
+    const repoPath = `${encodeURIComponent(owner!)}/${encodeURIComponent(repo!)}`;
+    const res = await fetch(
+      `https://api.github.com/repos/${repoPath}/issues/${encodeURIComponent(issueNum!)}/assignees`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'harness-dashboard',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ assignees: [cleanAssignee] }),
+      }
+    );
     return res.ok;
   } catch {
     return false;

--- a/packages/dashboard/tests/server/routes/actions-claim.external-id-path.test.ts
+++ b/packages/dashboard/tests/server/routes/actions-claim.external-id-path.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildActionsRouter } from '../../../src/server/routes/actions';
+import type { ServerContext } from '../../../src/server/context';
+import { DataCache } from '../../../src/server/cache';
+import { GatherCache } from '../../../src/server/gather-cache';
+import { SSEManager } from '../../../src/server/sse';
+
+// Same gatherer mocks the sibling claim tests use — the actions router imports
+// them at module load regardless of which route is exercised.
+vi.mock('../../../src/server/gather/security', () => ({
+  gatherSecurity: vi.fn().mockResolvedValue({
+    valid: true,
+    findings: [],
+    stats: { filesScanned: 0, errorCount: 0, warningCount: 0, infoCount: 0 },
+  }),
+}));
+vi.mock('../../../src/server/gather/perf', () => ({
+  gatherPerf: vi.fn().mockResolvedValue({
+    valid: true,
+    violations: [],
+    stats: { filesAnalyzed: 0, violationCount: 0 },
+  }),
+}));
+vi.mock('../../../src/server/gather/arch', () => ({
+  gatherArch: vi
+    .fn()
+    .mockResolvedValue({ passed: true, totalViolations: 0, regressions: [], newViolations: [] }),
+}));
+vi.mock('../../../src/server/gather/anomalies', () => ({
+  gatherAnomalies: vi
+    .fn()
+    .mockResolvedValue({ outliers: [], articulationPoints: [], overlapCount: 0 }),
+}));
+vi.mock('../../../src/server/identity', () => ({
+  resolveIdentity: vi.fn().mockResolvedValue({ username: 'testuser', source: 'git-config' }),
+  resolveRole: vi.fn().mockReturnValue('dev'),
+}));
+
+const origEnv = { ...process.env };
+
+/**
+ * Claiming a roadmap row syncs the assignment to GitHub, and the row's
+ * `External-ID` is interpolated into that authenticated request's path. These
+ * rows carry External-IDs crafted to break out of
+ * `/repos/<owner>/<repo>/issues/<n>/assignees`.
+ *
+ * Each attack string relies on a different primitive:
+ *  - a trailing `?` truncates the intended path suffix into a query string;
+ *  - `/../` segments collapse under WHATWG URL normalization;
+ *  - bare dot segments survive `encodeURIComponent` (which does not encode `.`)
+ *    and still collapse, so a character-class constraint alone is not enough.
+ */
+function roadmapWithExternalId(externalId: string): string {
+  return `---
+project: test
+version: 1
+last_synced: "2026-01-01T00:00:00Z"
+last_manual_edit: "2026-01-01T00:00:00Z"
+---
+
+# Roadmap
+
+## Milestone: MVP
+
+### API Gateway
+- **Status:** planned
+- **Spec:** —
+- **Summary:** REST API gateway
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P1
+- **External-ID:** ${externalId}
+`;
+}
+
+async function makeProject(externalId: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'dash-claim-extid-'));
+  await mkdir(path.join(root, 'docs'), { recursive: true });
+  await writeFile(
+    path.join(root, 'docs', 'roadmap.md'),
+    roadmapWithExternalId(externalId),
+    'utf-8'
+  );
+  return root;
+}
+
+function makeContext(projectPath: string): ServerContext {
+  const sseManager = new SSEManager();
+  vi.spyOn(sseManager, 'broadcast').mockResolvedValue(undefined);
+  return {
+    projectPath,
+    roadmapPath: path.join(projectPath, 'docs', 'roadmap.md'),
+    chartsPath: path.join(projectPath, 'docs', 'roadmap-charts.md'),
+    cache: new DataCache(60_000),
+    pollIntervalMs: 30_000,
+    sseManager,
+    gatherCache: new GatherCache(),
+  };
+}
+
+/**
+ * Resolve every URL the claim actually requested the way a real HTTP client
+ * would — through `new URL()` — and report `origin + pathname`. Asserting on the
+ * raw template string would pass even when `..` and `?` rewrite the path the
+ * server ultimately receives, which is the whole defect.
+ */
+function normalizedRequestPaths(): string[] {
+  return vi.mocked(fetch).mock.calls.map((call) => {
+    const url = new URL(String(call[0]));
+    return `${url.origin}${url.pathname}`;
+  });
+}
+
+async function claimWithExternalId(externalId: string): Promise<{
+  githubSynced: boolean;
+  requested: string[];
+  cleanup: () => Promise<void>;
+}> {
+  const projectRoot = await makeProject(externalId);
+  const app = new Hono();
+  app.route('/api', buildActionsRouter(makeContext(projectRoot)));
+  const res = await app.request('/api/actions/roadmap/claim', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ feature: 'API Gateway', assignee: 'testuser' }),
+  });
+  const body = (await res.json()) as { githubSynced: boolean };
+  return {
+    githubSynced: body.githubSynced,
+    requested: normalizedRequestPaths(),
+    cleanup: () => rm(projectRoot, { recursive: true, force: true }),
+  };
+}
+
+describe('POST /api/actions/roadmap/claim — External-ID is validated before it reaches the GitHub API path', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  beforeEach(() => {
+    process.env = { ...origEnv };
+    process.env['GITHUB_TOKEN'] = 'ghp_test';
+    // A permissive mock: every request "succeeds", so nothing but the fix itself
+    // can stop a crafted External-ID from reaching api.github.com.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true } as Response));
+  });
+
+  afterEach(async () => {
+    process.env = origEnv;
+    vi.unstubAllGlobals();
+    await Promise.all(cleanups.splice(0).map((fn) => fn()));
+  });
+
+  it.each([
+    // [External-ID, the endpoint it reaches today if left unvalidated]
+    ['github:x/../../../user/emails?#1', 'https://api.github.com/user/emails'],
+    ['github:a/../../user/repos?#1', 'https://api.github.com/user/repos'],
+    ['github:../..#1', 'https://api.github.com/issues/1/assignees'],
+    ['github:./.#1', 'https://api.github.com/repos/issues/1/assignees'],
+  ])(
+    'sends no authenticated request at all for the malformed External-ID %j (would otherwise reach %s)',
+    async (externalId, escapedEndpoint) => {
+      const { githubSynced, requested, cleanup } = await claimWithExternalId(externalId);
+      cleanups.push(cleanup);
+
+      expect(requested).not.toContain(escapedEndpoint);
+      // Stronger: a malformed External-ID must not produce a credentialed
+      // request at all, not merely one aimed somewhere else.
+      expect(requested).toEqual([]);
+      expect(githubSynced).toBe(false);
+    }
+  );
+
+  it('still assigns the issue for a well-formed External-ID', async () => {
+    const { githubSynced, requested, cleanup } = await claimWithExternalId(
+      'github:Intense-Visions/harness-engineering#1525'
+    );
+    cleanups.push(cleanup);
+
+    expect(requested).toEqual([
+      'https://api.github.com/repos/Intense-Visions/harness-engineering/issues/1525/assignees',
+    ]);
+    expect(githubSynced).toBe(true);
+  });
+
+  it('keeps an unpaired-surrogate External-ID inside /repos/ instead of failing the request', async () => {
+    // A lone surrogate is the one input the character class admits that
+    // encodeURIComponent throws on. It cannot survive the roadmap's UTF-8 file
+    // round-trip — it decodes to U+FFFD before the route ever sees it — so the
+    // throw is unreachable from here. What this pins is the part that matters:
+    // the resulting segment is still encoded and still under /repos/.
+    const { requested, cleanup } = await claimWithExternalId(
+      `github:o${String.fromCharCode(0xd800)}/r#1`
+    );
+    cleanups.push(cleanup);
+
+    expect(requested).toEqual(['https://api.github.com/repos/o%EF%BF%BD/r/issues/1/assignees']);
+  });
+
+  it('percent-encodes an owner/repo that is well-formed but not URL-safe', async () => {
+    const { requested, cleanup } = await claimWithExternalId('github:o%2e/r&x#7');
+    cleanups.push(cleanup);
+
+    expect(requested).toEqual(['https://api.github.com/repos/o%252e/r%26x/issues/7/assignees']);
+  });
+});


### PR DESCRIPTION
## What

`assignGithubIssue` in `packages/dashboard/src/server/routes/actions.ts` built the path of an **authenticated** `POST https://api.github.com/...` request out of a roadmap `External-ID` that was never validated and never encoded. This constrains the External-ID shape and percent-encodes every interpolated path segment, at that one call site.

Fleet: `security-fleet` / `SEC-FLEET-001`. Tier: FIX. Route: `bug`.

## Evidence class and trace

Evidence class: **`exploitable-path`** — CWE-441 (Unintended Proxy / Confused Deputy), CWE-20 (Improper Input Validation), OWASP A03.

Trace on the pre-fix code, at base `5cd661d74`:

| Step | Location |
| --- | --- |
| Entry point | `POST /api/actions/roadmap/claim` |
| Handler | `packages/dashboard/src/server/routes/actions.ts:435` — `handleClaim` |
| Taint source | `packages/dashboard/src/server/routes/actions.ts:419` — `runFileBackedClaim` reads `feat.externalId` verbatim from roadmap content; no validation on the path |
| Sink call | `packages/dashboard/src/server/routes/actions.ts:458` — `assignGithubIssue(outcome.externalId, assignee)` |
| Unconstrained parse | `packages/dashboard/src/server/routes/actions.ts:303` — `/^github:(.+?)#(\d+)$/`; the `.+?` admits `/`, `?` and `..` |
| Sink | `packages/dashboard/src/server/routes/actions.ts:309` — the capture is interpolated **unencoded** into the request path |
| Credential | `packages/dashboard/src/server/routes/actions.ts:301` and `:312` — `Authorization: Bearer ${process.env['GITHUB_TOKEN']}` |

`handleClaim` length-checks `feature` and `assignee` (`:441`) but nothing on the path ever checks `externalId`.

## Before / after — the *normalized* request

The rows below are the resolved URL, i.e. what the remote server actually receives: the raw template string run through the WHATWG `new URL()` normalizer, reported as `origin + pathname`. Two primitives are in play — a trailing `?` truncates the intended `/issues/<n>/assignees` suffix into a query string, and `/../` segments collapse under normalization.

| `External-ID` | Before (base `5cd661d74`) | After |
| --- | --- | --- |
| `github:x/../../../user/emails?#1` | `POST https://api.github.com/user/emails` | rejected — no request issued, `githubSynced: false` |
| `github:a/../../user/repos?#1` | `POST https://api.github.com/user/repos` | rejected — no request issued, `githubSynced: false` |
| `github:../..#1` | `POST https://api.github.com/issues/1/assignees` | rejected — no request issued, `githubSynced: false` |
| `github:./.#1` | `POST https://api.github.com/repos/issues/1/assignees` | rejected — no request issued, `githubSynced: false` |
| `github:o%2e/r&x#7` | `POST https://api.github.com/repos/o%2e/r&x/issues/7/assignees` | `POST https://api.github.com/repos/o%252e/r%26x/issues/7/assignees` |
| `github:Intense-Visions/harness-engineering#1525` (benign control) | `POST https://api.github.com/repos/Intense-Visions/harness-engineering/issues/1525/assignees` | unchanged |

## Scope of the issue — stated honestly, not inflated

- The host is a **fixed literal**. An attacker cannot change it. This is **method + path control against `api.github.com` using the operator's own ambient token** — it is **not** exfiltration of that token to an attacker-controlled host.
- The practical impact is that a crafted roadmap row can make the dashboard `POST` to an arbitrary `api.github.com` endpoint as the operator. The body is fixed (`{"assignees":[...]}`) and the method is fixed to `POST`, which bounds what is reachable, but endpoints such as `/user/repos` are `POST`-meaningful.
- The dashboard **binds `127.0.0.1` by default**, so reaching this endpoint at all is operator-gated. The realistic delivery is a roadmap row (a `docs/roadmap.d/` shard or `docs/roadmap.md` edit) that the operator then claims from their own dashboard, not a remote unauthenticated request.
- No credential value is exposed anywhere in this PR, the tests, or the finding. This is a missing-validation defect, not a leaked secret.

## The fix

One call site, `packages/dashboard/src/server/routes/actions.ts`:

- `GITHUB_EXTERNAL_ID_RE = /^github:([^/#?\s]+)\/([^/#?\s]+)#(\d+)$/` replaces `/^github:(.+?)#(\d+)$/`. **Three capture groups now (owner, repo, number) where there were two** — the destructuring changed accordingly and the `owner/repo` pair is rebuilt for the URL.
- Bare dot segments (`.`, `..`) are rejected explicitly.
- Each interpolated path segment is `encodeURIComponent`-ed, **inside** the existing `try`. The character class admits lone surrogates, which make `encodeURIComponent` throw `URIError`; encoding above the `try` would let that escape and 500 the request *after* `applyRoadmapDiff` had already persisted the claim. Inside the `try` it degrades to `githubSynced: false`, which is the contract this function already had.

Existing behavior is preserved exactly: `false` on no-match, `false` on missing token, `false` on fetch failure. No signature change, no new throw, no new status code.

## Assumptions made

1. **Roadmap `External-ID` content is attacker-influenceable in the threat model being defended** — that is, anyone who can land a roadmap shard or edit `docs/roadmap.md` can choose that string. If roadmap content is considered fully trusted, this change is hardening rather than a vulnerability fix. This assumption is stated, not proven, by this PR.
2. **`encodeURIComponent` alone is not sufficient, and this was verified rather than assumed.** It does not encode `.`, so `..` survives the character class and still collapses under normalization — `github:../..#1` reaches `POST https://api.github.com/issues/1/assignees` with the constrained regex and encoding but *without* the dot-segment guard. That is why the guard exists; it is one line beyond a pure regex-and-encode change and is required for the fix to actually close the finding.
3. **Rejection stays silent (returns `false`).** That matches the function's existing contract — the claim itself still succeeds and the response reports `githubSynced: false`. Surfacing a malformed External-ID to the operator would be a behavior change and is deliberately out of scope here.
4. `...` (three or more dots) is **not** rejected. It is not a path-traversal token, it resolves inside `/repos/`, and over-blocking it would reject a legal repository name.

## Testing

New: `packages/dashboard/tests/server/routes/actions-claim.external-id-path.test.ts`, co-located with the existing dashboard route tests.

It drives the **real** `POST /api/actions/roadmap/claim` route against a real temp roadmap whose `External-ID` carries each attack string, captures what the route actually requested, and asserts on `new URL(...).origin + pathname` — **not** on the raw template string, which would pass even while `..` and `?` rewrite the path the server receives. Both attack strings from the finding are covered, plus the dot-segment case, plus a benign control that must keep working, plus an encoding case.

Verified failing before the fix and passing after:

```
# before  (4 failed | 1 passed — the 1 pass is the benign control)
AssertionError: expected [ 'https://api.github.com/user/repos' ] to not include 'https://api.github.com/user/repos'
AssertionError: expected [ Array(1) ] to not include 'https://api.github.com/user/emails'
AssertionError: expected [ Array(1) ] to not include 'https://api.github.com/issues/1/assig…'
- "https://api.github.com/repos/o%252e/r%26x/issues/7/assignees"   (expected)
+ "https://api.github.com/repos/o%2e/r&x/issues/7/assignees"       (received)

# after
Test Files  135 passed (135)
     Tests  957 passed (957)      # whole packages/dashboard suite
```

Re-confirmed after the final round of edits by checking `actions.ts` back out at the base commit and re-running: **5 failed | 2 passed**. The two that pass either way are the benign control and the unpaired-surrogate case — the latter is a behavior pin, not a security assertion, and is labelled as such in the test.

Also run locally: `tsc --noEmit` on `packages/dashboard` (clean); `eslint` on the changed source file (clean); a 21-case bypass sweep against the new validator (backslash separators, pre-encoded slashes, NUL/TAB/LF/CR/NEL/NBSP/U+2028, userinfo `@`, port `:`, percent-encoded dots, fullwidth solidus) — **0 escaped the `/repos/` prefix**.

## Security review of this diff

An adversarial review was run over this diff before pushing (a first pass, not a verdict). It found **no bypass of the fixed code** — 163 targeted payloads plus a full-BMP brute force (~460k cases: every code point solo, embedded, and as dot-segment near-misses; 2-char and 3-char combinations over a high-risk alphabet; the issue-number group fuzzed) produced **0 escapes** of the `/repos/<owner>/<repo>/issues/<n>/assignees` shape. Independently, a 21-case sweep here (backslash separators, pre-encoded slashes, NUL/TAB/LF/CR/NEL/NBSP/U+2028, userinfo `@`, port `:`, percent-encoded dots, fullwidth solidus) also produced 0 escapes.

The result is structural rather than lucky: `encodeURIComponent` emits only `A-Za-z0-9-_.!~*'()`; of those the only character WHATWG URL treats specially is `.`, the only special *segments* are `.` and `..`, and both are rejected. `%` is itself encoded to `%25`, so `%2e` becomes the literal `%252e` and can never re-decode into a dot segment.

Two review findings were **acted on in this PR**: the `URIError` escape described above (moved inside the `try`), and a missing single-dot `.` test case (added). One finding is **not** actionable here and is recorded below.

## Noted and deliberately not touched

**A second, separate instance of this same defect is still live in `packages/core` — it is NOT fixed by this PR and needs its own tiering.** `packages/core/src/roadmap/external-id.ts:12` defines `/^github:([^/]+)\/([^#]+)#(\d+)$/`, whose `repo` group `[^#]+` admits both `/` and `?`. `parsed.repo` is interpolated unencoded into the same class of authenticated sink (`Authorization: Bearer ${this.token}` at `packages/core/src/roadmap/adapters/github-issues.ts:201`), notably at `adapters/github-issues.ts:475` — the exact analogue of the code fixed here — and also at `:325`, `:353`, `:502`, `:555`, plus `tracker/adapters/github-issues.ts:190`, `:355`, `:479`, `:573`, `:588`. Reproduced directly against the verbatim regex and the verbatim `:475` template:

| `External-ID` | resolves to |
| --- | --- |
| `github:x/../../../user/emails?#1` | `POST https://api.github.com/user/emails` |
| `github:a/../../../applications/CLIENTID/token?#1` | `POST https://api.github.com/applications/CLIENTID/token` |

It is fed by the same roadmap `External-ID` field. It is left untouched here **deliberately**: this PR's scope was approved as the single dashboard call site, and growing it to cover core would exceed that approval. Worth calling out honestly — `external-id.ts` documents itself as the "single source of truth… so the shape can never drift", and fixing only the dashboard means the permissive regex remains authoritative for every other caller.

Also noted, not touched:

- `packages/dashboard/src/client/components/roadmap/utils.ts:30` — `externalIdToUrl` uses the same loose `/^github:(.+?)#(\d+)$/`. Client-side, builds a display href only: no credential, no server request. Same class, materially lower severity.
- `handleClaim` (`actions.ts:465`) does `c.req.json<ClaimRequest>()` with no runtime validation. A non-string `assignee` (e.g. `5`) passes both guards — `!5` is `false`, `(5).length > 100` is `undefined > 100` → `false` — is written to the roadmap, then throws a `TypeError` at `assignee.startsWith(...)` *outside* the `try`, producing a 500 *after* the claim was committed. Pre-existing, unchanged context in this diff. Non-security correctness defect; parked for the build pipeline.
- Rejected path-escape attempts are silent (`return false` covers missing token, malformed ID, dot-segment reject, and network failure alike), so an attempt is indistinguishable from an unset `GITHUB_TOKEN` and leaves no log or metric. Adding a warn is a behavior change and was left out of this bounded fix.
- `harness check-deps` fails on `main` at `5cd661d74` with a pre-existing circular dependency (`packages/core/src/solutions/scan-candidates/read-commits.ts` → `git-scan.ts`). Confirmed pre-existing by stashing this diff and re-running on the clean base. Not touched here.

## Base freshness

Branched from `origin/main` at `5cd661d74`. That commit and its parent `9ea40937d` are both `[skip ci]` and never ran the PR gates, so the **merge base carries no gate evidence**. CI on this branch runs the gates for real, so the green here is genuinely fresh — the missing evidence is upstream of this PR, not in it.

---

Fleet provenance: authored through the real `harness-debugging` skill (`stages=[debugging]`); the session record is at `.harness/debug/resolved/2026-09-05-sec-fleet-001-external-id-path-injection.md` in the lane worktree. That directory is gitignored repo-wide (`.harness/.gitignore:4`), so it is not part of this diff. As a `bug`-routed item there is no `docs/changes/<slug>/plans/` directory, which is expected.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
