### PR TITLE
chore(config): enable github and exa MCP integrations; record security posture

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -8,13 +8,23 @@
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]
     },
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    },
     "playwright": {
       "command": "npx",
       "args": ["-y", "@playwright/mcp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server"],
+      "env": {
+        "EXA_API_KEY": "${EXA_API_KEY}"
+      }
     }
   },
   "hooks": {

--- a/.harness/security/timeline.json
+++ b/.harness/security/timeline.json
@@ -24428,6 +24428,66 @@
         "0020d9dbc68c53fd",
         "f2ceade87b90537d"
       ]
+    },
+    {
+      "capturedAt": "2026-09-05T15:26:52.320Z",
+      "commitHash": "5cd661d74a7cb4e3b4164a8c7fb36d75e298fd0f",
+      "securityScore": 95,
+      "totalFindings": 6,
+      "bySeverity": {
+        "error": 0,
+        "warning": 5,
+        "info": 1
+      },
+      "byCategory": {
+        "network": {
+          "findingCount": 1,
+          "errorCount": 0,
+          "warningCount": 0,
+          "infoCount": 1
+        },
+        "injection": {
+          "findingCount": 1,
+          "errorCount": 0,
+          "warningCount": 1,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 1,
+          "errorCount": 0,
+          "warningCount": 1,
+          "infoCount": 0
+        },
+        "crypto": {
+          "findingCount": 1,
+          "errorCount": 0,
+          "warningCount": 1,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "4ffbedd52621e958",
+        "6f68f4bf4cb985bf",
+        "f2ceade87b90537d",
+        "f786d4abdb76457f",
+        "bc2182c271a4f989",
+        "0020d9dbc68c53fd"
+      ]
     }
   ],
   "findingLifecycles": [
@@ -25528,6 +25588,50 @@
       "file": "packages/cli/src/commands/models.ts",
       "firstSeenAt": "2026-07-13T02:53:49.394Z",
       "firstSeenCommit": "e1f016d133cb1534d12c16633009c5969963f262",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "4ffbedd52621e958",
+      "ruleId": "SEC-NET-003",
+      "category": "network",
+      "severity": "info",
+      "file": "tests/scripts/design-capture.test.mjs",
+      "firstSeenAt": "2026-09-05T14:21:46.649Z",
+      "firstSeenCommit": "5cd661d74a7cb4e3b4164a8c7fb36d75e298fd0f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "6f68f4bf4cb985bf",
+      "ruleId": "SEC-NODE-001",
+      "category": "injection",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/workflow/execute-workflow.ts",
+      "firstSeenAt": "2026-09-05T14:21:46.649Z",
+      "firstSeenCommit": "5cd661d74a7cb4e3b4164a8c7fb36d75e298fd0f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "f786d4abdb76457f",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/core/src/fleet/claims/index.ts",
+      "firstSeenAt": "2026-09-05T14:21:46.649Z",
+      "firstSeenCommit": "5cd661d74a7cb4e3b4164a8c7fb36d75e298fd0f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "bc2182c271a4f989",
+      "ruleId": "SEC-PTH-001",
+      "category": "path-traversal",
+      "severity": "warning",
+      "file": "packages/cli/tests/e2e/support/fake-provider.ts",
+      "firstSeenAt": "2026-09-05T14:21:46.649Z",
+      "firstSeenCommit": "5cd661d74a7cb4e3b4164a8c7fb36d75e298fd0f",
       "resolvedAt": null,
       "resolvedCommit": null
     }

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,13 +8,23 @@
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]
     },
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    },
     "playwright": {
       "command": "npx",
       "args": ["-y", "@playwright/mcp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server"],
+      "env": {
+        "EXA_API_KEY": "${EXA_API_KEY}"
+      }
     }
   }
 }

--- a/harness.config.json
+++ b/harness.config.json
@@ -420,5 +420,9 @@
       "External Adoption"
     ],
     "excludedMetrics": []
+  },
+  "integrations": {
+    "enabled": ["github", "exa"],
+    "dismissed": []
   }
 }


### PR DESCRIPTION
Commits the working-tree changes left over after the 2026-09-05 `fleet-command` run, once `main` was synced to `180ebbb9c`.

## What's in it

**MCP server set** — `.mcp.json` and `.gemini/settings.json`, kept in sync:
- remove `sequential-thinking`
- add `playwright`, `github`, `exa`
- credentials are `${VAR}` references only — no literal secrets

**`harness.config.json`** — declare `integrations.enabled` = `["github", "exa"]` to match.

**`.harness/security/timeline.json`** — a 104-line security-posture snapshot auto-appended by `harness check-security` during the run's `security-fleet` lane. Records `commitHash 5cd661d74`, 6 findings (0 error / 5 warning / 1 info). The file had carried no entry since 2026-07-13.

All four files had been reformatted by a non-prettier writer (arrays expanded to multiline). `prettier --write` normalized that back, so the diff shows only semantic change.

## Deliberately excluded — and worth a look

The post-checkout hook regenerated `docs/roadmap.md` and the result **deletes the entire 92-line `## Assignment History` section**. That regeneration is not in this PR.

Cause: #1859 converted assignment history in `docs/roadmap.d/_meta.md` from a pipe table to a list. The globally-installed `harness` is the published **12.3.0**, which predates that change and still parses the old table format. It reads the new list, gets **0 records**, and `serializeRoadmap` (`packages/core/src/roadmap/serialize.ts:58`, "omit if empty") drops the section.

- Source data is **intact** — 18/18 records still in `docs/roadmap.d/_meta.md`
- Only the *regenerated aggregate* loses them
- Any user on the released CLI who runs `harness roadmap regen` before 12.4.0 ships will silently delete that section

Filed separately rather than papered over here.
