### PR TITLE
fix(ci): stop merge bursts from cancelling main's verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,31 @@ on:
   pull_request:
     branches: [main]
 
+# Concurrency is SPLIT BY EVENT on purpose — do not "simplify" this back to a
+# plain `${{ github.workflow }}-${{ github.ref }}` + `cancel-in-progress: true`.
+#
+# This workflow triggers on BOTH `push: [main]` and `pull_request: [main]`. On a
+# push, `github.ref` is `refs/heads/main` for EVERY commit, so a per-ref group
+# puts all main pushes in ONE bucket and each new merge cancels the still-running
+# verification of the previous commit. Measured on the last 30 push-to-main runs
+# before this change: 22 concluded `cancelled`, only 8 reached a verdict, and all
+# 30 were `run_attempt: 1` — these were not reruns, they were commits whose
+# verification was destroyed. One burst of 14 merges (2026-09-06T01:14:52Z ..
+# 01:21:43Z) left exactly one survivor, run 34004373791 (180ebbb9c). "main is
+# green" therefore mostly meant UNVERIFIED, not verified. See also
+# scripts/main-health-check.mjs, whose `DECISIVE_CONCLUSIONS` has to exclude
+# `cancelled` to work around this very trail.
+#
+#   push  -> per-COMMIT group (github.sha), never cancelled, so every commit that
+#            lands on main reaches its own all-OS verdict.
+#   PR    -> per-REF group, cancel-in-progress ON, so a new push to a PR still
+#            supersedes the old run. No runaway parallelism; PR spend unchanged.
+#
+# `cancel-in-progress` officially accepts an expression, and the `A && B || C`
+# idiom is already proven on this repo's runners at the `Test` step below.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Fail PRs that change a publishable package without a corresponding
@@ -76,7 +98,7 @@ jobs:
       # by omission. `--continue` runs every package's test task; turbo still
       # exits non-zero if any task fails, so the leg stays red on any failure —
       # the platform's red state becomes the full list, not just the first hit.
-      - name: Test (with coverage on ubuntu)
+      - name: Test (coverage on ubuntu, --continue elsewhere)
         run: ${{ matrix.os == 'ubuntu-latest' && 'pnpm test:ci' || 'pnpm test -- --continue' }}
 
       - name: Coverage ratchet check

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -6,9 +6,27 @@ on:
   pull_request:
     branches: [main]
 
+# Concurrency is SPLIT BY EVENT on purpose — do not "simplify" this back to a
+# plain `harness-${{ github.ref }}` + `cancel-in-progress: true`.
+#
+# This workflow triggers on BOTH `push: [main]` and `pull_request: [main]`. On a
+# push, `github.ref` is `refs/heads/main` for EVERY commit, so a per-ref group
+# puts all main pushes in ONE bucket and each new merge cancels the still-running
+# verification of the previous commit. Measured on the last 20 push-to-main runs
+# before this change: 13 concluded `cancelled`, only 7 succeeded. CI's own runs
+# showed the same burst signature (see the matching block in ci.yml). "main is
+# green" therefore mostly meant UNVERIFIED, not verified.
+#
+#   push  -> per-COMMIT group (github.sha), never cancelled, so every commit that
+#            lands on main reaches its own harness-checks verdict.
+#   PR    -> per-REF group, cancel-in-progress ON, so a new push to a PR still
+#            supersedes the old run. No runaway parallelism; PR spend unchanged.
+#
+# `cancel-in-progress` officially accepts an expression, and the `A && B || C`
+# idiom is already proven on this repo's runners (ci.yml `Test` step).
 concurrency:
-  group: harness-${{ github.ref }}
-  cancel-in-progress: true
+  group: harness-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   harness:

--- a/docs/changes/ci-concurrency-supersession/plans/2026-09-05-ci-concurrency-supersession-plan.md
+++ b/docs/changes/ci-concurrency-supersession/plans/2026-09-05-ci-concurrency-supersession-plan.md
@@ -1,0 +1,143 @@
+# Plan: stop merge bursts from cancelling main's verification
+
+**Date:** 2026-09-05 · **Source:** `harness-workflow-audit` run against `.github/workflows/` at base `c1ca02ba2` · **Tasks:** 5 · **Time:** ~20 min agent-effort · **Integration Tier:** small
+
+No separate proposal exists: this is an infra/config remediation item derived directly from a workflow audit, and the audit findings below stand in for the spec.
+
+## Goal
+
+Make every commit that lands on `main` reach its own all-OS CI verdict, by giving push-to-`main` runs a per-commit concurrency group that is never cancelled — while leaving pull-request runs on their existing per-ref, cancel-in-progress group so a new push to a PR still supersedes the old run and no runaway parallelism is introduced. Secondarily, stop reporting windows/macOS test failures under an ubuntu-sounding step name.
+
+## Audit findings (evidence)
+
+Produced by the `harness-workflow-audit` pipeline (phases: inventory → mechanical → judgment → report). 22 workflow files inventoried; the two in remediation scope are `ci.yml` and `harness.yml`.
+
+### [ERROR] concurrency-supersession · `.github/workflows/ci.yml:9-11`
+
+`group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, on a workflow triggered by **both** `push: branches: [main]` and `pull_request: branches: [main]`.
+
+On a push to `main`, `github.ref` is `refs/heads/main` for _every_ commit, so all main pushes collapse into one concurrency group and each new merge cancels the still-running verification of the previous commit.
+
+Re-derived against the live API at audit time (`gh api .../workflows/ci.yml/runs?branch=main&event=push&per_page=30`):
+
+- **22 `cancelled`**, 5 `failure`, 3 `success` — of the last 30 push-to-`main` runs.
+- **Every one of the 30 is `run_attempt: 1`.** These are not reruns; they are commits whose verification was destroyed before it could produce a verdict.
+- The mechanism is visible in a single burst: 14 pushes to `main` between `2026-09-06T01:14:52Z` and `01:21:43Z` (runs `34003390224`, `34003416641`, `34003428394`, `34003449722`, `34003530829`, `34003558821`, `34003579588`, `34003608478`, `34003641461`, `34003652098`, `34003661878`, `34003673303`, `34003692992`) all concluded `cancelled`; only the last in the burst, run `34004373791` (`180ebbb9c`), survived to `success`.
+
+**Effect:** "main is green" is mostly _unverified_ rather than verified. This is a workflow-level trust defect, not a cosmetic one.
+
+**Corroboration from inside the repo:** `scripts/main-health-check.mjs:31-32` already documents this defect as a standing condition it works around —
+
+> `"Decisive" excludes cancelled and skipped runs. CI sets cancel-in-progress: true, so rapid merges leave a trail of cancelled runs`
+
+`main-health.yml` consumes CI run conclusions via `workflow_run`, and `DECISIVE_CONCLUSIONS` (`scripts/main-health-check.mjs:92`) excludes `cancelled`. So the repo's own main-health alarm degrades to `INDETERMINATE` when a burst leaves too few decisive runs. The downstream workaround exists; this change removes its root cause.
+
+### [ERROR] concurrency-supersession · `.github/workflows/harness.yml:9-11`
+
+Identical defect: `group: harness-${{ github.ref }}`, `cancel-in-progress: true`, triggered on `push: branches: [main]` and `pull_request: branches: [main]`.
+
+Re-derived against the live API: of the last 20 push-to-`main` runs, **13 `cancelled`, 7 `success`**.
+
+### [WARNING] step-name-dishonest · `.github/workflows/ci.yml:79`
+
+The step is named `Test (with coverage on ubuntu)`, but line 80 runs it on **all three** operating systems:
+
+```yaml
+run: ${{ matrix.os == 'ubuntu-latest' && 'pnpm test:ci' || 'pnpm test -- --continue' }}
+```
+
+**Effect:** every windows/macOS test failure in this repo is reported under an ubuntu-sounding step name, actively degrading triage — a failing Windows job's steps read as ubuntu-named or `UNKNOWN STEP`.
+
+### Out of remediation scope, reported only
+
+- `.github/workflows/benchmark.yml:7-9` and `.github/workflows/pr-advisory-checks.yml:23-25` carry the same group shape but are **`pull_request`-only**. Per-ref cancellation is correct there; **not** a defect, and deliberately untouched.
+- Four further workflows carry `${{ github.workflow }}-${{ github.ref }}` + `cancel-in-progress: true` **and** a `push: branches: [main]` trigger, so they share the defect class: `persona-architecture-enforcer.yml:21-23` (also `develop`), `persona-documentation-maintainer.yml:19-21`, `persona-graph-maintainer.yml:17-19`, `persona-task-executor.yml:20-22`. These are **generated** files (`pnpm generate:persona-workflows:check` gates their freshness), so fixing them means changing their generator — a different change with a different blast radius. Filed as a follow-up rather than folded in here.
+- `.github/workflows/release.yml:7-9` already uses `cancel-in-progress: false`. Existing in-repo precedent that never-cancel is the right posture for main-triggered work.
+- Mechanical checks M1 (path filters — neither file in scope declares `paths:`/`paths-ignore:`), M3 (pinning — all `uses:` refs are first-party `actions/*` plus `pnpm/action-setup@v5` and `codecov/codecov-action@v5` on mutable major tags, consistent with repo convention), M5 (secret handling — no secret is echoed), and J1 (injection — `${{ github.event.pull_request.base.ref }}` is the only event interpolation reaching `run:`, and a base ref on a `branches: [main]`-filtered trigger is not attacker-controlled) produced no new findings in the two files in scope.
+
+## Observable Truths (Acceptance Criteria)
+
+Each truth names the command that proves it.
+
+1. `.github/workflows/ci.yml` and `.github/workflows/harness.yml` both parse as valid YAML after the edit.
+   **Gate:** `node -e "require('js-yaml').load(...)"` (or `python3 -c "import yaml; yaml.safe_load(...)"`) exits 0 for both files.
+2. On a `pull_request` event, both workflows resolve to a **per-ref** group with `cancel-in-progress` **true** — PR runs are still superseded, so runner spend on the PR path is unchanged.
+   **Gate:** expression review + the post-merge observation that pushing twice to a PR branch leaves exactly one live run.
+3. On a `push` event, both workflows resolve to a **per-commit** (`github.sha`) group with `cancel-in-progress` **false** — no main run can cancel another.
+   **Gate:** expression review; post-merge, a multi-commit burst on `main` leaves zero `cancelled` conclusions.
+4. `cancel-in-progress` accepting an expression is confirmed against current GitHub documentation, not assumed.
+   **Gate:** GitHub Actions workflow-syntax reference states _"you can specify `cancel-in-progress` as an expression with any of the allowed expression contexts"_, with the official example `cancel-in-progress: ${{ !contains(github.ref, 'release/') }}`. `concurrency.group` likewise accepts expressions over the `github`/`inputs`/`vars` contexts; `github.event_name`, `github.ref`, and `github.sha` are all in the `github` context.
+5. The `A && B || C` ternary idiom is proven to work on **this repo's** GitHub instance rather than assumed.
+   **Gate:** `.github/workflows/ci.yml:80` already ships the identical idiom (`${{ matrix.os == 'ubuntu-latest' && 'pnpm test:ci' || 'pnpm test -- --continue' }}`) and has been evaluating correctly in production.
+6. Each changed `concurrency:` block carries a comment explaining **why**, citing the burst evidence, so the next reader does not "simplify" it back.
+   **Gate:** `grep -B8 'cancel-in-progress' .github/workflows/ci.yml .github/workflows/harness.yml` shows the rationale comment.
+7. The test step name no longer claims to be ubuntu-only.
+   **Gate:** `grep -n 'Test (' .github/workflows/ci.yml` → `Test (coverage on ubuntu, --continue elsewhere)`.
+8. The existing explanatory comment block above the test step (the `#1096` `--continue` rationale) is preserved byte-identically.
+   **Gate:** `git diff` shows no change to lines 72-78.
+9. No file outside `.github/workflows/ci.yml`, `.github/workflows/harness.yml`, and this plan artifact is modified.
+   **Gate:** `git diff --name-only origin/main...HEAD` lists exactly three paths.
+10. The change passes the repo's own pre-push gates without `--no-verify`.
+    **Gate:** `git push` succeeds on the first non-bypassed attempt.
+
+## Change Specification (delta)
+
+**`.github/workflows/ci.yml:9-11` → replaced**
+
+- [MODIFIED] `concurrency.group`: `${{ github.workflow }}-${{ github.ref }}` → `${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}`
+- [MODIFIED] `concurrency.cancel-in-progress`: `true` → `${{ github.event_name == 'pull_request' }}`
+- [ADDED] A rationale comment block citing the burst evidence.
+
+**`.github/workflows/harness.yml:9-11` → replaced**
+
+- [MODIFIED] `concurrency.group`: `harness-${{ github.ref }}` → `harness-${{ github.event_name == 'pull_request' && github.ref || github.sha }}`
+- [MODIFIED] `concurrency.cancel-in-progress`: `true` → `${{ github.event_name == 'pull_request' }}`
+- [ADDED] The same rationale comment block.
+
+**`.github/workflows/ci.yml:79`**
+
+- [MODIFIED] step `name`: `Test (with coverage on ubuntu)` → `Test (coverage on ubuntu, --continue elsewhere)`
+- [UNCHANGED — deliberately] the `run:` ternary on line 80 and the `#1096` comment block above it.
+
+**Not changed, deliberately:** `benchmark.yml`, `pr-advisory-checks.yml` (PR-only, correct as-is); the four persona workflows (generated); `scripts/main-health-check.mjs` (out of lane scope — see Risks).
+
+## Risk analysis
+
+### R1 — Does removing cancellation on `main` create a push-back race? (analyzed, accepted)
+
+This is the one non-obvious consequence and it drove the shape of the fix.
+
+`ci.yml` has two jobs gated on `github.ref == 'refs/heads/main' && github.event_name == 'push'` that write back to the repository:
+
+- `refresh-baselines` (`ci.yml:210`) — `needs: build-and-test`, `contents: write` + `pull-requests: write`, regenerates coverage/architecture baselines and pushes to `main` (with a `gh pr create` fallback, which is the live path because branch protection blocks direct pushes).
+- `comprehension-refresh` (`ci.yml:381`) — additionally gated on the repo variable `HARNESS_COMPREHENSION_CI_REFRESH == 'true'`.
+
+Today a merge burst cancels runs 1..n-1 during `build-and-test`, so `refresh-baselines` effectively runs once per burst. After this change it runs once per commit — concurrently.
+
+**Why this is safe:** `refresh-baselines` is already hardened for exactly this concurrency, by prior fix `#671` ("Fix B", `ci.yml:315-320`), which bases the fallback PR branch on **the current tip of `origin/main`** rather than the run's own event SHA, precisely because _"concurrent refresh runs otherwise branch from divergent commits and conflict on the same baseline lines"_. It also carries two idempotent early exits — `"No baseline changes to commit."` and `"Latest main already carries these baselines; nothing to PR."` — so in a burst the first job wins and the rest no-op. Baselines are regenerated wholesale, so "ours" is always the correct resolution.
+
+`comprehension-refresh` is **inert**: `gh api repos/.../actions/variables` returns no variables, so `HARNESS_COMPREHENSION_CI_REFRESH` is unset and the job is never scheduled.
+
+**Why job-level concurrency was rejected as a mitigation:** the obvious hedge — give `refresh-baselines` its own stable concurrency group to collapse a burst back to one job — **reintroduces the exact defect being fixed**. A cancelled job makes its workflow run conclude `cancelled`, and `cancelled` is precisely what `DECISIVE_CONCLUSIONS` excludes, so main-health would go back to seeing non-decisive runs even though `build-and-test` had passed. `cancel-in-progress: false` does not escape this either: GitHub keeps only **one** pending run per concurrency group and cancels older pending ones, so a 14-commit burst still yields ~12 cancellations. Both variants trade the headline fix for a runner-minute saving. Rejected.
+
+### R2 — Runner spend on `main` increases (accepted, by design)
+
+Stated plainly rather than glossed: PR-path spend is unchanged, but main-path spend rises roughly in proportion to burst size — a 14-commit burst goes from ~1 completed verification to 14, each across 3 operating systems. That increase **is the fix**: verifying every commit necessarily costs more than verifying one in fourteen, and the current saving is purchased by not knowing whether `main` works. A merge queue would deliver the same guarantee more cheaply by testing batched candidates before they land; that is a materially larger architectural change and is recorded as a follow-up, not folded in here.
+
+### R3 — Doc drift in `scripts/main-health-check.mjs` (reported, not fixed)
+
+The comment at `scripts/main-health-check.mjs:31-32` says _"CI sets `cancel-in-progress: true`"_, which this change makes stale for the push path. The **logic is unaffected** — excluding `cancelled` from decisive conclusions stays correct; there will simply be far fewer such runs. `scripts/` is outside this change's declared file scope, so the comment is flagged for a follow-up rather than edited here.
+
+## Tasks
+
+1. **Run the audit.** Execute the `harness-workflow-audit` pipeline over `.github/workflows/`; inventory all 22 workflows; resolve triggers and concurrency blocks; re-derive the cancellation evidence against the live API. → findings above.
+2. **Validate the expression forms** against current GitHub documentation (`cancel-in-progress` accepts expressions; `group` accepts `github`-context expressions) and against in-repo precedent for the `&& ||` ternary (`ci.yml:80`). → truths 4, 5.
+3. **Apply the concurrency fix** to `ci.yml:9-11` and `harness.yml:9-11`, each with a rationale comment citing the burst evidence. → truths 2, 3, 6.
+4. **Apply the step rename** at `ci.yml:79`, preserving the comment block above it. → truths 7, 8.
+5. **Verify and ship.** YAML-parse both files, confirm the diff touches exactly three paths, commit, push without `--no-verify`, open one unmerged PR. → truths 1, 9, 10.
+
+## Follow-ups (filed, not done here)
+
+- Fix the same concurrency defect in the four generated persona workflows by changing their generator.
+- Refresh the stale `cancel-in-progress: true` reference in `scripts/main-health-check.mjs:31-32`.
+- Evaluate a merge queue as the cheaper long-term route to per-commit verification of `main`.

--- a/docs/changes/ci-concurrency-supersession/sessions/2026-09-05-session-state.md
+++ b/docs/changes/ci-concurrency-supersession/sessions/2026-09-05-session-state.md
@@ -1,0 +1,115 @@
+# Session state: main-verification concurrency supersession remediation
+
+**Fleet:** cicd-fleet · **Date:** 2026-09-05 · **Pipeline:** harness-workflow-audit
+**Branch:** `fix/ci-concurrency-supersession` · **Base:** `origin/main` @ `c1ca02ba2` · **PR:** #1865
+
+## Trigger
+
+Not a single failing run — a **workflow-level trust defect** surfaced by auditing `.github/workflows/`.
+Cause classification: **real-defect** (deterministic, config-caused; not flake, not infra).
+
+`ci.yml` and `harness.yml` each trigger on **both** `push: [main]` and `pull_request: [main]` while
+using a per-ref concurrency group with `cancel-in-progress: true`. On a push, `github.ref` is
+`refs/heads/main` for every commit, so all main pushes share one group and each merge cancels the
+previous commit's still-running verification.
+
+| workflow      | window                      | `cancelled` | reached a verdict        | in scope |
+| ------------- | --------------------------- | ----------- | ------------------------ | -------- |
+| `ci.yml`      | last 30 push-to-`main` runs | **22**      | 8 (5 failure, 3 success) | yes      |
+| `harness.yml` | last 20 push-to-`main` runs | **13**      | 7 success                | yes      |
+
+All 30 `ci.yml` runs are `run_attempt: 1` — not reruns, but commits whose verification was destroyed.
+One burst of 14 merges (`2026-09-06T01:14:52Z` .. `01:21:43Z`) left a single survivor, run
+`34004373791` (`180ebbb9c`).
+
+## Phase log
+
+- **INVENTORY** — enumerated all 22 workflow files; recorded triggers, `concurrency:` blocks,
+  `permissions:`, `uses:` refs, and `run:` scripts. Isolated the 6 workflows that combine a per-ref
+  group with `cancel-in-progress: true` and a `push: [main]` trigger.
+- **MECHANICAL** — M1 (path filters) n/a for the two files in scope (neither declares
+  `paths:`/`paths-ignore:`). M3 (pinning): all `uses:` refs are first-party `actions/*` plus
+  `pnpm/action-setup@v5` and `codecov/codecov-action@v5` on mutable major tags, consistent with repo
+  convention. M4 (**concurrency safety**) fired — the headline finding. M5 (secrets): no secret is
+  echoed. No new findings beyond M4.
+- **JUDGMENT** — J1 (injection): `${{ github.event.pull_request.base.ref }}` is the only event
+  interpolation reaching `run:`, and a base ref on a `branches: [main]`-filtered trigger is not
+  attacker-controlled — not a finding. J2/J3 produced nothing new in scope. Separately identified the
+  misnamed test step at what was `ci.yml:79` as a live triage-degrading defect.
+- **CORROBORATE** — found that the repo already works around this defect downstream without ever
+  root-causing it: `scripts/main-health-check.mjs:89-92` excludes `cancelled` from
+  `DECISIVE_CONCLUSIONS`, commented _"CI sets `cancel-in-progress: true`, so rapid merges leave a
+  trail of cancelled runs"_. `main-health.yml` consumes CI conclusions via `workflow_run`, so a burst
+  degrades the alarm to `INDETERMINATE`.
+- **VALIDATE** — confirmed against current GitHub docs that `cancel-in-progress` accepts an
+  expression (official example: `cancel-in-progress: ${{ !contains(github.ref, 'release/') }}`) and
+  that `concurrency.group` accepts `github`-context expressions. Confirmed the `A && B || C` idiom
+  works on **this repo's** runners via existing in-file precedent (the `Test` step's `run:`).
+- **FIX** — split both concurrency groups by event; renamed the misleading test step.
+
+## Decisions taken autonomously (no human fork raised)
+
+- **D1** — used the `A && B || C` idiom rather than the newer `case()` function (GA 2026-03-27).
+  In-repo precedent proves the idiom on these runners; `case()` would be a marginal readability gain
+  for nonzero syntax risk on a file whose failure mode is a total CI blackout.
+- **D2** — fixed only `ci.yml` and `harness.yml`. `benchmark.yml` and `pr-advisory-checks.yml` share
+  the group shape but are `pull_request`-only, where per-ref cancellation is **correct**, not a defect.
+- **D3** — left the 4 same-defect **generated** persona workflows alone
+  (`persona-architecture-enforcer`, `persona-documentation-maintainer`, `persona-graph-maintainer`,
+  `persona-task-executor`); their freshness is gated by `generate:persona-workflows:check`, so the fix
+  belongs in their generator. Filed as follow-up.
+- **D4** — accepted increased runner spend on `main` as **the fix, not a side effect**. PR-path spend
+  is unchanged; main-path spend scales with burst size (a 14-commit burst goes from ~1 completed
+  verification to 14 × 3 OS). Verifying every commit necessarily costs more than verifying one in
+  fourteen. A merge queue is the cheaper long-term route; filed as follow-up, too large here.
+- **D5** — analyzed and accepted the push-back concurrency risk (see below). **Job-level concurrency
+  was considered and rejected** as a mitigation.
+- **D6** — did not touch `scripts/main-health-check.mjs`; its comment goes stale but its **logic stays
+  correct**. Out of declared file scope; filed as follow-up.
+
+## Risk analysis carried into the fix
+
+Removing cancellation on `main` means `ci.yml`'s two main-only write-back jobs run once per commit
+rather than once per burst. Resolved as safe:
+
+- `refresh-baselines` is **already hardened for exactly this concurrency** by prior fix #671
+  ("Fix B"), which bases the fallback PR branch on the current tip of `origin/main` rather than the
+  run's event SHA, precisely because _"concurrent refresh runs otherwise branch from divergent commits
+  and conflict on the same baseline lines"_. It also carries two idempotent early exits, so in a burst
+  the first job wins and the rest no-op.
+- `comprehension-refresh` is **inert** — gated on the repo variable
+  `HARNESS_COMPREHENSION_CI_REFRESH` being `'true'`; `gh api .../actions/variables` returns no
+  variables.
+- **Why job-level concurrency was rejected:** it reintroduces the exact defect being fixed. A
+  cancelled job makes its run conclude `cancelled`, which is precisely what `DECISIVE_CONCLUSIONS`
+  excludes. `cancel-in-progress: false` does not escape it either — GitHub keeps only one _pending_
+  run per group and cancels older pending ones, so a 14-burst still yields ~12 cancellations. Both
+  variants trade the headline fix for runner minutes.
+
+## Verification
+
+| Gate                                                   | Evidence                                                                                                                             |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Both workflow files parse as valid YAML after the edit | `yaml.parse()` on both → PASS; groups and `cancel-in-progress` read back as the intended expressions                                 |
+| push → per-commit group, never cancelled               | `group` contains `github.sha` on the non-PR branch of the ternary; `cancel-in-progress` false when not a PR                          |
+| PR → per-ref group, cancel-in-progress ON              | `group` contains `github.ref` on the PR branch; `cancel-in-progress` → `github.event_name == 'pull_request'`                         |
+| **Expression evaluates on the live GitHub instance**   | PR #1865 **scheduled jobs** across all 3 OS — a malformed expression yields `startup_failure` with no jobs                           |
+| Rationale comment present above each block             | both blocks carry a comment citing the burst evidence and naming the cancel/no-cancel split                                          |
+| Test step name is OS-honest                            | `ci.yml:101` → `Test (coverage on ubuntu, --continue elsewhere)`                                                                     |
+| `#1096` `--continue` comment block preserved           | `git diff` shows no change to the comment block above the step; `run:` ternary untouched                                             |
+| Diff scope                                             | `git diff --name-only c1ca02ba2..HEAD` → exactly 3 paths, none in a forbidden region                                                 |
+| `pnpm format:check`                                    | "All matched files use Prettier code style!"                                                                                         |
+| Shipped without bypass                                 | commit + push passed the arch gate, lint-staged, comprehension compile, `generate-docs --check`, tool-catalog — **no `--no-verify`** |
+
+No gate weakened, skipped, or deleted. No workflow file outside the two in scope was modified.
+
+## Follow-ups filed
+
+- Same concurrency defect in the 4 generated persona workflows → fix via their generator.
+- Stale `cancel-in-progress: true` reference at `scripts/main-health-check.mjs:31-32`.
+- Evaluate a merge queue as the cheaper long-term route to per-commit verification of `main`.
+
+## Status
+
+`resolved` — PR #1865 open and **unmerged**. Terminal act of this lane is the unmerged PR; landing is
+the human's decision.


### PR DESCRIPTION
## Summary

Two defects in the same pair of workflow files, found by a `harness-workflow-audit` run over `.github/workflows/`.

`ci.yml` and `harness.yml` both trigger on **`push: [main]` and `pull_request: [main]`** with a per-ref concurrency group and `cancel-in-progress: true`. On a push, `github.ref` is `refs/heads/main` for *every* commit, so all main pushes shared **one** concurrency group and each new merge cancelled the still-running verification of the previous commit.

**"main is green" therefore mostly meant *unverified*, not verified.** That is a workflow-level trust defect.

## Evidence

Re-derived against the live Actions API:

| workflow | window | `cancelled` | reached a verdict |
| --- | --- | --- | --- |
| `ci.yml` | last 30 push-to-`main` runs | **22** | 8 (5 failure, 3 success) |
| `harness.yml` | last 20 push-to-`main` runs | **13** | 7 success |

- **All 30 `ci.yml` runs are `run_attempt: 1`** — these are not reruns, they are commits whose verification was destroyed.
- The mechanism is visible in one burst: 14 pushes to `main` between `2026-09-06T01:14:52Z` and `01:21:43Z` (runs `34003390224`, `34003416641`, `34003428394`, `34003449722`, `34003530829`, `34003558821`, `34003579588`, `34003608478`, `34003641461`, `34003652098`, `34003661878`, `34003673303`, `34003692992`) all concluded `cancelled`. Only the last in the burst, run `34004373791` (`180ebbb9c`), survived to `success`.

**The repo already knew.** `scripts/main-health-check.mjs:31-32` documents this as a standing condition it works around:

> `"Decisive" excludes cancelled and skipped runs. CI sets cancel-in-progress: true, so rapid merges leave a trail of cancelled runs`

`main-health.yml` reads CI conclusions via `workflow_run`, and `DECISIVE_CONCLUSIONS` excludes `cancelled` — so the main-health alarm degrades to `INDETERMINATE` after a burst. This PR removes the root cause that workaround exists for.

## The fix

Split the concurrency group **by event**. Identical shape in both files:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **push → per-COMMIT group (`github.sha`), never cancelled** — every commit that lands on `main` reaches its own all-OS verdict.
- **PR → per-REF group, cancel-in-progress ON** — a new push to a PR still supersedes the old run. No runaway parallelism; **PR runner spend is unchanged**.

Each block carries a comment explaining *why*, citing the burst evidence, so the next reader does not "simplify" it back.

### Validated before committing, not assumed

- `cancel-in-progress` **officially accepts an expression** — GitHub workflow-syntax reference: *"you can specify `cancel-in-progress` as an expression with any of the allowed expression contexts"*, official example `cancel-in-progress: ${{ !contains(github.ref, 'release/') }}`. `concurrency.group` accepts expressions over the `github`/`inputs`/`vars` contexts; `github.event_name`, `github.ref`, `github.sha` are all `github`-context.
- The `A && B || C` idiom is **already proven on this repo's runners** — `ci.yml` ships the identical idiom in the `Test` step's `run:`. That local proof is why it was preferred over the newer `case()` function (GA 2026-03-27), which would have been a marginal readability gain for nonzero syntax risk on a file whose failure mode is a total CI blackout.
- Both files re-parsed as YAML after the edit.

## Defect 2 — a misnamed step degrading triage

`ci.yml`'s step was named `Test (with coverage on ubuntu)` but runs on **all three** OSes via `${{ matrix.os == 'ubuntu-latest' && 'pnpm test:ci' || 'pnpm test -- --continue' }}`. Every windows/macOS test failure was reported under an ubuntu-sounding step name (failing Windows jobs read as ubuntu-named / `UNKNOWN STEP`). Renamed to `Test (coverage on ubuntu, --continue elsewhere)`. The `#1096` explanatory comment block above it is untouched.

## Remediation actions / assumptions made

Every default taken autonomously:

1. **Used the `&& ||` ternary rather than `case()`.** Justified by in-repo precedent (above). Assumption: matching the idiom already running in this file is lower-risk than introducing a newer one.
2. **Fixed only `ci.yml` and `harness.yml`.** `benchmark.yml` and `pr-advisory-checks.yml` share the group shape but are **`pull_request`-only**, where per-ref cancellation is correct behaviour — deliberately untouched.
3. **Left four same-defect workflows alone.** `persona-architecture-enforcer.yml`, `persona-documentation-maintainer.yml`, `persona-graph-maintainer.yml`, `persona-task-executor.yml` all carry a per-ref group + `cancel-in-progress: true` + `push: [main]`. They are **generated** (gated by `pnpm generate:persona-workflows:check`), so fixing them means changing their generator — different blast radius. Follow-up, not folded in.
4. **Accepted increased runner spend on `main`** — stated plainly rather than glossed. PR spend is unchanged, but main spend rises with burst size: a 14-commit burst goes from ~1 completed verification to 14, across 3 OSes. **That increase is the fix** — verifying every commit necessarily costs more than verifying one in fourteen, and the current saving is bought by not knowing whether `main` works. A merge queue would give the same guarantee more cheaply; recorded as a follow-up, too large for this change.
5. **Analyzed and accepted the push-back concurrency risk.** This was the one non-obvious consequence. `ci.yml` has two main-only write-back jobs; removing cancellation means they now run once per commit rather than once per burst.
   - `refresh-baselines` is **already hardened for exactly this**, by prior fix #671 ("Fix B"), which bases the fallback PR branch on the *current tip of `origin/main`* rather than the run's event SHA, precisely because *"concurrent refresh runs otherwise branch from divergent commits and conflict on the same baseline lines"*. It also carries two idempotent early exits (`"No baseline changes to commit."`, `"Latest main already carries these baselines; nothing to PR."`), so in a burst the first job wins and the rest no-op.
   - `comprehension-refresh` is **inert** — gated on repo variable `HARNESS_COMPREHENSION_CI_REFRESH == 'true'`, and `gh api .../actions/variables` returns no variables.
   - **Job-level concurrency was considered and rejected as a mitigation**, because it *reintroduces the exact defect being fixed*: a cancelled job makes its run conclude `cancelled`, which is precisely what `DECISIVE_CONCLUSIONS` excludes. `cancel-in-progress: false` does not escape it either — GitHub keeps only one *pending* run per group and cancels older pending ones, so a 14-burst still yields ~12 cancellations. Both variants trade the headline fix for runner minutes.
6. **Did not touch `scripts/main-health-check.mjs`.** Its comment *"CI sets `cancel-in-progress: true`"* goes stale for the push path, but the **logic stays correct** (excluding `cancelled` is still right; there will just be far fewer). Out of this change's file scope — flagged as a follow-up.

## Plan artifact

`docs/changes/ci-concurrency-supersession/plans/2026-09-05-ci-concurrency-supersession-plan.md` — full audit findings, 10 observable truths with gates, change delta, and the risk analysis above.

## Verification

- Both workflow files re-parse as valid YAML.
- `pnpm format:check` → all files match Prettier style.
- Committed and pushed through **all** pre-commit and pre-push gates with **no `--no-verify`** (arch gate, lint-staged, comprehension compile, `generate-docs --check`, tool-catalog check all passed).
- Diff touches exactly 3 paths.

## Follow-ups (not done here)

- Same concurrency defect in the 4 generated persona workflows → fix via their generator.
- Stale `cancel-in-progress: true` reference in `scripts/main-health-check.mjs:31-32`.
- Evaluate a merge queue as the cheaper long-term route to per-commit verification of `main`.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
