### PR TITLE
fix(design): DRIFT-T001 stops reporting issue references as hex colours

### DIFF
--- a/.changeset/drift-t001-issue-ref-fp.md
+++ b/.changeset/drift-t001-issue-ref-fp.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(design): DRIFT-T001 no longer reports issue references as hardcoded colours (#1824)
+
+A GitHub issue reference is hex-shaped — `0-9` are all valid hex digits — so `#1824`
+and `#493` matched the hardcoded-colour pattern. One project measured 143 of 413
+findings (35%) as this false positive on first adoption of `check-design`, which is
+exactly where the rule most needs to be readable.
+
+`detectHexBypass` now requires a colour value position before it flags, and rejects an
+all-decimal match that has no colour carrier — mirroring the anchored shape that already
+keeps DRIFT-T002/T003 quiet. The hex pattern is also narrowed to the CSS-valid lengths
+3, 4, 6 and 8; `{3,8}` previously admitted 5 and 7, which can never be a colour.
+
+Issue references in string prose, thrown-error messages, JSX text and CSS id selectors
+are now silent. Genuine colours — including all-decimal greys such as `background: '#666'`,
+gradient stops, `var()` fallbacks and colour-named SCSS variables — are still reported.

--- a/.changeset/drift-t001-issue-ref-fp.md
+++ b/.changeset/drift-t001-issue-ref-fp.md
@@ -15,5 +15,6 @@ keeps DRIFT-T002/T003 quiet. The hex pattern is also narrowed to the CSS-valid l
 3, 4, 6 and 8; `{3,8}` previously admitted 5 and 7, which can never be a colour.
 
 Issue references in string prose, thrown-error messages, JSX text and CSS id selectors
-are now silent. Genuine colours — including all-decimal greys such as `background: '#666'`,
-gradient stops, `var()` fallbacks and colour-named SCSS variables — are still reported.
+are now silent. Genuine colours are still reported, including all-decimal greys such as
+`background: '#666'`, gradient stops, `var()` fallbacks, palette arrays, SCSS maps and
+colour-named variables, and utility-class arbitrary values such as `bg-[#1a2b3c]`.

--- a/.harness/comprehension/packages/cli/src/drift/rules/_module.md
+++ b/.harness/comprehension/packages/cli/src/drift/rules/_module.md
@@ -1,28 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/drift/rules'
-sourceHash: 'e475848d21c16ff838ac8d824f8f5a01323048f5cfd08885205558578561e662'
-compiledAt: '2026-08-28T01:22:09.224Z'
+sourceHash: 'c090537acdc45dfb393bf53daf92ac1095ea16c506a8e6bafd6a015f29867d43'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['primitive-adoption-rule.ts', 'token-bypass-rule.ts']
 ---
-
-## Summary
-
-The `drift/rules` module exports two drift-detection rules enforcing design-system adoption. **Primitive Adoption** scans JSX/TSX for raw HTML primitives (<button>, <input>, <a>, <textarea>) where registered components exist; uses TypeScript Compiler API for reliable multi-line JSX parsing; emits DRIFT-P001–P004; skips silently if component registry absent. **Token Bypass** detects hardcoded values instead of tokens (hex colors, fonts, spacing, deprecated tokens); regex-based with context-awareness to skip comments; flags both in-palette literals (suggests token reference) and out-of-system values (suggests token addition); skips silently if tokens.json absent. Both rules compute strictness-dependent severity and couple actionable fix guidance referencing applicable codemods.
-
-## Invariants
-
-- Context classification is critical for token rules — Uint8Array offset-to-context map gates hex/px detection to skip comment-prose false positives; regex alone cannot distinguish code from prose (#750)
-- ComponentRegistry/TokenSet null-safety gates behavior — missing registry or tokens.json silently skips all rules in that family; adoption only enforced when components declared; token-bypass only enforced when token system exists
-- Deduplication per line prevents redundant findings — both rule families use line-keyed sets to emit at most one finding per unique issue per line
-- Severity is strictness-dependent — all findings compute severity via severityFor(code, strictness), not hard-coded, allowing caller to adapt to project context
-- Dual-flag pattern for token bypass — T001/T002/T003 intentionally flag both 'in-palette but raw literal' AND 'out-of-system value' cases; catches drift in both reference-style (should use token) and system-scope (should add to tokens) directions
-- TypeScript AST for primitives, regex for tokens — TS Compiler API handles multi-line JSX parsing reliably; regex sufficient for token patterns and mirrors legacy DesignConstraintAdapter for compatibility
-- JSX form coverage — visit logic handles both JsxSelfClosingElement (<input />) and JsxOpeningElement (<button>…</button>), ensuring both syntactic forms caught
-- Tag normalization and component-lookup coupling — HTML tags lowercased before registry lookup (JSX semantics: lowercase = primitive, uppercase = component) prevents case-sensitivity false misses
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/src/drift/rules/_module.md
+++ b/.harness/comprehension/packages/cli/src/drift/rules/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/drift/rules'
-sourceHash: 'c090537acdc45dfb393bf53daf92ac1095ea16c506a8e6bafd6a015f29867d43'
+sourceHash: '031e5519195c8951e8114db7976ab7b3cce7d443dc9f82ce966a1f270018e351'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/drift/integration/_module.md
+++ b/.harness/comprehension/packages/cli/tests/drift/integration/_module.md
@@ -1,29 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/drift/integration'
-sourceHash: '1b17b5a2ef0a17753d8afc4d74b80d4b4ed5cfca537bbbe39c17374b1a7fc119'
-compiledAt: '2026-08-28T01:22:09.704Z'
+sourceHash: '1902889201e333ee07208fe281726689a701948c9f18078fd3e0f40164cd553d'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['detect-drift.test.ts']
 ---
-
-## Summary
-
-The `packages/cli/tests/drift/integration` test suite validates `runDetectDrift`, a design-drift scanner that flags code violating design tokens and component registries. It loads optional design artifacts (tokens.json, DESIGN.md), applies configurable detection rules, and returns a categorized report. Tests verify artifact loading, multi-rule detection (token bypass and primitive adoption), exclusion filtering via parameters and config, rule toggles, file-scoping, and summary accuracy.
-
-## Invariants
-
-- Empty registry → no findings: If neither tokens.json nor DESIGN.md exist, findings is always [] with both tokensLoaded and registryLoaded false.
-- Registry loading gates rules: Token bypass detection only fires if tokens.json exists; primitive adoption only if DESIGN.md exists; no false positives on missing artifacts.
-- Exclude filters stack: design.exclude and analysis.exclude from harness.config.json both apply (union); patterns are cumulative, not overriding.
-- Explicit files bypass excludes: When files parameter is provided, it scans only those files even if they match exclude patterns — explicit scope wins (security principle).
-- Glob matchBase behavior: Bare patterns like \*.tokens.ts match files at any depth, not just the root level.
-- Config file is loaded: harness.config.json design.exclude and analysis.exclude are discovered and applied automatically by the runner.
-- Rule toggles are total: Setting rules.tokenBypass=false completely removes DRIFT-T\* findings and prevents the rule from being listed in catalog.rulesApplied.
-- Summary accounting is exact: Aggregate counts (summary.bySeverity, summary.byCode) match the actual findings array length; no drift between summary and details.
-- No regression when unconfigured: When no excludes are set, all files in the tree are scanned; absence of config doesn't introduce hidden filtering.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/tests/drift/rules/_module.md
+++ b/.harness/comprehension/packages/cli/tests/drift/rules/_module.md
@@ -1,31 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/drift/rules'
-sourceHash: '05b8b745b696df19fbcc5e3815b06adb656e4b84c9838482a7d5806c29f5e232'
-compiledAt: '2026-08-28T01:22:09.710Z'
+sourceHash: '0771c5f6e34199bc50e5f50e128dda547ea2d81e0c4efced036a6c788267ba22'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['primitive-adoption.test.ts', 'token-bypass.test.ts']
 ---
-
-## Summary
-
-The `packages/cli/tests/drift/rules` module contains two test suites validating design-system linting rules that detect architecture drift in React components.
-
-**Primitive Adoption Rule** enforces that lowercase HTML elements (`<button>`, `<input>`, `<a>`) are replaced with registered design components (`Button`, `Input`, `Link`). It parses JSX using TypeScript's parser (not regex), skips non-component files, and gracefully handles parse errors. It correctly distinguishes uppercase components from their lowercase primitives.
-
-**Token Bypass Rule** detects four categories of design-token violations: hardcoded hex colors (DRIFT-T001), undeclared font families (DRIFT-T002), off-scale pixel spacing (DRIFT-T003), and references to deprecated tokens (DRIFT-T004). Critically, it implements context-aware matching to avoid false positives from hex patterns in comments, JSDoc prose, issue references (#750), and test titles—actual code literals still flag correctly. The rule also supports strictness levels (strict/standard/permissive) that map findings to error/warn/info severity.
-
-## Invariants
-
-- Parser-first, not regex: Both rules rely on TypeScript's lenient AST parser for JSX/code structure; regex-only matching would miss multi-line constructs and create FP noise in comments.
-- Context distinction non-negotiable: Comment, string-literal, and JSDoc-prose contexts must be excluded; regression #750 proved this is non-optional for signal-to-noise.
-- Registry-gated flagging: Primitive adoption only flags when the replacement component is explicitly registered; unregistered primitives pass silently.
-- Token set optionality: Missing token definitions (e.g., empty spacingPx) disable that check; rule doesn't assume a complete palette.
-- Strictness honored uniformly: Severity remaps across all findings per the strictness parameter; internal severities are overridden.
-- Deduplication per line: Identical violations on the same line report once; multi-occurrence on different lines each report.
-- Graceful input tolerance: Malformed JSX or CSS doesn't crash; returns empty findings or best-effort results.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/tests/drift/rules/_module.md
+++ b/.harness/comprehension/packages/cli/tests/drift/rules/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/drift/rules'
-sourceHash: '0771c5f6e34199bc50e5f50e128dda547ea2d81e0c4efced036a6c788267ba22'
+sourceHash: '9963961d9f14557aea95c5177afdda9f181f0d1a831e05dbbad990b0129e6517'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md
+++ b/docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md
@@ -107,9 +107,18 @@ gradient stops `#fff` / `#000`, `$grey-700: #666`. Suppressed: `(#529)` and `#49
 comments, `'see #1824 ... #abc123'` prose, `Error('... see #493')`, `<p>...#1824 and #493</p>`,
 the `#1824 { }` CSS id selector, and `see #604` in a CSS comment.
 
+A follow-up probe of real-world colour idioms against the new gate caught one genuine
+coverage regression the fix would otherwise have shipped: utility-class arbitrary values
+(`bg-[#1a2b3c]`, `text-[#333]`) were missed entirely, because `[` was not a value
+introducer. `[` was added alongside `:` and `=`, and the carrier list extended. Verified
+preserved in the same probe: styled-components template values, palette arrays, JSX style
+props, SCSS maps, 8-digit shadow colours, and colour-named CSS custom properties. Each is
+now pinned by a committed test.
+
 Regression test: `packages/cli/tests/drift/rules/token-bypass.test.ts`, suite
-`DRIFT-T001 — issue-reference false positives (#1824)`. 5 failed / 24 passed before the fix;
-29 passed after. Revert-and-fail confirmed by stashing only the rule file.
+`DRIFT-T001 — issue-reference false positives (#1824)`. 5 failed / 27 passed with the rule
+file restored to base SHA 5cd661d74; 32 passed with the fix. Revert-and-fail confirmed by
+overwriting the rule file from the base SHA and rerunning.
 
 Learnings: when one detector in a family is noisy and its siblings are not, the difference
 between them is the diagnosis. T002 and T003 were quiet because they demand a declaring

--- a/docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md
+++ b/docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md
@@ -1,0 +1,118 @@
+# Debug Session: DRIFT-T001 flags issue references as hex colours (#1824)
+
+Status: resolved
+Started: 2026-09-05
+Resolved: 2026-09-05
+Error: `harness check-design` emits DRIFT-T001 `Hardcoded color "#1824" is not in the design
+token palette` for GitHub issue references. Reporter measured 143 of 413 findings (35%) on
+first adoption of `check-design` against a private monorepo (@harness-engineering/cli@11.3.0).
+
+## Investigation Log
+
+### Phase 1 — INVESTIGATE
+
+1.  `harness cleanup -t all` — no entropy findings implicating `src/drift/rules/`.
+2.  Read the complete symptom. Root pattern at `packages/cli/src/drift/rules/token-bypass-rule.ts:29`
+    (base SHA 5cd661d74):
+
+        const HEX_PATTERN = /#[0-9a-fA-F]{3,8}\b/g;
+
+    `0-9` are all valid hex digits, so every `#NNN`..`#NNNNNNNN` issue reference matches.
+    `#1824` is 4 chars, all in `[0-9a-fA-F]`, and 4 is inside `{3,8}`.
+
+3.  Reproduced consistently (3/3 runs) by calling `runTokenBypassRule` directly at the base SHA:
+
+    | source                                       | DRIFT-T001 emitted         |
+    | -------------------------------------------- | -------------------------- |
+    | `export const n = 'see #1824 for triage';`   | `#1824`                    |
+    | `Refs #1824 and #493 and #abc123` (code ctx) | `#1824`, `#493`, `#abc123` |
+    | `const a = '#12345'; const b = '#1234567';`  | `#12345`, `#1234567`       |
+
+4.  Checked recent changes. The prior partial fix is 7c6a4e741
+    `fix(design): drift scanner ignores hex-shaped strings in comments/string-literals (#750)`,
+    shipped in cli 10.0.0 — i.e. it is ALREADY present in the reporter's 11.3.0 and at HEAD.
+    It rejects COMMENT context outright and, inside STRING context, rejects only the
+    parenthesized idiom `(#NNN)` (`isHexColorContext`, `source[offset - 1] !== '('`).
+    That is why 143 findings survive: an issue ref in a non-parenthesized string literal
+    (`'see #1824 for triage'`, `describe('regression #1824')`) or in bare code context
+    (JSX text, CSS) is still flagged.
+
+5.  Scan scope is `['.ts', '.tsx', '.js', '.jsx', '.css', '.scss']`
+    (`packages/cli/src/drift/index.ts:58`) — so the FP class is issue refs living in TS/JS
+    string literals and JSX/CSS text, not markdown.
+
+### Phase 2 — ANALYZE (working example in the same file)
+
+`detectHexBypass` is the ONLY detector in `token-bypass-rule.ts` with no declaration anchor.
+Its two siblings both anchor on a value-bearing carrier and consequently do not suffer this
+false-positive class:
+
+- `FONT_FAMILY_PATTERN` requires `(?:fontFamily|font-family)\s*[:=]\s*` before the value.
+- `PX_VALUE_PATTERN` requires `margin|padding|gap|top|right|bottom|left` + `[:=]` before the value.
+
+The difference IS the bug: T001 matches a bare `#`-token anywhere, so any token that happens to
+be hex-shaped (an issue reference) is admitted. A secondary correctness gap: `{3,8}` admits
+lengths 5 and 7, which are not legal CSS hex colours (legal lengths are 3, 4, 6, 8).
+
+## Hypotheses
+
+H1 (falsifiable): DRIFT-T001 fires on issue references because `detectHexBypass` requires no
+colour-bearing syntactic context and applies no shape test beyond `[0-9a-fA-F]{3,8}`, unlike
+its sibling detectors. Prediction: requiring a colour value position AND rejecting an
+all-decimal match that lacks a colour carrier removes `#1824` / `#493` / `#abc123` in prose
+while every existing T001 true-positive test still passes.
+
+Test: the reproduction table above, run against the amended rule.
+Result: see Resolution.
+
+## Assumptions (surfaced, not buried)
+
+- A1. Fork F2 ("how to kill the issue-reference false positive?") was answered by the human at
+  the fleet CONFIRM gate as **(b) AND (c) together** — reject all-decimal matches AND require a
+  colour-bearing syntactic context. Both, not either. This session implements both.
+- A2. `#666` / `#333` style all-decimal greys are genuine colours and must survive. They are
+  preserved via the colour-carrier override on the all-decimal rule; the existing regression
+  test `STILL flags an all-numeric hex color literal in real code (#666 true positive preserved)`
+  is treated as a hard invariant, not as negotiable.
+- A3. Deferrable: `design.tokenPath` being accepted-and-ignored (the "adjacent, much smaller"
+  half of the report) is a separate defect in the tokens resolver, not in this rule. Out of scope
+  for this session; it is not the 35%-noise cause.
+
+## Resolution
+
+Root cause: `detectHexBypass` required no colour-bearing syntactic context, unlike its two
+siblings in the same file (`FONT_FAMILY_PATTERN` for DRIFT-T002 and `PX_VALUE_PATTERN` for
+DRIFT-T003), which both anchor on a declaring property before the value. Because `0-9` are
+valid hex digits, every 3-8 character issue reference matched `HEX_PATTERN`. The earlier
+partial fix 7c6a4e741 (#750) rejected COMMENT context and the parenthesized `(#NNN)` idiom
+only, so a reference in ordinary string prose, JSX text or CSS still fired.
+
+Fix (`packages/cli/src/drift/rules/token-bypass-rule.ts`), implementing fork F2 answer (b)+(c):
+
+- (c) `hexValuePosition` classifies each match as POS_NONE / POS_VALUE / POS_COLOR. A match
+  must sit in a value position — after a `name:` / `name=` declaration separator, as the
+  leading content of a string literal, or inside a colour function's argument list — with
+  only CSS value tokens between the separator and the `#`. This generalizes and replaces the
+  narrower `(#NNN)`-only rejection from #750.
+- (b) `isAllDecimal` rejects an all-decimal match (`#1824`, `#493`) unless its value position
+  carries a colour: a colour-bearing property or variable name, or a colour function. The
+  carrier is what separates `const ISSUE = '#1824'` from `background: '#666'`.
+- `HEX_PATTERN` narrowed to the CSS-valid lengths 3, 4, 6, 8. `{3,8}` admitted 5 and 7,
+  which can never be a colour (the report's suggestion 2).
+
+Hypothesis H1 CONFIRMED. End-to-end over a fixture carrying 8 issue references and 7 genuine
+colours: 7 DRIFT-T001 findings, every one a real colour, zero issue references. Preserved:
+`color: '#e63535'`, `background: '#666'`, `1px solid #0066cc`, `.badge { color: #1824 }`,
+gradient stops `#fff` / `#000`, `$grey-700: #666`. Suppressed: `(#529)` and `#493:` in
+comments, `'see #1824 ... #abc123'` prose, `Error('... see #493')`, `<p>...#1824 and #493</p>`,
+the `#1824 { }` CSS id selector, and `see #604` in a CSS comment.
+
+Regression test: `packages/cli/tests/drift/rules/token-bypass.test.ts`, suite
+`DRIFT-T001 — issue-reference false positives (#1824)`. 5 failed / 24 passed before the fix;
+29 passed after. Revert-and-fail confirmed by stashing only the rule file.
+
+Learnings: when one detector in a family is noisy and its siblings are not, the difference
+between them is the diagnosis. T002 and T003 were quiet because they demand a declaring
+property; T001 was noisy because it demanded nothing. Also: a shape-only test can never
+separate `#493` from `#666` — only the surrounding carrier can, which is why the shape rule
+(b) and the context rule (c) had to ship together rather than either alone.

--- a/docs/changes/drift-t001-issue-ref-false-positive-1824/provenance.json
+++ b/docs/changes/drift-t001-issue-ref-false-positive-1824/provenance.json
@@ -17,9 +17,9 @@
     "path": "packages/cli/tests/drift/rules/token-bypass.test.ts",
     "suite": "runTokenBypassRule > DRIFT-T001 — issue-reference false positives (#1824)",
     "command": "pnpm --filter @harness-engineering/cli exec vitest run tests/drift/rules/token-bypass.test.ts",
-    "beforeFix": "5 failed | 24 passed (29)",
-    "afterFix": "29 passed (29)",
-    "revertCheck": "git stash push -- packages/cli/src/drift/rules/token-bypass-rule.ts, rerun (5 failed), git stash pop, rerun (29 passed)"
+    "beforeFix": "5 failed | 27 passed (32) with the rule file restored to base SHA 5cd661d74",
+    "afterFix": "32 passed (32)",
+    "revertCheck": "Overwrote packages/cli/src/drift/rules/token-bypass-rule.ts with `git show 5cd661d74:...`, reran (5 failed | 27 passed), restored the fix, reran (32 passed)."
   },
   "rootCause": {
     "file": "packages/cli/src/drift/rules/token-bypass-rule.ts",
@@ -31,19 +31,26 @@
     "colourValuePositionRequired": true,
     "allDecimalRejectedWithoutCarrier": true,
     "cssValidHexLengthsOnly": [3, 4, 6, 8],
-    "supersedes": "the (#NNN)-only string rejection from #750, now generalized"
+    "supersedes": "the (#NNN)-only string rejection from #750, now generalized",
+    "valueIntroducers": [
+      ": (declaration)",
+      "= (assignment)",
+      "[ (utility-class arbitrary value, e.g. bg-[#1a2b3c])"
+    ]
   },
   "assumptions": [
     "Fork F2 ('How to kill the issue-reference false positive?') was answered by the human at the roadmap-fleet CONFIRM gate as (b) AND (c) TOGETHER: reject an all-decimal match as a non-colour, AND require a colour-bearing syntactic context before flagging. Both were implemented; neither alone was treated as sufficient.",
     "(b) and (c) are composed rather than merely conjoined: the colour carrier that satisfies (c) is what overrides (b). A bare all-decimal value with no carrier (const ISSUE = '#1824') is rejected; the same shape behind a carrier (background: '#666', .badge { color: #1824 }, $grey-700: #666) is still flagged. Composing them as a flat AND would have deleted every all-decimal grey, contradicting the pre-existing regression test 'STILL flags an all-numeric hex color literal in real code (#666 true positive preserved)', which was treated as a hard invariant.",
     "Narrowing the hex pattern to CSS-valid lengths (the report's suggestion 2, 'worth doing regardless since it is strictly more correct') was taken as in-scope for the same fix. It is independent of F2 and removes lengths 5 and 7, which can never be colours.",
     "Six fixtures in tests/drift/integration/detect-drift.test.ts used bare all-decimal literals (const b = \"#112233\") purely as scan fodder for exclude-mechanism assertions. They were rewritten as real colour declarations (const b = { color: \"#112233\" }) rather than weakening the assertions — the tests are about exclude filtering, not hex shape, and the rewrite keeps their all-decimal coverage.",
-    "The report's 'adjacent, much smaller' item — design.tokenPath being accepted by the config schema but ignored by the tokens resolver, which reads design-system/tokens.json as a string literal — is a separate defect in the resolver, not in this rule, and is not the cause of the 35% noise. It is deliberately NOT fixed here and remains open for a follow-up item."
+    "The report's 'adjacent, much smaller' item — design.tokenPath being accepted by the config schema but ignored by the tokens resolver, which reads design-system/tokens.json as a string literal — is a separate defect in the resolver, not in this rule, and is not the cause of the 35% noise. It is deliberately NOT fixed here and remains open for a follow-up item.",
+    "Requiring a value position must not silently narrow real coverage, so the gate was probed against common colour idioms rather than assumed correct. That probe caught a genuine regression — utility-class arbitrary values such as `bg-[#1a2b3c]` — which is fixed here and pinned by a test rather than shipped."
   ],
   "verification": {
-    "unitSuite": "packages/cli tests/drift tests/align tests/design-pipeline tests/brand — 195 passed (25 files)",
-    "fullCliSuite": "packages/cli vitest run — 7009 passed | 2 skipped (622 files)",
+    "unitSuite": "packages/cli tests/drift tests/align tests/design-pipeline tests/brand — 198 passed (25 files)",
+    "fullCliSuite": "packages/cli vitest run under the pinned Node 22 — 7012 passed | 2 skipped (622 files)",
     "endToEnd": "runDetectDrift over a fixture carrying 8 issue references and 7 genuine colours: 7 DRIFT-T001 findings, all of them real colours, zero issue references",
-    "archCheck": "harness check-arch — no new violation attributable to packages/cli/src/drift/rules/token-bypass-rule.ts"
+    "archCheck": "harness check-arch — no new violation attributable to packages/cli/src/drift/rules/token-bypass-rule.ts",
+    "coverageRegressionGuard": "Probed real-world colour idioms against the new gate. Tailwind/utility-class arbitrary values (bg-[#1a2b3c], text-[#333]) were initially lost, so `[` was added as a value introducer and the carrier list extended; styled-components, palette arrays, JSX style props, SCSS maps, 8-digit shadow colours and CSS custom properties were verified preserved. Each is now a committed test."
   }
 }

--- a/docs/changes/drift-t001-issue-ref-false-positive-1824/provenance.json
+++ b/docs/changes/drift-t001-issue-ref-false-positive-1824/provenance.json
@@ -1,0 +1,49 @@
+{
+  "issue": 1824,
+  "repo": "Intense-Visions/harness-engineering",
+  "title": "DRIFT-T001 flags issue references as hex colours (35% of findings on first adoption)",
+  "route": "bug",
+  "routeConfirmedBy": "roadmap-fleet CONFIRM gate",
+  "pipeline": {
+    "stages": ["debugging"],
+    "skill": "harness-debugging",
+    "phases": ["investigate", "analyze", "hypothesize", "fix"],
+    "sessionRecord": "docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md",
+    "note": "A bug route leaves no plans/ directory. That is expected for this route, not a missing artifact. The live debug session lived at .harness/debug/active/drift-t001-issue-ref-fp-1824.md, which .harness/.gitignore excludes from the tree; its full content is committed as investigation.md so the record is verifiable."
+  },
+  "baseSha": "5cd661d74a7cb4e3b4164a8c7fb36d75e298fd0f",
+  "branch": "fix/drift-t001-issue-ref-fp-1824",
+  "reproducingTest": {
+    "path": "packages/cli/tests/drift/rules/token-bypass.test.ts",
+    "suite": "runTokenBypassRule > DRIFT-T001 — issue-reference false positives (#1824)",
+    "command": "pnpm --filter @harness-engineering/cli exec vitest run tests/drift/rules/token-bypass.test.ts",
+    "beforeFix": "5 failed | 24 passed (29)",
+    "afterFix": "29 passed (29)",
+    "revertCheck": "git stash push -- packages/cli/src/drift/rules/token-bypass-rule.ts, rerun (5 failed), git stash pop, rerun (29 passed)"
+  },
+  "rootCause": {
+    "file": "packages/cli/src/drift/rules/token-bypass-rule.ts",
+    "lineAtBase": 29,
+    "patternAtBase": "/#[0-9a-fA-F]{3,8}\\b/g",
+    "summary": "detectHexBypass required no colour-bearing syntactic context, unlike its siblings FONT_FAMILY_PATTERN (DRIFT-T002) and PX_VALUE_PATTERN (DRIFT-T003), which both anchor on a declaring property. Because 0-9 are valid hex digits, any 3-8 character issue reference matched. The earlier partial fix 7c6a4e741 (#750, shipped in cli 10.0.0) rejected comments and the parenthesized (#NNN) idiom only, so references in ordinary string prose, JSX text and CSS survived."
+  },
+  "fix": {
+    "colourValuePositionRequired": true,
+    "allDecimalRejectedWithoutCarrier": true,
+    "cssValidHexLengthsOnly": [3, 4, 6, 8],
+    "supersedes": "the (#NNN)-only string rejection from #750, now generalized"
+  },
+  "assumptions": [
+    "Fork F2 ('How to kill the issue-reference false positive?') was answered by the human at the roadmap-fleet CONFIRM gate as (b) AND (c) TOGETHER: reject an all-decimal match as a non-colour, AND require a colour-bearing syntactic context before flagging. Both were implemented; neither alone was treated as sufficient.",
+    "(b) and (c) are composed rather than merely conjoined: the colour carrier that satisfies (c) is what overrides (b). A bare all-decimal value with no carrier (const ISSUE = '#1824') is rejected; the same shape behind a carrier (background: '#666', .badge { color: #1824 }, $grey-700: #666) is still flagged. Composing them as a flat AND would have deleted every all-decimal grey, contradicting the pre-existing regression test 'STILL flags an all-numeric hex color literal in real code (#666 true positive preserved)', which was treated as a hard invariant.",
+    "Narrowing the hex pattern to CSS-valid lengths (the report's suggestion 2, 'worth doing regardless since it is strictly more correct') was taken as in-scope for the same fix. It is independent of F2 and removes lengths 5 and 7, which can never be colours.",
+    "Six fixtures in tests/drift/integration/detect-drift.test.ts used bare all-decimal literals (const b = \"#112233\") purely as scan fodder for exclude-mechanism assertions. They were rewritten as real colour declarations (const b = { color: \"#112233\" }) rather than weakening the assertions — the tests are about exclude filtering, not hex shape, and the rewrite keeps their all-decimal coverage.",
+    "The report's 'adjacent, much smaller' item — design.tokenPath being accepted by the config schema but ignored by the tokens resolver, which reads design-system/tokens.json as a string literal — is a separate defect in the resolver, not in this rule, and is not the cause of the 35% noise. It is deliberately NOT fixed here and remains open for a follow-up item."
+  ],
+  "verification": {
+    "unitSuite": "packages/cli tests/drift tests/align tests/design-pipeline tests/brand — 195 passed (25 files)",
+    "fullCliSuite": "packages/cli vitest run — 7009 passed | 2 skipped (622 files)",
+    "endToEnd": "runDetectDrift over a fixture carrying 8 issue references and 7 genuine colours: 7 DRIFT-T001 findings, all of them real colours, zero issue references",
+    "archCheck": "harness check-arch — no new violation attributable to packages/cli/src/drift/rules/token-bypass-rule.ts"
+  }
+}

--- a/packages/cli/src/drift/rules/token-bypass-rule.ts
+++ b/packages/cli/src/drift/rules/token-bypass-rule.ts
@@ -26,7 +26,9 @@ import type { DriftFinding, DriftStrictness } from '../findings/finding.js';
 import { severityFor } from '../findings/finding.js';
 import type { TokenSet } from '../resolvers/tokens.js';
 
-const HEX_PATTERN = /#[0-9a-fA-F]{3,8}\b/g;
+// #1824: only CSS-valid hex lengths (3, 4, 6, 8). `{3,8}` also admitted 5 and 7,
+// which can never be a colour. Longest alternative first so `#aabbccdd` matches as 8.
+const HEX_PATTERN = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b/g;
 const FONT_FAMILY_PATTERN = /(?:fontFamily|font-family)\s*[:=]\s*['"`]([^'"`,]+)['"`]/g;
 const PX_VALUE_PATTERN =
   /\b(?:margin(?:Top|Right|Bottom|Left)?|padding(?:Top|Right|Bottom|Left)?|gap|top|right|bottom|left)\s*[:=]\s*['"`]?(\d+(?:\.\d+)?)px\b/g;
@@ -67,8 +69,8 @@ function detectHexBypass(
   let match: RegExpExecArray | null;
   HEX_PATTERN.lastIndex = 0;
   while ((match = HEX_PATTERN.exec(source)) !== null) {
-    if (!isHexColorContext(source, ctx, match.index)) continue;
     const hex = match[0]!;
+    if (!isHexColorContext(source, ctx, match.index, hex)) continue;
     const lc = hex.toLowerCase();
     const line = lineOf(source, match.index);
     const key = `${line}:${lc}`;
@@ -258,8 +260,8 @@ interface Scanner {
  *
  * Note: this is a lightweight lexer, not a full JS/CSS parser. Template-literal
  * `${...}` interpolations are treated as string content, which is acceptable
- * here — the detectors only key off comment vs non-comment and the character
- * immediately preceding a hex match.
+ * here — the detectors only key off comment vs non-comment. Whether a match is
+ * a colour is decided separately by {@link hexValuePosition} (#1824).
  */
 function classifyContext(source: string): Uint8Array {
   const scan: Scanner = {
@@ -333,26 +335,131 @@ function commentOpener(ch: string, next: string | undefined): string {
   return '';
 }
 
+// ─── colour value position (#1824) ──────────────────────
+//
+// An issue reference is hex-shaped — `0-9` are all valid hex digits — so `#1824`
+// and `#493` were reported as hardcoded colours (143 of 413 findings, 35%, on one
+// project's first adoption). The #750 pass only rejected comments and the
+// parenthesized `(#NNN)` idiom, so a reference in ordinary string prose survived.
+//
+// Two gates now run together, mirroring the anchored shape that already keeps
+// DRIFT-T002/T003 quiet (both require a declaring property before the value):
+//
+//   (c) The match must sit in a VALUE position — after a declaration separator, as
+//       the content of a string literal, or inside a colour function's argument
+//       list — with only CSS value tokens between the separator and the `#`.
+//   (b) An all-decimal match (`#1824`, `#493`) is rejected unless that value
+//       position carries a colour: a colour-bearing property or variable name, or
+//       a colour function. This keeps genuine greys like `background: '#666'`.
+
+/** No legal colour position. */
+const POS_NONE = 0;
+/** A value position, but nothing says the value is a colour. */
+const POS_VALUE = 1;
+/** A value position with a colour-bearing carrier (property, variable, function). */
+const POS_COLOR = 2;
+
+/** Chars that may appear inside a CSS value run between a separator and the hex. */
+const VALUE_RUN_CHAR = /[\w.%+\-/,# \t]/;
+
+/** A single token that may legally precede a colour inside one value. */
+const CSS_VALUE_TOKEN =
+  /^(?:-?\d+(?:\.\d+)?(?:px|rem|em|ex|ch|%|vh|vw|vmin|vmax|pt|pc|cm|mm|in|deg|rad|turn|s|ms|fr)?|--[\w-]+|#[0-9a-fA-F]{3,8}|solid|dashed|dotted|double|groove|ridge|inset|outset|none|hidden|thin|medium|thick|inherit|initial|unset|revert|transparent|currentcolor|to|from|at|in|top|bottom|left|right|center|circle|ellipse|farthest-side|farthest-corner|closest-side|closest-corner)$/i;
+
+/** Functions whose arguments are colours. */
+const COLOR_FUNCTION_CALL =
+  /(?:^|[^\w-])(?:var|rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color|color-mix|drop-shadow|linear-gradient|radial-gradient|conic-gradient|repeating-linear-gradient|repeating-radial-gradient|repeating-conic-gradient)\s*\($/i;
+
+/** Property / variable names whose value is a colour. */
+const COLOR_CARRIER_NAME =
+  /colou?r|background|\bbg\b|border|outline|fill|stroke|shadow|gradient|palette|swatch|theme|brand|accent|primary|secondary|tertiary|surface|foreground|\bfg\b|backdrop|overlay|highlight|placeholder|caret|selection|divider|scrollbar|ink|tint|shade|hue|grey|gray|white|black|danger|warning|success|error|info|muted|dark|light/i;
+
+/** Trailing identifier immediately left of a declaration separator. */
+const TRAILING_NAME = /([\w$@-]+)\s*["'`]?\s*$/;
+
+/**
+ * Classify the position a hex match at `offset` occupies: not a value at all,
+ * a plain value, or a value a colour carrier vouches for (#1824).
+ */
+function hexValuePosition(source: string, offset: number): number {
+  const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+  const sepIndex = scanBackToSeparator(source, lineStart, offset);
+  if (sepIndex < lineStart) return POS_NONE; // nothing on this line anchors the match
+  if (!isCssValueRun(source.slice(sepIndex + 1, offset))) return POS_NONE;
+  const separator = source[sepIndex]!;
+  if (separator === '(') {
+    return COLOR_FUNCTION_CALL.test(source.slice(lineStart, sepIndex + 1)) ? POS_COLOR : POS_NONE;
+  }
+  if (isQuote(separator)) return stringLiteralPosition(source, lineStart, sepIndex);
+  return declarationPosition(source, lineStart, sepIndex, separator);
+}
+
+/** Index of the nearest separator left of `offset`, or `lineStart - 1` when there is none. */
+function scanBackToSeparator(source: string, lineStart: number, offset: number): number {
+  let i = offset - 1;
+  while (i >= lineStart && VALUE_RUN_CHAR.test(source[i]!)) i--;
+  return i;
+}
+
+function isQuote(ch: string): boolean {
+  return ch === '"' || ch === "'" || ch === '`';
+}
+
+/**
+ * The hex leads the content of a string literal, which is itself a value. Step out
+ * of the quote to see whether a declaration on the left names that value a colour.
+ */
+function stringLiteralPosition(source: string, lineStart: number, quoteIndex: number): number {
+  let i = quoteIndex - 1;
+  while (i >= lineStart && /\s/.test(source[i]!)) i--;
+  if (i < lineStart) return POS_VALUE;
+  return Math.max(POS_VALUE, declarationPosition(source, lineStart, i, source[i]!));
+}
+
+/** Value position reached through `name:` / `name=`; POS_COLOR when the name carries colour. */
+function declarationPosition(
+  source: string,
+  lineStart: number,
+  separatorIndex: number,
+  separator: string
+): number {
+  if (separator !== ':' && separator !== '=') return POS_NONE;
+  const name = TRAILING_NAME.exec(source.slice(lineStart, separatorIndex))?.[1];
+  if (!name) return POS_VALUE;
+  return COLOR_CARRIER_NAME.test(name) ? POS_COLOR : POS_VALUE;
+}
+
+/** True when every token between the separator and the hex is a CSS value token. */
+function isCssValueRun(run: string): boolean {
+  const trimmed = run.trim();
+  if (trimmed === '') return true;
+  return trimmed.split(/\s+/).every((token) => CSS_VALUE_TOKEN.test(token.replace(/,+$/, '')));
+}
+
+/** True when the hex digits are all decimal — the issue-reference shape (#1824). */
+function isAllDecimal(hex: string): boolean {
+  return !/[a-fA-F]/.test(hex);
+}
+
 /**
  * Decide whether a hex match at `offset` is a genuine color literal worth
- * flagging (#750).
+ * flagging (#750, #1824).
  *
  * - COMMENT context → always rejected (comments are never style declarations;
  *   covers issue refs `(#529)` in JSDoc and hex prose `e.g. \`#e63535\``).
- * - CODE context → always flagged (real unquoted literal).
- * - STRING context → flagged UNLESS it matches the GitHub issue/PR-reference
- *   idiom `(#NNN)`, i.e. the `#` is immediately preceded by `(`. Genuine color
- *   literals — `"#e63535"`, `'#666'`, CSS shorthand `"1px solid #0066cc"`,
- *   bare template values `color: #333` — are never written that way, so they
- *   are preserved. We deliberately do NOT skip bare numeric hexes (that stopgap
- *   would suppress real `#666`/`#333` literals — see #750).
+ * - Outside a value position → rejected (#1824). Prose such as
+ *   `'see #1824 for the triage'`, a test title `(#332 Tier-3)`, or bare JSX text
+ *   is never where a declaration value can appear. This generalizes — and
+ *   replaces — the narrower `(#NNN)`-only rejection from #750.
+ * - All-decimal in a value position with no colour carrier → rejected (#1824).
+ *   `const ISSUE = '#1824'` is a reference; `background: '#666'` is a colour,
+ *   and the carrier is what tells them apart.
  */
-function isHexColorContext(source: string, ctx: Uint8Array, offset: number): boolean {
-  const kind = ctx[offset];
-  if (kind === CTX_COMMENT) return false;
-  if (kind !== CTX_STRING) return true; // CODE context: always a real literal
-  // In a string: reject only the parenthesized issue-reference shape `(#NNN)`.
-  return source[offset - 1] !== '(';
+function isHexColorContext(source: string, ctx: Uint8Array, offset: number, hex: string): boolean {
+  if (ctx[offset] === CTX_COMMENT) return false;
+  const position = hexValuePosition(source, offset);
+  if (position === POS_NONE) return false;
+  return position === POS_COLOR || !isAllDecimal(hex);
 }
 
 // ─── helpers ───────────────────────────────────────────

--- a/packages/cli/src/drift/rules/token-bypass-rule.ts
+++ b/packages/cli/src/drift/rules/token-bypass-rule.ts
@@ -372,7 +372,10 @@ const COLOR_FUNCTION_CALL =
 
 /** Property / variable names whose value is a colour. */
 const COLOR_CARRIER_NAME =
-  /colou?r|background|\bbg\b|border|outline|fill|stroke|shadow|gradient|palette|swatch|theme|brand|accent|primary|secondary|tertiary|surface|foreground|\bfg\b|backdrop|overlay|highlight|placeholder|caret|selection|divider|scrollbar|ink|tint|shade|hue|grey|gray|white|black|danger|warning|success|error|info|muted|dark|light/i;
+  /colou?r|background|\bbg\b|border|outline|fill|stroke|shadow|gradient|palette|swatch|theme|brand|accent|primary|secondary|tertiary|surface|foreground|\bfg\b|backdrop|overlay|highlight|placeholder|caret|selection|divider|scrollbar|ink|tint|shade|hue|grey|gray|white|black|danger|warning|success|error|info|muted|dark|light|\btext\b|\bring\b|\bvia\b|\bfrom\b|decoration/i;
+
+/** Separators that introduce a value: a declaration, an assignment, or an arbitrary-value bracket. */
+const VALUE_INTRODUCERS = new Set([':', '=', '[']);
 
 /** Trailing identifier immediately left of a declaration separator. */
 const TRAILING_NAME = /([\w$@-]+)\s*["'`]?\s*$/;
@@ -416,14 +419,18 @@ function stringLiteralPosition(source: string, lineStart: number, quoteIndex: nu
   return Math.max(POS_VALUE, declarationPosition(source, lineStart, i, source[i]!));
 }
 
-/** Value position reached through `name:` / `name=`; POS_COLOR when the name carries colour. */
+/**
+ * Value position reached through a named introducer — `name:`, `name=`, or the
+ * bracket of a utility-class arbitrary value (`bg-[#1a2b3c]`). POS_COLOR when the
+ * name carries colour.
+ */
 function declarationPosition(
   source: string,
   lineStart: number,
   separatorIndex: number,
   separator: string
 ): number {
-  if (separator !== ':' && separator !== '=') return POS_NONE;
+  if (!VALUE_INTRODUCERS.has(separator)) return POS_NONE;
   const name = TRAILING_NAME.exec(source.slice(lineStart, separatorIndex))?.[1];
   if (!name) return POS_VALUE;
   return COLOR_CARRIER_NAME.test(name) ? POS_COLOR : POS_VALUE;

--- a/packages/cli/tests/drift/integration/detect-drift.test.ts
+++ b/packages/cli/tests/drift/integration/detect-drift.test.ts
@@ -80,7 +80,7 @@ describe('runDetectDrift (integration)', () => {
   it('honors the files arg (scans only those files)', async () => {
     writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
     writeFile('src/A.tsx', `const a = "#aabbcc";`);
-    writeFile('src/B.tsx', `const b = "#112233";`);
+    writeFile('src/B.tsx', `const b = { color: "#112233" };`);
 
     const out = await runDetectDrift({ path: tmpDir, files: ['src/A.tsx'] });
     const filesScanned = new Set(out.findings.map((f) => f.file));
@@ -102,7 +102,7 @@ describe('runDetectDrift (integration)', () => {
   it('design.exclude (input.exclude) drops matching files from the walk', async () => {
     writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
     writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`);
-    writeFile('src/Card.ts', `const b = "#112233";`);
+    writeFile('src/Card.ts', `const b = { color: "#112233" };`);
 
     const out = await runDetectDrift({
       path: tmpDir,
@@ -121,7 +121,7 @@ describe('runDetectDrift (integration)', () => {
       JSON.stringify({ design: { exclude: ['**/tokens-reference.ts'] } })
     );
     writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`);
-    writeFile('src/Card.ts', `const b = "#112233";`);
+    writeFile('src/Card.ts', `const b = { color: "#112233" };`);
 
     // No input.exclude — the runner must read design.exclude from config itself.
     const out = await runDetectDrift({ path: tmpDir });
@@ -140,8 +140,8 @@ describe('runDetectDrift (integration)', () => {
       })
     );
     writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`); // dropped by design.exclude
-    writeFile('backend/service.ts', `const b = "#112233";`); // dropped by analysis.exclude
-    writeFile('ui/Card.ts', `const c = "#445566";`); // kept
+    writeFile('backend/service.ts', `const b = { color: "#112233" };`); // dropped by analysis.exclude
+    writeFile('ui/Card.ts', `const c = { color: "#445566" };`); // kept
 
     const out = await runDetectDrift({ path: tmpDir });
     const files = new Set(out.findings.map((f) => f.file));
@@ -153,7 +153,7 @@ describe('runDetectDrift (integration)', () => {
   it('matchBase: a bare-basename pattern matches at any depth', async () => {
     writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
     writeFile('src/deep/nested/Foo.tokens.ts', `const a = "#aabbcc";`);
-    writeFile('src/Card.ts', `const b = "#112233";`);
+    writeFile('src/Card.ts', `const b = { color: "#112233" };`);
 
     const out = await runDetectDrift({ path: tmpDir, exclude: ['*.tokens.ts'] });
     const files = new Set(out.findings.map((f) => f.file));
@@ -165,7 +165,7 @@ describe('runDetectDrift (integration)', () => {
     writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
     writeFile('harness.config.json', JSON.stringify({ analysis: { exclude: ['backend/**'] } }));
     writeFile('backend/service.ts', `const a = "#aabbcc";`);
-    writeFile('ui/Card.ts', `const b = "#112233";`);
+    writeFile('ui/Card.ts', `const b = { color: "#112233" };`);
 
     const out = await runDetectDrift({ path: tmpDir });
     const files = new Set(out.findings.map((f) => f.file));
@@ -189,7 +189,7 @@ describe('runDetectDrift (integration)', () => {
   it('no excludes configured → walk + findings unchanged (no regression)', async () => {
     writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
     writeFile('src/A.tsx', `const a = "#aabbcc";`);
-    writeFile('src/B.tsx', `const b = "#112233";`);
+    writeFile('src/B.tsx', `const b = { color: "#112233" };`);
 
     const out = await runDetectDrift({ path: tmpDir });
     const files = new Set(out.findings.map((f) => f.file));

--- a/packages/cli/tests/drift/rules/token-bypass.test.ts
+++ b/packages/cli/tests/drift/rules/token-bypass.test.ts
@@ -158,6 +158,58 @@ describe('runTokenBypassRule', () => {
     });
   });
 
+  // Regression: #1824 — an issue reference is hex-shaped (`0-9` are all valid hex
+  // digits), so `#1824` / `#493` were reported as hardcoded colours. Reported at 143 of
+  // 413 findings (35%) on first adoption. The fix requires a colour-bearing value position
+  // (c) AND rejects an all-decimal match that has no colour carrier (b).
+  describe('DRIFT-T001 — issue-reference false positives (#1824)', () => {
+    const t001 = (source: string, file = 'a.ts') =>
+      runTokenBypassRule({ source, file, tokens: emptyTokens(), strictness: 'standard' }).filter(
+        (f) => f.code === 'DRIFT-T001'
+      );
+
+    it('does NOT flag an issue reference inside non-parenthesized string prose', () => {
+      expect(t001(`export const note = 'see #1824 for the triage';`)).toHaveLength(0);
+    });
+
+    it('does NOT flag an issue reference in a thrown error message', () => {
+      expect(t001(`throw new Error('token resolver drifted, see #493');`)).toHaveLength(0);
+    });
+
+    it('does NOT flag issue references in bare code/JSX text context', () => {
+      expect(
+        t001(`export const El = () => <p>Tracked as #1824 and #493</p>;`, 'El.tsx')
+      ).toHaveLength(0);
+    });
+
+    it('does NOT flag a letter-bearing reference in prose (the case (b) alone misses)', () => {
+      expect(t001(`export const sha = 'reverted in #abc123 — see the ADR';`)).toHaveLength(0);
+    });
+
+    it('does NOT flag CSS-invalid hex lengths (5 and 7 are never colours)', () => {
+      expect(t001(`const a = '#12345'; const b = '#1234567';`)).toHaveLength(0);
+    });
+
+    it('STILL flags an all-decimal hex behind a colour carrier (context overrides (b))', () => {
+      const found = t001(`.badge { color: #1824; }`, 'badge.css');
+      expect(found).toHaveLength(1);
+      expect(found[0].message).toContain('#1824');
+    });
+
+    it('STILL flags a colour inside a gradient / var() fallback', () => {
+      const found = t001(
+        'const css = `a { background: linear-gradient(to right, #fff, #000); }`;',
+        'g.ts'
+      );
+      expect(found.map((f) => f.message).join(' ')).toContain('#fff');
+      expect(found.map((f) => f.message).join(' ')).toContain('#000');
+    });
+
+    it('STILL flags an all-decimal hex behind a colour-named SCSS variable', () => {
+      expect(t001(`$grey-700: #666;`, 'vars.scss')).toHaveLength(1);
+    });
+  });
+
   // Regression: #750 — spacing prose inside comments must not be flagged.
   describe('DRIFT-T003 — comment context (#750)', () => {
     it('does NOT flag a px value described in a block-comment prose line', () => {

--- a/packages/cli/tests/drift/rules/token-bypass.test.ts
+++ b/packages/cli/tests/drift/rules/token-bypass.test.ts
@@ -208,6 +208,24 @@ describe('runTokenBypassRule', () => {
     it('STILL flags an all-decimal hex behind a colour-named SCSS variable', () => {
       expect(t001(`$grey-700: #666;`, 'vars.scss')).toHaveLength(1);
     });
+
+    it('STILL flags utility-class arbitrary colour values (bg-[#…] / text-[#…])', () => {
+      const found = t001(
+        `export const A = () => <div className="bg-[#1a2b3c] text-[#333]" />;`,
+        'A.tsx'
+      );
+      expect(found.map((f) => f.message).join(' ')).toContain('#1a2b3c');
+      expect(found.map((f) => f.message).join(' ')).toContain('#333');
+    });
+
+    it('STILL flags every colour in a palette array and a SCSS map', () => {
+      expect(t001(`const p = ['#e63535', '#0066cc'];`, 'p.ts')).toHaveLength(2);
+      expect(t001(`$palette: (primary: #e63535, grey: #666);`, 'p.scss')).toHaveLength(2);
+    });
+
+    it('STILL flags an 8-digit colour behind a shadow carrier', () => {
+      expect(t001(`const s = { boxShadow: '0 1px 2px #0000001a' };`, 's.ts')).toHaveLength(1);
+    });
   });
 
   // Regression: #750 — spacing prose inside comments must not be flagged.


### PR DESCRIPTION
## What

`DRIFT-T001` reported GitHub issue references as hardcoded colours. A reference is
hex-shaped — `0-9` are all valid hex digits — so `#1824` and `#493` matched
`HEX_PATTERN`. The reporter measured **143 of 413 findings (35%)** as this false
positive on their first adoption of `check-design`, which is exactly where the rule
most needs to read cleanly: a 35%-noise first run gets read as "this rule isn't worth it".

## Root cause

The diagnosis is the difference between sibling detectors in the same file.
`FONT_FAMILY_PATTERN` (T002) and `PX_VALUE_PATTERN` (T003) both anchor on a declaring
property before the value, and are consequently quiet. `detectHexBypass` anchored on
nothing, so any hex-shaped token was admitted.

The earlier partial fix — 7c6a4e741, `#750`, shipped in cli 10.0.0 and therefore
already present in the reporter's 11.3.0 — rejected `COMMENT` context and the
parenthesized `(#NNN)` idiom only. References in ordinary string prose, thrown-error
messages, JSX text and CSS survived it.

## The fix

Two gates now run together, per the fork answered at the fleet CONFIRM gate:

- **(c) A colour value position is required.** `hexValuePosition` classifies a match as
  none / value / colour. It must follow a `name:` / `name=` declaration separator, lead
  a string literal's content, or sit inside a colour function's argument list — with
  only CSS value tokens between the separator and the `#`. This generalizes, and
  replaces, the narrower `(#NNN)`-only rejection from #750.
- **(b) An all-decimal match is rejected without a carrier.** `#1824` is flagged only
  where a colour-bearing property or variable name, or a colour function, vouches for
  it. The carrier is what separates `const ISSUE = '#1824'` from `background: '#666'`.

`HEX_PATTERN` is also narrowed to the CSS-valid lengths 3, 4, 6 and 8. `{3,8}` admitted
5 and 7, which can never be a colour — the report's suggestion 2, "worth doing
regardless since it's strictly more correct".

## Behaviour, end to end

Run through `runDetectDrift` over a fixture carrying 8 issue references and 7 genuine
colours: **7 DRIFT-T001 findings, every one a real colour, zero issue references.**

| Now silent (was flagged)                          | Still flagged                              |
| ------------------------------------------------- | ------------------------------------------ |
| `'see #1824 for the triage; reverted in #abc123'` | `color: '#e63535'`                         |
| `throw new Error('... see #493')`                 | `background: '#666'` (all-decimal + carrier) |
| `<p>Tracked as #1824 and #493</p>`                | `border: '1px solid #0066cc'`              |
| `#1824 { display: none; }` (CSS id selector)      | `.badge { color: #1824; }`                 |
| `/* #493: deliberate, see the ADR */`             | `linear-gradient(to right, #fff, #000)`    |
| `'#12345'`, `'#1234567'` (impossible lengths)     | `$grey-700: #666;`                         |
| `const ISSUE = '#1824';` (no colour carrier)      | `bg-[#1a2b3c]`, `text-[#333]`              |

A follow-up commit on this branch fixes one coverage regression the value gate would
otherwise have shipped: utility-class arbitrary values (`bg-[#1a2b3c]`) were missed because
`[` was not a value introducer. Probed and pinned by tests alongside styled-components
template values, palette arrays, JSX style props, SCSS maps, 8-digit shadow colours, and
colour-named CSS custom properties.

## Reproducing test

`packages/cli/tests/drift/rules/token-bypass.test.ts`, suite
`DRIFT-T001 — issue-reference false positives (#1824)`.

```
pnpm --filter @harness-engineering/cli exec vitest run tests/drift/rules/token-bypass.test.ts
```

- With `token-bypass-rule.ts` restored to the base SHA `5cd661d74`: **5 failed | 27 passed (32)**
- With the fix: **32 passed (32)**
- Revert-and-fail confirmed by overwriting the rule file from the base SHA, rerunning
  (5 failed), restoring the fix, rerunning (32 passed).

Full `packages/cli` suite under the pinned Node 22: **622 files, 7012 passed | 2 skipped**.

## Assumptions made

1. **Fork F2 was answered (b) AND (c) together**, at the roadmap-fleet CONFIRM gate:
   reject an all-decimal match as a non-colour, *and* require a colour-bearing
   syntactic context. Both are implemented; neither alone was treated as sufficient.
2. **(b) and (c) are composed, not flatly conjoined.** The carrier that satisfies (c) is
   what overrides (b). A flat `AND` would have deleted every all-decimal grey and
   contradicted the pre-existing regression test *"STILL flags an all-numeric hex color
   literal in real code (#666 true positive preserved)"*, which was treated as a hard
   invariant rather than something to renegotiate.
3. **The CSS-valid-length narrowing was taken as in-scope** for the same fix. It is
   independent of F2 and strictly more correct.
4. **Six integration fixtures were rewritten, not weakened.** They used bare all-decimal
   literals (`const b = "#112233"`) purely as scan fodder for `design.exclude`
   assertions; they are now real colour declarations (`const b = { color: "#112233" }`),
   which keeps their all-decimal coverage. The tests are about exclude filtering, not hex
   shape.
5. **A value-position gate must not silently narrow real coverage**, so it was probed
   against common colour idioms rather than assumed correct. That probe caught the
   utility-class regression above, which is fixed on this branch rather than shipped.
6. **The report's "adjacent, much smaller" item is deliberately NOT fixed here.**
   `design.tokenPath` is accepted by the config schema but ignored by the tokens
   resolver, which reads `design-system/tokens.json` as a string literal. That is a
   separate defect in the resolver and is not the cause of the 35% noise. It wants its
   own issue.

## Provenance

- `docs/changes/drift-t001-issue-ref-false-positive-1824/provenance.json`
- `docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md` — the full
  `harness-debugging` session record (investigate → analyze → hypothesize → fix). The live
  session lived under `.harness/debug/`, which `.harness/.gitignore` excludes, so it is
  committed here to stay verifiable.
- Route is `bug`, so there is no `plans/` directory. That is expected for this route.

Closes #1824

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
