### PR TITLE
test(orchestrator,core): cover the secret-backend selection switch and metric census

### DIFF
--- a/.harness/comprehension/packages/core/tests/metrics/_module.md
+++ b/.harness/comprehension/packages/core/tests/metrics/_module.md
@@ -1,11 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/metrics'
-sourceHash: '6e96d7795c63a0711bf13c9ada1ae9d94243118c01a266b81154c4788ccb9eba'
+sourceHash: '8722264623dd87085b4ac9b10a23f6b861937fd6d5ecf082d858f0b12b49d317'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ['adoption.test.ts', 'denominate.test.ts', 'render.test.ts', 'verdict.test.ts']
+members:
+  ['adoption.test.ts', 'census.test.ts', 'denominate.test.ts', 'render.test.ts', 'verdict.test.ts']
 ---
 
 ## Interface Contract
@@ -18,6 +19,6 @@ members: ['adoption.test.ts', 'denominate.test.ts', 'render.test.ts', 'verdict.t
 
 ```
 import { patternCoverage, scoreWithCoverage } from '../../src/harness-strength/scoring'
-import { ABSTENTION_PLACEHOLDER, MetricContractError, denominate, describePopulation, formatMetric, formatMetricBlock, formatMetricValue, formatPopulation, unknownPopulation, verdictForMetrics } from '../../src/metrics'
+import { ABSTENTION_PLACEHOLDER, MetricContractError, census, denominate, describePopulation, formatMetric, formatMetricBlock, formatMetricValue, formatPopulation, unknownPopulation, verdictForMetrics } from '../../src/metrics'
 import { describe, expect, it } from 'vitest'
 ```

--- a/.harness/comprehension/packages/orchestrator/tests/agent/secrets/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/agent/secrets/_module.md
@@ -1,33 +1,12 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/tests/agent/secrets"
-sourceHash: "ba70120bc90b112fb22520d30dde2d4a91e86a6c53e4cc7a428b5fc7519cd39b"
-compiledAt: "2026-08-28T01:22:12.471Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["env.test.ts", "onepassword.test.ts", "vault.test.ts"]
+module: 'packages/orchestrator/tests/agent/secrets'
+sourceHash: '5b1788b2db6a83cb4f20e5b14cb9f11984cd53c41a8856f780c08f3a639a174c'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members: ['env.test.ts', 'index.test.ts', 'onepassword.test.ts', 'vault.test.ts']
 ---
-
-## Summary
-
-This test suite validates three pluggable secret backends for the orchestrator agent—**EnvSecretBackend**, **OnePasswordSecretBackend**, and **VaultSecretBackend**. Each backend implements a common interface: `name` property, `resolveSecrets(keys[])` for fetching secrets by key, and `healthCheck()` for verifying provider availability.
-
-The tests confirm:
-- **EnvSecretBackend** reads directly from `process.env` and always passes health checks.
-- **OnePasswordSecretBackend** shells out to `op read` CLI per key; fails with `access_denied` when user isn't signed in.
-- **VaultSecretBackend** shells out to `vault kv get` once per call (batching all keys); fails with `access_denied` on permission errors.
-- All backends return a discriminated `Result` union (`{ok: true, value: {...}}` or `{ok: false, error: {category, ...}}`), with error categories: `secret_not_found` (missing key), `access_denied` (auth/CLI failure), `provider_unavailable` (CLI not installed).
-
-## Invariants
-
-- All three backends expose identical interface: name, resolveSecrets(keys[]), and healthCheck() with Result-like return types
-- Result discriminator pattern: callers branch on result.ok boolean; error handling depends on structure consistency
-- Error categorization is route-critical: missing secrets → category='secret_not_found' + key field; CLI/auth failures → category='access_denied'; missing CLI → category='provider_unavailable'
-- Empty key array is valid and must return {ok: true, value: {}}, not an error
-- EnvSecretBackend health check always succeeds; this backend is an offline fallback
-- CLI-based backends have different call patterns: OnePassword calls execFile once per key; Vault batches in one call
-- Process.env isolation: tests preserve/restore originalEnv; real code shares same isolation contract to prevent cross-test pollution
 
 ## Interface Contract
 
@@ -38,9 +17,11 @@ The tests confirm:
 ## Dependency Slice
 
 ```
+import { EnvSecretBackend, OnePasswordSecretBackend, VaultSecretBackend, createSecretBackend } from '../../../src/agent/secrets'
 import { EnvSecretBackend } from '../../../src/agent/secrets/env'
 import { OnePasswordSecretBackend } from '../../../src/agent/secrets/onepassword'
 import { VaultSecretBackend } from '../../../src/agent/secrets/vault'
+import { SecretConfig } from '@harness-engineering/types'
 import { execFile } from 'node:child_process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/packages/core/tests/metrics/census.test.ts
+++ b/packages/core/tests/metrics/census.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The census constructor (`census`).
+ *
+ * A census is the shape behind every `0/0 checks passed`, `0 files scanned`
+ * line: the population *is* the measurement, so there is no numerator subtlety
+ * to argue about and the bug class is at its cheapest to catch. Three sizes
+ * have to stay apart, and collapsing any pair of them is the failure:
+ *
+ *   N > 0  — measured; we examined N of the N there were.
+ *   0      — an abstention; we looked and there was nothing. Not a pass.
+ *   null   — unknown; we could not look at all. Points at the fetch, not the
+ *            selector, and so must not be reported as the empty case.
+ *
+ * `denominate` and its siblings are covered next door in `denominate.test.ts`.
+ * What is asserted here is only what `census` itself decides: the numerator and
+ * denominator it derives from a single size, and that it inherits rather than
+ * bypasses the population contract.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  ABSTENTION_PLACEHOLDER,
+  census,
+  formatMetricValue,
+  MetricContractError,
+} from '../../src/metrics';
+
+const scanned = { definition: 'source files under packages/, excluding generated output' };
+
+describe('census — a non-empty population is fully measured', () => {
+  const examined = census('scan.files', 12, scanned);
+
+  it('records the population size as the denominator', () => {
+    expect(examined.denominator).toBe(12);
+  });
+
+  it('counts every member of the population as examined', () => {
+    expect(examined.numerator).toBe(12);
+  });
+
+  it('is measured, so a reader may act on it', () => {
+    expect(examined.basis).toBe('measured');
+  });
+
+  it('is complete by construction — the value is 1, not a fraction', () => {
+    // The value carries no information in a census; the point is that it is
+    // never a partial ratio, which would invite "88% scanned" readings.
+    expect(examined.value).toBe(1);
+  });
+
+  it('carries its denominator in the note, so a copied figure keeps its population', () => {
+    expect(examined.note).toBe('12 of 12 source files under packages/, excluding generated output');
+  });
+
+  it('records a single-member population as measured rather than rounding it away', () => {
+    expect(census('scan.files', 1, scanned).basis).toBe('measured');
+  });
+});
+
+describe('census — a census of zero is an abstention, not a pass', () => {
+  const nothing = census('scan.files', 0, scanned);
+
+  it('records basis "abstained"', () => {
+    expect(nothing.basis).toBe('abstained');
+  });
+
+  it('carries no value, so nothing downstream can render it as a figure', () => {
+    // The bug this exists to catch: `0 of 0` reported as fully covered because
+    // the value was derived as 1 (or 100%) over an empty population. A null
+    // value is the only shape a renderer structurally cannot print as a figure.
+    expect(nothing.value).toBeNull();
+  });
+
+  it('renders as the abstention placeholder rather than a number', () => {
+    expect(formatMetricValue(nothing)).toBe(ABSTENTION_PLACEHOLDER);
+  });
+
+  it('keeps the zero denominator visible instead of erasing the population', () => {
+    expect(nothing.denominator).toBe(0);
+  });
+});
+
+describe('census — an unknown size stays distinct from an empty one', () => {
+  const unknown = census('scan.files', null, scanned);
+
+  it('records basis "unknown"', () => {
+    expect(unknown.basis).toBe('unknown');
+  });
+
+  it('keeps the denominator null rather than substituting zero', () => {
+    expect(unknown.denominator).toBeNull();
+  });
+
+  it('does not make the caller invent a numerator for a size it never learned', () => {
+    expect(unknown.numerator).toBe(0);
+  });
+
+  it('is not renderable as a figure either', () => {
+    expect(unknown.value).toBeNull();
+  });
+});
+
+describe('census — the population contract is inherited, not bypassed', () => {
+  it('refuses a census with no population definition', () => {
+    expect(() =>
+      // @ts-expect-error — the type forbids it, but a JS caller or an `any`-typed
+      // boundary can still reach the runtime check, which is the one that counts.
+      census('scan.files', 12, {})
+    ).toThrow(MetricContractError);
+  });
+
+  it('refuses a blank population definition rather than accepting the whitespace', () => {
+    expect(() => census('scan.files', 12, { definition: '   ' })).toThrow(/missing-population/);
+  });
+
+  it('names the offending metric and violation, so the emit site is findable', () => {
+    try {
+      census('scan.files', 0, { definition: '' });
+      expect.unreachable('a census with no stated population must not be emittable');
+    } catch (error) {
+      const contract = error as MetricContractError;
+      expect(contract.metric).toBe('scan.files');
+      expect(contract.violation).toBe('missing-population');
+    }
+  });
+
+  it('refuses a negative size — a census counts, it does not subtract', () => {
+    expect(() => census('scan.files', -1, scanned)).toThrow(/negative-denominator/);
+  });
+});

--- a/packages/orchestrator/tests/agent/secrets/index.test.ts
+++ b/packages/orchestrator/tests/agent/secrets/index.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The secret-backend selection switch (`createSecretBackend`).
+ *
+ * Each of the three backends already has its own suite next to this one. What
+ * had none is the switch that picks between them and — the dangerous half — the
+ * credential defaults it substitutes when the caller omits a field.
+ *
+ * A wrong default does not throw. It reads real secrets from the wrong vault,
+ * or points a production run at a developer's loopback Vault, and every layer
+ * above reports success. So the defaults are asserted where they are actually
+ * observable: the `op://…` reference and the `VAULT_ADDR` the selected backend
+ * spawns its CLI with. Asserting only `instanceof` would prove a constructor
+ * ran, not what it was configured with, and would keep passing if `'Private'`
+ * silently became `'Shared'`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SecretConfig } from '@harness-engineering/types';
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+
+import { execFile } from 'node:child_process';
+
+import {
+  createSecretBackend,
+  EnvSecretBackend,
+  OnePasswordSecretBackend,
+  VaultSecretBackend,
+} from '../../../src/agent/secrets';
+
+/** One `execFile` invocation, reduced to the parts a credential can hide in. */
+interface SpawnedCommand {
+  command: string;
+  args: string[];
+  env: Record<string, string | undefined>;
+}
+
+/**
+ * The commands the backend under test actually spawned.
+ *
+ * `execFile` is called as `(cmd, args, cb)` by the 1Password backend and
+ * `(cmd, args, options, cb)` by the Vault one, so the options object is located
+ * positionally rather than by index.
+ */
+function spawnedCommands(): SpawnedCommand[] {
+  const calls = vi.mocked(execFile).mock.calls as unknown as unknown[][];
+  return calls.map((call) => {
+    const options = call[2];
+    const env =
+      typeof options === 'object' && options !== null && 'env' in options
+        ? ((options as { env?: Record<string, string | undefined> }).env ?? {})
+        : {};
+    return { command: call[0] as string, args: call[1] as string[], env };
+  });
+}
+
+/** Make the spawned CLI succeed with `stdout`, so `resolveSecrets` runs to completion. */
+function stubTransport(stdout: string): void {
+  vi.mocked(execFile).mockImplementation((...callArgs: unknown[]) => {
+    const done = callArgs[callArgs.length - 1] as (
+      error: Error | null,
+      stdout: string,
+      stderr: string
+    ) => void;
+    done(null, stdout, '');
+    return {} as never;
+  });
+}
+
+/** A Vault `kv get -format=json` payload carrying `API_KEY`. */
+const VAULT_PAYLOAD = JSON.stringify({ data: { data: { API_KEY: 'resolved' } } });
+
+describe('createSecretBackend — env', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects the environment-variable backend', () => {
+    const backend = createSecretBackend({ backend: 'env', keys: ['API_KEY'] });
+
+    expect(backend).toBeInstanceOf(EnvSecretBackend);
+  });
+
+  it('reads from the process environment rather than any external provider', async () => {
+    const previous = process.env.HARNESS_TEST_SECRET;
+    process.env.HARNESS_TEST_SECRET = 'from-the-environment';
+    try {
+      const backend = createSecretBackend({ backend: 'env', keys: ['HARNESS_TEST_SECRET'] });
+
+      const result = await backend.resolveSecrets(['HARNESS_TEST_SECRET']);
+
+      expect(result).toEqual({ ok: true, value: { HARNESS_TEST_SECRET: 'from-the-environment' } });
+    } finally {
+      if (previous === undefined) delete process.env.HARNESS_TEST_SECRET;
+      else process.env.HARNESS_TEST_SECRET = previous;
+    }
+  });
+
+  it('ignores provider credentials that belong to a backend it was not asked for', async () => {
+    // A config carrying leftover Vault/1Password fields must not change which
+    // backend is selected — the switch keys off `backend` and nothing else.
+    // The key list is deliberately non-empty: either provider backend would
+    // spawn its CLI to resolve it, so an empty spawn log rules both of them out.
+    const backend = createSecretBackend({
+      backend: 'env',
+      keys: ['API_KEY'],
+      vaultAddr: 'https://vault.example.com',
+      opVault: 'Engineering',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()).toEqual([]);
+  });
+});
+
+describe('createSecretBackend — onepassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubTransport('resolved\n');
+  });
+
+  it('selects the 1Password backend', () => {
+    const backend = createSecretBackend({ backend: 'onepassword', keys: ['API_KEY'] });
+
+    expect(backend).toBeInstanceOf(OnePasswordSecretBackend);
+  });
+
+  it('reads from the 1Password vault the config named', async () => {
+    const backend = createSecretBackend({
+      backend: 'onepassword',
+      keys: ['API_KEY'],
+      opVault: 'Engineering',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()).toEqual([
+      { command: 'op', args: ['read', 'op://Engineering/API_KEY/password'], env: {} },
+    ]);
+  });
+
+  it('falls back to the "Private" vault when the config names none', async () => {
+    // The whole point of this assertion is the literal vault name: a changed
+    // default reads a different set of real secrets without failing anything.
+    const backend = createSecretBackend({ backend: 'onepassword', keys: ['API_KEY'] });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual(['read', 'op://Private/API_KEY/password']);
+  });
+});
+
+describe('createSecretBackend — vault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubTransport(VAULT_PAYLOAD);
+  });
+
+  it('selects the HashiCorp Vault backend', () => {
+    const backend = createSecretBackend({ backend: 'vault', keys: ['API_KEY'] });
+
+    expect(backend).toBeInstanceOf(VaultSecretBackend);
+  });
+
+  it('reads the secret path the config named', async () => {
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: 'https://vault.example.com',
+      vaultPath: 'secret/data/myapp',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual(['kv', 'get', '-format=json', 'secret/data/myapp']);
+  });
+
+  it('talks to the Vault server the config named', async () => {
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: 'https://vault.example.com',
+      vaultPath: 'secret/data/myapp',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.env.VAULT_ADDR).toBe('https://vault.example.com');
+  });
+
+  it('falls back to the loopback dev server when no address is configured', async () => {
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultPath: 'secret/data/myapp',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.env.VAULT_ADDR).toBe('http://127.0.0.1:8200');
+  });
+
+  it('falls back to the "secret/data/harness" path when none is configured', async () => {
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: 'https://vault.example.com',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual([
+      'kv',
+      'get',
+      '-format=json',
+      'secret/data/harness',
+    ]);
+  });
+});
+
+describe('createSecretBackend — an unrecognised backend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refuses the config, naming the backend it did not recognise', () => {
+    // Reachable from JSON config and `any`-typed boundaries even though the
+    // union type forbids it, which is exactly why the switch is exhaustive.
+    const config = { backend: 'hsm', keys: ['API_KEY'] } as unknown as SecretConfig;
+
+    expect(() => createSecretBackend(config)).toThrow(/^Unsupported secret backend: hsm$/);
+  });
+
+  it('refuses an empty backend name instead of falling back to a default', () => {
+    // A falsy backend name is exactly what an `if (!config.backend) return env`
+    // fallback would swallow: secrets would resolve from the wrong place and
+    // nothing above would look wrong. Matching the message proves the exhaustive
+    // branch is what rejected it, not some incidental TypeError.
+    const config = { backend: '', keys: ['API_KEY'] } as unknown as SecretConfig;
+
+    expect(() => createSecretBackend(config)).toThrow(/^Unsupported secret backend:/);
+  });
+});


### PR DESCRIPTION
Two exported functions had **zero test references anywhere in the repo**. Both are the kind of code whose failures are silent rather than loud, which is what made them worth covering first.

## What is covered

### `createSecretBackend` — `packages/orchestrator/src/agent/secrets/index.ts`

The three backends each already had their own suite. What had none is the switch that picks between them, and — the dangerous half — the credential **defaults** it substitutes when the caller omits a field. A wrong default does not throw: it reads real secrets from the wrong 1Password vault, or points a production run at a developer's loopback Vault, and every layer above reports success.

So each default is asserted where it is actually observable — the `op://…` reference and the `VAULT_ADDR`/path the selected backend spawns its CLI with — rather than by `instanceof` alone, which would prove a constructor ran and keep passing if `'Private'` silently became `'Shared'`.

- `env` → `EnvSecretBackend`, resolving from `process.env` and spawning nothing (asserted with a non-empty key list, so a wrongly-selected 1Password *or* Vault backend would show up in the spawn log).
- `onepassword` → reads `op://<opVault>/<key>/password`, defaulting to the literal `Private` vault.
- `vault` → reads the configured path with the configured `VAULT_ADDR`, defaulting to `http://127.0.0.1:8200` and `secret/data/harness`.
- An unrecognised backend name is refused by the exhaustive `default:` branch, message and all — including the empty-string case a `if (!config.backend)` fallback would swallow.

### `census` — `packages/core/src/metrics/denominate.ts`

Its siblings (`denominate`, `unknownPopulation`, `describePopulation`, `MetricContractError`) were covered; `census` itself was line 160, the one uncovered line in the module. The three sizes it has to keep apart are asserted directly:

- `N > 0` → `measured`, `numerator === denominator === N`, `value === 1` (complete by construction, never a partial ratio).
- `0` → `abstained`, `value === null`, and it renders as the abstention placeholder rather than a figure — the `0 of 0 reported as fully covered` bug the module's own docs call the cheapest to catch.
- `null` → `unknown` with a null denominator, so a failed fetch stays distinguishable from an empty population.
- The population contract is inherited, not bypassed: a missing/blank definition throws `MetricContractError` with `violation: 'missing-population'`.

## Coverage delta

Measured with `vitest run --coverage.enabled --coverage.include='…'` over the two suites, before and after.

| Target file | Metric | Before | After |
| --- | --- | --- | --- |
| `packages/orchestrator/src/agent/secrets/index.ts` | statements | **0%** | **100%** |
| | branches | **0%** | **100%** |
| | functions | **0%** | **100%** |
| | lines | **0%** (uncovered 11–23) | **100%** |
| `packages/core/src/metrics/denominate.ts` | statements | 98.27% | **100%** |
| | branches | 94% | **98%** |
| | functions | 92.3% | **100%** |
| | lines | 98.11% (uncovered 160) | **100%** |

Suite-level: orchestrator `tests/agent/secrets/` 16 → 29 tests; core `tests/metrics/` 53 → 71 tests. All green.

## How the tests were verified as load-bearing

Every assertion was checked to be discriminating: each expectation was mutated to a wrong value and the test observed to fail for the right reason, then restored. All 13 orchestrator tests and all 18 census tests fail under mutation — none is a green tautology. **No source file was modified at any point**, including during that check.

The suites were then critiqued with `harness test-craft` (8 rubrics × 33 tests), which returned 6 findings; all 6 were applied:

- dropped an assertion on `backend.name` that `env.test.ts` already makes verbatim (TEST-R006);
- strengthened the "no external provider is contacted" test, whose empty key list could not distinguish env from a wrongly-selected 1Password backend (TEST-R002);
- split the configured-Vault test so a failure names which of path/address broke (TEST-R005);
- replaced a `toThrow(Error)` that accepted any error at all with a match on the exhaustive branch's message (TEST-R002);
- deleted two census assertions strictly implied by neighbouring exact-value assertions (TEST-R006 ×2).

## Assumptions made

- **Characterized current behavior as-is.** Every default is asserted at the value the code produces today (`Private`, `http://127.0.0.1:8200`, `secret/data/harness`). These are pinning tests: they do not claim the defaults are the right ones, only that changing one is now a visible, deliberate act rather than a silent one.
- **Constructor options are asserted through the spawned command, not private fields.** `OnePasswordSecretBackend.vault` and `VaultSecretBackend.addr/path` are private, so the transport (`execFile` argv and child env) is the observable surface. `node:child_process` is stubbed the same way the three existing sibling suites stub it.
- **`instanceof` assertions are kept alongside the transport ones**, because "returns a `VaultSecretBackend`" is part of the stated contract of the factory even though the transport assertions subsume it.
- **The note wording for a census is asserted literally** (`'12 of 12 …'`), matching the convention already used in the neighbouring `denominate.test.ts`. It is mild coupling to prose, accepted for consistency with the existing suite.
- **Only the two named contracts are covered.** The census suite deliberately does not re-test `denominate`, `unknownPopulation`, or `describePopulation`, which are covered next door.

## Parked (not fixed here — no source was touched)

`createSecretBackend` defaults with `??`, which only substitutes on `null`/`undefined`. An **empty-string** `opVault` therefore produces the reference `op:///<key>/password` rather than falling back to `Private`; empty-string `vaultAddr`/`vaultPath` behave the same way. Whether that is a defect depends on whether an empty string is reachable from config parsing. No test was written for it, deliberately: characterizing it would cement behavior that may be unintended. Flagged for a follow-up decision.

Tests only — no source changes, no changeset required (`check-changesets.mjs` skips `/tests/`). The two `_module.md` comprehension shards in the diff were regenerated by the repo's pre-commit hook.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy