### PR TITLE
fix(core)!: reject path-traversing External-IDs and re-validate at every authenticated GitHub sink

### DIFF
--- a/.changeset/plain-pandas-repeat.md
+++ b/.changeset/plain-pandas-repeat.md
@@ -1,0 +1,24 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(core)!: constrain the canonical External-ID regex and re-validate at every authenticated GitHub API sink
+
+`parseExternalId` — the format authority named by ADR 0051 — matched
+`^github:([^/]+)\/([^#]+)#(\d+)$`. The owner capture admitted `.`, `..` and `?`; the repo
+capture additionally admitted `/`. Ten adapter call sites spliced those captures,
+unencoded, into `${apiBase}/repos/${owner}/${repo}/issues/${n}/...` on requests carrying
+`Authorization: Bearer <token>`, so a crafted `External-ID` in a PR-contributable roadmap
+shard could choose the path of a credentialed request — `github:x/../../../user/emails?#1`
+resolved to `POST https://api.github.com/user/emails`.
+
+Owner and repo are now held to GitHub's own name grammar, bare dot segments are rejected
+separately (`encodeURIComponent` does not encode `.`), and a new `githubRepoPath` export
+re-asserts and percent-encodes at each sink independently of the regex, so a future
+loosening of the pattern cannot silently re-open the traversal.
+
+**Breaking:** an `External-ID` that GitHub itself could never have issued is now rejected
+rather than parsed. No committed roadmap shard is affected — all 280 shards carrying a real
+`External-ID` still parse.
+
+Second instance of the class fixed for the dashboard in #1842.

--- a/.changeset/tame-hounds-shave.md
+++ b/.changeset/tame-hounds-shave.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/core': minor
+---
+
+fix(core): stop losing assignment-history records whose feature name contains a pipe
+
+The roadmap's `## Assignment History` section was emitted as a markdown pipe table and
+read back by recovering its four values POSITIONALLY from an unescaped `split('|')`.
+Nothing escaped the separator, and a feature name is free text (an H3 heading, or the
+MCP `manage_roadmap` write path). So a name such as `Auth | Login flow` serialized to a
+row with five cells, `action` landed on the wrong cell, failed its membership check, and
+the WHOLE record was dropped on the next read — silently, with no error and no warning
+(#1811).
+
+The column separator is now gone rather than escaped. Each record is written as a block
+of four `- **Key:** value` bullets — the same line grammar every feature row already
+uses — so `|` has no special meaning and cannot shift a value onto the wrong field.
+Newlines are handled by the existing summary-field codec; backticks, em-dashes and
+table-separator lookalikes are inert. `serialize → parse` is now an identity for every
+field value, including leading and trailing whitespace, which the table used to trim.
+
+Reading is backward-compatible: the legacy pipe table is still parsed, with its original
+tolerances, so a `roadmap.md` or `_meta.md` written before this change keeps its history
+instead of losing it on first read. Only the writer moved. The first re-serialization of
+a document migrates it. A legacy row whose value contained a `|` was already destroyed
+when it was written and cannot be recovered.
+
+This repo's own `docs/roadmap.d/_meta.md` and the regenerated `docs/roadmap.md` are
+migrated in this change, with all 18 existing records preserved.

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '7c66b80fdddef0e3cba73dfaa49e1220060d2677e74a9e2f15eb489e9a129fcf'
+sourceHash: '9b50ca192f87e3de9ed816ef0112fe3a5ef9ee67425faaf32f6790fdd458901a'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -108,6 +108,7 @@ export detectRoadmapStorageMode
 export fullSync
 export getRoadmapMode
 export getTrackerKindRegistration
+export githubRepoPath
 export groomRoadmap
 export isClaimableBy
 export isMachineAssignee

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,13 +1,14 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '9b50ca192f87e3de9ed816ef0112fe3a5ef9ee67425faaf32f6790fdd458901a'
+sourceHash: '4c61914f56c6b8ae13338b9417230e83301ce88caa3f3cb20d036d473d07c839'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
     'assignee-lifecycle.ts',
+    'assignment-history.ts',
     'derive-repo.ts',
     'external-id.ts',
     'heading.ts',
@@ -147,6 +148,7 @@ export syncToExternal
 import * as eventSourcing from '../state/event-sourcing'
 import { emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange } from '../waypoint/events'
 import { assigneeInvariantHolds, isMachineAssignee, setStatus } from './assignee-lifecycle'
+import { parseAssignmentHistory, serializeAssignmentHistory } from './assignment-history'
 import { deriveRepoFromGitRemote } from './derive-repo'
 import { GROUP_PREFIX, matchFeatureHeadings, serializeFeatureHeading } from './heading'
 import { decodeListField, encodeListField } from './list-field'

--- a/.harness/comprehension/packages/core/src/roadmap/adapters/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/adapters/_module.md
@@ -1,33 +1,19 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap/adapters'
-sourceHash: '6817da6f7c184bac70dd98ef437ed3f9eb625265da6dfeb9a2d66dbac2897b68'
-compiledAt: '2026-08-28T01:22:10.499Z'
+sourceHash: 'fa824d10207be552dc1ac588f44ce806d5cc7a432dc6d1972ea5568dae7a669f'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['github-issues.ts']
 ---
-
-## Summary
-
-GitHubIssuesSyncAdapter mediates between Harness roadmap features and GitHub Issues, handling bidirectional sync of planning metadata (title, labels, milestone, assignee, state). It wraps the GitHub REST API with rate-limit-aware retry logic, maintains a milestone name→ID cache within the adapter lifetime, and enforces a critical invariant: machine-owned claims (orchestrator assignments) never leak to GitHub's human assignee field. The adapter respects a config-driven status map to translate internal feature statuses to GitHub's open/closed states, and re-exports buildExternalId/parseExternalId from the canonical external-id module to keep the github:owner/repo#NNN format stable across sync and reconcile boundaries.
-
-## Invariants
-
-- Canonical external-ID format lives in one place — github:owner/repo#NNN is defined in ../external-id and re-exported here; callers importing from this adapter see a stable import site even if internal structure changes.
-- Machine assignees never reach GitHub — pushAssigneeToExternal gates all assignee writes; resolveAssigneeLogin returns null for machine IDs as defense-in-depth, preventing orchestrator claims from clobbering human ownership.
-- CI-safe mode via syncIssueState option — when options.syncIssueState === false, state patching is omitted (labels still converge), allowing CI agents to reconcile planning metadata without closing/reopening issues.
-- Status-to-external-state mapping is config-driven — config.statusMap is the single source of truth for which feature statuses map to 'open' vs 'closed'; used consistently across labelsForStatus, closeIfDone, and updateTicket.
-- Retry logic respects Retry-After header — fetchWithRetry prefers the header over computed backoff; unrecognized headers fall back to exponential backoff with jitter.
-- Status-specific labels disambiguate open issues — when a non-backlog status maps to 'open', a status-specific label is added to distinguish it from other open statuses in GitHub's UI.
-- Milestone cache is instance-scoped — loaded once per adapter instance and reused; ensures consistency within a sync session but allows independent instances to refresh independently.
 
 ## Interface Contract
 
 ```ts
 export GitHubIssuesSyncAdapter
 export buildExternalId
+export githubRepoPath
 export parseExternalId
 ```
 
@@ -35,7 +21,7 @@ export parseExternalId
 
 ```
 import { pushAssigneeToExternal } from '../assignee-lifecycle'
-import { buildExternalId, parseExternalId } from '../external-id'
+import { buildExternalId, githubRepoPath, parseExternalId } from '../external-id'
 import { TicketWriteOptions, TrackerSyncAdapter } from '../tracker-sync'
 import { Err, ExternalTicket, ExternalTicketState, Ok, Result, RoadmapFeature, TrackerComment, TrackerSyncConfig } from '@harness-engineering/types'
 ```

--- a/.harness/comprehension/packages/core/src/roadmap/tracker/adapters/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/tracker/adapters/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap/tracker/adapters'
-sourceHash: '28588d79c7b2e421441b941a13f2fc2256e9b1de70bcec22acd93a9c3ed55810'
+sourceHash: 'a3964daafddff8476ecf8e321503e6abba20aebae9d83ef4cc5c946861247d21'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -28,6 +28,7 @@ export PnyonTrackerAdapter
 export WaypointHttp
 export WaypointHttpError
 export buildExternalId
+export githubRepoPath
 export parseExternalId
 ```
 
@@ -40,7 +41,7 @@ import { ConflictError, ConflictErrorClass, FeaturePatch, HistoryEvent, HistoryE
 import { refetchAndCompare } from '../conflict'
 import { ETagStore } from '../etag-store'
 import from '../factory'
-import { GitHubHttp, buildExternalId, parseExternalId } from './github-http'
+import { GitHubHttp, buildExternalId, githubRepoPath, parseExternalId } from './github-http'
 import { LinearTrackerAdapter } from './linear'
 import { WaypointCommand, WaypointHttp, WaypointHttpError, WaypointItem, WaypointItemPatch } from './waypoint-http'
 import { Err, FeatureStatus, Ok, Priority, Result } from '@harness-engineering/types'

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '2ab7ac3467a6761da3e8782abc57d646e0e78df3a2084e1318fc8d6055b44629'
+sourceHash: '1afd158e8f84759ca54976b3cddcba19f519cdd6aaecc91f06e4e1ec8ec63d29'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -10,6 +10,7 @@ members:
     'assignee-lifecycle-waypoint.test.ts',
     'assignee-lifecycle.test.ts',
     'derive-repo.test.ts',
+    'external-id-path-traversal.test.ts',
     'fixtures.ts',
     'github-issues-state-guard.test.ts',
     'github-issues.test.ts',
@@ -67,6 +68,7 @@ export VALID_ROADMAP_MD
 import { GitHubIssuesSyncAdapter, parseExternalId } from '../../src/roadmap/adapters/github-issues'
 import { assigneeInvariantHolds, claim, isClaimableBy, isMachineAssignee, pushAssigneeToExternal, release, setStatus } from '../../src/roadmap/assignee-lifecycle'
 import { deriveRepoFromGitRemote, parseOwnerRepoFromRemoteUrl } from '../../src/roadmap/derive-repo'
+import { githubRepoPath, parseExternalId } from '../../src/roadmap/external-id'
 import { FEATURE_PREFIX, GROUP_PREFIX, matchFeatureHeadings, parseFeatureHeading, serializeFeatureHeading } from '../../src/roadmap/heading'
 import { checkRoadmapHealth, defaultIsArchive, groomRoadmap, isUnactionablePlanned } from '../../src/roadmap/health'
 import { decodeListField, encodeListItem } from '../../src/roadmap/list-field'
@@ -95,6 +97,7 @@ import { _resetSyncMutex, fullSync, syncFromExternal, syncRowToExternal, syncToE
 import { TrackedFeature } from '../../src/roadmap/tracker'
 import { loadTrackerSyncConfig } from '../../src/roadmap/tracker-config'
 import { ExternalSyncOptions, TrackerSyncAdapter, resolveReverseStatus } from '../../src/roadmap/tracker-sync'
+import { GitHubIssuesTrackerAdapter } from '../../src/roadmap/tracker/adapters/github-issues'
 import { emitEvent } from '../../src/state/event-sourcing'
 import { initWaypointEmitter, resetWaypointEmitterForTests } from '../../src/waypoint/emitter'
 import { EMPTY_BACKLOG, EMPTY_BACKLOG_MD, EXTENDED_FIELDS_MD, EXTENDED_FIELDS_ROADMAP, GROUPED_ROADMAP, GROUPED_ROADMAP_MD, HISTORY_MD, HISTORY_ROADMAP, INVALID_STATUS_MD, MARKER_NAMES, NO_FRONTMATTER_MD, VALID_ROADMAP, VALID_ROADMAP_MD } from './fixtures'

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '1afd158e8f84759ca54976b3cddcba19f519cdd6aaecc91f06e4e1ec8ec63d29'
+sourceHash: '8c924a05853c748c2179480a84acf9673779217f23ffb2a3883f843c297770f3'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -9,6 +9,7 @@ members:
   [
     'assignee-lifecycle-waypoint.test.ts',
     'assignee-lifecycle.test.ts',
+    'assignment-history-round-trip.test.ts',
     'derive-repo.test.ts',
     'external-id-path-traversal.test.ts',
     'fixtures.ts',
@@ -32,6 +33,7 @@ members:
     'promote.test.ts',
     'reconcile.test.ts',
     'referenced-issues.test.ts',
+    'repro-assignment-history-pipe.test.ts',
     'serialize-extended.test.ts',
     'serialize-groups.test.ts',
     'serialize-list-field-comma.test.ts',
@@ -67,6 +69,7 @@ export VALID_ROADMAP_MD
 ```
 import { GitHubIssuesSyncAdapter, parseExternalId } from '../../src/roadmap/adapters/github-issues'
 import { assigneeInvariantHolds, claim, isClaimableBy, isMachineAssignee, pushAssigneeToExternal, release, setStatus } from '../../src/roadmap/assignee-lifecycle'
+import { parseAssignmentHistory, serializeAssignmentHistory } from '../../src/roadmap/assignment-history'
 import { deriveRepoFromGitRemote, parseOwnerRepoFromRemoteUrl } from '../../src/roadmap/derive-repo'
 import { githubRepoPath, parseExternalId } from '../../src/roadmap/external-id'
 import { FEATURE_PREFIX, GROUP_PREFIX, matchFeatureHeadings, parseFeatureHeading, serializeFeatureHeading } from '../../src/roadmap/heading'
@@ -84,7 +87,7 @@ import { reconcileDoneFromClosedIssues } from '../../src/roadmap/reconcile'
 import { parseReferencedIssues } from '../../src/roadmap/referenced-issues'
 import { serializeFeature, serializeRoadmap } from '../../src/roadmap/serialize'
 import { resolveRoadmapStoreForFile } from '../../src/roadmap/store/factory'
-import { serializeMeta } from '../../src/roadmap/store/meta'
+import { parseMeta, serializeMeta } from '../../src/roadmap/store/meta'
 import { assertSemanticRoundTrip, roadmapToShards } from '../../src/roadmap/store/migration'
 import { slugifyFeatureName } from '../../src/roadmap/store/monolith-store'
 import { writeRegeneratedRoadmap } from '../../src/roadmap/store/regenerator'
@@ -101,7 +104,7 @@ import { GitHubIssuesTrackerAdapter } from '../../src/roadmap/tracker/adapters/g
 import { emitEvent } from '../../src/state/event-sourcing'
 import { initWaypointEmitter, resetWaypointEmitterForTests } from '../../src/waypoint/emitter'
 import { EMPTY_BACKLOG, EMPTY_BACKLOG_MD, EXTENDED_FIELDS_MD, EXTENDED_FIELDS_ROADMAP, GROUPED_ROADMAP, GROUPED_ROADMAP_MD, HISTORY_MD, HISTORY_ROADMAP, INVALID_STATUS_MD, MARKER_NAMES, NO_FRONTMATTER_MD, VALID_ROADMAP, VALID_ROADMAP_MD } from './fixtures'
-import { MIGRATION_ROADMAP, MONOLITH_ROADMAP, OLD_ROADMAP_MD } from './store/fixtures'
+import { META_WITH_HISTORY, MIGRATION_ROADMAP, MONOLITH_ROADMAP, OLD_ROADMAP_MD } from './store/fixtures'
 import { getRoadmapMode } from '@harness-engineering/core'
 import { AssignmentRecord, Err, ExternalTicket, ExternalTicketState, FeatureStatus, Ok, Result, Roadmap, RoadmapFeature, RoadmapMilestone, SdlcEvent, TrackerSyncConfig } from '@harness-engineering/types'
 import * as fs from 'fs'

--- a/.harness/comprehension/packages/core/tests/roadmap/store/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/store/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap/store'
-sourceHash: 'b2d0118b500ace5c3a479ab804a9326ce2cd806358f31675e971a58f2a7f239b'
-compiledAt: '2026-08-28T01:22:10.984Z'
+sourceHash: 'db85fa26db7d31ee00cb776b641916ca58081bfa84f8ebe2dfc0a0f383bd92b9'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'apply-diff.test.ts',
@@ -27,22 +26,6 @@ members:
     'shard.test.ts',
   ]
 ---
-
-## Summary
-
-**`packages/core/tests/roadmap/store`** is the comprehensive test suite and fixture library for the roadmap storage layer, validating both monolithic and sharded storage modes across 17 test files. It ensures safe mutation semantics, archive lifecycle management, and data integrity throughout the roadmap store abstraction.
-
-Key responsibilities: fixture provisioning (standardized roadmaps/shards in multiple formats), atomic mutation validation (add/patch/remove with all-or-nothing semantics), archive/restore lifecycle with active-read exclusion, storage mode abstraction (monolith vs shard), and round-trip preservation of metadata and assignment history.
-
-## Invariants
-
-- Slug collision detection (F4): applyRoadmapDiff must reject two features that slugify identically before executing any mutations; fail-closed to prevent silent slug→feature index collapse
-- Silent milestone-move prevention (F5): features cannot simultaneously change body AND move milestones via patchFeature (which preserves recorded milestone/order); must fail to prevent silent move loss
-- Archive exclusion from active reads: readShardDir and regenerate must exclude archive/ subdirectory; shallow listDir behavior (immediate children only) ensures archive appears as directory entry, never exposing nested .md files to active aggregates
-- Byte-perfect round-trips: archive→restore cycles must preserve shard bytes exactly; no normalization or mutation between move and restoration
-- Idempotency per slug: archive/restore operations silently skip missing slugs rather than error; multiple invocations of same slug list have no side effects
-- Fail-closed mutation: applyRoadmapDiff validates all changes before executing any mutations; first error stops processing and leaves store unmodified
-- Shallow directory semantics: entire archive strategy depends on fsp.readdir behavior; nested paths like archive/slug.md appear as single 'archive' entry in parent listing, not as .md files
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/orchestrator/tests/tracker/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/tracker/_module.md
@@ -1,30 +1,12 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/tests/tracker"
-sourceHash: "6e8a24e97ce4a9dc4080332ca7700ae4f23738368468eb103df3f16baffef81f"
-compiledAt: "2026-08-28T01:22:12.736Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["file-less-stub.test.ts", "roadmap.test.ts"]
+module: 'packages/orchestrator/tests/tracker'
+sourceHash: '29fc8f86ffde6dd748f919ffeea7e43863d33244db82ac877fcc189ae4f9ea04'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members: ['file-less-stub.test.ts', 'roadmap.test.ts']
 ---
-
-## Summary
-
-This test suite validates the tracker dispatch and roadmap adapter layer of the Orchestrator — the subsystem responsible for fetching work items (issues, features) from either GitHub Issues or markdown roadmap files, then marking them complete after workflows finish.
-
-**file-less-stub.test.ts** verifies the tracker factory logic: routes to GitHubIssuesIssueTrackerAdapter when config specifies "github-issues", routes to RoadmapTrackerAdapter for "roadmap", and defensively falls back to file-backed mode when harness.config.json is absent (never throws).
-
-**roadmap.test.ts** exercises the RoadmapTrackerAdapter with real markdown I/O: fetches candidate issues filtered by activeStates config, fetches issues by specific states (including custom states like 'needs-human'), resolves issue state by ID, and tests markIssueComplete() which transitions features to terminal states and writes the roadmap back while maintaining round-trip fidelity.
-
-## Invariants
-
-- Router factory is config-driven and defensive — orchestrator instantiates the correct adapter type; if harness.config.json is absent, it defaults to file-backed mode (never crashes)
-- RoadmapTrackerAdapter reads and writes markdown losslessly — the adapter uses the canonical roadmap store serializer, so content round-trips without mutation
-- State filtering is precise — fetchCandidateIssues() returns only items in activeStates; fetchIssuesByStates() returns items matching the supplied array
-- markIssueComplete is idempotent and fault-tolerant: already-terminal features and deleted features both result in no-op; missing terminalStates config returns explicit error
-- ID generation is deterministic — features are identified by SHA256(name).slice(0,8) + sanitized name, enabling dispatch replay and reconciliation
-- Tests use real file I/O, not mocks — temp directories and post-mutation file inspection ensure fidelity to production serialization behavior
 
 ## Interface Contract
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -800,7 +800,7 @@ nothing — it must not be read as a pass.
 
 ### `parseRoadmap(content)`
 
-Parses a roadmap markdown file into a structured `Roadmap` object. Supports extended fields: `Assignee`, `Priority` (P0–P3), `External-ID`. Parses `## Assignment History` section as a sentinel-bounded table into `AssignmentRecord[]`.
+Parses a roadmap markdown file into a structured `Roadmap` object. Supports extended fields: `Assignee`, `Priority` (P0–P3), `External-ID`. Parses the sentinel-bounded `## Assignment History` section into `AssignmentRecord[]` (four `- **Key:** value` bullets per record; the pre-v5 pipe table is still read).
 
 ### `serializeRoadmap(roadmap)`
 

--- a/docs/changes/assignment-history-format-1811/debug-session.md
+++ b/docs/changes/assignment-history-format-1811/debug-session.md
@@ -1,0 +1,114 @@
+# Debug Session: assignment-history records dropped when a field contains a pipe
+
+Status: resolved
+Started: 2026-09-05
+Issue: https://github.com/Intense-Visions/harness-engineering/issues/1811
+Error: `parseRoadmap(serializeRoadmap(r)).assignmentHistory` returns `[]` for a record
+whose `feature` is `Auth | Login flow`. Silent — no error, no warning.
+
+## Investigation Log
+
+### Phase 1 — INVESTIGATE (read-only)
+
+- `harness cleanup` (entropy): only pre-existing doc drift under `docs/api/*.md`
+  (RENAMED/NOT_FOUND symbol references). NOTHING near `packages/core/src/roadmap/`.
+  Not related.
+- Reproduced deterministically at base `463e0162a` (head of #1843) with the pushed
+  repro `3d6970b25` cherry-picked:
+  `cd packages/core && npx vitest run tests/roadmap/repro-assignment-history-pipe.test.ts`
+  -> `1 failed`, assertion `Expected [ {feature: 'Auth | Login flow', ...} ] / Received []`.
+  Assertion failure, not a resolution error. Ran twice, identical.
+- Data flow traced backward from the empty array:
+  1. `parse.ts::parseAssignmentHistory` returns `[]`.
+  2. Its row reader does `trimmed.split('|').map(trim).filter(c => c.length > 0)`.
+  3. For `| Auth | Login flow | alice | assigned | 2026-03-21 |` that yields
+     `['Auth', 'Login flow', 'alice', 'assigned', '2026-03-21']` — FIVE cells.
+  4. `cells[2]` is therefore `'alice'`, which fails the
+     `['assigned','completed','unassigned']` membership check, and the row is
+     `continue`d — the record is dropped with no diagnostic.
+  5. The row came from `serialize.ts::serializeAssignmentHistory`, which
+     interpolates `record.feature` into a pipe table cell with NO escaping.
+
+### Phase 2 — ANALYZE
+
+- Working examples in the SAME module family: `summary-field.ts` (#1756) and
+  `list-field.ts` (#1757). Both fix the identical class of bug — a line-oriented
+  grammar whose separator is legal inside a value — by owning a reversible codec
+  in a dedicated module shared by the emitter and the reader.
+- Difference: those two fields live on `- **Field:** value` bullets, where the
+  ONLY hostile character is the newline. Assignment history is the one place the
+  roadmap grammar uses a _column_ separator (`|`), so it has a second hostile
+  character that no codec in the repo covers.
+- `heading.ts` is the module-level precedent for "single source of truth shared
+  with both readers, so the emitter cannot drift from them" (#1261).
+- Blast radius re-derived, NOT taken on trust: `grep -rl 'Assignment History'`
+  over committed sources returns `docs/roadmap.d/_meta.md` (source of truth, 17
+  data rows) and `docs/roadmap.md` (the regenerated aggregate, section at line
+  3161, identical 17 rows). NO per-feature shard carries history. Both
+  `docs/roadmap.md` and `docs/roadmap.d/**` are in `.prettierignore`, so
+  `format:check` does not police their layout.
+
+### Assumptions surfaced
+
+- ASSUMPTION: legacy `_meta.md` / `roadmap.md` files in flight (other branches,
+  adopter repos) still carry the pipe table, so the reader must keep parsing it.
+  Consequence if wrong: none — legacy reading is strictly additive.
+- ASSUMPTION (F3, answered by the human at the CONFIRM gate): the chosen fix is
+  (b) move OFF the pipe-table format entirely, NOT (a) escape `|`.
+- DEFERRABLE: leading/trailing spaces inside a value now round-trip (the old
+  table trimmed them). Strictly an improvement; not asserted either way.
+
+## Hypotheses
+
+H1: "Every record whose `feature` or `assignee` contains a `|` is dropped because
+the row reader recovers cells positionally from an unescaped `split('|')`, so any
+embedded pipe shifts `action` off column 2."
+Prediction: a record with a pipe in `assignee` (not `feature`) is dropped too, and
+a record with a pipe in `date` (the LAST column) is NOT dropped but is corrupted.
+Test: table-driven round-trip over adversarial values.
+Result: CONFIRMED — see `tests/roadmap/assignment-history-round-trip.test.ts`.
+
+## Resolution
+
+Resolved: 2026-09-05
+
+Root cause: `serializeAssignmentHistory` interpolated four free-text values into a
+markdown pipe table row with NO escaping, and `parseAssignmentHistory` recovered them
+POSITIONALLY from `split('|').filter(nonEmpty)`. The separator is legal inside every
+value, so any embedded `|` shifted `action` off column 2, failed the action-membership
+check, and dropped the record with no diagnostic.
+
+Fix: removed the column separator instead of escaping it (human-answered fork F3 = (b)).
+`packages/core/src/roadmap/assignment-history.ts` is the new single source of truth for
+the section grammar — the emitter AND both readers. A record is now four `- **Key:**
+value` bullets at column 0, the same line grammar every feature row uses, so `|` has no
+special meaning. Newlines reuse the existing `summary-field` codec (#1756). The legacy
+pipe table is STILL read, with its original tolerances, so no in-flight document loses
+history; only the writer moved.
+
+Follow-on edits the root-cause fix forced:
+
+- `serialize.ts` / `parse.ts` now re-export from the new module, so every historical
+  import path (`from '../serialize'`, `from '../parse'`) still resolves.
+- `preservation.ts` learned the `Feature`/`Action`/`Date` bullets, or the #839
+  write-preservation guard would have reported the new section as unpreservable content.
+- `docs/roadmap.d/_meta.md` migrated (18 records in, 18 records out, deep-equal) and
+  `docs/roadmap.md` regenerated with `harness roadmap regen` (one diff hunk).
+
+Regression tests:
+
+- `packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts` (cherry-picked
+  from the bug-fleet repro branch, `3d6970b25`, unchanged — it is format-agnostic).
+- `packages/core/tests/roadmap/assignment-history-round-trip.test.ts` (new; 15
+  adversarial values x 3 fields, plus ordering, double round-trip, the preservation
+  guard, legacy read, legacy migration, and `_meta.md` byte-stability).
+
+Revert-and-fail: with `serialize.ts` and `parse.ts` restored to the base commit,
+`31 failed | 24 passed (55)`; restored, `55 passed (55)`.
+
+Learnings: the roadmap grammar had ONE place that used a column separator instead of a
+line-per-value bullet, and that one place was the one with unescaped round-trip loss —
+after #1756 (newline in summary) and #1757 (comma in list) had already fixed the same
+class twice. The durable lesson is not "add a third codec": it is that a separator which
+is legal inside its own values is the defect, and the roadmap's own bullet grammar had
+the answer all along.

--- a/docs/changes/assignment-history-format-1811/provenance.json
+++ b/docs/changes/assignment-history-format-1811/provenance.json
@@ -1,0 +1,49 @@
+{
+  "issue": 1811,
+  "issueUrl": "https://github.com/Intense-Visions/harness-engineering/issues/1811",
+  "fleet": "roadmap-fleet",
+  "route": "bug",
+  "stages": ["debugging"],
+  "pipeline": "harness-debugging",
+  "phases": ["investigate", "analyze", "hypothesize", "fix"],
+  "debugSession": "docs/changes/assignment-history-format-1811/debug-session.md",
+  "reproducingTests": [
+    "packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts",
+    "packages/core/tests/roadmap/assignment-history-round-trip.test.ts"
+  ],
+  "reproducingTestOrigin": {
+    "cherryPickedFrom": "3d6970b254d0840c7515a8ad95f3ca47ef0e307f",
+    "branch": "repro/roadmap-assignment-history-pipe",
+    "note": "The pushed bug-fleet repro is format-agnostic (it asserts round-trip equality, not the pipe table), so it was cherry-picked unchanged and remains valid under the new format."
+  },
+  "redGreenEvidence": {
+    "command": "cd packages/core && npx vitest run tests/roadmap/repro-assignment-history-pipe.test.ts tests/roadmap/assignment-history-round-trip.test.ts",
+    "beforeFix": "31 failed | 24 passed (55)",
+    "afterFix": "55 passed (55)",
+    "revertAndFail": "serialize.ts and parse.ts restored to the base commit with the new module left in place; the round-trip assertions failed by assertion (not resolution), then passed again on restore.",
+    "baseOnlyRepro": "At base 463e0162a the cherry-picked repro failed by assertion: Expected [ { feature: 'Auth | Login flow', ... } ] / Received []."
+  },
+  "stackedOn": {
+    "pr": 1854,
+    "branch": "fix/external-id-path-traversal-1843",
+    "baseCommit": "463e0162af3de1fd9f2d4112df88797805ddaf27",
+    "note": "Conductor-imposed serialization. This PR targets that branch, not main, and must land after #1854."
+  },
+  "assumptions": [
+    "F3 answered by the human at the CONFIRM gate as option (b): move assignment history OFF the pipe-table format entirely, NOT (a) escape the pipe. Built as answered; the cheaper escaping option was deliberately not taken.",
+    "Legacy documents in flight (other branches, adopter repos) still carry the pipe table, so the reader keeps parsing it. Writing moved; reading did not.",
+    "Blast radius re-derived rather than taken on trust: assignment history is roadmap-level metadata written once into docs/roadmap.d/_meta.md, plus the regenerated aggregate docs/roadmap.md. No per-feature shard carries it, and none was edited.",
+    "docs/roadmap.md and docs/roadmap.d/** are in .prettierignore, so format:check does not police their layout; the emitted format was verified prettier-stable anyway for the doc examples that are checked.",
+    "Leading/trailing whitespace inside a value now round-trips (the pipe table trimmed it). Treated as a strict improvement; not asserted as a contract either way.",
+    "A record STARTS at its `- **Feature:**` bullet, so the blank lines between record blocks are cosmetic and a reformatter may add or drop them.",
+    "A `bug` route emits no plans/ directory. Expected, not a defect."
+  ],
+  "migration": {
+    "file": "docs/roadmap.d/_meta.md",
+    "recordsBefore": 18,
+    "recordsAfter": 18,
+    "aggregateRegeneratedWith": "node packages/cli/dist/bin/harness.js roadmap regen",
+    "aggregateDiffHunks": 1
+  },
+  "debugSessionNote": ".harness/debug/ is gitignored, so the resolved session record is committed here instead."
+}

--- a/docs/changes/external-id-path-traversal-1843/debug-session.md
+++ b/docs/changes/external-id-path-traversal-1843/debug-session.md
@@ -1,0 +1,124 @@
+# Debug Session: External-ID path traversal into authenticated api.github.com sink (#1843)
+
+Status: resolved
+Resolved: 2026-09-05
+Started: 2026-09-05
+Error: Not a thrown error — a security defect (CWE-22 / CWE-20 / CWE-441).
+`parseExternalId` accepts an External-ID whose `owner`/`repo` captures contain `/`, `..`
+and `?`, and callers splice those captures unencoded into
+`${apiBase}/repos/${owner}/${repo}/issues/${n}/...` on a request carrying
+`Authorization: Bearer <token>`. WHATWG URL normalization collapses the dot segments,
+so the credentialed request lands on an attacker-chosen path.
+
+## Investigation Log
+
+### Step 2 — read the defect precisely
+
+`packages/core/src/roadmap/external-id.ts:12` @ 5cd661d74:
+const EXTERNAL_ID_RE = /^github:([^/]+)\/([^#]+)#(\d+)$/;
+`[^/]+` (owner) admits `.`, `..`, `?`; `[^#]+` (repo) additionally admits `/`.
+Neither capture is length-bounded or grammar-checked against GitHub's own
+owner/repo name rules.
+
+### Step 3 — reproduced consistently (verbatim regex + verbatim URL template, node 22)
+
+    ESCAPED   github:x/../../../user/emails?#1
+        -> https://api.github.com/user/emails?/issues/1/assignees
+    ESCAPED   github:a/../../../applications/CLIENTID/token?#1
+        -> https://api.github.com/applications/CLIENTID/token?/issues/1/assignees
+    ESCAPED   github:o/../../../user/repos?#1
+        -> https://api.github.com/user/repos?/issues/1/assignees
+    contained github:Intense-Visions/harness-engineering#1843
+        -> https://api.github.com/repos/Intense-Visions/harness-engineering/issues/1843/assignees
+
+3 of 4 probes escape `/repos/`. Deterministic — no intermittency. The trailing `?`
+truncates the intended `/issues/<n>/assignees` suffix into a query string.
+
+### Step 4 — recent changes
+
+`external-id.ts` has exactly one commit: 863df8f6c (#684). The regex was permissive from
+introduction; this is not a regression, it is an original defect.
+
+### Step 6 — data flow, backward from the sink
+
+Source: the `- **External-ID:**` field of any `docs/roadmap.d/*.md` shard (fleet-written,
+PR-contributable) -> roadmap store -> adapter method -> `parseExternalId` ->
+`${parsed.owner}/${parsed.repo}` -> `fetchWithRetry` / `GitHubHttp.request` with
+`Authorization: Bearer ${token}`.
+
+Ten sinks interpolate the parsed captures:
+packages/core/src/roadmap/adapters/github-issues.ts 325, 353, 475, 502, 555
+packages/core/src/roadmap/tracker/adapters/github-issues.ts 190, 355, 479, 573, 588
+All ten sit inside `try { ... } catch { return Err(...) }`, so a rejection at the sink
+degrades to the same `Err` contract the `if (!parsed)` guard already produces.
+
+Two of the ten (tracker `fetchById`:190 and `update`:355) happen to be shielded by an
+incidental `parsed.owner !== this.owner` equality check. The other eight are not — every
+sink in `roadmap/adapters/github-issues.ts` is unshielded, as are tracker
+`fetchRawLabels`:479, `appendHistory`:573 and `fetchHistory`:588.
+
+## Uncertainty Surfacing
+
+- Assumption (authorized): tightening the regex is BREAKING and was explicitly authorized
+  by the human at the fleet CONFIRM gate; the compatibility-migration check was considered
+  and deliberately dropped. A shard-rejection sweep is required as a _report_, not a gate.
+- Deferrable: `parseRepoParts` (config-derived `this.owner`/`this.repo`) is operator-supplied
+  config rather than PR-contributable content, so it is a different trust tier. Not in scope.
+- Deferrable: `packages/orchestrator/src/core/pr-detector.ts:43` re-implements its own
+  parse; it feeds no authenticated path sink. Noted, not in scope.
+
+## Hypotheses
+
+H1: The credentialed request's path is attacker-chosen because (a) `EXTERNAL_ID_RE`
+accepts owner/repo values GitHub could never issue, and (b) no sink re-validates or
+percent-encodes before interpolation.
+Prediction: with the verbatim regex + verbatim template, a crafted External-ID yields a
+resolved URL whose pathname does not start with `/repos/`.
+Test: the repro script above.
+Result: CONFIRMED — 3 of 4 probes escape.
+
+## Resolution
+
+Root cause: `EXTERNAL_ID_RE` at `packages/core/src/roadmap/external-id.ts:12` defined the
+canonical External-ID format as `^github:([^/]+)\/([^#]+)#(\d+)$`. Those captures are
+"everything up to the next delimiter", not GitHub's owner/repo name grammar, so `.`, `..`,
+`?` and (for repo) `/` all parsed. Ten adapter sinks then interpolated the captures,
+unencoded, into a path on a request carrying the operator's token. The primitive is
+method + path control against `api.github.com` with an ambient credential — not
+exfiltration to an attacker host, since `apiBase` is a fixed literal.
+
+Fix (both layers, per the human's answer to F1):
+
+1. Regex tightened to owner `[A-Za-z0-9][A-Za-z0-9-]{0,38}` / repo `[A-Za-z0-9._-]{1,100}`,
+   plus an explicit `isDotSegment` guard in `parseExternalId` — necessary because
+   `encodeURIComponent` does not encode `.`, so `..` survives both the character class and
+   the encoding (the lesson #1842 learned the hard way).
+2. New `githubRepoPath(owner, repo)` re-asserts and percent-encodes at the sink. It never
+   consults the regex, so it still holds if the regex is loosened again. Called at all ten
+   call sites immediately before URL construction; all ten already sat inside
+   `try { ... } catch { return Err(...) }`, so a rejection degrades to the same `Err`
+   contract the `if (!parsed)` guard produced.
+
+Regression test: `packages/core/tests/roadmap/external-id-path-traversal.test.ts`
+before fix: 69 failed | 11 passed (80)
+after fix: 80 passed (80)
+revert-and-fail (`git stash push -- packages/core/src`, test kept): 69 failed | 11 passed
+— test verified to catch the bug.
+
+Shard sweep (reported, not gated — breaking was authorized): the shipped validation was
+run over all 282 `docs/roadmap.d/*.md` shards. 280 carry a real External-ID, 2 carry an
+em-dash placeholder, and **0 are rejected**. A repo-wide scan of 538 distinct
+`github:...#N` literals rejects only the 7 attack probes this test introduces plus
+`docs/changes/strategy-init-gateway/proposal.md:69` `github:...#543`, which is a prose
+ellipsis, not a live External-ID.
+
+Learnings:
+
+- "The one regex that defines the format" is a security boundary the moment any consumer
+  splices its captures into a credentialed URL. A delimiter-negation character class
+  (`[^/]+`, `[^#]+`) is a parser, not a validator.
+- Fixing one call site (#1842) while leaving the format authority permissive inverts the
+  intent: the hardened copy becomes the exception. Fix the authority, then re-assert at
+  the sinks.
+- `encodeURIComponent` is not a traversal defence on its own — it leaves `.` untouched, so
+  bare dot segments need their own rejection.

--- a/docs/changes/external-id-path-traversal-1843/provenance.json
+++ b/docs/changes/external-id-path-traversal-1843/provenance.json
@@ -1,0 +1,67 @@
+{
+  "issue": 1843,
+  "repo": "Intense-Visions/harness-engineering",
+  "route": "bug",
+  "fleet": "roadmap-fleet",
+  "stages": ["debugging"],
+  "pipeline": "harness-debugging",
+  "phases": ["investigate", "analyze", "hypothesize", "fix"],
+  "baseSha": "5cd661d74",
+  "branch": "fix/external-id-path-traversal-1843",
+  "debugSession": ".harness/debug/resolved/1843-external-id-path-traversal.md (gitignored via .harness/.gitignore:4 `debug/`)",
+  "debugSessionCommittedCopy": "docs/changes/external-id-path-traversal-1843/debug-session.md",
+  "reproducingTest": "packages/core/tests/roadmap/external-id-path-traversal.test.ts",
+  "reproducingTestCommand": "cd packages/core && npx vitest run tests/roadmap/external-id-path-traversal.test.ts",
+  "reproducingTestBeforeFix": "69 failed | 11 passed (80)",
+  "reproducingTestAfterFix": "80 passed (80)",
+  "revertAndFailCheck": {
+    "method": "git stash push -- packages/core/src (test kept), rerun, git stash pop",
+    "result": "69 failed | 11 passed (80) with src reverted; 80 passed (80) with the fix restored"
+  },
+  "rootCause": "packages/core/src/roadmap/external-id.ts:12 defined EXTERNAL_ID_RE as /^github:([^/]+)\\/([^#]+)#(\\d+)$/. The owner capture admitted '.', '..' and '?'; the repo capture additionally admitted '/'. Ten adapter sinks spliced the captures unencoded into ${apiBase}/repos/${owner}/${repo}/issues/${n}/... on requests carrying Authorization: Bearer <token>. Under WHATWG URL normalization the dot segments collapse and a trailing '?' truncates the intended suffix into a query string, giving method+path control against api.github.com with the operator's ambient token.",
+  "fix": {
+    "layer1": "Tightened EXTERNAL_ID_RE to GitHub's own owner/repo name grammar (owner [A-Za-z0-9][A-Za-z0-9-]{0,38}, repo [A-Za-z0-9._-]{1,100}) plus an explicit dot-segment guard in parseExternalId, because encodeURIComponent does not encode '.'.",
+    "layer2": "Added githubRepoPath(owner, repo) \u2014 an independent, regex-free assertion plus percent-encoding \u2014 and called it at all ten api.github.com call sites immediately before interpolation, so a future regression in EXTERNAL_ID_RE cannot silently re-open the traversal."
+  },
+  "sinksHardened": [
+    "packages/core/src/roadmap/adapters/github-issues.ts updateTicket",
+    "packages/core/src/roadmap/adapters/github-issues.ts fetchTicketState",
+    "packages/core/src/roadmap/adapters/github-issues.ts assignTicket",
+    "packages/core/src/roadmap/adapters/github-issues.ts addComment",
+    "packages/core/src/roadmap/adapters/github-issues.ts fetchComments/fetchCommentPage",
+    "packages/core/src/roadmap/tracker/adapters/github-issues.ts fetchById",
+    "packages/core/src/roadmap/tracker/adapters/github-issues.ts update",
+    "packages/core/src/roadmap/tracker/adapters/github-issues.ts fetchRawLabels",
+    "packages/core/src/roadmap/tracker/adapters/github-issues.ts appendHistory",
+    "packages/core/src/roadmap/tracker/adapters/github-issues.ts fetchHistory"
+  ],
+  "shardSweep": {
+    "question": "How many committed docs/roadmap.d shards does the SHIPPED validation reject?",
+    "method": "Transcribed the shipped EXTERNAL_ID_RE + isDotSegment + githubRepoPath and ran all three over every '- **External-ID:**' value in docs/roadmap.d/*.md.",
+    "filesScanned": 282,
+    "shardsWithRealExternalId": 280,
+    "shardsWithPlaceholderExternalId": 2,
+    "shardsRejected": 0,
+    "rejectedShards": [],
+    "repoWideLiteralScan": "538 distinct 'github:...#N' literals across packages/ and docs/; the only non-probe rejection is docs/changes/strategy-init-gateway/proposal.md:69 'github:...#543', a prose ellipsis in a proposal, not a live External-ID."
+  },
+  "assumptions": [
+    "F1 was answered (c) BOTH by the human at the fleet CONFIRM gate: tighten the regex AND add a defence-in-depth assertion at the api.github.com sink. Neither half was treated as optional.",
+    "BREAKING was explicitly authorized by the human. A compatibility/migration check was considered and deliberately dropped, so no compat shim was reinstated. The shard sweep is reported as a finding (0 rejections), not enforced as a gate.",
+    "Scope boundary honoured: docs/roadmap.d/*.md was read but never edited (#1811 is being built on top of this branch and owns _meta.md).",
+    "PR #1842 (the dashboard instance of the same class) was NOT branched from and its dashboard change was NOT duplicated. This branch is based on origin/main 5cd661d74.",
+    "parseRepoParts-derived this.owner/this.repo come from operator-supplied harness config, a different trust tier from PR-contributable shard content, so they were left unchanged.",
+    "packages/orchestrator/src/core/pr-detector.ts re-implements its own permissive parse but feeds no authenticated path sink; noted as deferrable, not fixed here.",
+    "A 'bug' route leaves no plans/ directory \u2014 expected, not a defect."
+  ],
+  "verification": {
+    "node": "v22.23.2 (repo .nvmrc pin)",
+    "coreSuite": "466 passed | 1 skipped (467 files), 5124 passed | 1 skipped (5125 tests)",
+    "roadmapSuite": "67 passed | 1 skipped (68 files), 775 passed | 1 skipped (776 tests)",
+    "dashboardSuite": "134 passed (134 files), 950 passed (950 tests)",
+    "orchestratorSuite": "260 passed | 1 skipped (261 files), 2883 passed | 1 skipped (2884 tests) \u2014 one EADDRINUSE ephemeral-port flake outside the diff on the first run, clean on rerun",
+    "typecheck": "tsc --noEmit -p packages/core/tsconfig.json exit 0",
+    "coreBarrel": "node scripts/generate-core-barrel.mjs --check \u2014 up to date",
+    "build": "pnpm turbo build \u2014 13/13 successful"
+  }
+}

--- a/docs/guides/roadmap-sync.md
+++ b/docs/guides/roadmap-sync.md
@@ -69,11 +69,20 @@ last_manual_edit: 2026-04-02
 
 ## Assignment History
 
-| Feature        | Assignee | Action    | Date       |
-| -------------- | -------- | --------- | ---------- |
-| Authentication | @alice   | assigned  | 2026-03-15 |
-| Authentication | @alice   | completed | 2026-03-28 |
-| API Gateway    | @alice   | assigned  | 2026-04-01 |
+- **Feature:** Authentication
+- **Assignee:** @alice
+- **Action:** assigned
+- **Date:** 2026-03-15
+
+- **Feature:** Authentication
+- **Assignee:** @alice
+- **Action:** completed
+- **Date:** 2026-03-28
+
+- **Feature:** API Gateway
+- **Assignee:** @alice
+- **Action:** assigned
+- **Date:** 2026-04-01
 ```
 
 ### Feature Fields
@@ -412,17 +421,33 @@ These fields are conditionally emitted — if none are set on a feature, the mar
 
 ## Assignment History
 
-An `## Assignment History` section is automatically maintained at the bottom of `roadmap.md`:
+An `## Assignment History` section is automatically maintained at the bottom of `roadmap.md`. Each record is a block of four `- **Key:** value` bullets — the same line grammar a feature row uses:
 
 ```markdown
 ## Assignment History
 
-| Feature       | Assignee | Action    | Date       |
-| ------------- | -------- | --------- | ---------- |
-| Widget System | @alice   | assigned  | 2026-04-01 |
-| Widget System | @alice   | completed | 2026-04-03 |
-| API Gateway   | @bob     | assigned  | 2026-04-02 |
+- **Feature:** Widget System
+- **Assignee:** @alice
+- **Action:** assigned
+- **Date:** 2026-04-01
+
+- **Feature:** Widget System
+- **Assignee:** @alice
+- **Action:** completed
+- **Date:** 2026-04-03
+
+- **Feature:** API Gateway
+- **Assignee:** @bob
+- **Action:** assigned
+- **Date:** 2026-04-02
 ```
+
+A record starts at its `- **Feature:**` bullet, so the blank lines between blocks
+are cosmetic. The section was a markdown pipe table before v5; a feature name
+containing a `|` silently destroyed its own record on the next read, so the column
+separator was removed rather than escaped (#1811). Documents still carrying the old
+table are read as before — only the writer changed — but a legacy row whose value
+contained a `|` was already lost when it was written and cannot be recovered.
 
 Reassignment produces two records: `unassigned` for the previous assignee, then `assigned` for the new one. This provides a complete audit trail and enables affinity-based routing.
 

--- a/docs/roadmap.d/_meta.md
+++ b/docs/roadmap.d/_meta.md
@@ -34,23 +34,93 @@ milestones:
 ---
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Performance Engineering Knowledge Skills | @chadjw | assigned | 2026-04-09 |
-| Phase 2: Code Signal Extractors | @chadjw | assigned | 2026-04-23 |
-| Phase 3: Connector Enhancement | @chadjw | assigned | 2026-04-22 |
-| Phase 4: Knowledge Pipeline & Diagrams | @chadjw | assigned | 2026-04-23 |
-| Hermes Phase 0.1: Reference Slack Bridge | @cwarner | assigned | 2026-05-15 |
-| design-pipeline sub-project #2: audit-component-anatomy | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #0: brand-guidelines source-of-truth | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #3: audit-brand-compliance | @chadjw | assigned | 2026-06-02 |
-| Init design + roadmap polish follow-ups | @chadjw | assigned | 2026-06-03 |
-| Build harness:outcome-eval skill | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Build harness:audit-harness-strength self-audit skill | chad.warner@capillarytech.com | assigned | 2026-06-23 |
-| Ship the 5-signal dashboard panel and signals.md doc | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Ship a required-review GitHub Action template | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Stop the pre-commit auto-baseline-update for arch | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | assigned | 2026-06-25 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | unassigned | 2026-06-25 |
-| Per-subagent token attribution in burn | Chad Warner | unassigned | 2026-08-10 |
+
+- **Feature:** Performance Engineering Knowledge Skills
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-09
+
+- **Feature:** Phase 2: Code Signal Extractors
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Phase 3: Connector Enhancement
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-22
+
+- **Feature:** Phase 4: Knowledge Pipeline & Diagrams
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Hermes Phase 0.1: Reference Slack Bridge
+- **Assignee:** @cwarner
+- **Action:** assigned
+- **Date:** 2026-05-15
+
+- **Feature:** design-pipeline sub-project #2: audit-component-anatomy
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #0: brand-guidelines source-of-truth
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #3: audit-brand-compliance
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-02
+
+- **Feature:** Init design + roadmap polish follow-ups
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-03
+
+- **Feature:** Build harness:outcome-eval skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Build harness:audit-harness-strength self-audit skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Ship the 5-signal dashboard panel and signals.md doc
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Ship a required-review GitHub Action template
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Stop the pre-commit auto-baseline-update for arch
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-25
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** unassigned
+- **Date:** 2026-06-25
+
+- **Feature:** Per-subagent token attribution in burn
+- **Assignee:** Chad Warner
+- **Action:** unassigned
+- **Date:** 2026-08-10

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3159,23 +3159,93 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ## v4.0 Business Knowledge System
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Performance Engineering Knowledge Skills | @chadjw | assigned | 2026-04-09 |
-| Phase 2: Code Signal Extractors | @chadjw | assigned | 2026-04-23 |
-| Phase 3: Connector Enhancement | @chadjw | assigned | 2026-04-22 |
-| Phase 4: Knowledge Pipeline & Diagrams | @chadjw | assigned | 2026-04-23 |
-| Hermes Phase 0.1: Reference Slack Bridge | @cwarner | assigned | 2026-05-15 |
-| design-pipeline sub-project #2: audit-component-anatomy | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #0: brand-guidelines source-of-truth | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #3: audit-brand-compliance | @chadjw | assigned | 2026-06-02 |
-| Init design + roadmap polish follow-ups | @chadjw | assigned | 2026-06-03 |
-| Build harness:outcome-eval skill | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Build harness:audit-harness-strength self-audit skill | chad.warner@capillarytech.com | assigned | 2026-06-23 |
-| Ship the 5-signal dashboard panel and signals.md doc | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Ship a required-review GitHub Action template | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Stop the pre-commit auto-baseline-update for arch | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | assigned | 2026-06-25 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | unassigned | 2026-06-25 |
-| Per-subagent token attribution in burn | Chad Warner | unassigned | 2026-08-10 |
+
+- **Feature:** Performance Engineering Knowledge Skills
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-09
+
+- **Feature:** Phase 2: Code Signal Extractors
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Phase 3: Connector Enhancement
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-22
+
+- **Feature:** Phase 4: Knowledge Pipeline & Diagrams
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Hermes Phase 0.1: Reference Slack Bridge
+- **Assignee:** @cwarner
+- **Action:** assigned
+- **Date:** 2026-05-15
+
+- **Feature:** design-pipeline sub-project #2: audit-component-anatomy
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #0: brand-guidelines source-of-truth
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #3: audit-brand-compliance
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-02
+
+- **Feature:** Init design + roadmap polish follow-ups
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-03
+
+- **Feature:** Build harness:outcome-eval skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Build harness:audit-harness-strength self-audit skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Ship the 5-signal dashboard panel and signals.md doc
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Ship a required-review GitHub Action template
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Stop the pre-commit auto-baseline-update for arch
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-25
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** unassigned
+- **Date:** 2026-06-25
+
+- **Feature:** Per-subagent token attribution in burn
+- **Assignee:** Chad Warner
+- **Action:** unassigned
+- **Date:** 2026-08-10

--- a/packages/core/src/roadmap/adapters/github-issues.ts
+++ b/packages/core/src/roadmap/adapters/github-issues.ts
@@ -12,8 +12,8 @@ import { pushAssigneeToExternal } from '../assignee-lifecycle';
 // External-ID parse/build live in one canonical module (../external-id) so the
 // `github:owner/repo#NNN` format never drifts between the sync and reconcile edges.
 // Re-exported here so this adapter's existing import site stays stable.
-import { parseExternalId, buildExternalId } from '../external-id';
-export { parseExternalId, buildExternalId } from '../external-id';
+import { parseExternalId, buildExternalId, githubRepoPath } from '../external-id';
+export { parseExternalId, buildExternalId, githubRepoPath } from '../external-id';
 
 /**
  * Determine which labels to apply based on status and config.
@@ -281,6 +281,10 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId format: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying this.token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId format: "${externalId}"`));
       const syncIssueState = options?.syncIssueState ?? true;
 
       const patch: Record<string, unknown> = {};
@@ -322,7 +326,7 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
 
       const response = await fetchWithRetry(
         this.fetchFn,
-        `${this.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+        `${this.apiBase}/repos/${repoPath}/issues/${parsed.number}`,
         {
           method: 'PATCH',
           headers: this.headers(),
@@ -347,10 +351,14 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId format: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying this.token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId format: "${externalId}"`));
 
       const response = await fetchWithRetry(
         this.fetchFn,
-        `${this.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+        `${this.apiBase}/repos/${repoPath}/issues/${parsed.number}`,
         {
           method: 'GET',
           headers: this.headers(),
@@ -466,13 +474,17 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId format: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying this.token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId format: "${externalId}"`));
 
       // Strip leading @ from assignee
       const login = assignee.startsWith('@') ? assignee.slice(1) : assignee;
 
       const response = await fetchWithRetry(
         this.fetchFn,
-        `${this.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/assignees`,
+        `${this.apiBase}/repos/${repoPath}/issues/${parsed.number}/assignees`,
         {
           method: 'POST',
           headers: this.headers(),
@@ -496,10 +508,14 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId format: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying this.token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId format: "${externalId}"`));
 
       const response = await fetchWithRetry(
         this.fetchFn,
-        `${this.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/comments`,
+        `${this.apiBase}/repos/${repoPath}/issues/${parsed.number}/comments`,
         {
           method: 'POST',
           headers: this.headers(),
@@ -536,6 +552,8 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
   }
 
   private async fetchCommentPage(
+    /** Already validated and percent-encoded by the caller (#1843). */
+    repoPath: string,
     parsed: { owner: string; repo: string; number: number },
     page: number
   ): Promise<
@@ -552,7 +570,7 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
     const perPage = 100;
     const response = await fetchWithRetry(
       this.fetchFn,
-      `${this.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/comments?per_page=${perPage}&page=${page}`,
+      `${this.apiBase}/repos/${repoPath}/issues/${parsed.number}/comments?per_page=${perPage}&page=${page}`,
       { method: 'GET', headers: this.headers() },
       this.retryOpts
     );
@@ -577,13 +595,17 @@ export class GitHubIssuesSyncAdapter implements TrackerSyncAdapter {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId format: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying this.token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId format: "${externalId}"`));
 
       const comments: TrackerComment[] = [];
       const perPage = 100;
       let page = 1;
 
       while (true) {
-        const pageResult = await this.fetchCommentPage(parsed, page);
+        const pageResult = await this.fetchCommentPage(repoPath, parsed, page);
         if (!pageResult.ok) return pageResult;
 
         for (const comment of pageResult.value) {

--- a/packages/core/src/roadmap/assignment-history.ts
+++ b/packages/core/src/roadmap/assignment-history.ts
@@ -1,0 +1,239 @@
+import type { AssignmentRecord, Result } from '@harness-engineering/types';
+import { Ok } from '@harness-engineering/types';
+// The newline escape codec lives in `./summary-field`, the single source of truth
+// already shared by the `- **Summary:**` bullet's emitter and reader (#1756). The
+// bullet grammar this module adopts has exactly the same hostile character, so it
+// reuses that codec rather than growing a second one.
+import { encodeSummaryField, decodeSummaryField } from './summary-field';
+
+/**
+ * Single source of truth for the `## Assignment History` section grammar — both
+ * the emitter and BOTH readers.
+ *
+ * ## Why this is not a pipe table any more (#1811)
+ *
+ * History used to be emitted as a markdown pipe table, one record per row:
+ *
+ * ```markdown
+ * | Feature | Assignee | Action | Date |
+ * |---------|----------|--------|------|
+ * | Auth | alice | assigned | 2026-03-21 |
+ * ```
+ *
+ * and read back by splitting each row on `|` and recovering the four values
+ * POSITIONALLY. Nothing escaped the separator, and a feature name is free text
+ * (an H3 heading, or the MCP `manage_roadmap` write path). So a name such as
+ * `Auth | Login flow` serialized to a row with five cells; `action` landed on
+ * cell 2 (`alice`), failed the action-membership check, and the WHOLE record was
+ * dropped — silently, with no error and no warning. Round-trip data loss.
+ *
+ * This is the same class of bug already fixed for the comma-in-list field (#1757)
+ * and the newline-in-summary field (#1756), and those two were fixed with a
+ * reversible escape codec over the existing separator. Escaping `|` was available
+ * here too, and was the cheaper change — it was considered and deliberately NOT
+ * taken. Escaping keeps a column separator that is legal inside every value, so
+ * the format stays one un-escaped write path away from the same bug; the human
+ * decision on this issue was to remove the separator instead of guarding it.
+ *
+ * ## The format
+ *
+ * Each record is a block of four `- **Key:** value` bullets, the SAME line
+ * grammar every feature row already uses, blank-line separated:
+ *
+ * ```markdown
+ * ## Assignment History
+ *
+ * - **Feature:** Auth | Login flow
+ * - **Assignee:** alice
+ * - **Action:** assigned
+ * - **Date:** 2026-03-21
+ *
+ * - **Feature:** API Gateway
+ * - **Assignee:** bob
+ * - **Action:** completed
+ * - **Date:** 2026-04-01
+ * ```
+ *
+ * There is no column separator, so `|` needs no escaping and cannot shift a
+ * value onto the wrong field. Each value owns a whole line, bounded by the line
+ * ending — which leaves the newline as the only hostile character, exactly the
+ * situation {@link encodeSummaryField} already solves. Backticks, pipes,
+ * em-dashes and table-separator lookalikes are all inert.
+ *
+ * A record STARTS at its `- **Feature:**` bullet: that is the record boundary, so
+ * the blank lines between blocks are cosmetic and a reformatter may add or drop
+ * them freely. Bullets are anchored at column 0 to match the anchoring
+ * `parseRoadmap` and `findUnpreservedLines` use everywhere else.
+ *
+ * ## Reading legacy documents
+ *
+ * {@link parseAssignmentHistory} ALSO still reads the old pipe table, unchanged
+ * and with its original tolerances, so a shard `_meta` file or a monolith
+ * aggregate written before this change — in another branch, or in an adopter repo
+ * that has not re-serialized yet — keeps its history instead of losing it on first
+ * read. Only the writer moved. A legacy row whose value contains a `|` is still
+ * lost, since that information never survived being written; nothing can recover
+ * it.
+ *
+ * This module is a pure grammar helper over a string: it opens no file and knows
+ * nothing about where the document it parses lives.
+ */
+
+/** The section's H2 heading. Its own line, and the sentinel every reader bounds on. */
+export const ASSIGNMENT_HISTORY_HEADING = '## Assignment History';
+
+/** The four bullet labels, in emission order. */
+const FIELD_LABELS = ['Feature', 'Assignee', 'Action', 'Date'] as const;
+
+type FieldLabel = (typeof FIELD_LABELS)[number];
+
+/** Bullet label -> the `AssignmentRecord` key it carries. */
+const FIELD_KEYS: Record<FieldLabel, keyof AssignmentRecord> = {
+  Feature: 'feature',
+  Assignee: 'assignee',
+  Action: 'action',
+  Date: 'date',
+};
+
+const VALID_ACTIONS: ReadonlySet<string> = new Set(['assigned', 'completed', 'unassigned']);
+
+/**
+ * One record bullet. The value is optional so an empty field emits (and reads
+ * back as) `- **Key:**` with no trailing space — a trailing space would be
+ * stripped by any reformatter and turn an empty value into a parse miss.
+ * Exactly ONE space separates the marker from the value, so a value with leading
+ * whitespace round-trips instead of being trimmed away.
+ */
+const FIELD_BULLET = /^- \*\*(Feature|Assignee|Action|Date):\*\*(?: (.*))?$/;
+
+/** A legacy pipe-table separator row (`|---|---|`), which opens the data rows. */
+const LEGACY_SEPARATOR = /^\|[-\s|]+\|$/;
+
+/** Emit one `- **Key:** value` bullet, omitting the separator space when empty. */
+function emitFieldBullet(label: FieldLabel, value: string): string {
+  const encoded = encodeSummaryField(value);
+  return encoded === '' ? `- **${label}:**` : `- **${label}:** ${encoded}`;
+}
+
+/**
+ * Emit the whole `## Assignment History` section: the heading, a blank line, then
+ * one blank-line-separated four-bullet block per record, in order. Returns the
+ * lines (no trailing blank), so callers own their own surrounding spacing.
+ *
+ * Emitting nothing for an empty list is the CALLER's job — both call sites guard
+ * on `length > 0` because a `_meta.md` with no history must stay byte-identical
+ * to one written before the section existed.
+ */
+export function serializeAssignmentHistory(records: AssignmentRecord[]): string[] {
+  const lines: string[] = [ASSIGNMENT_HISTORY_HEADING, ''];
+  records.forEach((record, index) => {
+    if (index > 0) lines.push('');
+    for (const label of FIELD_LABELS) lines.push(emitFieldBullet(label, record[FIELD_KEYS[label]]));
+  });
+  return lines;
+}
+
+/**
+ * Slice the `## Assignment History` section body out of a document, bounded by the
+ * next H2 so a future section after history is not swallowed. Returns `null` when
+ * the document has no history section at all.
+ */
+function extractSection(body: string): string | null {
+  const heading = body.match(/^## Assignment History[ \t]*\n/m);
+  if (!heading || heading.index === undefined) return null;
+  const afterHeading = body.slice(heading.index + heading[0].length);
+  const nextH2 = afterHeading.search(/^## /m);
+  return nextH2 === -1 ? afterHeading : afterHeading.slice(0, nextH2);
+}
+
+/** A record under construction: fields arrive one bullet at a time. */
+type RecordDraft = Partial<Record<keyof AssignmentRecord, string>>;
+
+/** A draft becomes a record only once all four fields are present and `action` is real. */
+function finalizeDraft(draft: RecordDraft | null): AssignmentRecord | null {
+  if (!draft) return null;
+  const { feature, assignee, action, date } = draft;
+  if (feature === undefined || assignee === undefined || date === undefined) return null;
+  if (action === undefined || !VALID_ACTIONS.has(action)) return null;
+  return { feature, assignee, action: action as AssignmentRecord['action'], date };
+}
+
+/**
+ * Read the current bullet-block format. A `- **Feature:**` bullet closes the
+ * previous record and opens a new one; the other three fill in the open record.
+ * Anything else on the line is ignored, so blank lines and the legacy table are
+ * simply not this reader's business.
+ */
+function readBulletRecords(lines: string[]): AssignmentRecord[] {
+  const records: AssignmentRecord[] = [];
+  let draft: RecordDraft | null = null;
+
+  for (const line of lines) {
+    const match = line.match(FIELD_BULLET);
+    if (!match) continue;
+    const label = match[1] as FieldLabel;
+    if (label === 'Feature') {
+      const finished = finalizeDraft(draft);
+      if (finished) records.push(finished);
+      draft = {};
+    }
+    draft ??= {};
+    draft[FIELD_KEYS[label]] = decodeSummaryField(match[2] ?? '');
+  }
+
+  const last = finalizeDraft(draft);
+  if (last) records.push(last);
+  return records;
+}
+
+/**
+ * Read the legacy pipe table, preserving its original tolerances verbatim: rows
+ * before the `|---|` separator are header and are skipped, a table with NO
+ * separator is treated as empty, empty cells are dropped by the positional
+ * split, and a row whose third value is not an action is skipped.
+ *
+ * Kept for reading only — nothing writes this shape any more (#1811).
+ */
+function readLegacyTableRecords(lines: string[]): AssignmentRecord[] {
+  const records: AssignmentRecord[] = [];
+  let pastHeader = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) continue;
+    if (!pastHeader) {
+      if (LEGACY_SEPARATOR.test(trimmed)) pastHeader = true;
+      continue;
+    }
+    const cells = trimmed
+      .split('|')
+      .map((cell) => cell.trim())
+      .filter((cell) => cell.length > 0);
+    if (cells.length < 4) continue;
+    if (!VALID_ACTIONS.has(cells[2]!)) continue;
+    records.push({
+      feature: cells[0]!,
+      assignee: cells[1]!,
+      action: cells[2] as AssignmentRecord['action'],
+      date: cells[3]!,
+    });
+  }
+
+  return records;
+}
+
+/**
+ * Parse the `## Assignment History` section of `body` into records. An absent
+ * section yields `[]`.
+ *
+ * Both shapes are read: current bullet blocks first, then any legacy table rows.
+ * A real document only ever holds one of the two, so the concatenation order is
+ * observable only for a hand-mixed section, where "new format, then old" is as
+ * good an answer as any.
+ */
+export function parseAssignmentHistory(body: string): Result<AssignmentRecord[]> {
+  const section = extractSection(body);
+  if (section === null) return Ok([]);
+  const lines = section.split('\n');
+  return Ok([...readBulletRecords(lines), ...readLegacyTableRecords(lines)]);
+}

--- a/packages/core/src/roadmap/external-id.ts
+++ b/packages/core/src/roadmap/external-id.ts
@@ -6,10 +6,45 @@
  * auto-done reconciler edges import these instead of inlining the regex, so the
  * `github:owner/repo#NNN` shape can never drift between the sync and reconcile
  * paths. Re-exported from the package barrel.
+ *
+ * An External-ID is untrusted input: it arrives verbatim from `docs/roadmap.d/*.md`
+ * shard content, which is fleet-written and PR-contributable, and every consumer
+ * interpolates the parsed captures into an `api.github.com` path on a request that
+ * carries the operator's token. The format is therefore validated twice — once
+ * here by `parseExternalId`, and again at each sink by `githubRepoPath` (#1843).
  */
 
-/** The one regex that defines the External-ID format. */
-const EXTERNAL_ID_RE = /^github:([^/]+)\/([^#]+)#(\d+)$/;
+/**
+ * The one regex that defines the External-ID format.
+ *
+ * `owner` and `repo` are held to GitHub's own name grammar rather than
+ * "anything up to the next delimiter". The permissive `([^/]+)\/([^#]+)` this
+ * replaces admitted `/`, `..` and `?`, so a crafted External-ID could choose the
+ * path of a token-bearing request: `github:x/../../../user/emails?#1` resolved to
+ * `POST https://api.github.com/user/emails`, the dot segments collapsing under
+ * WHATWG URL normalization and the trailing `?` truncating the intended
+ * `/issues/<n>/assignees` suffix into a query string (#1843, sibling of #1842).
+ *
+ * Owner: 1-39 characters, alphanumeric or hyphen, must start alphanumeric.
+ * Repo: 1-100 characters, alphanumeric or `.`, `_`, `-`.
+ *
+ * Tightening this is deliberately BREAKING — an External-ID that GitHub itself
+ * could never have issued is now rejected rather than parsed. That trade was made
+ * knowingly: the alternative is leaving an authenticated path-choice primitive in
+ * the format authority named by ADR 0051.
+ */
+const EXTERNAL_ID_RE = /^github:([A-Za-z0-9][A-Za-z0-9-]{0,38})\/([A-Za-z0-9._-]{1,100})#(\d+)$/;
+
+/**
+ * `.` and `..` have to be rejected separately from the character classes above:
+ * they are made of characters a legitimate repo name may contain, and
+ * `encodeURIComponent` leaves `.` untouched, so a bare dot segment survives both
+ * the regex and the encoding and still collapses under URL normalization. This
+ * was found the hard way in #1842.
+ */
+function isDotSegment(segment: string): boolean {
+  return segment === '.' || segment === '..';
+}
 
 /**
  * Parse `github:owner/repo#42` into `{ owner, repo, number }`.
@@ -20,7 +55,39 @@ export function parseExternalId(
 ): { owner: string; repo: string; number: number } | null {
   const match = externalId.match(EXTERNAL_ID_RE);
   if (!match) return null;
-  return { owner: match[1]!, repo: match[2]!, number: parseInt(match[3]!, 10) };
+  const owner = match[1]!;
+  const repo = match[2]!;
+  if (isDotSegment(owner) || isDotSegment(repo)) return null;
+  return { owner, repo, number: parseInt(match[3]!, 10) };
+}
+
+/**
+ * Percent-encode an `owner`/`repo` pair for interpolation into an
+ * `api.github.com` path, returning null when either segment could steer the
+ * request somewhere other than the repository it names.
+ *
+ * This is the second, independent defence for #1843 and it deliberately never
+ * consults `EXTERNAL_ID_RE`: call it at the sink, immediately before building the
+ * URL, so that loosening the regex again cannot silently re-open the traversal.
+ * The explicit rejections and the encoding are both load-bearing — the rejections
+ * catch a regressed regex, and the encoding neutralises anything the rejections
+ * do not anticipate.
+ */
+export function githubRepoPath(owner: string, repo: string): string | null {
+  for (const segment of [owner, repo]) {
+    if (segment.length === 0) return null;
+    if (isDotSegment(segment)) return null;
+    // `/` would append path segments; `?` and `#` would truncate the intended
+    // suffix into a query string or fragment; whitespace is never a valid name.
+    if (/[/?#\s]/.test(segment)) return null;
+  }
+  try {
+    return `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  } catch {
+    // encodeURIComponent throws URIError on a lone surrogate. Treating that as an
+    // unusable External-ID matches every caller's existing "invalid id" contract.
+    return null;
+  }
 }
 
 /** Build the External-ID string `github:owner/repo#number` from parts. */

--- a/packages/core/src/roadmap/index.ts
+++ b/packages/core/src/roadmap/index.ts
@@ -65,7 +65,7 @@ export { parseReferencedIssues } from './referenced-issues';
  * auto-done reconciler edges to map issue numbers ↔ roadmap rows without
  * format drift.
  */
-export { parseExternalId, buildExternalId } from './external-id';
+export { parseExternalId, buildExternalId, githubRepoPath } from './external-id';
 
 /**
  * Shared tracker config loader for harness.config.json.

--- a/packages/core/src/roadmap/parse.ts
+++ b/packages/core/src/roadmap/parse.ts
@@ -6,7 +6,6 @@ import type {
   RoadmapGroup,
   FeatureStatus,
   Priority,
-  AssignmentRecord,
   Result,
 } from '@harness-engineering/types';
 import { Ok, Err } from '@harness-engineering/types';
@@ -22,6 +21,13 @@ import { decodeSummaryField } from './summary-field';
 // for the reversible comma escaping shared by the `Blockers` / `Plan` bullets
 // (see that module for the grammar rationale, #1757).
 import { decodeListField } from './list-field';
+// The `## Assignment History` section grammar (both readers AND the emitter) lives
+// in `./assignment-history`, the single source of truth shared with the serializer.
+// It is re-exported here so `parseAssignmentHistory` keeps its historical import
+// path for the shard `_meta` reader (#1811).
+import { parseAssignmentHistory } from './assignment-history';
+
+export { parseAssignmentHistory };
 
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   'backlog',
@@ -329,50 +335,4 @@ export function parseFeatureBlock(name: string, body: string): Result<RoadmapFea
     externalId: optionalField(fieldMap, 'External-ID'),
     updatedAt: optionalField(fieldMap, 'Updated-At'),
   });
-}
-
-export function parseAssignmentHistory(body: string): Result<AssignmentRecord[]> {
-  const historyMatch = body.match(/^## Assignment History\s*\n/m);
-  if (!historyMatch || historyMatch.index === undefined) return Ok([]);
-
-  const historyStart = historyMatch.index + historyMatch[0].length;
-  const rawHistoryBody = body.slice(historyStart);
-  // Bound to next H2 heading so future sections after history are not consumed
-  const nextH2 = rawHistoryBody.search(/^## /m);
-  const historyBody = nextH2 === -1 ? rawHistoryBody : rawHistoryBody.slice(0, nextH2);
-
-  const records: AssignmentRecord[] = [];
-  // Parse markdown table rows. Rows before the separator (|---|...|) are
-  // skipped (header). If no separator exists the table is treated as empty —
-  // this is intentional tolerance for malformed tables.
-  const lines = historyBody.split('\n');
-  let pastHeader = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith('|')) continue;
-    if (!pastHeader) {
-      if (trimmed.match(/^\|[-\s|]+\|$/)) {
-        pastHeader = true;
-      }
-      continue;
-    }
-    // Parse data row: | Feature | Assignee | Action | Date |
-    const cells = trimmed
-      .split('|')
-      .map((c) => c.trim())
-      .filter((c) => c.length > 0);
-    if (cells.length < 4) continue;
-
-    const action = cells[2] as AssignmentRecord['action'];
-    if (!['assigned', 'completed', 'unassigned'].includes(action)) continue;
-
-    records.push({
-      feature: cells[0]!,
-      assignee: cells[1]!,
-      action,
-      date: cells[3]!,
-    });
-  }
-
-  return Ok(records);
 }

--- a/packages/core/src/roadmap/preservation.ts
+++ b/packages/core/src/roadmap/preservation.ts
@@ -30,6 +30,13 @@ const MODELED_FIELD_KEYS: ReadonlySet<string> = new Set([
   'Priority',
   'External-ID',
   'Updated-At',
+  // `## Assignment History` record bullets (#1811). The section stopped being a
+  // pipe table and became four `- **Key:** value` bullets per record, reusing the
+  // same line grammar, so its lines are preservable for the same reason a feature
+  // row's are. `Assignee` above is shared with the feature block.
+  'Feature',
+  'Action',
+  'Date',
 ]);
 
 /** A source line whose content a monolith rewrite would drop. */
@@ -44,8 +51,10 @@ export interface UnpreservedLine {
  * Return the lines of `markdown` that a `serializeRoadmap` rewrite would silently
  * drop. A line is preservable iff it is frontmatter (regenerated from the model),
  * part of the preamble (everything before the first `## ` heading, which the model
- * now carries verbatim — #1328), blank, an H1 title, an H2/H3 heading, an
- * assignment-history table row, or a single-line modeled `- **Key:** …` field.
+ * now carries verbatim — #1328), blank, an H1 title, an H2/H3 heading, a legacy
+ * assignment-history table row, or a single-line modeled `- **Key:** …` field
+ * (which now includes the `Feature`/`Action`/`Date` bullets an assignment-history
+ * record is written as, #1811).
  * Everything else — multi-line field
  * continuations, unmodeled bullets, blockquotes, comments, arbitrary prose — is
  * reported. An empty result means the document round-trips without content loss.

--- a/packages/core/src/roadmap/serialize.ts
+++ b/packages/core/src/roadmap/serialize.ts
@@ -1,9 +1,4 @@
-import type {
-  Roadmap,
-  RoadmapMilestone,
-  RoadmapFeature,
-  AssignmentRecord,
-} from '@harness-engineering/types';
+import type { Roadmap, RoadmapMilestone, RoadmapFeature } from '@harness-engineering/types';
 // The H3 heading emitter lives in `./heading`, the single source of truth shared
 // with both readers, so the emitter cannot drift from them (#1261).
 import { serializeFeatureHeading } from './heading';
@@ -15,6 +10,13 @@ import { encodeSummaryField } from './summary-field';
 // for the reversible comma escaping shared by the `Blockers` / `Plan` bullets
 // (see that module for the grammar rationale, #1757).
 import { encodeListField } from './list-field';
+// The `## Assignment History` section grammar (emitter AND both readers) lives in
+// `./assignment-history`, the single source of truth shared with the parser. It is
+// re-exported here so `serializeAssignmentHistory` keeps its historical import
+// path for the shard `_meta` writer (#1811).
+import { serializeAssignmentHistory } from './assignment-history';
+
+export { serializeAssignmentHistory };
 
 const EM_DASH = '\u2014';
 
@@ -132,17 +134,5 @@ export function serializeFeature(feature: RoadmapFeature): string[] {
     `- **Plan:** ${listOrDash(feature.plans)}`,
     ...serializeExtendedLines(feature),
   ];
-  return lines;
-}
-
-export function serializeAssignmentHistory(records: AssignmentRecord[]): string[] {
-  const lines = [
-    '## Assignment History',
-    '| Feature | Assignee | Action | Date |',
-    '|---------|----------|--------|------|',
-  ];
-  for (const record of records) {
-    lines.push(`| ${record.feature} | ${record.assignee} | ${record.action} | ${record.date} |`);
-  }
   return lines;
 }

--- a/packages/core/src/roadmap/tracker/adapters/github-http.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-http.ts
@@ -233,4 +233,4 @@ function hasNextLink(link: string | null): boolean {
 
 // External-ID parse/build come from the one canonical module (../../external-id);
 // re-exported here so this adapter's importers keep a single import site.
-export { parseExternalId, buildExternalId } from '../../external-id';
+export { parseExternalId, buildExternalId, githubRepoPath } from '../../external-id';

--- a/packages/core/src/roadmap/tracker/adapters/github-issues.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-issues.ts
@@ -8,7 +8,7 @@ import type {
   HistoryEvent,
   ConflictError,
 } from '../client';
-import { GitHubHttp, parseExternalId, buildExternalId } from './github-http';
+import { GitHubHttp, parseExternalId, buildExternalId, githubRepoPath } from './github-http';
 import { ETagStore } from '../etag-store';
 import { parseBodyBlock, serializeBodyBlock, type BodyMeta } from '../body-metadata';
 import { refetchAndCompare } from '../conflict';
@@ -177,6 +177,10 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying the operator's token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId: "${externalId}"`));
       if (parsed.owner !== this.owner || parsed.repo !== this.repo) {
         return Err(new Error('externalId repo does not match adapter repo'));
       }
@@ -187,7 +191,7 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
       if (cached) init.extraHeaders = { 'If-None-Match': cached.etag };
 
       const res = await this.http.request(
-        `${this.http.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+        `${this.http.apiBase}/repos/${repoPath}/issues/${parsed.number}`,
         init
       );
 
@@ -322,6 +326,10 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying the operator's token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId: "${externalId}"`));
       if (parsed.owner !== this.owner || parsed.repo !== this.repo) {
         return Err(new Error('externalId repo does not match adapter repo'));
       }
@@ -352,7 +360,7 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
       // re-issue a GET when body-meta fields are touched (P2-IMP-6).
       const reqBody = await this.buildIssuePatchBody(externalId, patch, priorFeature);
       const res = await this.http.request(
-        `${this.http.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+        `${this.http.apiBase}/repos/${repoPath}/issues/${parsed.number}`,
         { method: 'PATCH', body: JSON.stringify(reqBody) }
       );
       if (!res.ok) return Err(new Error(`GitHub ${res.status}: ${await res.text()}`));
@@ -475,8 +483,12 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying the operator's token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId: "${externalId}"`));
       const res = await this.http.request(
-        `${this.http.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+        `${this.http.apiBase}/repos/${repoPath}/issues/${parsed.number}`,
         { method: 'GET' }
       );
       if (!res.ok) return Err(new Error(`GitHub ${res.status}: ${await res.text()}`));
@@ -568,9 +580,13 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying the operator's token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId: "${externalId}"`));
       const body = `${GitHubIssuesTrackerAdapter.HISTORY_PREFIX}\n${JSON.stringify(event)}`;
       const res = await this.http.request(
-        `${this.http.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/comments`,
+        `${this.http.apiBase}/repos/${repoPath}/issues/${parsed.number}/comments`,
         { method: 'POST', body: JSON.stringify({ body }) }
       );
       if (!res.ok) return Err(new Error(`GitHub ${res.status}: ${await res.text()}`));
@@ -584,8 +600,12 @@ export class GitHubIssuesTrackerAdapter implements RoadmapTrackerClient {
     try {
       const parsed = parseExternalId(externalId);
       if (!parsed) return Err(new Error(`Invalid externalId: "${externalId}"`));
+      // Re-assert at the sink, immediately before the parsed captures are spliced
+      // into a path on a request carrying the operator's token (#1843).
+      const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+      if (!repoPath) return Err(new Error(`Invalid externalId: "${externalId}"`));
       const buildUrl = (page: number) =>
-        `${this.http.apiBase}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/comments?per_page=100&page=${page}`;
+        `${this.http.apiBase}/repos/${repoPath}/issues/${parsed.number}/comments?per_page=100&page=${page}`;
       const { items } = await this.http.paginate<{ body: string; created_at: string }>(buildUrl);
       const events: HistoryEvent[] = [];
       for (const c of items) {

--- a/packages/core/tests/roadmap/assignment-history-round-trip.test.ts
+++ b/packages/core/tests/roadmap/assignment-history-round-trip.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import type { AssignmentRecord, Roadmap } from '@harness-engineering/types';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import {
+  serializeAssignmentHistory,
+  parseAssignmentHistory,
+} from '../../src/roadmap/assignment-history';
+import { findUnpreservedLines } from '../../src/roadmap/preservation';
+import { parseMeta, serializeMeta } from '../../src/roadmap/store/meta';
+import { VALID_ROADMAP } from './fixtures';
+import { META_WITH_HISTORY } from './store/fixtures';
+
+// Round-trip fidelity of the `## Assignment History` section (#1811).
+//
+// The section used to be a markdown pipe table whose four values were recovered
+// POSITIONALLY from an unescaped `split('|')`. A feature name is free text, so a
+// name containing `|` produced a row with extra cells; `action` landed on the
+// wrong cell, failed its membership check, and the whole record was dropped —
+// silently. The fix moved the section off the table onto four `- **Key:** value`
+// bullets per record, so there is no column separator to collide with.
+//
+// These tests are deliberately format-AGNOSTIC: every assertion is about what
+// survives `serialize → parse`, never about which bytes are emitted. That is what
+// makes them a regression guard rather than a snapshot of today's grammar.
+
+/** Values that a pipe-table cell could not carry. `|` is the #1811 reproducer. */
+const ADVERSARIAL: ReadonlyArray<{ name: string; value: string }> = [
+  { name: 'an embedded pipe (the #1811 reproducer)', value: 'Auth | Login flow' },
+  { name: 'a leading and trailing pipe', value: '|Auth|' },
+  { name: 'consecutive pipes', value: 'Auth || Login' },
+  { name: 'a table-separator lookalike', value: '---|---|---' },
+  { name: 'an embedded newline', value: 'Auth\nLogin flow' },
+  { name: 'a carriage return', value: 'Auth\r\nLogin flow' },
+  { name: 'backticks', value: 'Fix `parseAssignmentHistory()` crash' },
+  { name: 'a backslash', value: 'C:\\path\\to\\thing' },
+  { name: 'an escape sequence that must not be decoded twice', value: 'literal \\n and \\| here' },
+  { name: 'a comma (the #1757 separator)', value: 'Notification System, phase 2' },
+  { name: 'an em dash', value: 'Auth \u2014 Login flow' },
+  { name: 'a markdown bullet lookalike', value: '- **Action:** completed' },
+  { name: 'an H2 lookalike', value: '## Assignment History' },
+  { name: 'leading and trailing spaces', value: '  padded  ' },
+  { name: 'an empty string', value: '' },
+];
+
+function roadmapWithHistory(history: AssignmentRecord[]): Roadmap {
+  const roadmap = structuredClone(VALID_ROADMAP);
+  roadmap.assignmentHistory = history;
+  return roadmap;
+}
+
+/** `serialize → parse` through the full monolith document. */
+function roundTrip(history: AssignmentRecord[]): AssignmentRecord[] {
+  const result = parseRoadmap(serializeRoadmap(roadmapWithHistory(history)));
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw result.error;
+  return result.value.assignmentHistory;
+}
+
+describe('assignment history round-trips adversarial field values (#1811)', () => {
+  for (const { name, value } of ADVERSARIAL) {
+    it(`preserves a record whose feature name contains ${name}`, () => {
+      const history: AssignmentRecord[] = [
+        { feature: value, assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+      ];
+      expect(roundTrip(history)).toEqual(history);
+    });
+
+    it(`preserves a record whose assignee contains ${name}`, () => {
+      const history: AssignmentRecord[] = [
+        { feature: 'Auth', assignee: value, action: 'completed', date: '2026-03-21' },
+      ];
+      expect(roundTrip(history)).toEqual(history);
+    });
+
+    it(`preserves a record whose date contains ${name}`, () => {
+      const history: AssignmentRecord[] = [
+        { feature: 'Auth', assignee: 'alice', action: 'unassigned', date: value },
+      ];
+      expect(roundTrip(history)).toEqual(history);
+    });
+  }
+
+  it('preserves order and count across a multi-record history with hostile values', () => {
+    const history: AssignmentRecord[] = [
+      { feature: 'Auth | Login', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+      { feature: 'Auth | Login', assignee: 'alice', action: 'completed', date: '2026-03-22' },
+      { feature: 'API\nGateway', assignee: 'b|b', action: 'assigned', date: '2026-03-23' },
+      { feature: 'Plain feature', assignee: 'carol', action: 'unassigned', date: '2026-03-24' },
+    ];
+    expect(roundTrip(history)).toEqual(history);
+  });
+
+  it('survives TWO round-trips (the emitted form re-parses to itself)', () => {
+    const history: AssignmentRecord[] = [
+      {
+        feature: 'Auth | Login \\ flow',
+        assignee: 'a|ice',
+        action: 'assigned',
+        date: '2026-03-21',
+      },
+    ];
+    expect(roundTrip(roundTrip(history))).toEqual(history);
+  });
+
+  it('emits no pipe-table row for a pipe-free history (the format really moved)', () => {
+    const md = serializeAssignmentHistory([
+      { feature: 'Auth', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+    ]).join('\n');
+    expect(md).not.toMatch(/^\|/m);
+    expect(md).toContain('- **Feature:** Auth');
+  });
+
+  it('a rewrite of the emitted section loses no lines (preservation guard, #839)', () => {
+    const md = serializeRoadmap(
+      roadmapWithHistory([
+        { feature: 'Auth | Login', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+      ])
+    );
+    expect(findUnpreservedLines(md)).toEqual([]);
+  });
+});
+
+describe('assignment history still READS the legacy pipe table (#1811)', () => {
+  const LEGACY = [
+    '## Assignment History',
+    '| Feature | Assignee | Action | Date |',
+    '|---------|----------|--------|------|',
+    '| Core foundation | alice | assigned | 2026-01-02 |',
+    '| Core foundation | bob | unassigned | 2026-01-03 |',
+  ].join('\n');
+
+  it('recovers every legacy row, so an un-migrated document keeps its history', () => {
+    const result = parseAssignmentHistory(LEGACY);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([
+      { feature: 'Core foundation', assignee: 'alice', action: 'assigned', date: '2026-01-02' },
+      { feature: 'Core foundation', assignee: 'bob', action: 'unassigned', date: '2026-01-03' },
+    ]);
+  });
+
+  it('keeps the legacy tolerance: a table with no separator row reads as empty', () => {
+    const noSeparator = [
+      '## Assignment History',
+      '| Feature | Assignee | Action | Date |',
+      '| Core foundation | alice | assigned | 2026-01-02 |',
+    ].join('\n');
+    const result = parseAssignmentHistory(noSeparator);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([]);
+  });
+
+  it('migrates a legacy document to the new format without losing a record', () => {
+    const parsed = parseAssignmentHistory(LEGACY);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const migrated = serializeAssignmentHistory(parsed.value).join('\n');
+    expect(migrated).not.toMatch(/^\|/m);
+    const reparsed = parseAssignmentHistory(migrated);
+    expect(reparsed.ok).toBe(true);
+    if (reparsed.ok) expect(reparsed.value).toEqual(parsed.value);
+  });
+});
+
+describe('assignment history in the shard `_meta.md` (#1811)', () => {
+  it('round-trips hostile values through serializeMeta -> parseMeta', () => {
+    const meta = {
+      ...META_WITH_HISTORY,
+      assignmentHistory: [
+        { feature: 'Auth | Login', assignee: 'a|ice', action: 'assigned', date: '2026-01-02' },
+        { feature: 'Auth | Login', assignee: 'a|ice', action: 'completed', date: '2026-01-03' },
+      ] as AssignmentRecord[],
+    };
+    const result = parseMeta(serializeMeta(meta));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.assignmentHistory).toEqual(meta.assignmentHistory);
+  });
+
+  it('keeps the byte-stability contract: a history-free `_meta.md` is unchanged', () => {
+    const { assignmentHistory: _dropped, ...historyFree } = META_WITH_HISTORY;
+    const md = serializeMeta(historyFree);
+    expect(md).not.toContain('## Assignment History');
+    expect(md.endsWith('---\n')).toBe(true);
+  });
+});

--- a/packages/core/tests/roadmap/external-id-path-traversal.test.ts
+++ b/packages/core/tests/roadmap/external-id-path-traversal.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Regression tests for #1843 — a roadmap `External-ID` could choose the path of an
+ * authenticated `api.github.com` request.
+ *
+ * The External-ID arrives verbatim from `docs/roadmap.d/*.md` shard content, which is
+ * fleet-written and PR-contributable. `parseExternalId` used to accept
+ * `github:x/../../../user/emails?#1`, and every adapter spliced the resulting captures
+ * unencoded into `${apiBase}/repos/${owner}/${repo}/issues/${n}/...` on a request
+ * carrying `Authorization: Bearer <token>`. Under WHATWG URL normalization the dot
+ * segments collapse and the trailing `?` truncates the intended suffix into a query
+ * string, so `POST .../assignees` became `POST https://api.github.com/user/emails`.
+ *
+ * These tests exercise the *traversal* — the URL the adapter actually hands to `fetch` —
+ * not merely the shape of the regex. Both defence layers are covered independently:
+ * the tightened regex (`parseExternalId`) and the sink-side assertion + percent-encoding
+ * (`githubRepoPath`), so a future regression in either one is caught on its own.
+ *
+ * Sibling of #1842, which hardened the dashboard instance of the same class.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { parseExternalId, githubRepoPath } from '../../src/roadmap/external-id';
+import { GitHubIssuesSyncAdapter } from '../../src/roadmap/adapters/github-issues';
+import { GitHubIssuesTrackerAdapter } from '../../src/roadmap/tracker/adapters/github-issues';
+import type { TrackerSyncConfig } from '@harness-engineering/types';
+
+/**
+ * External-IDs that steer the credentialed request off `/repos/`. Every one of these
+ * parsed successfully before the fix.
+ */
+const TRAVERSING_IDS = [
+  'github:x/../../../user/emails?#1',
+  'github:a/../../../applications/CLIENTID/token?#1',
+  'github:o/../../../user/repos?#1',
+  'github:owner/repo/../../../user/emails?#1',
+  'github:../../user/emails?#1',
+  'github:owner/..#1',
+  'github:./x#1',
+  'github:owner/repo?scope=x#1',
+];
+
+const BENIGN_ID = 'github:Intense-Visions/harness-engineering#1843';
+
+const SYNC_CONFIG: TrackerSyncConfig = {
+  kind: 'github',
+  repo: 'Intense-Visions/harness-engineering',
+  labels: ['harness-managed'],
+  statusMap: {
+    backlog: 'open',
+    planned: 'open',
+    'in-progress': 'open',
+    done: 'closed',
+    blocked: 'open',
+    'needs-human': 'open',
+  },
+  reverseStatusMap: {
+    closed: 'done',
+    'open:in-progress': 'in-progress',
+    'open:blocked': 'blocked',
+    'open:planned': 'planned',
+    'open:needs-human': 'needs-human',
+  },
+};
+
+function recordingFetch(): { fetchFn: typeof fetch; urls: () => string[] } {
+  const urls: string[] = [];
+  const fn = vi.fn(async (url: unknown) => {
+    urls.push(String(url));
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: async () => '[]',
+      json: async () => [],
+    };
+  });
+  return { fetchFn: fn as unknown as typeof fetch, urls: () => urls };
+}
+
+/**
+ * The invariant the traversal breaks: after WHATWG normalization the request must still
+ * address an issue under `/repos/`. Asserting on the *resolved* URL rather than the
+ * template is what makes this a traversal test — `/repos/x/../../../user/emails?...`
+ * matches a naive prefix check but resolves to `/user/emails`.
+ */
+function expectStaysUnderRepos(rawUrl: string, externalId: string): void {
+  const resolved = new URL(rawUrl);
+  expect(
+    resolved.pathname.startsWith('/repos/'),
+    `External-ID ${externalId} escaped /repos/: ${rawUrl} resolved to ${resolved.toString()}`
+  ).toBe(true);
+  expect(
+    resolved.pathname.includes('/issues/'),
+    `External-ID ${externalId} escaped the issues path: ${resolved.toString()}`
+  ).toBe(true);
+}
+
+describe('#1843 layer 1 — parseExternalId rejects owner/repo that can steer a URL path', () => {
+  for (const externalId of TRAVERSING_IDS) {
+    it(`rejects ${externalId}`, () => {
+      expect(parseExternalId(externalId)).toBeNull();
+    });
+  }
+
+  it('still parses a real External-ID', () => {
+    expect(parseExternalId(BENIGN_ID)).toEqual({
+      owner: 'Intense-Visions',
+      repo: 'harness-engineering',
+      number: 1843,
+    });
+  });
+
+  it('still parses the owner/repo name characters GitHub actually issues', () => {
+    expect(parseExternalId('github:a-b/c.d_e-f#7')).toEqual({
+      owner: 'a-b',
+      repo: 'c.d_e-f',
+      number: 7,
+    });
+  });
+});
+
+describe('#1843 layer 2 — githubRepoPath re-asserts at the sink, independent of the regex', () => {
+  // This layer is what survives a future regression in EXTERNAL_ID_RE: it never consults
+  // the regex, so it holds even if the regex is loosened again.
+  it.each([
+    ['..', 'repo'],
+    ['owner', '..'],
+    ['.', 'repo'],
+    ['owner', '.'],
+    ['x', '../../../user/emails?'],
+    ['owner/../..', 'repo'],
+    ['owner', 'repo?scope=x'],
+    ['owner', 'repo#frag'],
+    ['owner', 'a b'],
+    ['', 'repo'],
+    ['owner', ''],
+  ])('rejects owner=%j repo=%j', (owner, repo) => {
+    expect(githubRepoPath(owner, repo)).toBeNull();
+  });
+
+  it('returns the encoded path for a real owner/repo', () => {
+    expect(githubRepoPath('Intense-Visions', 'harness-engineering')).toBe(
+      'Intense-Visions/harness-engineering'
+    );
+  });
+
+  it('percent-encodes rather than trusting the caller — a lone surrogate does not throw', () => {
+    expect(githubRepoPath('owner', '\uD800')).toBeNull();
+  });
+});
+
+describe('#1843 sink — GitHubIssuesSyncAdapter never fetches outside /repos/', () => {
+  const methods: Array<[string, (a: GitHubIssuesSyncAdapter, id: string) => Promise<unknown>]> = [
+    ['assignTicket', (a, id) => a.assignTicket(id, 'someone')],
+    ['addComment', (a, id) => a.addComment(id, 'hello')],
+    ['fetchTicketState', (a, id) => a.fetchTicketState(id)],
+    ['fetchComments', (a, id) => a.fetchComments(id)],
+  ];
+
+  for (const [name, call] of methods) {
+    for (const externalId of TRAVERSING_IDS) {
+      it(`${name} refuses ${externalId}`, async () => {
+        const { fetchFn, urls } = recordingFetch();
+        const adapter = new GitHubIssuesSyncAdapter({
+          token: 'secret-token',
+          config: SYNC_CONFIG,
+          fetchFn,
+        });
+
+        const result = (await call(adapter, externalId)) as { ok: boolean };
+
+        // The contract for a malformed External-ID is already `Err` — traversing IDs
+        // must land in exactly that bucket rather than being issued.
+        expect(result.ok).toBe(false);
+        for (const url of urls()) expectStaysUnderRepos(url, externalId);
+        expect(urls()).toHaveLength(0);
+      });
+    }
+  }
+
+  it('still issues the real request for a valid External-ID', async () => {
+    const { fetchFn, urls } = recordingFetch();
+    const adapter = new GitHubIssuesSyncAdapter({
+      token: 'secret-token',
+      config: SYNC_CONFIG,
+      fetchFn,
+    });
+
+    await adapter.assignTicket(BENIGN_ID, 'someone');
+
+    expect(urls()).toEqual([
+      'https://api.github.com/repos/Intense-Visions/harness-engineering/issues/1843/assignees',
+    ]);
+    expectStaysUnderRepos(urls()[0]!, BENIGN_ID);
+  });
+});
+
+describe('#1843 sink — GitHubIssuesTrackerAdapter never fetches outside /repos/', () => {
+  const methods: Array<[string, (a: GitHubIssuesTrackerAdapter, id: string) => Promise<unknown>]> =
+    [
+      ['appendHistory', (a, id) => a.appendHistory(id, { at: '2026-01-01T00:00:00Z' } as never)],
+      ['fetchHistory', (a, id) => a.fetchHistory(id)],
+      ['fetchById', (a, id) => a.fetchById(id)],
+    ];
+
+  for (const [name, call] of methods) {
+    for (const externalId of TRAVERSING_IDS) {
+      it(`${name} refuses ${externalId}`, async () => {
+        const { fetchFn, urls } = recordingFetch();
+        const adapter = new GitHubIssuesTrackerAdapter({
+          token: 'secret-token',
+          repo: 'Intense-Visions/harness-engineering',
+          fetchFn,
+        });
+
+        const result = (await call(adapter, externalId)) as { ok: boolean };
+
+        expect(result.ok).toBe(false);
+        for (const url of urls()) expectStaysUnderRepos(url, externalId);
+        expect(urls()).toHaveLength(0);
+      });
+    }
+  }
+});

--- a/packages/core/tests/roadmap/fixtures.ts
+++ b/packages/core/tests/roadmap/fixtures.ts
@@ -339,10 +339,16 @@ last_manual_edit: 2026-04-01T09:00:00Z
 - **External-ID:** github:harness-eng/harness#42
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Core Library Design | @cwarner | assigned | 2026-03-15 |
-| Core Library Design | @cwarner | completed | 2026-04-01 |
+
+- **Feature:** Core Library Design
+- **Assignee:** @cwarner
+- **Action:** assigned
+- **Date:** 2026-03-15
+
+- **Feature:** Core Library Design
+- **Assignee:** @cwarner
+- **Action:** completed
+- **Date:** 2026-04-01
 `;
 
 export const HISTORY_ROADMAP: Roadmap = {

--- a/packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts
+++ b/packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import { VALID_ROADMAP } from './fixtures';
+
+// Reproduction for the assignment-history table pipe round-trip data loss.
+//
+// The roadmap Assignment History section is emitted as a markdown pipe table
+// (`serializeAssignmentHistory`): `| ${feature} | ${assignee} | ${action} | ${date} |`.
+// `parseAssignmentHistory` reads it back by splitting each row on `|` and
+// `.filter(c => c.length > 0)`. There is NO escaping of `|` in any cell, so a
+// feature name (or assignee) that contains a pipe — free-text authored via the
+// H3 heading / the MCP `manage_roadmap` write path — splits into extra cells on
+// the next parse. The `action` column then lands on a non-action cell, the
+// row's `cells[2]` fails the `['assigned','completed','unassigned']` membership
+// check, and the WHOLE record is silently dropped.
+//
+// This is the same class of line-oriented round-trip data loss already fixed for
+// the comma-in-list field (#1757) and the newline-in-summary field (#1756), but
+// the pipe-in-table-cell case for Assignment History was never covered — those
+// fixes explicitly scoped themselves to the single-line `- **Field:**` bullets.
+//
+// At the pinned base SHA this test FAILS by ASSERTION (reparsed history is `[]`,
+// the record is gone), not by a compile/resolution error.
+describe('roadmap round-trip: pipe in assignment-history feature name', () => {
+  it('preserves an assignment record whose feature name contains a pipe', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.assignmentHistory = [
+      { feature: 'Auth | Login flow', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+    ];
+
+    const markdown = serializeRoadmap(roadmap);
+    const reparsed = parseRoadmap(markdown);
+
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+
+    // The record survives the parse → serialize → parse cycle intact.
+    expect(reparsed.value.assignmentHistory).toEqual(roadmap.assignmentHistory);
+  });
+});

--- a/packages/core/tests/roadmap/serialize-extended.test.ts
+++ b/packages/core/tests/roadmap/serialize-extended.test.ts
@@ -32,11 +32,25 @@ describe('serializeRoadmap() — extended fields', () => {
     expect(result).toContain('- **Priority:** P2');
   });
 
-  it('serializes assignment history table', () => {
+  it('serializes assignment history as one bullet block per record', () => {
     const result = serializeRoadmap(HISTORY_ROADMAP);
     expect(result).toContain('## Assignment History');
-    expect(result).toContain('| Core Library Design | @cwarner | assigned | 2026-03-15 |');
-    expect(result).toContain('| Core Library Design | @cwarner | completed | 2026-04-01 |');
+    expect(result).toContain(
+      [
+        '- **Feature:** Core Library Design',
+        '- **Assignee:** @cwarner',
+        '- **Action:** assigned',
+        '- **Date:** 2026-03-15',
+      ].join('\n')
+    );
+    expect(result).toContain(
+      [
+        '- **Feature:** Core Library Design',
+        '- **Assignee:** @cwarner',
+        '- **Action:** completed',
+        '- **Date:** 2026-04-01',
+      ].join('\n')
+    );
   });
 
   it('omits assignment history section when empty', () => {

--- a/packages/core/tests/roadmap/store/fixtures.ts
+++ b/packages/core/tests/roadmap/store/fixtures.ts
@@ -153,10 +153,16 @@ milestones:
 ---
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Core foundation | alice | assigned | 2026-01-02 |
-| Core foundation | bob | unassigned | 2026-01-03 |
+
+- **Feature:** Core foundation
+- **Assignee:** alice
+- **Action:** assigned
+- **Date:** 2026-01-02
+
+- **Feature:** Core foundation
+- **Assignee:** bob
+- **Action:** unassigned
+- **Date:** 2026-01-03
 `;
 
 export const META_WITH_HISTORY: RoadmapMeta = {

--- a/packages/orchestrator/tests/tracker/roadmap.test.ts
+++ b/packages/orchestrator/tests/tracker/roadmap.test.ts
@@ -17,6 +17,23 @@ function idFor(name: string): string {
 }
 
 /**
+ * The `### <name>` block of one feature, from its heading up to the next H3/H2.
+ *
+ * Assertions about a feature's own fields MUST be scoped this way. The
+ * `## Assignment History` section records each release as four `- **Key:** value`
+ * bullets (#1811), so it legitimately carries the released `- **Assignee:**` — a
+ * whole-document `not.toContain('**Assignee:**')` would now be asserting that the
+ * audit trail is empty, which is the opposite of what these tests mean.
+ */
+function featureBlock(markdown: string, name: string): string {
+  const start = markdown.indexOf(`### ${name}\n`);
+  if (start === -1) return '';
+  const rest = markdown.slice(start);
+  const end = rest.slice(1).search(/^#{2,3} /m);
+  return end === -1 ? rest : rest.slice(0, end + 1);
+}
+
+/**
  * The adapter reads + writes roadmap CONTENT through the store
  * (`resolveRoadmapStoreForFile` → `applyRoadmapDiff`), so these tests drive a REAL
  * monolith roadmap file under a temp dir rather than `node:fs` mocks. The
@@ -242,9 +259,15 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       const written = await readBack();
       expect(written).toMatch(/### Task 1\n\n- \*\*Status:\*\* done/);
       // setStatus auto-cleared the assignee on the move away from in-progress.
-      expect(written).not.toContain('**Assignee:** orchestrator-5c895000');
+      expect(featureBlock(written, 'Task 1')).not.toContain('**Assignee:** orchestrator-5c895000');
       // The release is recorded as an `unassigned` history entry.
-      expect(written).toContain('| Task 1 | orchestrator-5c895000 | unassigned |');
+      expect(written).toContain(
+        [
+          '- **Feature:** Task 1',
+          '- **Assignee:** orchestrator-5c895000',
+          '- **Action:** unassigned',
+        ].join('\n')
+      );
     });
 
     it('leaves no assignee after a full claim → complete round-trip', async () => {
@@ -265,8 +288,16 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       expect(completeResult.ok).toBe(true);
       const completed = await readBack();
       expect(completed).toMatch(/### Task 1\n\n- \*\*Status:\*\* done/);
-      expect(completed).not.toContain('**Assignee:** orchestrator-5c895000');
-      expect(completed).toContain('| Task 1 | orchestrator-5c895000 | unassigned |');
+      expect(featureBlock(completed, 'Task 1')).not.toContain(
+        '**Assignee:** orchestrator-5c895000'
+      );
+      expect(completed).toContain(
+        [
+          '- **Feature:** Task 1',
+          '- **Assignee:** orchestrator-5c895000',
+          '- **Action:** unassigned',
+        ].join('\n')
+      );
     });
   });
 
@@ -386,10 +417,14 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       expect(written).toMatch(/### Task 1\n\n- \*\*Status:\*\* planned/);
       // Assignee cleared to null; with Priority and External-ID also null,
       // the serializer omits the entire extended-fields group.
-      expect(written).not.toContain('**Assignee:**');
+      expect(featureBlock(written, 'Task 1')).not.toContain('**Assignee:**');
       // Release is routed through the lifecycle authority, so it logs an
       // `unassigned` history record (audit symmetry with claim/complete).
-      expect(written).toContain('| Task 1 | orch-abc123 | unassigned |');
+      expect(written).toContain(
+        ['- **Feature:** Task 1', '- **Assignee:** orch-abc123', '- **Action:** unassigned'].join(
+          '\n'
+        )
+      );
     });
 
     it('is a no-op when the feature is not found', async () => {


### PR DESCRIPTION
Closes #1843

Second live instance of the class fixed for the dashboard in #1842 — this one in `packages/core`, the format authority ADR 0051 names. Branched from `origin/main` `5cd661d74`, **not** from #1842, and it does not touch #1842's dashboard change.

## The defect

`packages/core/src/roadmap/external-id.ts:12` defined the canonical format as:

```
/^github:([^/]+)\/([^#]+)#(\d+)$/
```

Those captures are "everything up to the next delimiter", not GitHub's owner/repo name grammar. The owner capture admitted `.`, `..` and `?`; the repo capture additionally admitted `/`. Ten adapter call sites then spliced them, **unencoded**, into `${apiBase}/repos/${owner}/${repo}/issues/${n}/...` on a request carrying `Authorization: Bearer <token>`.

Reproduced at `5cd661d74` against the verbatim regex and the verbatim URL template (Node 22) — 3 of 4 probes escape `/repos/`:

| External-ID | resolves to |
| --- | --- |
| `github:x/../../../user/emails?#1` | `POST https://api.github.com/user/emails` |
| `github:a/../../../applications/CLIENTID/token?#1` | `POST https://api.github.com/applications/CLIENTID/token` |
| `github:o/../../../user/repos?#1` | `POST https://api.github.com/user/repos` |
| `github:Intense-Visions/harness-engineering#1843` | *(contained — resolves correctly)* |

The dot segments collapse under WHATWG URL normalization and the trailing `?` truncates the intended `/issues/<n>/assignees` suffix into a query string. The source is the `- **External-ID:**` field of any `docs/roadmap.d/*.md` shard, which is fleet-written and PR-contributable.

Scope, stated honestly: `apiBase` is a fixed literal and normalization cannot change the host, so this is **not** token exfiltration to an attacker-controlled host. The primitive is **method + path control against `api.github.com` using the operator's ambient token**.

## The fix — both layers

The fork was answered **(c) BOTH**, and both halves land.

**Layer 1 — tighten the authority.** `EXTERNAL_ID_RE` is now held to GitHub's own name grammar (owner `[A-Za-z0-9][A-Za-z0-9-]{0,38}`, repo `[A-Za-z0-9._-]{1,100}`), plus an explicit dot-segment guard in `parseExternalId`. The guard is separate on purpose: `encodeURIComponent` leaves `.` untouched, so `..` survives both the character class and the encoding — the lesson #1842 learned the hard way.

**Layer 2 — re-assert at the sink.** New `githubRepoPath(owner, repo)` export re-validates and percent-encodes. It **never consults the regex**, so it still holds if the pattern is loosened again. It is called at all ten call sites immediately before the URL is built:

- `roadmap/adapters/github-issues.ts` — `updateTicket`, `fetchTicketState`, `assignTicket`, `addComment`, `fetchComments`/`fetchCommentPage`
- `roadmap/tracker/adapters/github-issues.ts` — `fetchById`, `update`, `fetchRawLabels`, `appendHistory`, `fetchHistory`

Only two of those ten (`fetchById`, `update`) had any incidental protection before, via an `parsed.owner !== this.owner` equality check. The other eight had none. All ten already sat inside `try { ... } catch { return Err(...) }`, so a rejection degrades to exactly the `Err` the existing `if (!parsed)` guard produced — no caller contract changes.

## Breaking change — explicitly authorized

An `External-ID` that GitHub itself could never have issued is now **rejected** rather than parsed. The human considered a compatibility/migration check at the CONFIRM gate and **deliberately dropped it**; no compat shim was reinstated.

**Shard-rejection sweep (the requested finding).** I transcribed the *shipped* validation — `EXTERNAL_ID_RE` + `isDotSegment` + `githubRepoPath`, all three — and ran it over every `- **External-ID:**` value in `docs/roadmap.d/*.md`:

- 282 shards scanned (283 files minus `_meta.md`)
- 280 carry a real External-ID; 2 carry an em-dash placeholder; 0 have no field
- **0 shards rejected.** No shard is named because none failed.

Widened to a repo-wide scan of **538** distinct `github:...#N` literals across `packages/` and `docs/`: the only rejections are the 7 attack probes this PR's own test introduces, plus `docs/changes/strategy-init-gateway/proposal.md:69` `` `github:...#543` `` — a prose ellipsis in a proposal, not a live External-ID.

No `docs/roadmap.d/*.md` file is edited by this PR (`git status -- docs/roadmap.d` → 0), leaving that surface clear for #1811.

## Reproducing test

`packages/core/tests/roadmap/external-id-path-traversal.test.ts` (223 lines, 80 cases). It exercises the **traversal** — it drives the real adapters with an injected recording `fetchFn` and asserts on the URL actually handed to `fetch`, resolved through `new URL()`, not on the shape of the regex. `/repos/x/../../../user/emails?…` passes a naive prefix check and still resolves to `/user/emails`; the assertion is that `new URL(url).pathname` still starts with `/repos/` and contains `/issues/`. Both defence layers are covered independently, so a regression in either one fails on its own.

```
cd packages/core && npx vitest run tests/roadmap/external-id-path-traversal.test.ts
```

| | result |
| --- | --- |
| before the fix | **69 failed \| 11 passed (80)** |
| after the fix | **80 passed (80)** |
| revert-and-fail (`git stash push -- packages/core/src`, test kept) | **69 failed \| 11 passed (80)**, then 80 passed on restore |

## Verification (Node v22.23.2, the `.nvmrc` pin)

- `packages/core` full suite — 466 passed \| 1 skipped (467 files), **5124 passed** \| 1 skipped
- `packages/dashboard` — 134 files, **950 passed**
- `packages/orchestrator` — 260 passed \| 1 skipped (261 files), **2883 passed** \| 1 skipped. One `EADDRINUSE 127.0.0.1:54643` ephemeral-port flake outside the diff on the first run; clean on rerun.
- `pnpm turbo typecheck lint` — 34/34 successful
- `pnpm turbo build` — 13/13 successful
- `scripts/generate-core-barrel.mjs --check` — up to date
- Pushed through the full pre-push gauntlet (changeset, whole-tree `format:check`, coverage ratchet, reference-docs freshness, tool-catalog) with **no** `--no-verify`.

## Assumptions made

1. **F1 was answered (c) BOTH** by the human at the fleet CONFIRM gate — tighten the regex *and* add a defence-in-depth assertion at the `api.github.com` sink. Neither half was treated as optional or as a substitute for the other.
2. **Breaking was explicitly authorized.** A compatibility/migration check was considered and deliberately dropped, so the stricter regex ships without one. The shard sweep above is reported as a **finding** (0 rejections), not enforced as a gate.
3. **Scope boundary honoured:** `docs/roadmap.d/*.md` was read for the sweep but never edited — #1811 is being built on top of this branch and owns `_meta.md`.
4. **#1842 was not branched from and its dashboard change is not duplicated.** Base is `origin/main` `5cd661d74`.
5. `parseRepoParts`-derived `this.owner`/`this.repo` come from operator-supplied `harness.config.json`, a different trust tier from PR-contributable shard content, so they were left unchanged.
6. `packages/orchestrator/src/core/pr-detector.ts:43` re-implements its own permissive parse, but it feeds no authenticated path sink. Noted as deferrable follow-up, not fixed here.
7. A `bug` route leaves **no** `plans/` directory — expected, not a defect. The committed pipeline artifacts are `docs/changes/external-id-path-traversal-1843/provenance.json` and `debug-session.md` (the live session under `.harness/debug/` is gitignored by `.harness/.gitignore:4`, so a copy is committed for verifiability).

Refs #1842. Related: ADR `0051-slug-identity-external-id-sync-key.md`.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
