### PR TITLE
chore(roadmap): reconcile 6 shipped-but-stale shards to done

### DIFF
--- a/docs/roadmap.d/emit-provenance-trailer-from-agent-commits.md
+++ b/docs/roadmap.d/emit-provenance-trailer-from-agent-commits.md
@@ -6,7 +6,7 @@ order: 99
 
 ### Emit a machine-readable provenance trailer from agent-authored commits
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** Harness-authored work is statistically invisible. Measured across two orgs: a personal org carries **69 AI co-author trailers in 6,570 commits (1%)**, and a dogfood product repo **974 in 4,618 (21%)** — while its highest-volume author shows **5 trailers across 3,988 commits**, because the fleet path emits nothing. Consequences compound: org-wide AI-adoption reporting undercounts by roughly 5x and cannot distinguish the autonomous tier from interactive assistance (the distinction that explains an 18x throughput gap); cost attribution has no key to join spend to authorship; and in a regulated codebase there is no record of which agent, skill and version produced a change touching a gated path. Build: a distinct trailer — `Harness-Run: <skill>@<version>` plus lane and agent id — emitted by the fleet path rather than co-opting `Co-authored-by`, so tier detection is mechanical and the trailer doubles as the accountability record. Foundation for `cost-per-merged-pr-attribution` and for human-in-the-loop attestation on gated paths.
 - **Blockers:** —

--- a/docs/roadmap.d/merged-but-unreleased-inventory-metric.md
+++ b/docs/roadmap.d/merged-but-unreleased-inventory-metric.md
@@ -6,7 +6,7 @@ order: 94
 
 ### Track merged-but-unreleased inventory as a first-class metric
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** A dogfood consumer with **1,132 merged pull requests has 0 GitHub releases and 0 tags**, alongside **138 pending changesets** — every one an unshipped unit of declared change. The release pipeline is configured and active (`release.yml`, plus several per-target deploy workflows) and 30 deployments exist across preview and production environments, so this is not a broken pipeline but an unmeasured one: merge throughput rose without release throughput following, and nothing in the harness noticed. Merged is not shipped, and a throughput claim built on merge counts is inflated by exactly this gap. Build: pending-changeset count and age, merged-but-unreleased PR count, and time-from-merge-to-release as tracked signals per surface, with a threshold that warns when inventory outgrows release cadence. Cheap to compute, and it converts a silent accumulation into a visible one.
 - **Blockers:** —

--- a/docs/roadmap.d/orchestrator-codex-backend-subprocess-env-air-gap.md
+++ b/docs/roadmap.d/orchestrator-codex-backend-subprocess-env-air-gap.md
@@ -6,7 +6,7 @@ order: 6
 
 ### Orchestrator Codex Backend Subprocess Env Air-Gap (follow-up)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** Apply the subprocess env allowlist air-gap to the Codex backend. The gateway policy-envelope work air-gapped the Claude backend's subprocess spawn (replaced `env: process.env` with an explicit allowlist), but the Codex backend (`packages/orchestrator/src/backends/codex.ts`) still passes the full parent environment to its spawned subprocess — the same leak, unpatched. Extend the shared subprocess-env allowlist + PolicyMetadata stamping to codex.ts so both backends enforce the boundary identically. Follow-up to the orchestrator gateway policy envelope + subprocess air-gap.
 - **Blockers:** —

--- a/docs/roadmap.d/rate-limit-aware-fan-out-governor.md
+++ b/docs/roadmap.d/rate-limit-aware-fan-out-governor.md
@@ -6,7 +6,7 @@ order: 100
 
 ### Make fan-out rate-limit aware, not just slot aware
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** Fleet concurrency is governed by compute slots (`min(16, CPUs - 2)` per workflow, with `fleet-command` holding each lane to a share of a global pool) but not by the API budgets the leaves actually consume. Measured during a 90-day org analysis: GitHub **code search is capped at 10 requests per minute**, and secondary rate limits fired repeatedly under modest parallelism — 10-way fan-out on the commits API produced silent under-fetching that returned wrong answers rather than errors (287 of 430 repositories read as zero). A slot-governed fleet whose leaves are API-bound will therefore degrade into throttling and, worse, into quietly incomplete results. Build: per-resource budgets alongside slot budgets, backoff shared across a fleet rather than per-leaf, and a hard rule that a truncated or throttled fetch fails the leaf instead of returning partial data. Pairs with `standardize-parallel-execution`; the failure mode is correctness, not just speed.
 - **Blockers:** —

--- a/docs/roadmap.d/rework-rate-instrumentation.md
+++ b/docs/roadmap.d/rework-rate-instrumentation.md
@@ -6,7 +6,7 @@ order: 96
 
 ### Instrument rework rate per surface
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** On a dogfood consumer, **215 of 1,411 distinct issue references appear in more than one commit — 15.2%**. Some of that is legitimately multi-part work; the remainder is rework, and rework at the autonomous tier is waste that scales directly with the token budget rather than with headcount. Today nothing distinguishes "this issue took four PRs because it was large" from "this issue took four PRs because the first three were wrong," so the harness cannot tell an operator that a surface is churning. Build: per-surface rework rate from issue-to-PR fan-out plus superseded/closed-unmerged PRs, separated from planned multi-part delivery by roadmap linkage, and surfaced next to throughput so the two are never read apart. Prerequisite for claiming any efficiency win: a 10x throughput gain with a 15% rework rate is a 10x waste gain too.
 - **Blockers:** —

--- a/docs/roadmap.d/stability-gate-on-ranked-outputs.md
+++ b/docs/roadmap.d/stability-gate-on-ranked-outputs.md
@@ -6,7 +6,7 @@ order: 97
 
 ### Never emit a ranked list without a stability check
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** A contributor-scoring exercise across 69 people and two adjacent 45-day windows produced a Spearman rank correlation of **0.62 overall, near zero in the middle band, with a mean movement of 12–15 places**. Individual position was not reproducible; only broad tier membership was. The same exercise also produced an invalid band analysis on the first pass — bands defined by the *mean* of two measurements force those measurements to anti-correlate within band, yielding impossible negative correlations. Both failure modes apply to every ranked output the harness emits: hotspots, risk areas, craft targets, critical paths, skill recommendations. Build: any ordered output computes over two windows, reports the correlation, and **degrades to tiers when correlation is low** rather than presenting a spurious order; bands are always defined on one window and validated against the other, never on the average. Turns a methodological trap into a mechanical guard.
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1114,7 +1114,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Never emit a ranked list without a stability check
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** A contributor-scoring exercise across 69 people and two adjacent 45-day windows produced a Spearman rank correlation of **0.62 overall, near zero in the middle band, with a mean movement of 12–15 places**. Individual position was not reproducible; only broad tier membership was. The same exercise also produced an invalid band analysis on the first pass — bands defined by the *mean* of two measurements force those measurements to anti-correlate within band, yielding impossible negative correlations. Both failure modes apply to every ranked output the harness emits: hotspots, risk areas, craft targets, critical paths, skill recommendations. Build: any ordered output computes over two windows, reports the correlation, and **degrades to tiers when correlation is low** rather than presenting a spurious order; bands are always defined on one window and validated against the other, never on the average. Turns a methodological trap into a mechanical guard.
 - **Blockers:** —
@@ -1547,7 +1547,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Track merged-but-unreleased inventory as a first-class metric
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** A dogfood consumer with **1,132 merged pull requests has 0 GitHub releases and 0 tags**, alongside **138 pending changesets** — every one an unshipped unit of declared change. The release pipeline is configured and active (`release.yml`, plus several per-target deploy workflows) and 30 deployments exist across preview and production environments, so this is not a broken pipeline but an unmeasured one: merge throughput rose without release throughput following, and nothing in the harness noticed. Merged is not shipped, and a throughput claim built on merge counts is inflated by exactly this gap. Build: pending-changeset count and age, merged-but-unreleased PR count, and time-from-merge-to-release as tracked signals per surface, with a threshold that warns when inventory outgrows release cadence. Cheap to compute, and it converts a silent accumulation into a visible one.
 - **Blockers:** —
@@ -1558,7 +1558,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Instrument rework rate per surface
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** On a dogfood consumer, **215 of 1,411 distinct issue references appear in more than one commit — 15.2%**. Some of that is legitimately multi-part work; the remainder is rework, and rework at the autonomous tier is waste that scales directly with the token budget rather than with headcount. Today nothing distinguishes "this issue took four PRs because it was large" from "this issue took four PRs because the first three were wrong," so the harness cannot tell an operator that a surface is churning. Build: per-surface rework rate from issue-to-PR fan-out plus superseded/closed-unmerged PRs, separated from planned multi-part delivery by roadmap linkage, and surfaced next to throughput so the two are never read apart. Prerequisite for claiming any efficiency win: a 10x throughput gain with a 15% rework rate is a 10x waste gain too.
 - **Blockers:** —
@@ -1945,7 +1945,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Emit a machine-readable provenance trailer from agent-authored commits
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** Harness-authored work is statistically invisible. Measured across two orgs: a personal org carries **69 AI co-author trailers in 6,570 commits (1%)**, and a dogfood product repo **974 in 4,618 (21%)** — while its highest-volume author shows **5 trailers across 3,988 commits**, because the fleet path emits nothing. Consequences compound: org-wide AI-adoption reporting undercounts by roughly 5x and cannot distinguish the autonomous tier from interactive assistance (the distinction that explains an 18x throughput gap); cost attribution has no key to join spend to authorship; and in a regulated codebase there is no record of which agent, skill and version produced a change touching a gated path. Build: a distinct trailer — `Harness-Run: <skill>@<version>` plus lane and agent id — emitted by the fleet path rather than co-opting `Co-authored-by`, so tier detection is mechanical and the trailer doubles as the accountability record. Foundation for `cost-per-merged-pr-attribution` and for human-in-the-loop attestation on gated paths.
 - **Blockers:** —
@@ -2435,6 +2435,17 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#603
 
+### Orchestrator Codex Backend Subprocess Env Air-Gap (follow-up)
+
+- **Status:** done
+- **Spec:** —
+- **Summary:** Apply the subprocess env allowlist air-gap to the Codex backend. The gateway policy-envelope work air-gapped the Claude backend's subprocess spawn (replaced `env: process.env` with an explicit allowlist), but the Codex backend (`packages/orchestrator/src/backends/codex.ts`) still passes the full parent environment to its spawned subprocess — the same leak, unpatched. Extend the shared subprocess-env allowlist + PolicyMetadata stamping to codex.ts so both backends enforce the boundary identically. Follow-up to the orchestrator gateway policy envelope + subprocess air-gap.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1158
+
 ### Orchestrator Gateway Policy Envelope and Subprocess Air-Gap
 
 - **Status:** done
@@ -2445,17 +2456,6 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#604
-
-### Orchestrator Codex Backend Subprocess Env Air-Gap (follow-up)
-
-- **Status:** planned
-- **Spec:** —
-- **Summary:** Apply the subprocess env allowlist air-gap to the Codex backend. The gateway policy-envelope work air-gapped the Claude backend's subprocess spawn (replaced `env: process.env` with an explicit allowlist), but the Codex backend (`packages/orchestrator/src/backends/codex.ts`) still passes the full parent environment to its spawned subprocess — the same leak, unpatched. Extend the shared subprocess-env allowlist + PolicyMetadata stamping to codex.ts so both backends enforce the boundary identically. Follow-up to the orchestrator gateway policy envelope + subprocess air-gap.
-- **Blockers:** —
-- **Plan:** —
-- **Assignee:** —
-- **Priority:** —
-- **External-ID:** github:Intense-Visions/harness-engineering#1158
 
 ### Standardize Parallel Execution
 
@@ -2470,7 +2470,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Make fan-out rate-limit aware, not just slot aware
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** Fleet concurrency is governed by compute slots (`min(16, CPUs - 2)` per workflow, with `fleet-command` holding each lane to a share of a global pool) but not by the API budgets the leaves actually consume. Measured during a 90-day org analysis: GitHub **code search is capped at 10 requests per minute**, and secondary rate limits fired repeatedly under modest parallelism — 10-way fan-out on the commits API produced silent under-fetching that returned wrong answers rather than errors (287 of 430 repositories read as zero). A slot-governed fleet whose leaves are API-bound will therefore degrade into throttling and, worse, into quietly incomplete results. Build: per-resource budgets alongside slot budgets, backoff shared across a fleet rather than per-leaf, and a hard rule that a truncated or throttled fetch fails the leaf instead of returning partial data. Pairs with `standardize-parallel-execution`; the failure mode is correctness, not just speed.
 - **Blockers:** —


### PR DESCRIPTION
## What

Six roadmap shards still read `Status: planned` while their work is **already merged and present on `main`**. This flips them to `done` and regenerates the aggregate.

| Shard | Issue | Resolving PR | Code on `main` (re-derived) |
| --- | --- | --- | --- |
| `emit-provenance-trailer-from-agent-commits` | #1531 | #1776 | `docs/reference/provenance-trailer.md` |
| `rework-rate-instrumentation` | #1528 | #1786 | `packages/core/src/rework/` |
| `stability-gate-on-ranked-outputs` | #1529 | #1780 | `packages/core/src/ranking/stability.ts` |
| `merged-but-unreleased-inventory-metric` | #1526 | #1782 | `packages/core/src/release-inventory/` |
| `rate-limit-aware-fan-out-governor` | #1532 | #1589 | `packages/core/src/fleet/rate-budget/` |
| `orchestrator-codex-backend-subprocess-env-air-gap` | #1158 | #1504 | `Closes #1158`; issue already closed |

## How this was found

`roadmap-fleet` SELECT cross-checked **all 81** candidate issue numbers (all 53 buildable shards + 30 `route:roadmap-fleet` issues) against **1000 PRs** (#338–#1848, all states), then filtered the raw `#N` mention index by grepping `origin/main` for the shipped code.

That second filter is load-bearing. A raw mention index is heavily false-positive here: **#1683**, **#1449**, **#1279** and **#606** are omnibus shard-*registration* PRs that name dozens of issue numbers without resolving any of them. Treating those mentions as resolutions would have wrongly dropped ~25 live candidates.

Stale rate: **6 shard-visible + 1 issue-only out of 81 ≈ 8.6%**.

## Closing keyword — deliberately `Refs`, not `Closes`

This PR does not resolve any of these issues; the PRs in the table above already did. `Refs` is correct and intentional here, and #1526/#1532/#1691 are being closed separately with a comment citing their resolving PR.

## Notes for the reviewer

- **Aggregate diff artifact.** The two adjacent `Priority: —` sections for #1158 and #604 swap position under `harness roadmap regen` because they share a sort key. **#604 was already `done` on `main` and is untouched by this change** — only its rendered position moved. End state was verified per-issue against the regenerated aggregate rather than read off the diff.
- **#1691** (project-wide E2E framework, resolved by merged PR #1735) is also stale but has **no shard** in `docs/roadmap.d`, so it is reconciled by closing the issue, not by a shard edit. It is the mirror of #1158, which is shard-only.
- Aggregate regenerated with `harness roadmap regen` (buildless, tokenless). Shards remain the source of truth.

## Assumptions made

- Flipped `Status` **only**. `Spec:`/`Plan:` links to each resolving PR's `docs/changes/**` artifacts were deliberately *not* added, to keep the diff minimal and reviewable. Those links are a reasonable follow-up.
- Treated presence of the shipped code on `origin/main` — not the PR's mention of the issue — as the criterion for "resolved".

Refs #1531 #1528 #1529 #1526 #1532 #1158

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy