### PR TITLE
fix(core): move assignment history off the pipe table so a piped feature name cannot destroy its own record

### DIFF
--- a/.changeset/tame-hounds-shave.md
+++ b/.changeset/tame-hounds-shave.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/core': minor
+---
+
+fix(core): stop losing assignment-history records whose feature name contains a pipe
+
+The roadmap's `## Assignment History` section was emitted as a markdown pipe table and
+read back by recovering its four values POSITIONALLY from an unescaped `split('|')`.
+Nothing escaped the separator, and a feature name is free text (an H3 heading, or the
+MCP `manage_roadmap` write path). So a name such as `Auth | Login flow` serialized to a
+row with five cells, `action` landed on the wrong cell, failed its membership check, and
+the WHOLE record was dropped on the next read — silently, with no error and no warning
+(#1811).
+
+The column separator is now gone rather than escaped. Each record is written as a block
+of four `- **Key:** value` bullets — the same line grammar every feature row already
+uses — so `|` has no special meaning and cannot shift a value onto the wrong field.
+Newlines are handled by the existing summary-field codec; backticks, em-dashes and
+table-separator lookalikes are inert. `serialize → parse` is now an identity for every
+field value, including leading and trailing whitespace, which the table used to trim.
+
+Reading is backward-compatible: the legacy pipe table is still parsed, with its original
+tolerances, so a `roadmap.md` or `_meta.md` written before this change keeps its history
+instead of losing it on first read. Only the writer moved. The first re-serialization of
+a document migrates it. A legacy row whose value contained a `|` was already destroyed
+when it was written and cannot be recovered.
+
+This repo's own `docs/roadmap.d/_meta.md` and the regenerated `docs/roadmap.md` are
+migrated in this change, with all 18 existing records preserved.

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,13 +1,14 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '9b50ca192f87e3de9ed816ef0112fe3a5ef9ee67425faaf32f6790fdd458901a'
+sourceHash: '4c61914f56c6b8ae13338b9417230e83301ce88caa3f3cb20d036d473d07c839'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
     'assignee-lifecycle.ts',
+    'assignment-history.ts',
     'derive-repo.ts',
     'external-id.ts',
     'heading.ts',
@@ -147,6 +148,7 @@ export syncToExternal
 import * as eventSourcing from '../state/event-sourcing'
 import { emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange } from '../waypoint/events'
 import { assigneeInvariantHolds, isMachineAssignee, setStatus } from './assignee-lifecycle'
+import { parseAssignmentHistory, serializeAssignmentHistory } from './assignment-history'
 import { deriveRepoFromGitRemote } from './derive-repo'
 import { GROUP_PREFIX, matchFeatureHeadings, serializeFeatureHeading } from './heading'
 import { decodeListField, encodeListField } from './list-field'

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '1afd158e8f84759ca54976b3cddcba19f519cdd6aaecc91f06e4e1ec8ec63d29'
+sourceHash: '8c924a05853c748c2179480a84acf9673779217f23ffb2a3883f843c297770f3'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -9,6 +9,7 @@ members:
   [
     'assignee-lifecycle-waypoint.test.ts',
     'assignee-lifecycle.test.ts',
+    'assignment-history-round-trip.test.ts',
     'derive-repo.test.ts',
     'external-id-path-traversal.test.ts',
     'fixtures.ts',
@@ -32,6 +33,7 @@ members:
     'promote.test.ts',
     'reconcile.test.ts',
     'referenced-issues.test.ts',
+    'repro-assignment-history-pipe.test.ts',
     'serialize-extended.test.ts',
     'serialize-groups.test.ts',
     'serialize-list-field-comma.test.ts',
@@ -67,6 +69,7 @@ export VALID_ROADMAP_MD
 ```
 import { GitHubIssuesSyncAdapter, parseExternalId } from '../../src/roadmap/adapters/github-issues'
 import { assigneeInvariantHolds, claim, isClaimableBy, isMachineAssignee, pushAssigneeToExternal, release, setStatus } from '../../src/roadmap/assignee-lifecycle'
+import { parseAssignmentHistory, serializeAssignmentHistory } from '../../src/roadmap/assignment-history'
 import { deriveRepoFromGitRemote, parseOwnerRepoFromRemoteUrl } from '../../src/roadmap/derive-repo'
 import { githubRepoPath, parseExternalId } from '../../src/roadmap/external-id'
 import { FEATURE_PREFIX, GROUP_PREFIX, matchFeatureHeadings, parseFeatureHeading, serializeFeatureHeading } from '../../src/roadmap/heading'
@@ -84,7 +87,7 @@ import { reconcileDoneFromClosedIssues } from '../../src/roadmap/reconcile'
 import { parseReferencedIssues } from '../../src/roadmap/referenced-issues'
 import { serializeFeature, serializeRoadmap } from '../../src/roadmap/serialize'
 import { resolveRoadmapStoreForFile } from '../../src/roadmap/store/factory'
-import { serializeMeta } from '../../src/roadmap/store/meta'
+import { parseMeta, serializeMeta } from '../../src/roadmap/store/meta'
 import { assertSemanticRoundTrip, roadmapToShards } from '../../src/roadmap/store/migration'
 import { slugifyFeatureName } from '../../src/roadmap/store/monolith-store'
 import { writeRegeneratedRoadmap } from '../../src/roadmap/store/regenerator'
@@ -101,7 +104,7 @@ import { GitHubIssuesTrackerAdapter } from '../../src/roadmap/tracker/adapters/g
 import { emitEvent } from '../../src/state/event-sourcing'
 import { initWaypointEmitter, resetWaypointEmitterForTests } from '../../src/waypoint/emitter'
 import { EMPTY_BACKLOG, EMPTY_BACKLOG_MD, EXTENDED_FIELDS_MD, EXTENDED_FIELDS_ROADMAP, GROUPED_ROADMAP, GROUPED_ROADMAP_MD, HISTORY_MD, HISTORY_ROADMAP, INVALID_STATUS_MD, MARKER_NAMES, NO_FRONTMATTER_MD, VALID_ROADMAP, VALID_ROADMAP_MD } from './fixtures'
-import { MIGRATION_ROADMAP, MONOLITH_ROADMAP, OLD_ROADMAP_MD } from './store/fixtures'
+import { META_WITH_HISTORY, MIGRATION_ROADMAP, MONOLITH_ROADMAP, OLD_ROADMAP_MD } from './store/fixtures'
 import { getRoadmapMode } from '@harness-engineering/core'
 import { AssignmentRecord, Err, ExternalTicket, ExternalTicketState, FeatureStatus, Ok, Result, Roadmap, RoadmapFeature, RoadmapMilestone, SdlcEvent, TrackerSyncConfig } from '@harness-engineering/types'
 import * as fs from 'fs'

--- a/.harness/comprehension/packages/core/tests/roadmap/store/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/store/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap/store'
-sourceHash: 'b2d0118b500ace5c3a479ab804a9326ce2cd806358f31675e971a58f2a7f239b'
-compiledAt: '2026-08-28T01:22:10.984Z'
+sourceHash: 'db85fa26db7d31ee00cb776b641916ca58081bfa84f8ebe2dfc0a0f383bd92b9'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'apply-diff.test.ts',
@@ -27,22 +26,6 @@ members:
     'shard.test.ts',
   ]
 ---
-
-## Summary
-
-**`packages/core/tests/roadmap/store`** is the comprehensive test suite and fixture library for the roadmap storage layer, validating both monolithic and sharded storage modes across 17 test files. It ensures safe mutation semantics, archive lifecycle management, and data integrity throughout the roadmap store abstraction.
-
-Key responsibilities: fixture provisioning (standardized roadmaps/shards in multiple formats), atomic mutation validation (add/patch/remove with all-or-nothing semantics), archive/restore lifecycle with active-read exclusion, storage mode abstraction (monolith vs shard), and round-trip preservation of metadata and assignment history.
-
-## Invariants
-
-- Slug collision detection (F4): applyRoadmapDiff must reject two features that slugify identically before executing any mutations; fail-closed to prevent silent slug→feature index collapse
-- Silent milestone-move prevention (F5): features cannot simultaneously change body AND move milestones via patchFeature (which preserves recorded milestone/order); must fail to prevent silent move loss
-- Archive exclusion from active reads: readShardDir and regenerate must exclude archive/ subdirectory; shallow listDir behavior (immediate children only) ensures archive appears as directory entry, never exposing nested .md files to active aggregates
-- Byte-perfect round-trips: archive→restore cycles must preserve shard bytes exactly; no normalization or mutation between move and restoration
-- Idempotency per slug: archive/restore operations silently skip missing slugs rather than error; multiple invocations of same slug list have no side effects
-- Fail-closed mutation: applyRoadmapDiff validates all changes before executing any mutations; first error stops processing and leaves store unmodified
-- Shallow directory semantics: entire archive strategy depends on fsp.readdir behavior; nested paths like archive/slug.md appear as single 'archive' entry in parent listing, not as .md files
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/orchestrator/tests/tracker/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/tracker/_module.md
@@ -1,30 +1,12 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/tests/tracker"
-sourceHash: "6e8a24e97ce4a9dc4080332ca7700ae4f23738368468eb103df3f16baffef81f"
-compiledAt: "2026-08-28T01:22:12.736Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["file-less-stub.test.ts", "roadmap.test.ts"]
+module: 'packages/orchestrator/tests/tracker'
+sourceHash: '29fc8f86ffde6dd748f919ffeea7e43863d33244db82ac877fcc189ae4f9ea04'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members: ['file-less-stub.test.ts', 'roadmap.test.ts']
 ---
-
-## Summary
-
-This test suite validates the tracker dispatch and roadmap adapter layer of the Orchestrator — the subsystem responsible for fetching work items (issues, features) from either GitHub Issues or markdown roadmap files, then marking them complete after workflows finish.
-
-**file-less-stub.test.ts** verifies the tracker factory logic: routes to GitHubIssuesIssueTrackerAdapter when config specifies "github-issues", routes to RoadmapTrackerAdapter for "roadmap", and defensively falls back to file-backed mode when harness.config.json is absent (never throws).
-
-**roadmap.test.ts** exercises the RoadmapTrackerAdapter with real markdown I/O: fetches candidate issues filtered by activeStates config, fetches issues by specific states (including custom states like 'needs-human'), resolves issue state by ID, and tests markIssueComplete() which transitions features to terminal states and writes the roadmap back while maintaining round-trip fidelity.
-
-## Invariants
-
-- Router factory is config-driven and defensive — orchestrator instantiates the correct adapter type; if harness.config.json is absent, it defaults to file-backed mode (never crashes)
-- RoadmapTrackerAdapter reads and writes markdown losslessly — the adapter uses the canonical roadmap store serializer, so content round-trips without mutation
-- State filtering is precise — fetchCandidateIssues() returns only items in activeStates; fetchIssuesByStates() returns items matching the supplied array
-- markIssueComplete is idempotent and fault-tolerant: already-terminal features and deleted features both result in no-op; missing terminalStates config returns explicit error
-- ID generation is deterministic — features are identified by SHA256(name).slice(0,8) + sanitized name, enabling dispatch replay and reconciliation
-- Tests use real file I/O, not mocks — temp directories and post-mutation file inspection ensure fidelity to production serialization behavior
 
 ## Interface Contract
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -800,7 +800,7 @@ nothing — it must not be read as a pass.
 
 ### `parseRoadmap(content)`
 
-Parses a roadmap markdown file into a structured `Roadmap` object. Supports extended fields: `Assignee`, `Priority` (P0–P3), `External-ID`. Parses `## Assignment History` section as a sentinel-bounded table into `AssignmentRecord[]`.
+Parses a roadmap markdown file into a structured `Roadmap` object. Supports extended fields: `Assignee`, `Priority` (P0–P3), `External-ID`. Parses the sentinel-bounded `## Assignment History` section into `AssignmentRecord[]` (four `- **Key:** value` bullets per record; the pre-v5 pipe table is still read).
 
 ### `serializeRoadmap(roadmap)`
 

--- a/docs/changes/assignment-history-format-1811/debug-session.md
+++ b/docs/changes/assignment-history-format-1811/debug-session.md
@@ -1,0 +1,114 @@
+# Debug Session: assignment-history records dropped when a field contains a pipe
+
+Status: resolved
+Started: 2026-09-05
+Issue: https://github.com/Intense-Visions/harness-engineering/issues/1811
+Error: `parseRoadmap(serializeRoadmap(r)).assignmentHistory` returns `[]` for a record
+whose `feature` is `Auth | Login flow`. Silent — no error, no warning.
+
+## Investigation Log
+
+### Phase 1 — INVESTIGATE (read-only)
+
+- `harness cleanup` (entropy): only pre-existing doc drift under `docs/api/*.md`
+  (RENAMED/NOT_FOUND symbol references). NOTHING near `packages/core/src/roadmap/`.
+  Not related.
+- Reproduced deterministically at base `463e0162a` (head of #1843) with the pushed
+  repro `3d6970b25` cherry-picked:
+  `cd packages/core && npx vitest run tests/roadmap/repro-assignment-history-pipe.test.ts`
+  -> `1 failed`, assertion `Expected [ {feature: 'Auth | Login flow', ...} ] / Received []`.
+  Assertion failure, not a resolution error. Ran twice, identical.
+- Data flow traced backward from the empty array:
+  1. `parse.ts::parseAssignmentHistory` returns `[]`.
+  2. Its row reader does `trimmed.split('|').map(trim).filter(c => c.length > 0)`.
+  3. For `| Auth | Login flow | alice | assigned | 2026-03-21 |` that yields
+     `['Auth', 'Login flow', 'alice', 'assigned', '2026-03-21']` — FIVE cells.
+  4. `cells[2]` is therefore `'alice'`, which fails the
+     `['assigned','completed','unassigned']` membership check, and the row is
+     `continue`d — the record is dropped with no diagnostic.
+  5. The row came from `serialize.ts::serializeAssignmentHistory`, which
+     interpolates `record.feature` into a pipe table cell with NO escaping.
+
+### Phase 2 — ANALYZE
+
+- Working examples in the SAME module family: `summary-field.ts` (#1756) and
+  `list-field.ts` (#1757). Both fix the identical class of bug — a line-oriented
+  grammar whose separator is legal inside a value — by owning a reversible codec
+  in a dedicated module shared by the emitter and the reader.
+- Difference: those two fields live on `- **Field:** value` bullets, where the
+  ONLY hostile character is the newline. Assignment history is the one place the
+  roadmap grammar uses a _column_ separator (`|`), so it has a second hostile
+  character that no codec in the repo covers.
+- `heading.ts` is the module-level precedent for "single source of truth shared
+  with both readers, so the emitter cannot drift from them" (#1261).
+- Blast radius re-derived, NOT taken on trust: `grep -rl 'Assignment History'`
+  over committed sources returns `docs/roadmap.d/_meta.md` (source of truth, 17
+  data rows) and `docs/roadmap.md` (the regenerated aggregate, section at line
+  3161, identical 17 rows). NO per-feature shard carries history. Both
+  `docs/roadmap.md` and `docs/roadmap.d/**` are in `.prettierignore`, so
+  `format:check` does not police their layout.
+
+### Assumptions surfaced
+
+- ASSUMPTION: legacy `_meta.md` / `roadmap.md` files in flight (other branches,
+  adopter repos) still carry the pipe table, so the reader must keep parsing it.
+  Consequence if wrong: none — legacy reading is strictly additive.
+- ASSUMPTION (F3, answered by the human at the CONFIRM gate): the chosen fix is
+  (b) move OFF the pipe-table format entirely, NOT (a) escape `|`.
+- DEFERRABLE: leading/trailing spaces inside a value now round-trip (the old
+  table trimmed them). Strictly an improvement; not asserted either way.
+
+## Hypotheses
+
+H1: "Every record whose `feature` or `assignee` contains a `|` is dropped because
+the row reader recovers cells positionally from an unescaped `split('|')`, so any
+embedded pipe shifts `action` off column 2."
+Prediction: a record with a pipe in `assignee` (not `feature`) is dropped too, and
+a record with a pipe in `date` (the LAST column) is NOT dropped but is corrupted.
+Test: table-driven round-trip over adversarial values.
+Result: CONFIRMED — see `tests/roadmap/assignment-history-round-trip.test.ts`.
+
+## Resolution
+
+Resolved: 2026-09-05
+
+Root cause: `serializeAssignmentHistory` interpolated four free-text values into a
+markdown pipe table row with NO escaping, and `parseAssignmentHistory` recovered them
+POSITIONALLY from `split('|').filter(nonEmpty)`. The separator is legal inside every
+value, so any embedded `|` shifted `action` off column 2, failed the action-membership
+check, and dropped the record with no diagnostic.
+
+Fix: removed the column separator instead of escaping it (human-answered fork F3 = (b)).
+`packages/core/src/roadmap/assignment-history.ts` is the new single source of truth for
+the section grammar — the emitter AND both readers. A record is now four `- **Key:**
+value` bullets at column 0, the same line grammar every feature row uses, so `|` has no
+special meaning. Newlines reuse the existing `summary-field` codec (#1756). The legacy
+pipe table is STILL read, with its original tolerances, so no in-flight document loses
+history; only the writer moved.
+
+Follow-on edits the root-cause fix forced:
+
+- `serialize.ts` / `parse.ts` now re-export from the new module, so every historical
+  import path (`from '../serialize'`, `from '../parse'`) still resolves.
+- `preservation.ts` learned the `Feature`/`Action`/`Date` bullets, or the #839
+  write-preservation guard would have reported the new section as unpreservable content.
+- `docs/roadmap.d/_meta.md` migrated (18 records in, 18 records out, deep-equal) and
+  `docs/roadmap.md` regenerated with `harness roadmap regen` (one diff hunk).
+
+Regression tests:
+
+- `packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts` (cherry-picked
+  from the bug-fleet repro branch, `3d6970b25`, unchanged — it is format-agnostic).
+- `packages/core/tests/roadmap/assignment-history-round-trip.test.ts` (new; 15
+  adversarial values x 3 fields, plus ordering, double round-trip, the preservation
+  guard, legacy read, legacy migration, and `_meta.md` byte-stability).
+
+Revert-and-fail: with `serialize.ts` and `parse.ts` restored to the base commit,
+`31 failed | 24 passed (55)`; restored, `55 passed (55)`.
+
+Learnings: the roadmap grammar had ONE place that used a column separator instead of a
+line-per-value bullet, and that one place was the one with unescaped round-trip loss —
+after #1756 (newline in summary) and #1757 (comma in list) had already fixed the same
+class twice. The durable lesson is not "add a third codec": it is that a separator which
+is legal inside its own values is the defect, and the roadmap's own bullet grammar had
+the answer all along.

--- a/docs/changes/assignment-history-format-1811/provenance.json
+++ b/docs/changes/assignment-history-format-1811/provenance.json
@@ -1,0 +1,49 @@
+{
+  "issue": 1811,
+  "issueUrl": "https://github.com/Intense-Visions/harness-engineering/issues/1811",
+  "fleet": "roadmap-fleet",
+  "route": "bug",
+  "stages": ["debugging"],
+  "pipeline": "harness-debugging",
+  "phases": ["investigate", "analyze", "hypothesize", "fix"],
+  "debugSession": "docs/changes/assignment-history-format-1811/debug-session.md",
+  "reproducingTests": [
+    "packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts",
+    "packages/core/tests/roadmap/assignment-history-round-trip.test.ts"
+  ],
+  "reproducingTestOrigin": {
+    "cherryPickedFrom": "3d6970b254d0840c7515a8ad95f3ca47ef0e307f",
+    "branch": "repro/roadmap-assignment-history-pipe",
+    "note": "The pushed bug-fleet repro is format-agnostic (it asserts round-trip equality, not the pipe table), so it was cherry-picked unchanged and remains valid under the new format."
+  },
+  "redGreenEvidence": {
+    "command": "cd packages/core && npx vitest run tests/roadmap/repro-assignment-history-pipe.test.ts tests/roadmap/assignment-history-round-trip.test.ts",
+    "beforeFix": "31 failed | 24 passed (55)",
+    "afterFix": "55 passed (55)",
+    "revertAndFail": "serialize.ts and parse.ts restored to the base commit with the new module left in place; the round-trip assertions failed by assertion (not resolution), then passed again on restore.",
+    "baseOnlyRepro": "At base 463e0162a the cherry-picked repro failed by assertion: Expected [ { feature: 'Auth | Login flow', ... } ] / Received []."
+  },
+  "stackedOn": {
+    "pr": 1854,
+    "branch": "fix/external-id-path-traversal-1843",
+    "baseCommit": "463e0162af3de1fd9f2d4112df88797805ddaf27",
+    "note": "Conductor-imposed serialization. This PR targets that branch, not main, and must land after #1854."
+  },
+  "assumptions": [
+    "F3 answered by the human at the CONFIRM gate as option (b): move assignment history OFF the pipe-table format entirely, NOT (a) escape the pipe. Built as answered; the cheaper escaping option was deliberately not taken.",
+    "Legacy documents in flight (other branches, adopter repos) still carry the pipe table, so the reader keeps parsing it. Writing moved; reading did not.",
+    "Blast radius re-derived rather than taken on trust: assignment history is roadmap-level metadata written once into docs/roadmap.d/_meta.md, plus the regenerated aggregate docs/roadmap.md. No per-feature shard carries it, and none was edited.",
+    "docs/roadmap.md and docs/roadmap.d/** are in .prettierignore, so format:check does not police their layout; the emitted format was verified prettier-stable anyway for the doc examples that are checked.",
+    "Leading/trailing whitespace inside a value now round-trips (the pipe table trimmed it). Treated as a strict improvement; not asserted as a contract either way.",
+    "A record STARTS at its `- **Feature:**` bullet, so the blank lines between record blocks are cosmetic and a reformatter may add or drop them.",
+    "A `bug` route emits no plans/ directory. Expected, not a defect."
+  ],
+  "migration": {
+    "file": "docs/roadmap.d/_meta.md",
+    "recordsBefore": 18,
+    "recordsAfter": 18,
+    "aggregateRegeneratedWith": "node packages/cli/dist/bin/harness.js roadmap regen",
+    "aggregateDiffHunks": 1
+  },
+  "debugSessionNote": ".harness/debug/ is gitignored, so the resolved session record is committed here instead."
+}

--- a/docs/guides/roadmap-sync.md
+++ b/docs/guides/roadmap-sync.md
@@ -69,11 +69,20 @@ last_manual_edit: 2026-04-02
 
 ## Assignment History
 
-| Feature        | Assignee | Action    | Date       |
-| -------------- | -------- | --------- | ---------- |
-| Authentication | @alice   | assigned  | 2026-03-15 |
-| Authentication | @alice   | completed | 2026-03-28 |
-| API Gateway    | @alice   | assigned  | 2026-04-01 |
+- **Feature:** Authentication
+- **Assignee:** @alice
+- **Action:** assigned
+- **Date:** 2026-03-15
+
+- **Feature:** Authentication
+- **Assignee:** @alice
+- **Action:** completed
+- **Date:** 2026-03-28
+
+- **Feature:** API Gateway
+- **Assignee:** @alice
+- **Action:** assigned
+- **Date:** 2026-04-01
 ```
 
 ### Feature Fields
@@ -412,17 +421,33 @@ These fields are conditionally emitted — if none are set on a feature, the mar
 
 ## Assignment History
 
-An `## Assignment History` section is automatically maintained at the bottom of `roadmap.md`:
+An `## Assignment History` section is automatically maintained at the bottom of `roadmap.md`. Each record is a block of four `- **Key:** value` bullets — the same line grammar a feature row uses:
 
 ```markdown
 ## Assignment History
 
-| Feature       | Assignee | Action    | Date       |
-| ------------- | -------- | --------- | ---------- |
-| Widget System | @alice   | assigned  | 2026-04-01 |
-| Widget System | @alice   | completed | 2026-04-03 |
-| API Gateway   | @bob     | assigned  | 2026-04-02 |
+- **Feature:** Widget System
+- **Assignee:** @alice
+- **Action:** assigned
+- **Date:** 2026-04-01
+
+- **Feature:** Widget System
+- **Assignee:** @alice
+- **Action:** completed
+- **Date:** 2026-04-03
+
+- **Feature:** API Gateway
+- **Assignee:** @bob
+- **Action:** assigned
+- **Date:** 2026-04-02
 ```
+
+A record starts at its `- **Feature:**` bullet, so the blank lines between blocks
+are cosmetic. The section was a markdown pipe table before v5; a feature name
+containing a `|` silently destroyed its own record on the next read, so the column
+separator was removed rather than escaped (#1811). Documents still carrying the old
+table are read as before — only the writer changed — but a legacy row whose value
+contained a `|` was already lost when it was written and cannot be recovered.
 
 Reassignment produces two records: `unassigned` for the previous assignee, then `assigned` for the new one. This provides a complete audit trail and enables affinity-based routing.
 

--- a/docs/roadmap.d/_meta.md
+++ b/docs/roadmap.d/_meta.md
@@ -34,23 +34,93 @@ milestones:
 ---
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Performance Engineering Knowledge Skills | @chadjw | assigned | 2026-04-09 |
-| Phase 2: Code Signal Extractors | @chadjw | assigned | 2026-04-23 |
-| Phase 3: Connector Enhancement | @chadjw | assigned | 2026-04-22 |
-| Phase 4: Knowledge Pipeline & Diagrams | @chadjw | assigned | 2026-04-23 |
-| Hermes Phase 0.1: Reference Slack Bridge | @cwarner | assigned | 2026-05-15 |
-| design-pipeline sub-project #2: audit-component-anatomy | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #0: brand-guidelines source-of-truth | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #3: audit-brand-compliance | @chadjw | assigned | 2026-06-02 |
-| Init design + roadmap polish follow-ups | @chadjw | assigned | 2026-06-03 |
-| Build harness:outcome-eval skill | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Build harness:audit-harness-strength self-audit skill | chad.warner@capillarytech.com | assigned | 2026-06-23 |
-| Ship the 5-signal dashboard panel and signals.md doc | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Ship a required-review GitHub Action template | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Stop the pre-commit auto-baseline-update for arch | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | assigned | 2026-06-25 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | unassigned | 2026-06-25 |
-| Per-subagent token attribution in burn | Chad Warner | unassigned | 2026-08-10 |
+
+- **Feature:** Performance Engineering Knowledge Skills
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-09
+
+- **Feature:** Phase 2: Code Signal Extractors
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Phase 3: Connector Enhancement
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-22
+
+- **Feature:** Phase 4: Knowledge Pipeline & Diagrams
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Hermes Phase 0.1: Reference Slack Bridge
+- **Assignee:** @cwarner
+- **Action:** assigned
+- **Date:** 2026-05-15
+
+- **Feature:** design-pipeline sub-project #2: audit-component-anatomy
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #0: brand-guidelines source-of-truth
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #3: audit-brand-compliance
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-02
+
+- **Feature:** Init design + roadmap polish follow-ups
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-03
+
+- **Feature:** Build harness:outcome-eval skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Build harness:audit-harness-strength self-audit skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Ship the 5-signal dashboard panel and signals.md doc
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Ship a required-review GitHub Action template
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Stop the pre-commit auto-baseline-update for arch
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-25
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** unassigned
+- **Date:** 2026-06-25
+
+- **Feature:** Per-subagent token attribution in burn
+- **Assignee:** Chad Warner
+- **Action:** unassigned
+- **Date:** 2026-08-10

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3159,23 +3159,93 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ## v4.0 Business Knowledge System
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Performance Engineering Knowledge Skills | @chadjw | assigned | 2026-04-09 |
-| Phase 2: Code Signal Extractors | @chadjw | assigned | 2026-04-23 |
-| Phase 3: Connector Enhancement | @chadjw | assigned | 2026-04-22 |
-| Phase 4: Knowledge Pipeline & Diagrams | @chadjw | assigned | 2026-04-23 |
-| Hermes Phase 0.1: Reference Slack Bridge | @cwarner | assigned | 2026-05-15 |
-| design-pipeline sub-project #2: audit-component-anatomy | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #0: brand-guidelines source-of-truth | @chadjw | assigned | 2026-05-23 |
-| design-pipeline sub-project #3: audit-brand-compliance | @chadjw | assigned | 2026-06-02 |
-| Init design + roadmap polish follow-ups | @chadjw | assigned | 2026-06-03 |
-| Build harness:outcome-eval skill | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Build harness:audit-harness-strength self-audit skill | chad.warner@capillarytech.com | assigned | 2026-06-23 |
-| Ship the 5-signal dashboard panel and signals.md doc | chad.warner@capillarytech.com | assigned | 2026-06-22 |
-| Ship a required-review GitHub Action template | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Stop the pre-commit auto-baseline-update for arch | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | chad.warner@gmail.com | assigned | 2026-06-23 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | assigned | 2026-06-25 |
-| Add architecture thresholds to basic and intermediate templates | @chadjw | unassigned | 2026-06-25 |
-| Per-subagent token attribution in burn | Chad Warner | unassigned | 2026-08-10 |
+
+- **Feature:** Performance Engineering Knowledge Skills
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-09
+
+- **Feature:** Phase 2: Code Signal Extractors
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Phase 3: Connector Enhancement
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-22
+
+- **Feature:** Phase 4: Knowledge Pipeline & Diagrams
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-04-23
+
+- **Feature:** Hermes Phase 0.1: Reference Slack Bridge
+- **Assignee:** @cwarner
+- **Action:** assigned
+- **Date:** 2026-05-15
+
+- **Feature:** design-pipeline sub-project #2: audit-component-anatomy
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #0: brand-guidelines source-of-truth
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-05-23
+
+- **Feature:** design-pipeline sub-project #3: audit-brand-compliance
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-02
+
+- **Feature:** Init design + roadmap polish follow-ups
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-03
+
+- **Feature:** Build harness:outcome-eval skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Build harness:audit-harness-strength self-audit skill
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Ship the 5-signal dashboard panel and signals.md doc
+- **Assignee:** chad.warner@capillarytech.com
+- **Action:** assigned
+- **Date:** 2026-06-22
+
+- **Feature:** Ship a required-review GitHub Action template
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Stop the pre-commit auto-baseline-update for arch
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** chad.warner@gmail.com
+- **Action:** assigned
+- **Date:** 2026-06-23
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** assigned
+- **Date:** 2026-06-25
+
+- **Feature:** Add architecture thresholds to basic and intermediate templates
+- **Assignee:** @chadjw
+- **Action:** unassigned
+- **Date:** 2026-06-25
+
+- **Feature:** Per-subagent token attribution in burn
+- **Assignee:** Chad Warner
+- **Action:** unassigned
+- **Date:** 2026-08-10

--- a/packages/core/src/roadmap/assignment-history.ts
+++ b/packages/core/src/roadmap/assignment-history.ts
@@ -1,0 +1,239 @@
+import type { AssignmentRecord, Result } from '@harness-engineering/types';
+import { Ok } from '@harness-engineering/types';
+// The newline escape codec lives in `./summary-field`, the single source of truth
+// already shared by the `- **Summary:**` bullet's emitter and reader (#1756). The
+// bullet grammar this module adopts has exactly the same hostile character, so it
+// reuses that codec rather than growing a second one.
+import { encodeSummaryField, decodeSummaryField } from './summary-field';
+
+/**
+ * Single source of truth for the `## Assignment History` section grammar — both
+ * the emitter and BOTH readers.
+ *
+ * ## Why this is not a pipe table any more (#1811)
+ *
+ * History used to be emitted as a markdown pipe table, one record per row:
+ *
+ * ```markdown
+ * | Feature | Assignee | Action | Date |
+ * |---------|----------|--------|------|
+ * | Auth | alice | assigned | 2026-03-21 |
+ * ```
+ *
+ * and read back by splitting each row on `|` and recovering the four values
+ * POSITIONALLY. Nothing escaped the separator, and a feature name is free text
+ * (an H3 heading, or the MCP `manage_roadmap` write path). So a name such as
+ * `Auth | Login flow` serialized to a row with five cells; `action` landed on
+ * cell 2 (`alice`), failed the action-membership check, and the WHOLE record was
+ * dropped — silently, with no error and no warning. Round-trip data loss.
+ *
+ * This is the same class of bug already fixed for the comma-in-list field (#1757)
+ * and the newline-in-summary field (#1756), and those two were fixed with a
+ * reversible escape codec over the existing separator. Escaping `|` was available
+ * here too, and was the cheaper change — it was considered and deliberately NOT
+ * taken. Escaping keeps a column separator that is legal inside every value, so
+ * the format stays one un-escaped write path away from the same bug; the human
+ * decision on this issue was to remove the separator instead of guarding it.
+ *
+ * ## The format
+ *
+ * Each record is a block of four `- **Key:** value` bullets, the SAME line
+ * grammar every feature row already uses, blank-line separated:
+ *
+ * ```markdown
+ * ## Assignment History
+ *
+ * - **Feature:** Auth | Login flow
+ * - **Assignee:** alice
+ * - **Action:** assigned
+ * - **Date:** 2026-03-21
+ *
+ * - **Feature:** API Gateway
+ * - **Assignee:** bob
+ * - **Action:** completed
+ * - **Date:** 2026-04-01
+ * ```
+ *
+ * There is no column separator, so `|` needs no escaping and cannot shift a
+ * value onto the wrong field. Each value owns a whole line, bounded by the line
+ * ending — which leaves the newline as the only hostile character, exactly the
+ * situation {@link encodeSummaryField} already solves. Backticks, pipes,
+ * em-dashes and table-separator lookalikes are all inert.
+ *
+ * A record STARTS at its `- **Feature:**` bullet: that is the record boundary, so
+ * the blank lines between blocks are cosmetic and a reformatter may add or drop
+ * them freely. Bullets are anchored at column 0 to match the anchoring
+ * `parseRoadmap` and `findUnpreservedLines` use everywhere else.
+ *
+ * ## Reading legacy documents
+ *
+ * {@link parseAssignmentHistory} ALSO still reads the old pipe table, unchanged
+ * and with its original tolerances, so a shard `_meta` file or a monolith
+ * aggregate written before this change — in another branch, or in an adopter repo
+ * that has not re-serialized yet — keeps its history instead of losing it on first
+ * read. Only the writer moved. A legacy row whose value contains a `|` is still
+ * lost, since that information never survived being written; nothing can recover
+ * it.
+ *
+ * This module is a pure grammar helper over a string: it opens no file and knows
+ * nothing about where the document it parses lives.
+ */
+
+/** The section's H2 heading. Its own line, and the sentinel every reader bounds on. */
+export const ASSIGNMENT_HISTORY_HEADING = '## Assignment History';
+
+/** The four bullet labels, in emission order. */
+const FIELD_LABELS = ['Feature', 'Assignee', 'Action', 'Date'] as const;
+
+type FieldLabel = (typeof FIELD_LABELS)[number];
+
+/** Bullet label -> the `AssignmentRecord` key it carries. */
+const FIELD_KEYS: Record<FieldLabel, keyof AssignmentRecord> = {
+  Feature: 'feature',
+  Assignee: 'assignee',
+  Action: 'action',
+  Date: 'date',
+};
+
+const VALID_ACTIONS: ReadonlySet<string> = new Set(['assigned', 'completed', 'unassigned']);
+
+/**
+ * One record bullet. The value is optional so an empty field emits (and reads
+ * back as) `- **Key:**` with no trailing space — a trailing space would be
+ * stripped by any reformatter and turn an empty value into a parse miss.
+ * Exactly ONE space separates the marker from the value, so a value with leading
+ * whitespace round-trips instead of being trimmed away.
+ */
+const FIELD_BULLET = /^- \*\*(Feature|Assignee|Action|Date):\*\*(?: (.*))?$/;
+
+/** A legacy pipe-table separator row (`|---|---|`), which opens the data rows. */
+const LEGACY_SEPARATOR = /^\|[-\s|]+\|$/;
+
+/** Emit one `- **Key:** value` bullet, omitting the separator space when empty. */
+function emitFieldBullet(label: FieldLabel, value: string): string {
+  const encoded = encodeSummaryField(value);
+  return encoded === '' ? `- **${label}:**` : `- **${label}:** ${encoded}`;
+}
+
+/**
+ * Emit the whole `## Assignment History` section: the heading, a blank line, then
+ * one blank-line-separated four-bullet block per record, in order. Returns the
+ * lines (no trailing blank), so callers own their own surrounding spacing.
+ *
+ * Emitting nothing for an empty list is the CALLER's job — both call sites guard
+ * on `length > 0` because a `_meta.md` with no history must stay byte-identical
+ * to one written before the section existed.
+ */
+export function serializeAssignmentHistory(records: AssignmentRecord[]): string[] {
+  const lines: string[] = [ASSIGNMENT_HISTORY_HEADING, ''];
+  records.forEach((record, index) => {
+    if (index > 0) lines.push('');
+    for (const label of FIELD_LABELS) lines.push(emitFieldBullet(label, record[FIELD_KEYS[label]]));
+  });
+  return lines;
+}
+
+/**
+ * Slice the `## Assignment History` section body out of a document, bounded by the
+ * next H2 so a future section after history is not swallowed. Returns `null` when
+ * the document has no history section at all.
+ */
+function extractSection(body: string): string | null {
+  const heading = body.match(/^## Assignment History[ \t]*\n/m);
+  if (!heading || heading.index === undefined) return null;
+  const afterHeading = body.slice(heading.index + heading[0].length);
+  const nextH2 = afterHeading.search(/^## /m);
+  return nextH2 === -1 ? afterHeading : afterHeading.slice(0, nextH2);
+}
+
+/** A record under construction: fields arrive one bullet at a time. */
+type RecordDraft = Partial<Record<keyof AssignmentRecord, string>>;
+
+/** A draft becomes a record only once all four fields are present and `action` is real. */
+function finalizeDraft(draft: RecordDraft | null): AssignmentRecord | null {
+  if (!draft) return null;
+  const { feature, assignee, action, date } = draft;
+  if (feature === undefined || assignee === undefined || date === undefined) return null;
+  if (action === undefined || !VALID_ACTIONS.has(action)) return null;
+  return { feature, assignee, action: action as AssignmentRecord['action'], date };
+}
+
+/**
+ * Read the current bullet-block format. A `- **Feature:**` bullet closes the
+ * previous record and opens a new one; the other three fill in the open record.
+ * Anything else on the line is ignored, so blank lines and the legacy table are
+ * simply not this reader's business.
+ */
+function readBulletRecords(lines: string[]): AssignmentRecord[] {
+  const records: AssignmentRecord[] = [];
+  let draft: RecordDraft | null = null;
+
+  for (const line of lines) {
+    const match = line.match(FIELD_BULLET);
+    if (!match) continue;
+    const label = match[1] as FieldLabel;
+    if (label === 'Feature') {
+      const finished = finalizeDraft(draft);
+      if (finished) records.push(finished);
+      draft = {};
+    }
+    draft ??= {};
+    draft[FIELD_KEYS[label]] = decodeSummaryField(match[2] ?? '');
+  }
+
+  const last = finalizeDraft(draft);
+  if (last) records.push(last);
+  return records;
+}
+
+/**
+ * Read the legacy pipe table, preserving its original tolerances verbatim: rows
+ * before the `|---|` separator are header and are skipped, a table with NO
+ * separator is treated as empty, empty cells are dropped by the positional
+ * split, and a row whose third value is not an action is skipped.
+ *
+ * Kept for reading only — nothing writes this shape any more (#1811).
+ */
+function readLegacyTableRecords(lines: string[]): AssignmentRecord[] {
+  const records: AssignmentRecord[] = [];
+  let pastHeader = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) continue;
+    if (!pastHeader) {
+      if (LEGACY_SEPARATOR.test(trimmed)) pastHeader = true;
+      continue;
+    }
+    const cells = trimmed
+      .split('|')
+      .map((cell) => cell.trim())
+      .filter((cell) => cell.length > 0);
+    if (cells.length < 4) continue;
+    if (!VALID_ACTIONS.has(cells[2]!)) continue;
+    records.push({
+      feature: cells[0]!,
+      assignee: cells[1]!,
+      action: cells[2] as AssignmentRecord['action'],
+      date: cells[3]!,
+    });
+  }
+
+  return records;
+}
+
+/**
+ * Parse the `## Assignment History` section of `body` into records. An absent
+ * section yields `[]`.
+ *
+ * Both shapes are read: current bullet blocks first, then any legacy table rows.
+ * A real document only ever holds one of the two, so the concatenation order is
+ * observable only for a hand-mixed section, where "new format, then old" is as
+ * good an answer as any.
+ */
+export function parseAssignmentHistory(body: string): Result<AssignmentRecord[]> {
+  const section = extractSection(body);
+  if (section === null) return Ok([]);
+  const lines = section.split('\n');
+  return Ok([...readBulletRecords(lines), ...readLegacyTableRecords(lines)]);
+}

--- a/packages/core/src/roadmap/parse.ts
+++ b/packages/core/src/roadmap/parse.ts
@@ -6,7 +6,6 @@ import type {
   RoadmapGroup,
   FeatureStatus,
   Priority,
-  AssignmentRecord,
   Result,
 } from '@harness-engineering/types';
 import { Ok, Err } from '@harness-engineering/types';
@@ -22,6 +21,13 @@ import { decodeSummaryField } from './summary-field';
 // for the reversible comma escaping shared by the `Blockers` / `Plan` bullets
 // (see that module for the grammar rationale, #1757).
 import { decodeListField } from './list-field';
+// The `## Assignment History` section grammar (both readers AND the emitter) lives
+// in `./assignment-history`, the single source of truth shared with the serializer.
+// It is re-exported here so `parseAssignmentHistory` keeps its historical import
+// path for the shard `_meta` reader (#1811).
+import { parseAssignmentHistory } from './assignment-history';
+
+export { parseAssignmentHistory };
 
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   'backlog',
@@ -329,50 +335,4 @@ export function parseFeatureBlock(name: string, body: string): Result<RoadmapFea
     externalId: optionalField(fieldMap, 'External-ID'),
     updatedAt: optionalField(fieldMap, 'Updated-At'),
   });
-}
-
-export function parseAssignmentHistory(body: string): Result<AssignmentRecord[]> {
-  const historyMatch = body.match(/^## Assignment History\s*\n/m);
-  if (!historyMatch || historyMatch.index === undefined) return Ok([]);
-
-  const historyStart = historyMatch.index + historyMatch[0].length;
-  const rawHistoryBody = body.slice(historyStart);
-  // Bound to next H2 heading so future sections after history are not consumed
-  const nextH2 = rawHistoryBody.search(/^## /m);
-  const historyBody = nextH2 === -1 ? rawHistoryBody : rawHistoryBody.slice(0, nextH2);
-
-  const records: AssignmentRecord[] = [];
-  // Parse markdown table rows. Rows before the separator (|---|...|) are
-  // skipped (header). If no separator exists the table is treated as empty —
-  // this is intentional tolerance for malformed tables.
-  const lines = historyBody.split('\n');
-  let pastHeader = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith('|')) continue;
-    if (!pastHeader) {
-      if (trimmed.match(/^\|[-\s|]+\|$/)) {
-        pastHeader = true;
-      }
-      continue;
-    }
-    // Parse data row: | Feature | Assignee | Action | Date |
-    const cells = trimmed
-      .split('|')
-      .map((c) => c.trim())
-      .filter((c) => c.length > 0);
-    if (cells.length < 4) continue;
-
-    const action = cells[2] as AssignmentRecord['action'];
-    if (!['assigned', 'completed', 'unassigned'].includes(action)) continue;
-
-    records.push({
-      feature: cells[0]!,
-      assignee: cells[1]!,
-      action,
-      date: cells[3]!,
-    });
-  }
-
-  return Ok(records);
 }

--- a/packages/core/src/roadmap/preservation.ts
+++ b/packages/core/src/roadmap/preservation.ts
@@ -30,6 +30,13 @@ const MODELED_FIELD_KEYS: ReadonlySet<string> = new Set([
   'Priority',
   'External-ID',
   'Updated-At',
+  // `## Assignment History` record bullets (#1811). The section stopped being a
+  // pipe table and became four `- **Key:** value` bullets per record, reusing the
+  // same line grammar, so its lines are preservable for the same reason a feature
+  // row's are. `Assignee` above is shared with the feature block.
+  'Feature',
+  'Action',
+  'Date',
 ]);
 
 /** A source line whose content a monolith rewrite would drop. */
@@ -44,8 +51,10 @@ export interface UnpreservedLine {
  * Return the lines of `markdown` that a `serializeRoadmap` rewrite would silently
  * drop. A line is preservable iff it is frontmatter (regenerated from the model),
  * part of the preamble (everything before the first `## ` heading, which the model
- * now carries verbatim — #1328), blank, an H1 title, an H2/H3 heading, an
- * assignment-history table row, or a single-line modeled `- **Key:** …` field.
+ * now carries verbatim — #1328), blank, an H1 title, an H2/H3 heading, a legacy
+ * assignment-history table row, or a single-line modeled `- **Key:** …` field
+ * (which now includes the `Feature`/`Action`/`Date` bullets an assignment-history
+ * record is written as, #1811).
  * Everything else — multi-line field
  * continuations, unmodeled bullets, blockquotes, comments, arbitrary prose — is
  * reported. An empty result means the document round-trips without content loss.

--- a/packages/core/src/roadmap/serialize.ts
+++ b/packages/core/src/roadmap/serialize.ts
@@ -1,9 +1,4 @@
-import type {
-  Roadmap,
-  RoadmapMilestone,
-  RoadmapFeature,
-  AssignmentRecord,
-} from '@harness-engineering/types';
+import type { Roadmap, RoadmapMilestone, RoadmapFeature } from '@harness-engineering/types';
 // The H3 heading emitter lives in `./heading`, the single source of truth shared
 // with both readers, so the emitter cannot drift from them (#1261).
 import { serializeFeatureHeading } from './heading';
@@ -15,6 +10,13 @@ import { encodeSummaryField } from './summary-field';
 // for the reversible comma escaping shared by the `Blockers` / `Plan` bullets
 // (see that module for the grammar rationale, #1757).
 import { encodeListField } from './list-field';
+// The `## Assignment History` section grammar (emitter AND both readers) lives in
+// `./assignment-history`, the single source of truth shared with the parser. It is
+// re-exported here so `serializeAssignmentHistory` keeps its historical import
+// path for the shard `_meta` writer (#1811).
+import { serializeAssignmentHistory } from './assignment-history';
+
+export { serializeAssignmentHistory };
 
 const EM_DASH = '\u2014';
 
@@ -132,17 +134,5 @@ export function serializeFeature(feature: RoadmapFeature): string[] {
     `- **Plan:** ${listOrDash(feature.plans)}`,
     ...serializeExtendedLines(feature),
   ];
-  return lines;
-}
-
-export function serializeAssignmentHistory(records: AssignmentRecord[]): string[] {
-  const lines = [
-    '## Assignment History',
-    '| Feature | Assignee | Action | Date |',
-    '|---------|----------|--------|------|',
-  ];
-  for (const record of records) {
-    lines.push(`| ${record.feature} | ${record.assignee} | ${record.action} | ${record.date} |`);
-  }
   return lines;
 }

--- a/packages/core/tests/roadmap/assignment-history-round-trip.test.ts
+++ b/packages/core/tests/roadmap/assignment-history-round-trip.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import type { AssignmentRecord, Roadmap } from '@harness-engineering/types';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import {
+  serializeAssignmentHistory,
+  parseAssignmentHistory,
+} from '../../src/roadmap/assignment-history';
+import { findUnpreservedLines } from '../../src/roadmap/preservation';
+import { parseMeta, serializeMeta } from '../../src/roadmap/store/meta';
+import { VALID_ROADMAP } from './fixtures';
+import { META_WITH_HISTORY } from './store/fixtures';
+
+// Round-trip fidelity of the `## Assignment History` section (#1811).
+//
+// The section used to be a markdown pipe table whose four values were recovered
+// POSITIONALLY from an unescaped `split('|')`. A feature name is free text, so a
+// name containing `|` produced a row with extra cells; `action` landed on the
+// wrong cell, failed its membership check, and the whole record was dropped —
+// silently. The fix moved the section off the table onto four `- **Key:** value`
+// bullets per record, so there is no column separator to collide with.
+//
+// These tests are deliberately format-AGNOSTIC: every assertion is about what
+// survives `serialize → parse`, never about which bytes are emitted. That is what
+// makes them a regression guard rather than a snapshot of today's grammar.
+
+/** Values that a pipe-table cell could not carry. `|` is the #1811 reproducer. */
+const ADVERSARIAL: ReadonlyArray<{ name: string; value: string }> = [
+  { name: 'an embedded pipe (the #1811 reproducer)', value: 'Auth | Login flow' },
+  { name: 'a leading and trailing pipe', value: '|Auth|' },
+  { name: 'consecutive pipes', value: 'Auth || Login' },
+  { name: 'a table-separator lookalike', value: '---|---|---' },
+  { name: 'an embedded newline', value: 'Auth\nLogin flow' },
+  { name: 'a carriage return', value: 'Auth\r\nLogin flow' },
+  { name: 'backticks', value: 'Fix `parseAssignmentHistory()` crash' },
+  { name: 'a backslash', value: 'C:\\path\\to\\thing' },
+  { name: 'an escape sequence that must not be decoded twice', value: 'literal \\n and \\| here' },
+  { name: 'a comma (the #1757 separator)', value: 'Notification System, phase 2' },
+  { name: 'an em dash', value: 'Auth \u2014 Login flow' },
+  { name: 'a markdown bullet lookalike', value: '- **Action:** completed' },
+  { name: 'an H2 lookalike', value: '## Assignment History' },
+  { name: 'leading and trailing spaces', value: '  padded  ' },
+  { name: 'an empty string', value: '' },
+];
+
+function roadmapWithHistory(history: AssignmentRecord[]): Roadmap {
+  const roadmap = structuredClone(VALID_ROADMAP);
+  roadmap.assignmentHistory = history;
+  return roadmap;
+}
+
+/** `serialize → parse` through the full monolith document. */
+function roundTrip(history: AssignmentRecord[]): AssignmentRecord[] {
+  const result = parseRoadmap(serializeRoadmap(roadmapWithHistory(history)));
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw result.error;
+  return result.value.assignmentHistory;
+}
+
+describe('assignment history round-trips adversarial field values (#1811)', () => {
+  for (const { name, value } of ADVERSARIAL) {
+    it(`preserves a record whose feature name contains ${name}`, () => {
+      const history: AssignmentRecord[] = [
+        { feature: value, assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+      ];
+      expect(roundTrip(history)).toEqual(history);
+    });
+
+    it(`preserves a record whose assignee contains ${name}`, () => {
+      const history: AssignmentRecord[] = [
+        { feature: 'Auth', assignee: value, action: 'completed', date: '2026-03-21' },
+      ];
+      expect(roundTrip(history)).toEqual(history);
+    });
+
+    it(`preserves a record whose date contains ${name}`, () => {
+      const history: AssignmentRecord[] = [
+        { feature: 'Auth', assignee: 'alice', action: 'unassigned', date: value },
+      ];
+      expect(roundTrip(history)).toEqual(history);
+    });
+  }
+
+  it('preserves order and count across a multi-record history with hostile values', () => {
+    const history: AssignmentRecord[] = [
+      { feature: 'Auth | Login', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+      { feature: 'Auth | Login', assignee: 'alice', action: 'completed', date: '2026-03-22' },
+      { feature: 'API\nGateway', assignee: 'b|b', action: 'assigned', date: '2026-03-23' },
+      { feature: 'Plain feature', assignee: 'carol', action: 'unassigned', date: '2026-03-24' },
+    ];
+    expect(roundTrip(history)).toEqual(history);
+  });
+
+  it('survives TWO round-trips (the emitted form re-parses to itself)', () => {
+    const history: AssignmentRecord[] = [
+      {
+        feature: 'Auth | Login \\ flow',
+        assignee: 'a|ice',
+        action: 'assigned',
+        date: '2026-03-21',
+      },
+    ];
+    expect(roundTrip(roundTrip(history))).toEqual(history);
+  });
+
+  it('emits no pipe-table row for a pipe-free history (the format really moved)', () => {
+    const md = serializeAssignmentHistory([
+      { feature: 'Auth', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+    ]).join('\n');
+    expect(md).not.toMatch(/^\|/m);
+    expect(md).toContain('- **Feature:** Auth');
+  });
+
+  it('a rewrite of the emitted section loses no lines (preservation guard, #839)', () => {
+    const md = serializeRoadmap(
+      roadmapWithHistory([
+        { feature: 'Auth | Login', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+      ])
+    );
+    expect(findUnpreservedLines(md)).toEqual([]);
+  });
+});
+
+describe('assignment history still READS the legacy pipe table (#1811)', () => {
+  const LEGACY = [
+    '## Assignment History',
+    '| Feature | Assignee | Action | Date |',
+    '|---------|----------|--------|------|',
+    '| Core foundation | alice | assigned | 2026-01-02 |',
+    '| Core foundation | bob | unassigned | 2026-01-03 |',
+  ].join('\n');
+
+  it('recovers every legacy row, so an un-migrated document keeps its history', () => {
+    const result = parseAssignmentHistory(LEGACY);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([
+      { feature: 'Core foundation', assignee: 'alice', action: 'assigned', date: '2026-01-02' },
+      { feature: 'Core foundation', assignee: 'bob', action: 'unassigned', date: '2026-01-03' },
+    ]);
+  });
+
+  it('keeps the legacy tolerance: a table with no separator row reads as empty', () => {
+    const noSeparator = [
+      '## Assignment History',
+      '| Feature | Assignee | Action | Date |',
+      '| Core foundation | alice | assigned | 2026-01-02 |',
+    ].join('\n');
+    const result = parseAssignmentHistory(noSeparator);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([]);
+  });
+
+  it('migrates a legacy document to the new format without losing a record', () => {
+    const parsed = parseAssignmentHistory(LEGACY);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const migrated = serializeAssignmentHistory(parsed.value).join('\n');
+    expect(migrated).not.toMatch(/^\|/m);
+    const reparsed = parseAssignmentHistory(migrated);
+    expect(reparsed.ok).toBe(true);
+    if (reparsed.ok) expect(reparsed.value).toEqual(parsed.value);
+  });
+});
+
+describe('assignment history in the shard `_meta.md` (#1811)', () => {
+  it('round-trips hostile values through serializeMeta -> parseMeta', () => {
+    const meta = {
+      ...META_WITH_HISTORY,
+      assignmentHistory: [
+        { feature: 'Auth | Login', assignee: 'a|ice', action: 'assigned', date: '2026-01-02' },
+        { feature: 'Auth | Login', assignee: 'a|ice', action: 'completed', date: '2026-01-03' },
+      ] as AssignmentRecord[],
+    };
+    const result = parseMeta(serializeMeta(meta));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.assignmentHistory).toEqual(meta.assignmentHistory);
+  });
+
+  it('keeps the byte-stability contract: a history-free `_meta.md` is unchanged', () => {
+    const { assignmentHistory: _dropped, ...historyFree } = META_WITH_HISTORY;
+    const md = serializeMeta(historyFree);
+    expect(md).not.toContain('## Assignment History');
+    expect(md.endsWith('---\n')).toBe(true);
+  });
+});

--- a/packages/core/tests/roadmap/fixtures.ts
+++ b/packages/core/tests/roadmap/fixtures.ts
@@ -339,10 +339,16 @@ last_manual_edit: 2026-04-01T09:00:00Z
 - **External-ID:** github:harness-eng/harness#42
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Core Library Design | @cwarner | assigned | 2026-03-15 |
-| Core Library Design | @cwarner | completed | 2026-04-01 |
+
+- **Feature:** Core Library Design
+- **Assignee:** @cwarner
+- **Action:** assigned
+- **Date:** 2026-03-15
+
+- **Feature:** Core Library Design
+- **Assignee:** @cwarner
+- **Action:** completed
+- **Date:** 2026-04-01
 `;
 
 export const HISTORY_ROADMAP: Roadmap = {

--- a/packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts
+++ b/packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import { VALID_ROADMAP } from './fixtures';
+
+// Reproduction for the assignment-history table pipe round-trip data loss.
+//
+// The roadmap Assignment History section is emitted as a markdown pipe table
+// (`serializeAssignmentHistory`): `| ${feature} | ${assignee} | ${action} | ${date} |`.
+// `parseAssignmentHistory` reads it back by splitting each row on `|` and
+// `.filter(c => c.length > 0)`. There is NO escaping of `|` in any cell, so a
+// feature name (or assignee) that contains a pipe — free-text authored via the
+// H3 heading / the MCP `manage_roadmap` write path — splits into extra cells on
+// the next parse. The `action` column then lands on a non-action cell, the
+// row's `cells[2]` fails the `['assigned','completed','unassigned']` membership
+// check, and the WHOLE record is silently dropped.
+//
+// This is the same class of line-oriented round-trip data loss already fixed for
+// the comma-in-list field (#1757) and the newline-in-summary field (#1756), but
+// the pipe-in-table-cell case for Assignment History was never covered — those
+// fixes explicitly scoped themselves to the single-line `- **Field:**` bullets.
+//
+// At the pinned base SHA this test FAILS by ASSERTION (reparsed history is `[]`,
+// the record is gone), not by a compile/resolution error.
+describe('roadmap round-trip: pipe in assignment-history feature name', () => {
+  it('preserves an assignment record whose feature name contains a pipe', () => {
+    const roadmap = structuredClone(VALID_ROADMAP);
+    roadmap.assignmentHistory = [
+      { feature: 'Auth | Login flow', assignee: 'alice', action: 'assigned', date: '2026-03-21' },
+    ];
+
+    const markdown = serializeRoadmap(roadmap);
+    const reparsed = parseRoadmap(markdown);
+
+    expect(reparsed.ok).toBe(true);
+    if (!reparsed.ok) return;
+
+    // The record survives the parse → serialize → parse cycle intact.
+    expect(reparsed.value.assignmentHistory).toEqual(roadmap.assignmentHistory);
+  });
+});

--- a/packages/core/tests/roadmap/serialize-extended.test.ts
+++ b/packages/core/tests/roadmap/serialize-extended.test.ts
@@ -32,11 +32,25 @@ describe('serializeRoadmap() — extended fields', () => {
     expect(result).toContain('- **Priority:** P2');
   });
 
-  it('serializes assignment history table', () => {
+  it('serializes assignment history as one bullet block per record', () => {
     const result = serializeRoadmap(HISTORY_ROADMAP);
     expect(result).toContain('## Assignment History');
-    expect(result).toContain('| Core Library Design | @cwarner | assigned | 2026-03-15 |');
-    expect(result).toContain('| Core Library Design | @cwarner | completed | 2026-04-01 |');
+    expect(result).toContain(
+      [
+        '- **Feature:** Core Library Design',
+        '- **Assignee:** @cwarner',
+        '- **Action:** assigned',
+        '- **Date:** 2026-03-15',
+      ].join('\n')
+    );
+    expect(result).toContain(
+      [
+        '- **Feature:** Core Library Design',
+        '- **Assignee:** @cwarner',
+        '- **Action:** completed',
+        '- **Date:** 2026-04-01',
+      ].join('\n')
+    );
   });
 
   it('omits assignment history section when empty', () => {

--- a/packages/core/tests/roadmap/store/fixtures.ts
+++ b/packages/core/tests/roadmap/store/fixtures.ts
@@ -153,10 +153,16 @@ milestones:
 ---
 
 ## Assignment History
-| Feature | Assignee | Action | Date |
-|---------|----------|--------|------|
-| Core foundation | alice | assigned | 2026-01-02 |
-| Core foundation | bob | unassigned | 2026-01-03 |
+
+- **Feature:** Core foundation
+- **Assignee:** alice
+- **Action:** assigned
+- **Date:** 2026-01-02
+
+- **Feature:** Core foundation
+- **Assignee:** bob
+- **Action:** unassigned
+- **Date:** 2026-01-03
 `;
 
 export const META_WITH_HISTORY: RoadmapMeta = {

--- a/packages/orchestrator/tests/tracker/roadmap.test.ts
+++ b/packages/orchestrator/tests/tracker/roadmap.test.ts
@@ -17,6 +17,23 @@ function idFor(name: string): string {
 }
 
 /**
+ * The `### <name>` block of one feature, from its heading up to the next H3/H2.
+ *
+ * Assertions about a feature's own fields MUST be scoped this way. The
+ * `## Assignment History` section records each release as four `- **Key:** value`
+ * bullets (#1811), so it legitimately carries the released `- **Assignee:**` — a
+ * whole-document `not.toContain('**Assignee:**')` would now be asserting that the
+ * audit trail is empty, which is the opposite of what these tests mean.
+ */
+function featureBlock(markdown: string, name: string): string {
+  const start = markdown.indexOf(`### ${name}\n`);
+  if (start === -1) return '';
+  const rest = markdown.slice(start);
+  const end = rest.slice(1).search(/^#{2,3} /m);
+  return end === -1 ? rest : rest.slice(0, end + 1);
+}
+
+/**
  * The adapter reads + writes roadmap CONTENT through the store
  * (`resolveRoadmapStoreForFile` → `applyRoadmapDiff`), so these tests drive a REAL
  * monolith roadmap file under a temp dir rather than `node:fs` mocks. The
@@ -242,9 +259,15 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       const written = await readBack();
       expect(written).toMatch(/### Task 1\n\n- \*\*Status:\*\* done/);
       // setStatus auto-cleared the assignee on the move away from in-progress.
-      expect(written).not.toContain('**Assignee:** orchestrator-5c895000');
+      expect(featureBlock(written, 'Task 1')).not.toContain('**Assignee:** orchestrator-5c895000');
       // The release is recorded as an `unassigned` history entry.
-      expect(written).toContain('| Task 1 | orchestrator-5c895000 | unassigned |');
+      expect(written).toContain(
+        [
+          '- **Feature:** Task 1',
+          '- **Assignee:** orchestrator-5c895000',
+          '- **Action:** unassigned',
+        ].join('\n')
+      );
     });
 
     it('leaves no assignee after a full claim → complete round-trip', async () => {
@@ -265,8 +288,16 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       expect(completeResult.ok).toBe(true);
       const completed = await readBack();
       expect(completed).toMatch(/### Task 1\n\n- \*\*Status:\*\* done/);
-      expect(completed).not.toContain('**Assignee:** orchestrator-5c895000');
-      expect(completed).toContain('| Task 1 | orchestrator-5c895000 | unassigned |');
+      expect(featureBlock(completed, 'Task 1')).not.toContain(
+        '**Assignee:** orchestrator-5c895000'
+      );
+      expect(completed).toContain(
+        [
+          '- **Feature:** Task 1',
+          '- **Assignee:** orchestrator-5c895000',
+          '- **Action:** unassigned',
+        ].join('\n')
+      );
     });
   });
 
@@ -386,10 +417,14 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       expect(written).toMatch(/### Task 1\n\n- \*\*Status:\*\* planned/);
       // Assignee cleared to null; with Priority and External-ID also null,
       // the serializer omits the entire extended-fields group.
-      expect(written).not.toContain('**Assignee:**');
+      expect(featureBlock(written, 'Task 1')).not.toContain('**Assignee:**');
       // Release is routed through the lifecycle authority, so it logs an
       // `unassigned` history record (audit symmetry with claim/complete).
-      expect(written).toContain('| Task 1 | orch-abc123 | unassigned |');
+      expect(written).toContain(
+        ['- **Feature:** Task 1', '- **Assignee:** orch-abc123', '- **Action:** unassigned'].join(
+          '\n'
+        )
+      );
     });
 
     it('is a no-op when the feature is not found', async () => {


### PR DESCRIPTION
## ⚠️ Stacked PR — base is `fix/external-id-path-traversal-1843`, not `main`

This targets **#1854**'s branch (base commit `463e0162a`) under a conductor-imposed
serialization, so the diff shows only this change. **It must land after #1854.**
A stacked PR often gets no CI until its base merges — if checks do not start here,
that is expected, not red.

Closes #1811

## The bug

The roadmap's `## Assignment History` section was emitted as a markdown pipe table and
read back by recovering its four values **positionally** from an unescaped `split('|')`.
Nothing escaped the separator, and a feature name is free text — an H3 heading, or the
MCP `manage_roadmap` write path. So a name such as `Auth | Login flow` serialized to a
row with five cells, `action` landed on the wrong cell, failed its membership check, and
the **whole record was dropped** on the next read. Silently: no error, no warning.

## The fix

The column separator is **gone**, not escaped.

Escaping `|` was available and cheaper, and was **deliberately not taken** — this was the
human-answered fork on the issue (option **b**). Escaping keeps a separator that is legal
inside every value, one un-escaped write path away from the same bug, after #1756
(newline in summary) and #1757 (comma in list) had already fixed this class twice.

`packages/core/src/roadmap/assignment-history.ts` is the new single source of truth for
the section grammar — the emitter **and both readers**, the same shape as `heading.ts`
(#1261). A record is four `- **Key:** value` bullets at column 0, the line grammar every
feature row already uses:

```markdown
## Assignment History

- **Feature:** Auth | Login flow
- **Assignee:** alice
- **Action:** assigned
- **Date:** 2026-03-21
```

`|` has no special meaning and cannot shift a value onto the wrong field. Each value owns
a whole line, so the newline is the only hostile character left — and that is exactly
what the existing `summary-field` codec already solves, so it is reused rather than
duplicated. Backticks, em-dashes and table-separator lookalikes are inert. Leading and
trailing whitespace now survives, which the table used to trim.

## Backward compatibility

Reading is unchanged: the legacy pipe table is **still parsed**, with its original
tolerances (header rows skipped, a separator-less table read as empty), so a document
written before this change keeps its history instead of losing it on first read. Only the
writer moved; the first re-serialization migrates the document. A legacy row whose value
contained a `|` was already destroyed when it was written and cannot be recovered.

## This repo's own roadmap is migrated here

- `docs/roadmap.d/_meta.md` re-serialized: **18 records in, 18 deep-equal records out**
  (verified by parsing before and after and comparing).
- `docs/roadmap.md` regenerated with `harness roadmap regen` — **one diff hunk**, every
  removed line a table row, no shard other than `_meta.md` touched.

## Follow-on edits the root cause forced

- `serialize.ts` / `parse.ts` re-export from the new module, so every historical import
  path still resolves for the shard `_meta` reader and writer.
- `preservation.ts` learned the `Feature`/`Action`/`Date` bullets. Without that the #839
  write-preservation guard would have reported the section it now emits as unpreservable
  content and refused the write.
- Three `packages/orchestrator/tests/tracker/roadmap.test.ts` assertions were **scoped**,
  not weakened. They used a whole-document `not.toContain('**Assignee:**')` as a proxy for
  "the feature's assignee is cleared". The assignment history legitimately records the
  released assignee — that is the audit trail — so the probe now slices the `### Task 1`
  block via a new `featureBlock()` helper. The information those tests guard was never
  absent from the document; it was in the table row before.

## Evidence

Reproducing test: `packages/core/tests/roadmap/repro-assignment-history-pipe.test.ts`,
cherry-picked **unchanged** from the bug-fleet repro branch (`3d6970b25`). It asserts
round-trip equality, not the table, so it stayed valid under the new format. At base
`463e0162a` it failed **by assertion**:

```
- Expected: [ { action: 'assigned', assignee: 'alice', date: '2026-03-21', feature: 'Auth | Login flow' } ]
+ Received: []
```

`packages/core/tests/roadmap/assignment-history-round-trip.test.ts` adds 15 adversarial
values × 3 free-text fields, plus ordering, a double round-trip, the preservation guard,
the legacy read, the legacy migration, and `_meta.md` byte-stability.

Revert-and-fail, personally observed:

```
cd packages/core && npx vitest run \
  tests/roadmap/repro-assignment-history-pipe.test.ts \
  tests/roadmap/assignment-history-round-trip.test.ts

# serialize.ts + parse.ts reverted to the base commit:  31 failed | 24 passed (55)
# restored:                                             55 passed (55)
```

Full local gates on Node 22: `packages/core` roadmap suite 830 passed | 1 skipped,
`packages/cli` roadmap + MCP 172 passed, `packages/orchestrator` tracker 18 passed,
repo-wide `format:check`, `typecheck` and `lint` clean, and the full pre-push gate
(coverage ratchet, changeset, reference-docs freshness, tool catalog) passed.

## Assumptions made

- **F3 answered (b) by the human at the CONFIRM gate**: move assignment history off the
  pipe table entirely, *not* escape the pipe. Built as answered.
- Legacy documents in flight (other branches, adopter repos) still carry the pipe table,
  so the reader keeps parsing it. Strictly additive.
- Blast radius re-derived rather than taken on trust: assignment history is roadmap-level
  metadata written **once** into `_meta.md` plus the regenerated aggregate. No per-feature
  shard carries it, and none was edited.
- `docs/roadmap.md` and `docs/roadmap.d/**` are in `.prettierignore`, so `format:check`
  does not police their layout. The emitted format was verified prettier-stable anyway,
  for the doc examples that *are* checked.
- Leading/trailing whitespace inside a value now round-trips. Treated as a strict
  improvement; not asserted as a contract either way.
- A record **starts** at its `- **Feature:**` bullet, so the blank lines between record
  blocks are cosmetic and a reformatter may add or drop them.
- The `Assignee` bullet key is now shared between a feature row and a history record.
  Parsing is unaffected (the section is bounded before milestone parsing), but a naive
  whole-document grep can no longer tell them apart — the orchestrator test change above
  is the one place in the repo that relied on that, and no `src/` code did.
- A `bug` route emits no `plans/` directory. Expected, not a defect.

Provenance: `docs/changes/assignment-history-format-1811/provenance.json`
(with the resolved debug session committed alongside it, since `.harness/debug/` is
gitignored).

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
