### PR TITLE
test(cli): cover the copy/test/security/naming/spec craft command layer

### DIFF
--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '4fd8cee931904f68676859d2876dfa148c3e9524e309bde8e640c07060501124'
+sourceHash: 'e783db85edc7ef07eacb7cb5365e40e9962783eacf959ab039b5503b48ebfe26'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -30,6 +30,8 @@ members:
     'cleanup-sessions.test.ts',
     'cleanup.test.ts',
     'compound-scan-candidates.test.ts',
+    'copy-craft-command.test.ts',
+    'craft-command-harness.ts',
     'create-skill.test.ts',
     'cross-check.test.ts',
     'dashboard.test.ts',
@@ -70,6 +72,7 @@ members:
     'migrate.test.ts',
     'models-probe.test.ts',
     'models.test.ts',
+    'naming-craft-command.test.ts',
     'outcome-eval-ci.test.ts',
     'perf.test.ts',
     'persona-list.test.ts',
@@ -88,6 +91,7 @@ members:
     'rollback.test.ts',
     'scan-config.test.ts',
     'search.test.ts',
+    'security-craft-command.test.ts',
     'setup-mcp.picker-message.test.ts',
     'setup-mcp.test.ts',
     'setup.test.ts',
@@ -103,6 +107,7 @@ members:
     'skill-validate.test.ts',
     'skill.test.ts',
     'snapshot.test.ts',
+    'spec-craft-command.test.ts',
     'stale-constraints.test.ts',
     'state-show.test.ts',
     'state-streams.test.ts',
@@ -114,6 +119,7 @@ members:
     'telemetry-synthesize.test.ts',
     'telemetry-wizard.test.ts',
     'telemetry.test.ts',
+    'test-craft-command.test.ts',
     'traceability.test.ts',
     'uninstall-constraints.test.ts',
     'uninstall.test.ts',
@@ -137,7 +143,9 @@ members:
 ## Interface Contract
 
 ```ts
-
+export ProcessExitCalled
+export llmCalls
+export runCraftCommand
 ```
 
 ## Dependency Slice
@@ -163,6 +171,7 @@ import { createCheckVocabularyCommand, runCheckVocabulary } from '../../src/comm
 import { createCleanupCommand, runCleanup } from '../../src/commands/cleanup'
 import { runCleanupAll, runCleanupSessions } from '../../src/commands/cleanup-sessions'
 import { runCompoundScanCandidatesCommand } from '../../src/commands/compound/scan-candidates'
+import from '../../src/commands/copy-craft.js'
 import { createCreateSkillCommand, generateSkillFiles } from '../../src/commands/create-skill'
 import { createCrossCheckCommand } from '../../src/commands/cross-check'
 import { createDashboardCommand } from '../../src/commands/dashboard'
@@ -206,6 +215,7 @@ import { extractNpmPackages, parseNpmSpec, runMcpGuardCheck } from '../../src/co
 import { detectLegacyArtifacts, runMigrate } from '../../src/commands/migrate'
 import { runMigrateBackends } from '../../src/commands/migrate-backends'
 import { refreshExitCode, runModelsApprove, runModelsProbe, runModelsProposals, runModelsRefresh, runModelsReject } from '../../src/commands/models'
+import from '../../src/commands/naming-craft.js'
 import { OutcomeEvaluatorLike, buildOutcomeBody, deriveExitCode, emitOutcomeEvalCi, resolveSpecPath, runOutcomeEvalCi } from '../../src/commands/outcome-eval-ci'
 import { createPerfCommand } from '../../src/commands/perf'
 import { createPersonaCommand } from '../../src/commands/persona/index'
@@ -221,6 +231,7 @@ import { createLocalInvoke } from '../../src/commands/review-ci-local-adapter'
 import { referencesTargetPr, runRollbackEvaluate, runRollbackSweepCommand, summarizeSweepReport } from '../../src/commands/rollback'
 import { runScanConfig } from '../../src/commands/scan-config'
 import { createSearchCommand } from '../../src/commands/search'
+import from '../../src/commands/security-craft.js'
 import { configureTier0Integrations, runSetup } from '../../src/commands/setup'
 import { ALL_MCP_TOOLS, CURSOR_CURATED_TOOLS, createSetupMcpCommand, runCursorToolPicker, setupMcp } from '../../src/commands/setup-mcp'
 import { createShareCommand } from '../../src/commands/share'
@@ -235,6 +246,7 @@ import { createSearchCommand, runSearch } from '../../src/commands/skill/search'
 import { createUpdateCommand } from '../../src/commands/skill/update'
 import { createValidateCommand, validateSkillEntry } from '../../src/commands/skill/validate'
 import { createSnapshotCommand, runSnapshotCapture } from '../../src/commands/snapshot'
+import from '../../src/commands/spec-craft.js'
 import { createStaleConstraintsCommand } from '../../src/commands/stale-constraints'
 import { createStateCommand } from '../../src/commands/state/index'
 import { createShowCommand } from '../../src/commands/state/show'
@@ -245,6 +257,7 @@ import { createTaintCommand } from '../../src/commands/taint'
 import { createTelemetryCommand } from '../../src/commands/telemetry'
 import { ensureTelemetryConfigured, isTelemetryConfigured, writeTelemetryConfig } from '../../src/commands/telemetry-wizard'
 import { createTelemetryCommand } from '../../src/commands/telemetry/index'
+import from '../../src/commands/test-craft.js'
 import { createTraceabilityCommand } from '../../src/commands/traceability'
 import { createUninstallCommand, runUninstall } from '../../src/commands/uninstall'
 import { runUninstallConstraints } from '../../src/commands/uninstall-constraints'
@@ -256,6 +269,7 @@ import { SCOPED_WALKERS, deriveChangedSurface, filterToDesignSurface } from '../
 import { createWaypointCommand } from '../../src/commands/waypoint'
 import { resolveConfig } from '../../src/config/loader'
 import { HarnessConfig } from '../../src/config/schema'
+import { CopyCraftInput, CopyCraftOutput } from '../../src/copy-craft/index.js'
 import { createProgram } from '../../src/index'
 import { readMcpConfig, writeMcpEntry, writeOpencodeMcpEntry } from '../../src/integrations/config'
 import { CATALOG_LAST_REVIEWED, INTEGRATION_REGISTRY } from '../../src/integrations/registry'
@@ -269,6 +283,7 @@ import { runDesignCraft } from '../../src/mcp/tools/design-craft'
 import { runDetectDrift } from '../../src/mcp/tools/detect-drift'
 import { handleGetImpact } from '../../src/mcp/tools/graph/index'
 import from '../../src/mcp/utils/graph-loader'
+import { NamingCraftInput, NamingCraftOutput } from '../../src/naming-craft/index.js'
 import { logger } from '../../src/output/logger'
 import { prompt } from '../../src/output/prompt'
 import { loadPersona } from '../../src/persona/loader'
@@ -281,15 +296,19 @@ import { cleanupTempDir, extractTarball, placeSkillContent, removeSkillContent }
 import { validateForPublish } from '../../src/registry/validator'
 import { ROLLBACK_EVENTS_FILE } from '../../src/rollback/breadcrumb'
 import { SweepSignalRule } from '../../src/rollback/sweep'
+import { SecurityCraftInput, SecurityCraftOutput } from '../../src/security-craft/index.js'
 import { HealthSnapshot, captureHealthSnapshot, isSnapshotFresh, loadCachedSnapshot } from '../../src/skill/health-snapshot'
 import { loadOrRebuildIndex } from '../../src/skill/index-builder'
 import { derivePackageJson } from '../../src/skill/package-json'
 import { recommend } from '../../src/skill/recommendation-engine'
 import { RecommendationResult } from '../../src/skill/recommendation-types'
+import { SpecCraftInput, SpecCraftOutput } from '../../src/spec-craft/index.js'
+import { TestCraftInput, TestCraftOutput } from '../../src/test-craft/index.js'
 import { CLIError, ExitCode } from '../../src/utils/errors'
 import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
+import { llmCalls, runCraftCommand } from './craft-command-harness.js'
 import * as clack from '@clack/prompts'
 import { CiReviewResult, DiffInfo, Err, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
 import from '@harness-engineering/graph'

--- a/packages/cli/tests/commands/copy-craft-command.test.ts
+++ b/packages/cli/tests/commands/copy-craft-command.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Behavior tests for the `harness copy-craft` command layer
+ * (packages/cli/src/commands/copy-craft.ts).
+ *
+ * Scope is the COMMAND, not the engine: option parsing, the input object
+ * handed to `runCopyCraft`, the two output modes, the rendered human report,
+ * and the exit-code contract. The engine itself is covered by
+ * tests/copy-craft/**; here it is mocked so the command's own behavior is the
+ * only thing under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { CopyCraftInput, CopyCraftOutput } from '../../src/copy-craft/index.js';
+import { runCraftCommand, llmCalls } from './craft-command-harness.js';
+
+const runCopyCraft = vi.fn();
+
+vi.mock('../../src/copy-craft/index.js', () => ({
+  runCopyCraft: (input: CopyCraftInput) => runCopyCraft(input),
+}));
+
+const { createCopyCraftCommand } = await import('../../src/commands/copy-craft.js');
+
+const PROJECT = '/fixtures/copy-craft-project';
+
+type CopyFinding = CopyCraftOutput['findings'][number];
+
+function finding(overrides: Partial<CopyFinding> = {}): CopyFinding {
+  return {
+    code: 'COPY-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: {
+      file: 'src/a.ts',
+      line: 12,
+      surface: 'error',
+      snippet: 'Error: something went wrong',
+    },
+    message: 'Name the failed operation instead of restating the exception.',
+    cite: { rubricId: 'COPY-R001', source: 'Nielsen, Error Message Guidelines' },
+    derived: { priority: 3 },
+    ...overrides,
+  } as CopyFinding;
+}
+
+function output(overrides: Partial<CopyCraftOutput> = {}): CopyCraftOutput {
+  const summary: CopyCraftOutput['summary'] = {
+    phaseRun: ['critique'],
+    mode: 'fast',
+    durationMs: 1234,
+    llmCalls: llmCalls(),
+    catalog: { rubricsApplied: ['COPY-R001', 'COPY-R002'], surfacesScanned: ['error', 'log'] },
+    counts: {
+      error: 2,
+      log: 1,
+      'cli-output': 0,
+      commit: 0,
+      'pr-description': 0,
+      comment: 0,
+    },
+    skippedSurfaces: [],
+    runId: 'run-copy-1',
+  };
+  return {
+    findings: [finding()],
+    summary,
+    ...overrides,
+  };
+}
+
+/** The input object the command handed to the engine on the most recent run. */
+function capturedInput(): CopyCraftInput {
+  expect(runCopyCraft).toHaveBeenCalledTimes(1);
+  return runCopyCraft.mock.calls[0]![0] as CopyCraftInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runCopyCraft.mockResolvedValue(output());
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('copy-craft command — option parsing', () => {
+  it('passes the resolved --cwd through as the engine input path', async () => {
+    await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(capturedInput().path).toBe(PROJECT);
+  });
+
+  it('falls back to the process working directory when --cwd is not given', async () => {
+    await runCraftCommand(createCopyCraftCommand());
+
+    expect(capturedInput().path).toBe(process.cwd());
+  });
+
+  it('parses --max-files into a number, not the raw string', async () => {
+    await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-files', '7'],
+    });
+
+    expect(capturedInput().maxFiles).toBe(7);
+  });
+
+  it('parses --max-items-per-file into a number', async () => {
+    await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-items-per-file', '3'],
+    });
+
+    expect(capturedInput().maxItemsPerFile).toBe(3);
+  });
+
+  it('parses --pr-limit into a number', async () => {
+    await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--pr-limit', '5'],
+    });
+
+    expect(capturedInput().prLimit).toBe(5);
+  });
+
+  it('collects repeated values for the variadic --files scope', async () => {
+    await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--files', 'src/a.ts', 'src/b.ts'],
+    });
+
+    expect(capturedInput().files).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('forwards --surfaces as the surface restriction list', async () => {
+    await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--surfaces', 'error', 'commit'],
+    });
+
+    expect(capturedInput().surfaces).toEqual(['error', 'commit']);
+  });
+
+  it('forwards --commits-since verbatim as a string window', async () => {
+    await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--commits-since', '3 weeks ago'],
+    });
+
+    expect(capturedInput().commitsSince).toBe('3 weeks ago');
+  });
+
+  it('omits unsupplied flags from the input entirely rather than setting them undefined', async () => {
+    // The command uses conditional assignment specifically so the engine sees
+    // an absent key and applies its own default. A key present with value
+    // `undefined` would defeat that, so absence — not value — is the contract.
+    await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(Object.keys(capturedInput())).toEqual(['path']);
+  });
+});
+
+describe('copy-craft command — JSON output mode', () => {
+  it('emits the engine result as parseable JSON', async () => {
+    const result = output();
+    runCopyCraft.mockResolvedValue(result);
+
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual(result);
+  });
+
+  it('suppresses the human report when --json is set', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('Summary:');
+    expect(run.stdoutText).not.toContain('Diagnostic:');
+  });
+
+  it('pretty-prints the report so a human can read the piped JSON', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout[1]).toBe('  "findings": [');
+  });
+});
+
+describe('copy-craft command — human report', () => {
+  it('groups findings under a per-surface heading', async () => {
+    runCopyCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding({ target: { file: 'src/a.ts', line: 1, surface: 'error', snippet: 'boom' } }),
+          finding({ target: { file: 'src/b.ts', line: 2, surface: 'log', snippet: 'tick' } }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('[error]');
+    expect(run.stdout).toContain('[log]');
+  });
+
+  it('renders a finding as code, axes, and file:line', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('  COPY-R001 [polish/medium/high] src/a.ts:12');
+  });
+
+  it('omits the line suffix when the finding carries no line number', async () => {
+    runCopyCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding({ target: { file: 'HEAD~1', surface: 'commit', snippet: 'fix stuff' } }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('  COPY-R001 [polish/medium/high] HEAD~1');
+  });
+
+  it('prints the critiqued snippet in quotes beneath the finding', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('    "Error: something went wrong"');
+  });
+
+  it('leaves a snippet of exactly 80 characters untruncated', async () => {
+    const snippet = 'x'.repeat(80);
+    runCopyCraft.mockResolvedValue(
+      output({
+        findings: [finding({ target: { file: 'src/a.ts', line: 1, surface: 'error', snippet } })],
+      })
+    );
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(`    "${snippet}"`);
+  });
+
+  it('truncates a snippet of 81 characters to 80 plus an ellipsis', async () => {
+    const snippet = 'x'.repeat(81);
+    runCopyCraft.mockResolvedValue(
+      output({
+        findings: [finding({ target: { file: 'src/a.ts', line: 1, surface: 'error', snippet } })],
+      })
+    );
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(`    "${'x'.repeat(80)}…"`);
+  });
+
+  it('prints the finding message', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      '    Name the failed operation instead of restating the exception.'
+    );
+  });
+
+  it('withholds the rubric citation outside verbose mode', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('source:');
+  });
+
+  it('adds the rubric citation under --verbose', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--verbose', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    source: Nielsen, Error Message Guidelines');
+  });
+
+  it('summarises finding count, per-surface tallies, rubrics, calls, cost, and duration', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'Summary: 1 findings across error=2, log=1 (2 rubrics, 4 LLM calls, $0.1234, 1234ms)'
+    );
+  });
+
+  it('says "no items" in the summary when every surface tallied zero', async () => {
+    const empty = output();
+    empty.summary.counts = {
+      error: 0,
+      log: 0,
+      'cli-output': 0,
+      commit: 0,
+      'pr-description': 0,
+      comment: 0,
+    };
+    runCopyCraft.mockResolvedValue(empty);
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).toContain('Summary: 1 findings across no items ');
+  });
+
+  it('reports the analyzed item tally in the diagnostic line', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('Diagnostic: provider=mock; analyzed 3 copy items, skipped 0');
+  });
+
+  it('explains an empty extraction as unsupported surfaces when nothing was skipped', async () => {
+    const empty = output({ findings: [] });
+    empty.summary.counts = {
+      error: 0,
+      log: 0,
+      'cli-output': 0,
+      commit: 0,
+      'pr-description': 0,
+      comment: 0,
+    };
+    runCopyCraft.mockResolvedValue(empty);
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; 0 analyzable copy items (no items on supported source (.ts, .tsx, .js, .jsx) or git surfaces)'
+    );
+  });
+
+  it('attributes an empty extraction to skipped surfaces when some were skipped', async () => {
+    const empty = output({ findings: [] });
+    empty.summary.counts = {
+      error: 0,
+      log: 0,
+      'cli-output': 0,
+      commit: 0,
+      'pr-description': 0,
+      comment: 0,
+    };
+    empty.summary.skippedSurfaces = [{ surface: 'commit', reason: 'git not available' }];
+    runCopyCraft.mockResolvedValue(empty);
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; 0 analyzable copy items (no items extracted; some surfaces skipped (see below))'
+    );
+  });
+
+  it('lists each skipped surface with its reason', async () => {
+    const skipped = output();
+    skipped.summary.skippedSurfaces = [
+      { surface: 'commit', reason: 'git not available' },
+      { surface: 'pr-description', reason: 'gh not authenticated' },
+    ];
+    runCopyCraft.mockResolvedValue(skipped);
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('Skipped surfaces:');
+    expect(run.stdout).toContain('  - commit: git not available');
+    expect(run.stdout).toContain('  - pr-description: gh not authenticated');
+  });
+
+  it('names the resolved LLM provider in the diagnostic rather than a fixed label', async () => {
+    // The diagnostic exists so a silently-defaulted backend is visible. If the
+    // command hardcoded the provider string, this would still read "mock".
+    vi.stubEnv('HARNESS_CRAFT_LLM', 'in-session');
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).toContain('Diagnostic: provider=in-session;');
+  });
+
+  it('still prints the human report under --quiet', async () => {
+    // --quiet resolves to a non-JSON mode, so the report is rendered; only the
+    // verbose-only rubric citation is withheld.
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--quiet', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('  COPY-R001 [polish/medium/high] src/a.ts:12');
+    expect(run.stdoutText).not.toContain('source:');
+  });
+
+  it('omits the skipped-surfaces block when no surface was skipped', async () => {
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('Skipped surfaces:');
+  });
+
+  it('states that there are no findings rather than printing an empty list', async () => {
+    runCopyCraft.mockResolvedValue(output({ findings: [] }));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('No copy findings.');
+  });
+});
+
+describe('copy-craft command — exit codes', () => {
+  it('exits VALIDATION_FAILED when any finding is foundational', async () => {
+    runCopyCraft.mockResolvedValue(
+      output({ findings: [finding({ tier: 'polish' }), finding({ tier: 'foundational' })] })
+    );
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(1);
+  });
+
+  it('exits SUCCESS when findings exist but none are foundational', async () => {
+    runCopyCraft.mockResolvedValue(
+      output({ findings: [finding({ tier: 'polish' }), finding({ tier: 'aspirational' })] })
+    );
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(0);
+  });
+
+  it('exits SUCCESS on a clean run with no findings at all', async () => {
+    runCopyCraft.mockResolvedValue(output({ findings: [] }));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(0);
+  });
+});
+
+describe('copy-craft command — engine failure', () => {
+  it('exits ERROR when the engine throws', async () => {
+    runCopyCraft.mockRejectedValue(new Error('provider unreachable'));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(2);
+  });
+
+  it('reports the failure on stderr in human mode', async () => {
+    runCopyCraft.mockRejectedValue(new Error('provider unreachable'));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stderrText).toContain('copy-craft failed: provider unreachable');
+  });
+
+  it('keeps stdout free of a partial report when the engine throws in human mode', async () => {
+    runCopyCraft.mockRejectedValue(new Error('provider unreachable'));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).toBe('');
+  });
+
+  it('emits a machine-readable error envelope on stdout in JSON mode', async () => {
+    runCopyCraft.mockRejectedValue(new Error('provider unreachable'));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'provider unreachable' });
+  });
+
+  it('keeps the error envelope on a single line, unlike the pretty-printed report', async () => {
+    runCopyCraft.mockRejectedValue(new Error('provider unreachable'));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toEqual(['{"error":"provider unreachable"}']);
+  });
+
+  it('does not also write to stderr in JSON mode', async () => {
+    runCopyCraft.mockRejectedValue(new Error('provider unreachable'));
+
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stderrText).toBe('');
+  });
+
+  it('stringifies a non-Error rejection rather than reporting "undefined"', async () => {
+    runCopyCraft.mockRejectedValue('plain string failure');
+
+    const run = await runCraftCommand(createCopyCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'plain string failure' });
+  });
+});

--- a/packages/cli/tests/commands/craft-command-harness.ts
+++ b/packages/cli/tests/commands/craft-command-harness.ts
@@ -1,0 +1,144 @@
+/**
+ * Local test harness for the craft CLI command layer
+ * (`packages/cli/src/commands/{copy,test,security,naming,spec}-craft.ts`).
+ *
+ * Every craft command shares the same shell: a Commander subcommand whose
+ * action reads `optsWithGlobals()`, resolves an output mode, delegates to an
+ * engine, renders, and terminates the process with a tier-derived exit code.
+ * Driving that shell needs three things the tests should not each re-derive:
+ *
+ *   1. A parent `Command` carrying the global flags (`--json`, `--verbose`,
+ *      `--quiet`, `--cwd`) so `optsWithGlobals()` resolves the way it does
+ *      under the real `harness` program.
+ *   2. `process.exit` turned into a throw, so the exit code becomes an
+ *      assertable value instead of killing the vitest worker.
+ *   3. Captured stdout/stderr, ANSI-stripped, so assertions read the text a
+ *      user would actually see.
+ *
+ * Deliberately local to tests/commands/ — it encodes the craft command shell,
+ * not a repo-wide convention, and must not be promoted into a shared helper
+ * without a second consumer family asking for it.
+ */
+
+import { Command } from 'commander';
+import { vi } from 'vitest';
+
+/** Thrown in place of terminating the worker when the command calls `process.exit`. */
+export class ProcessExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+    this.name = 'ProcessExitCalled';
+  }
+}
+
+export interface CraftRunResult {
+  /**
+   * The code passed to `process.exit`, or `undefined` if the action returned
+   * without exiting. Every craft command exits on every path, so `undefined`
+   * is itself a contract violation worth asserting against.
+   */
+  exitCode: number | undefined;
+  /** ANSI-stripped `console.log` lines, in emission order, newlines split out. */
+  stdout: string[];
+  /** ANSI-stripped `console.error` lines (where `logger.error` writes). */
+  stderr: string[];
+  /** stdout re-joined with newlines — convenient for whole-report assertions. */
+  stdoutText: string;
+  /** stderr re-joined with newlines. */
+  stderrText: string;
+}
+
+// eslint-disable-next-line no-control-regex -- stripping ANSI SGR sequences requires the ESC literal
+const ANSI = /\[[0-9;]*m/g;
+
+function renderConsoleArgs(args: unknown[]): string {
+  return args
+    .map((a) => (typeof a === 'string' ? a : String(a)))
+    .join(' ')
+    .replace(ANSI, '');
+}
+
+export interface RunCraftCommandOptions {
+  /** Global flags placed before the subcommand name, e.g. `['--json']`. */
+  globalArgs?: string[];
+  /** Subcommand arguments, e.g. `['--max-files', '7']`. */
+  args?: string[];
+}
+
+/**
+ * Run a craft subcommand end-to-end through Commander and report what a user
+ * would observe: the exit code, stdout, and stderr.
+ *
+ * The subcommand is mounted under a parent program that declares the real
+ * global flags, so `cmd.optsWithGlobals()` inside the action sees them exactly
+ * as it does in production.
+ */
+export async function runCraftCommand(
+  command: Command,
+  options: RunCraftCommandOptions = {}
+): Promise<CraftRunResult> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    stdout.push(...renderConsoleArgs(args).split('\n'));
+  });
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    stderr.push(...renderConsoleArgs(args).split('\n'));
+  });
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ProcessExitCalled(code ?? 0);
+  }) as never);
+
+  const program = new Command('harness')
+    .option('--json', 'Output as JSON')
+    .option('--quiet', 'Minimal output')
+    .option('--verbose', 'Verbose output')
+    .option('--cwd <path>', 'Working directory')
+    .exitOverride();
+  program.addCommand(command);
+
+  const argv = [...(options.globalArgs ?? []), command.name(), ...(options.args ?? [])];
+
+  let exitCode: number | undefined;
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } catch (err) {
+    if (err instanceof ProcessExitCalled) {
+      exitCode = err.code;
+    } else {
+      throw err;
+    }
+  } finally {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    stdoutText: stdout.join('\n'),
+    stderrText: stderr.join('\n'),
+  };
+}
+
+/**
+ * Shared `llmCalls` block. Every craft summary carries the same shape and the
+ * printers all render `count` and `costUsd.toFixed(4)`.
+ */
+export function llmCalls(overrides: Partial<{ count: number; costUsd: number }> = {}): {
+  provider: string;
+  model: string;
+  count: number;
+  costUsd: number;
+} {
+  return {
+    provider: 'mock',
+    model: 'mock-model',
+    count: 4,
+    costUsd: 0.1234,
+    ...overrides,
+  };
+}

--- a/packages/cli/tests/commands/naming-craft-command.test.ts
+++ b/packages/cli/tests/commands/naming-craft-command.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Behavior tests for the `harness naming-craft` command layer
+ * (packages/cli/src/commands/naming-craft.ts).
+ *
+ * Scope is the COMMAND: option parsing, the input handed to `runNamingCraft`,
+ * the JSON-vs-human branch, the convention line, the scan diagnostic, and the
+ * exit-code contract. The engine is mocked; tests/naming-craft/** covers it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NamingCraftInput, NamingCraftOutput } from '../../src/naming-craft/index.js';
+import { runCraftCommand, llmCalls } from './craft-command-harness.js';
+
+const runNamingCraft = vi.fn();
+
+vi.mock('../../src/naming-craft/index.js', () => ({
+  runNamingCraft: (input: NamingCraftInput) => runNamingCraft(input),
+}));
+
+const { createNamingCraftCommand } = await import('../../src/commands/naming-craft.js');
+
+const PROJECT = '/fixtures/naming-craft-project';
+
+type NamingFinding = NamingCraftOutput['findings'][number];
+
+function finding(overrides: Partial<NamingFinding> = {}): NamingFinding {
+  return {
+    code: 'NAME-R002',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: { file: 'src/cart.ts', line: 31, identifier: 'd', kind: 'variable' },
+    message: 'A single letter hides what the value is; name the quantity.',
+    cite: { rubricId: 'NAME-R002', source: 'Martin, Clean Code ch.2' },
+    derived: { priority: 5 },
+    ...overrides,
+  } as NamingFinding;
+}
+
+function output(overrides: Partial<NamingCraftOutput> = {}): NamingCraftOutput {
+  const summary: NamingCraftOutput['summary'] = {
+    phaseRun: ['critique'],
+    mode: 'fast',
+    durationMs: 640,
+    llmCalls: llmCalls({ count: 9, costUsd: 0.02 }),
+    catalog: { rubricsApplied: ['NAME-R001', 'NAME-R002'] },
+    convention: {
+      variables: 'camelCase',
+      functions: 'camelCase',
+      types: 'PascalCase',
+      files: 'kebab-case',
+    },
+    filesScanned: 18,
+    runId: 'run-naming-1',
+  };
+  return { findings: [finding()], summary, ...overrides };
+}
+
+function capturedInput(): NamingCraftInput {
+  expect(runNamingCraft).toHaveBeenCalledTimes(1);
+  return runNamingCraft.mock.calls[0]![0] as NamingCraftInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runNamingCraft.mockResolvedValue(output());
+});
+
+describe('naming-craft command — option parsing', () => {
+  it('passes the resolved --cwd through as the engine input path', async () => {
+    await runCraftCommand(createNamingCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(capturedInput().path).toBe(PROJECT);
+  });
+
+  it('falls back to the process working directory when --cwd is not given', async () => {
+    await runCraftCommand(createNamingCraftCommand());
+
+    expect(capturedInput().path).toBe(process.cwd());
+  });
+
+  it('parses --max-files into a number, not the raw string', async () => {
+    await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-files', '7'],
+    });
+
+    expect(capturedInput().maxFiles).toBe(7);
+  });
+
+  it('parses --max-identifiers-per-file into a number', async () => {
+    await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-identifiers-per-file', '4'],
+    });
+
+    expect(capturedInput().maxIdentifiersPerFile).toBe(4);
+  });
+
+  it('collects repeated values for the variadic --files scope', async () => {
+    await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--files', 'src/a.ts', 'src/b.ts'],
+    });
+
+    expect(capturedInput().files).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('forwards --kinds as the identifier-kind restriction list', async () => {
+    await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--kinds', 'variable', 'type'],
+    });
+
+    expect(capturedInput().kinds).toEqual(['variable', 'type']);
+  });
+
+  it('omits unsupplied flags from the input entirely rather than setting them undefined', async () => {
+    await runCraftCommand(createNamingCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(Object.keys(capturedInput())).toEqual(['path']);
+  });
+});
+
+describe('naming-craft command — JSON output mode', () => {
+  it('emits the engine result as parseable JSON', async () => {
+    const result = output();
+    runNamingCraft.mockResolvedValue(result);
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual(result);
+  });
+
+  it('suppresses the human report when --json is set', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('Convention:');
+  });
+});
+
+describe('naming-craft command — human report', () => {
+  it('groups findings under the file that produced them', async () => {
+    runNamingCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding(),
+          finding({
+            target: { file: 'src/order.ts', line: 3, identifier: 'tmp2', kind: 'function' },
+          }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('src/cart.ts');
+    expect(run.stdout).toContain('src/order.ts');
+  });
+
+  it('renders a finding as code, axes, kind, identifier, and line', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('  NAME-R002 [polish/medium/high] variable d:31');
+  });
+
+  it('omits the line suffix for a file-kind finding that carries no line', async () => {
+    runNamingCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding({ target: { file: 'src/Utils.ts', identifier: 'Utils.ts', kind: 'file' } }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('  NAME-R002 [polish/medium/high] file Utils.ts');
+  });
+
+  it('prints the finding message', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    A single letter hides what the value is; name the quantity.');
+  });
+
+  it('adds the rubric citation under --verbose', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--verbose', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    source: Martin, Clean Code ch.2');
+  });
+
+  it('withholds the rubric citation outside verbose mode', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('source:');
+  });
+
+  it('summarises findings, rubrics, calls, cost, and duration', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Summary: 1 findings (rubrics: 2, LLM calls: 9, cost: $0.0200, 640ms)'
+    );
+  });
+
+  it('reports the detected convention per identifier kind', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Convention: vars=camelCase, funcs=camelCase, types=PascalCase, files=kebab-case'
+    );
+  });
+
+  it('renders an undetected convention as "?" rather than as null', async () => {
+    const undetected = output();
+    undetected.summary.convention = {
+      variables: null,
+      functions: null,
+      types: null,
+      files: null,
+    };
+    runNamingCraft.mockResolvedValue(undetected);
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('Convention: vars=?, funcs=?, types=?, files=?');
+  });
+
+  it('states that there are no findings rather than printing an empty list', async () => {
+    runNamingCraft.mockResolvedValue(output({ findings: [] }));
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('No naming findings.');
+  });
+});
+
+describe('naming-craft command — scan diagnostic', () => {
+  it('reports the scanned file tally', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('Diagnostic: provider=mock; analyzed 18 files, skipped 0');
+  });
+
+  it('explains a zero-file scan as an unsupported-language project', async () => {
+    // Without this, "0 findings" on a Python repo would read as a clean bill of health.
+    const nothing = output({ findings: [] });
+    nothing.summary.filesScanned = 0;
+    runNamingCraft.mockResolvedValue(nothing);
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; 0 analyzable files ' +
+        '(no source files for supported languages (.ts, .tsx, .js, .jsx))'
+    );
+  });
+});
+
+describe('naming-craft command — exit codes', () => {
+  it('exits VALIDATION_FAILED when any finding is foundational', async () => {
+    runNamingCraft.mockResolvedValue(
+      output({ findings: [finding({ tier: 'polish' }), finding({ tier: 'foundational' })] })
+    );
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.exitCode).toBe(1);
+  });
+
+  it('exits SUCCESS when findings exist but none are foundational', async () => {
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.exitCode).toBe(0);
+  });
+});
+
+describe('naming-craft command — engine failure', () => {
+  it('exits ERROR when the engine throws', async () => {
+    runNamingCraft.mockRejectedValue(new Error('identifier extraction failed'));
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.exitCode).toBe(2);
+  });
+
+  it('reports the failure on stderr in human mode', async () => {
+    runNamingCraft.mockRejectedValue(new Error('identifier extraction failed'));
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stderrText).toContain('naming-craft failed: identifier extraction failed');
+  });
+
+  it('emits a machine-readable error envelope on stdout in JSON mode', async () => {
+    runNamingCraft.mockRejectedValue(new Error('identifier extraction failed'));
+
+    const run = await runCraftCommand(createNamingCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'identifier extraction failed' });
+  });
+});

--- a/packages/cli/tests/commands/security-craft-command.test.ts
+++ b/packages/cli/tests/commands/security-craft-command.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Behavior tests for the `harness security-craft` command layer
+ * (packages/cli/src/commands/security-craft.ts).
+ *
+ * Scope is the COMMAND: option parsing, the input handed to
+ * `runSecurityCraft`, the JSON-vs-human branch, the signal-aware scan
+ * diagnostic (which distinguishes "skipped, no signal" from "nothing
+ * analyzable"), and the exit-code contract. The engine is mocked;
+ * tests/security-craft/** covers it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SecurityCraftInput, SecurityCraftOutput } from '../../src/security-craft/index.js';
+import { runCraftCommand, llmCalls } from './craft-command-harness.js';
+
+const runSecurityCraft = vi.fn();
+
+vi.mock('../../src/security-craft/index.js', () => ({
+  runSecurityCraft: (input: SecurityCraftInput) => runSecurityCraft(input),
+}));
+
+const { createSecurityCraftCommand } = await import('../../src/commands/security-craft.js');
+
+const PROJECT = '/fixtures/security-craft-project';
+
+type SecurityFinding = SecurityCraftOutput['findings'][number];
+
+function finding(overrides: Partial<SecurityFinding> = {}): SecurityFinding {
+  return {
+    code: 'SEC-R003',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'large',
+    confidence: 'medium',
+    target: { file: 'src/api/run.ts', signal: 'child_process.exec', line: 88 },
+    message: 'Shell interpolation of a request-derived path is unguarded.',
+    cite: { rubricId: 'SEC-R003', source: 'OWASP ASVS 5.3' },
+    derived: { priority: 8 },
+    ...overrides,
+  } as SecurityFinding;
+}
+
+function counts(
+  overrides: Partial<SecurityCraftOutput['summary']['counts']> = {}
+): SecurityCraftOutput['summary']['counts'] {
+  return { filesScanned: 12, filesSkippedNoSignal: 30, signalsDetected: 19, ...overrides };
+}
+
+function output(overrides: Partial<SecurityCraftOutput> = {}): SecurityCraftOutput {
+  const summary: SecurityCraftOutput['summary'] = {
+    phaseRun: ['critique'],
+    mode: 'fast',
+    durationMs: 2500,
+    llmCalls: llmCalls({ count: 11, costUsd: 0.75 }),
+    catalog: { rubricsApplied: ['SEC-R001', 'SEC-R002', 'SEC-R003'] },
+    counts: counts(),
+    runId: 'run-sec-1',
+  };
+  return { findings: [finding()], summary, ...overrides };
+}
+
+function capturedInput(): SecurityCraftInput {
+  expect(runSecurityCraft).toHaveBeenCalledTimes(1);
+  return runSecurityCraft.mock.calls[0]![0] as SecurityCraftInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runSecurityCraft.mockResolvedValue(output());
+});
+
+describe('security-craft command — option parsing', () => {
+  it('passes the resolved --cwd through as the engine input path', async () => {
+    await runCraftCommand(createSecurityCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(capturedInput().path).toBe(PROJECT);
+  });
+
+  it('falls back to the process working directory when --cwd is not given', async () => {
+    await runCraftCommand(createSecurityCraftCommand());
+
+    expect(capturedInput().path).toBe(process.cwd());
+  });
+
+  it('parses --max-files into a number, not the raw string', async () => {
+    await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-files', '7'],
+    });
+
+    expect(capturedInput().maxFiles).toBe(7);
+  });
+
+  it('parses --max-signals-per-file into a number', async () => {
+    await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-signals-per-file', '2'],
+    });
+
+    expect(capturedInput().maxSignalsPerFile).toBe(2);
+  });
+
+  it('collects repeated values for the variadic --files scope', async () => {
+    await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--files', 'src/a.ts', 'src/b.ts'],
+    });
+
+    expect(capturedInput().files).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('collects repeated values for the variadic --packages scope', async () => {
+    await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--packages', 'cli', 'core'],
+    });
+
+    expect(capturedInput().packages).toEqual(['cli', 'core']);
+  });
+
+  it('omits unsupplied flags from the input entirely rather than setting them undefined', async () => {
+    await runCraftCommand(createSecurityCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(Object.keys(capturedInput())).toEqual(['path']);
+  });
+});
+
+describe('security-craft command — JSON output mode', () => {
+  it('emits the engine result as parseable JSON', async () => {
+    const result = output();
+    runSecurityCraft.mockResolvedValue(result);
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual(result);
+  });
+
+  it('suppresses the human report when --json is set', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('Diagnostic:');
+  });
+});
+
+describe('security-craft command — human report', () => {
+  it('groups findings under the file that produced them', async () => {
+    runSecurityCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding(),
+          finding({ target: { file: 'src/api/auth.ts', signal: 'jwt.verify', line: 4 } }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('src/api/run.ts');
+    expect(run.stdout).toContain('src/api/auth.ts');
+  });
+
+  it('renders a finding as code, axes, and signal:line', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('  SEC-R003 [polish/large/medium] child_process.exec:88');
+  });
+
+  it('prints the finding message', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    Shell interpolation of a request-derived path is unguarded.');
+  });
+
+  it('adds the rubric citation under --verbose', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--verbose', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    source: OWASP ASVS 5.3');
+  });
+
+  it('withholds the rubric citation outside verbose mode', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('source:');
+  });
+
+  it('summarises findings, files, skips, signals, rubrics, calls, cost, and duration', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Summary: 1 findings across 12 files (30 skipped, 19 signals, 3 rubrics, ' +
+        '11 LLM calls, $0.7500, 2500ms)'
+    );
+  });
+
+  it('states that there are no findings rather than printing an empty list', async () => {
+    runSecurityCraft.mockResolvedValue(output({ findings: [] }));
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('No security findings.');
+  });
+});
+
+describe('security-craft command — scan diagnostic', () => {
+  it('names "no security signal" as the reason files were skipped', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; analyzed 12 files, skipped 30 — no security signal'
+    );
+  });
+
+  it('drops the skip reason when nothing was skipped', async () => {
+    const nothingSkipped = output();
+    nothingSkipped.summary.counts = counts({ filesSkippedNoSignal: 0 });
+    runSecurityCraft.mockResolvedValue(nothingSkipped);
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('Diagnostic: provider=mock; analyzed 12 files, skipped 0');
+    expect(run.stdoutText).not.toContain('no security signal');
+  });
+
+  it('distinguishes an unsupported-language project from a clean one', async () => {
+    // Zero scanned AND zero skipped means no analyzable input existed at all —
+    // which must not read like "scanned everything, found nothing".
+    const nothingAnalyzable = output({ findings: [] });
+    nothingAnalyzable.summary.counts = counts({
+      filesScanned: 0,
+      filesSkippedNoSignal: 0,
+      signalsDetected: 0,
+    });
+    runSecurityCraft.mockResolvedValue(nothingAnalyzable);
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; 0 analyzable files ' +
+        '(no source files for supported languages (.ts, .tsx, .js, .jsx))'
+    );
+  });
+
+  it('still reports a real scan when every scanned file was skipped for lack of signal', async () => {
+    const allSkipped = output({ findings: [] });
+    allSkipped.summary.counts = counts({
+      filesScanned: 0,
+      filesSkippedNoSignal: 40,
+      signalsDetected: 0,
+    });
+    runSecurityCraft.mockResolvedValue(allSkipped);
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; analyzed 0 files, skipped 40 — no security signal'
+    );
+  });
+});
+
+describe('security-craft command — exit codes', () => {
+  it('exits VALIDATION_FAILED when any finding is foundational', async () => {
+    runSecurityCraft.mockResolvedValue(
+      output({ findings: [finding({ tier: 'aspirational' }), finding({ tier: 'foundational' })] })
+    );
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.exitCode).toBe(1);
+  });
+
+  it('exits SUCCESS when findings exist but none are foundational', async () => {
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.exitCode).toBe(0);
+  });
+});
+
+describe('security-craft command — engine failure', () => {
+  it('exits ERROR when the engine throws', async () => {
+    runSecurityCraft.mockRejectedValue(new Error('AST walk failed'));
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.exitCode).toBe(2);
+  });
+
+  it('reports the failure on stderr in human mode', async () => {
+    runSecurityCraft.mockRejectedValue(new Error('AST walk failed'));
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+    });
+
+    expect(run.stderrText).toContain('security-craft failed: AST walk failed');
+  });
+
+  it('emits a machine-readable error envelope on stdout in JSON mode', async () => {
+    runSecurityCraft.mockRejectedValue(new Error('AST walk failed'));
+
+    const run = await runCraftCommand(createSecurityCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'AST walk failed' });
+  });
+});

--- a/packages/cli/tests/commands/spec-craft-command.test.ts
+++ b/packages/cli/tests/commands/spec-craft-command.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Behavior tests for the `harness spec-craft` command layer
+ * (packages/cli/src/commands/spec-craft.ts).
+ *
+ * Scope is the COMMAND: option parsing, the input handed to `runSpecCraft`,
+ * the JSON-vs-human branch, the per-section report rendering, the scan
+ * diagnostic, and the exit-code contract. The engine is mocked;
+ * tests/spec-craft/** covers it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SpecCraftInput, SpecCraftOutput } from '../../src/spec-craft/index.js';
+import { runCraftCommand, llmCalls } from './craft-command-harness.js';
+
+const runSpecCraft = vi.fn();
+
+vi.mock('../../src/spec-craft/index.js', () => ({
+  runSpecCraft: (input: SpecCraftInput) => runSpecCraft(input),
+}));
+
+const { createSpecCraftCommand } = await import('../../src/commands/spec-craft.js');
+
+const PROJECT = '/fixtures/spec-craft-project';
+
+type SpecFinding = SpecCraftOutput['findings'][number];
+
+function finding(overrides: Partial<SpecFinding> = {}): SpecFinding {
+  return {
+    code: 'SPEC-R004',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'large',
+    confidence: 'medium',
+    target: { file: 'docs/changes/x/proposal.md', section: 'Decisions', line: 54 },
+    message: 'The decision records the choice but not the alternative it beat.',
+    cite: { rubricId: 'SPEC-R004', source: 'Nygard, Documenting Architecture Decisions' },
+    derived: { priority: 7 },
+    ...overrides,
+  } as SpecFinding;
+}
+
+function output(overrides: Partial<SpecCraftOutput> = {}): SpecCraftOutput {
+  const summary: SpecCraftOutput['summary'] = {
+    phaseRun: ['critique'],
+    mode: 'fast',
+    durationMs: 1500,
+    llmCalls: llmCalls({ count: 14, costUsd: 1.5 }),
+    catalog: { rubricsApplied: ['SPEC-R001', 'SPEC-R004', 'SPEC-R007'] },
+    docsScanned: 6,
+    sectionsScanned: 41,
+    runId: 'run-spec-1',
+  };
+  return { findings: [finding()], summary, ...overrides };
+}
+
+function capturedInput(): SpecCraftInput {
+  expect(runSpecCraft).toHaveBeenCalledTimes(1);
+  return runSpecCraft.mock.calls[0]![0] as SpecCraftInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runSpecCraft.mockResolvedValue(output());
+});
+
+describe('spec-craft command — option parsing', () => {
+  it('passes the resolved --cwd through as the engine input path', async () => {
+    await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(capturedInput().path).toBe(PROJECT);
+  });
+
+  it('falls back to the process working directory when --cwd is not given', async () => {
+    await runCraftCommand(createSpecCraftCommand());
+
+    expect(capturedInput().path).toBe(process.cwd());
+  });
+
+  it('parses --max-files into a number, not the raw string', async () => {
+    await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-files', '7'],
+    });
+
+    expect(capturedInput().maxFiles).toBe(7);
+  });
+
+  it('parses --max-sections-per-file into a number', async () => {
+    await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-sections-per-file', '3'],
+    });
+
+    expect(capturedInput().maxSectionsPerFile).toBe(3);
+  });
+
+  it('collects repeated values for the variadic --files scope', async () => {
+    await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--files', 'docs/a.md', 'docs/b.md'],
+    });
+
+    expect(capturedInput().files).toEqual(['docs/a.md', 'docs/b.md']);
+  });
+
+  it('forwards --kinds as the spec-kind restriction list', async () => {
+    await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--kinds', 'adr'],
+    });
+
+    expect(capturedInput().kinds).toEqual(['adr']);
+  });
+
+  it('forwards --sections as the canonical section restriction list', async () => {
+    await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--sections', 'Decisions', 'Alternatives'],
+    });
+
+    expect(capturedInput().sections).toEqual(['Decisions', 'Alternatives']);
+  });
+
+  it('omits unsupplied flags from the input entirely rather than setting them undefined', async () => {
+    await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(Object.keys(capturedInput())).toEqual(['path']);
+  });
+});
+
+describe('spec-craft command — JSON output mode', () => {
+  it('emits the engine result as parseable JSON', async () => {
+    const result = output();
+    runSpecCraft.mockResolvedValue(result);
+
+    const run = await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual(result);
+  });
+
+  it('suppresses the human report when --json is set', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('Diagnostic:');
+  });
+});
+
+describe('spec-craft command — human report', () => {
+  it('groups findings under the document that produced them', async () => {
+    runSpecCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding(),
+          finding({
+            target: { file: 'docs/knowledge/decisions/0001.md', section: 'Context', line: 9 },
+          }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('docs/changes/x/proposal.md');
+    expect(run.stdout).toContain('docs/knowledge/decisions/0001.md');
+  });
+
+  it('renders a finding as code, axes, and the H2 section heading with its line', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('  SPEC-R004 [polish/large/medium] ## Decisions:54');
+  });
+
+  it('prints the finding message', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      '    The decision records the choice but not the alternative it beat.'
+    );
+  });
+
+  it('adds the rubric citation under --verbose', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--verbose', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    source: Nygard, Documenting Architecture Decisions');
+  });
+
+  it('withholds the rubric citation outside verbose mode', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('source:');
+  });
+
+  it('summarises findings, docs, sections, rubrics, calls, cost, and duration', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'Summary: 1 findings across 6 docs (41 sections, 3 rubrics, 14 LLM calls, $1.5000, 1500ms)'
+    );
+  });
+
+  it('states that there are no findings rather than printing an empty list', async () => {
+    runSpecCraft.mockResolvedValue(output({ findings: [] }));
+
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('No spec findings.');
+  });
+});
+
+describe('spec-craft command — scan diagnostic', () => {
+  it('reports the scanned document tally', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('Diagnostic: provider=mock; analyzed 6 docs, skipped 0');
+  });
+
+  it('explains a zero-doc scan as no specs in scope', async () => {
+    // Otherwise "0 findings" against a repo with no proposals reads as a pass.
+    const nothing = output({ findings: [] });
+    nothing.summary.docsScanned = 0;
+    nothing.summary.sectionsScanned = 0;
+    runSpecCraft.mockResolvedValue(nothing);
+
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'Diagnostic: provider=mock; 0 analyzable docs (no proposals or ADRs found in scope)'
+    );
+  });
+});
+
+describe('spec-craft command — exit codes', () => {
+  it('exits VALIDATION_FAILED when any finding is foundational', async () => {
+    runSpecCraft.mockResolvedValue(
+      output({ findings: [finding({ tier: 'polish' }), finding({ tier: 'foundational' })] })
+    );
+
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(1);
+  });
+
+  it('exits SUCCESS when findings exist but none are foundational', async () => {
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(0);
+  });
+});
+
+describe('spec-craft command — engine failure', () => {
+  it('exits ERROR when the engine throws', async () => {
+    runSpecCraft.mockRejectedValue(new Error('section parse failed'));
+
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(2);
+  });
+
+  it('reports the failure on stderr in human mode', async () => {
+    runSpecCraft.mockRejectedValue(new Error('section parse failed'));
+
+    const run = await runCraftCommand(createSpecCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stderrText).toContain('spec-craft failed: section parse failed');
+  });
+
+  it('emits a machine-readable error envelope on stdout in JSON mode', async () => {
+    runSpecCraft.mockRejectedValue(new Error('section parse failed'));
+
+    const run = await runCraftCommand(createSpecCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'section parse failed' });
+  });
+});

--- a/packages/cli/tests/commands/test-craft-command.test.ts
+++ b/packages/cli/tests/commands/test-craft-command.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Behavior tests for the `harness test-craft` command layer
+ * (packages/cli/src/commands/test-craft.ts).
+ *
+ * Scope is the COMMAND: `buildInput`'s option mapping, the two output modes,
+ * the honesty branches in the empty-result report (found-nothing vs
+ * abstained), the truncation/error warnings, and the exit-code contract.
+ * The engine is mocked; tests/test-craft/** covers it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TestCraftInput, TestCraftOutput } from '../../src/test-craft/index.js';
+import { runCraftCommand, llmCalls } from './craft-command-harness.js';
+
+const runTestCraft = vi.fn();
+
+vi.mock('../../src/test-craft/index.js', () => ({
+  runTestCraft: (input: TestCraftInput) => runTestCraft(input),
+}));
+
+const { createTestCraftCommand } = await import('../../src/commands/test-craft.js');
+
+const PROJECT = '/fixtures/test-craft-project';
+
+type TestFinding = TestCraftOutput['findings'][number];
+
+function finding(overrides: Partial<TestFinding> = {}): TestFinding {
+  return {
+    code: 'TEST-R007',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: {
+      file: 'tests/a.test.ts',
+      line: 42,
+      testName: 'returns the total',
+      nesting: ['cart', 'totals'],
+      framework: 'vitest',
+    },
+    message: 'Asserts the implementation, not the contract.',
+    cite: { rubricId: 'TEST-R007', source: 'Beck, Test Desiderata' },
+    derived: { priority: 4 },
+    ...overrides,
+  } as TestFinding;
+}
+
+function counts(
+  overrides: Partial<TestCraftOutput['summary']['counts']> = {}
+): TestCraftOutput['summary']['counts'] {
+  return {
+    filesScanned: 5,
+    testsExtracted: 20,
+    testsSkippedOrTodo: 1,
+    sourcePaired: 4,
+    critiqueErrors: 0,
+    testsTruncated: 0,
+    ...overrides,
+  };
+}
+
+function output(overrides: Partial<TestCraftOutput> = {}): TestCraftOutput {
+  const summary: TestCraftOutput['summary'] = {
+    phaseRun: ['critique'],
+    mode: 'fast',
+    durationMs: 900,
+    llmCalls: llmCalls({ count: 6, costUsd: 0.5 }),
+    catalog: { rubricsApplied: ['TEST-R001', 'TEST-R007'] },
+    counts: counts(),
+    frameworksDetected: { vitest: 4, jest: 1, mocha: 0, playwright: 0, pytest: 0, unknown: 0 },
+    runId: 'run-test-1',
+  };
+  return { findings: [finding()], summary, ...overrides };
+}
+
+function capturedInput(): TestCraftInput {
+  expect(runTestCraft).toHaveBeenCalledTimes(1);
+  return runTestCraft.mock.calls[0]![0] as TestCraftInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runTestCraft.mockResolvedValue(output());
+});
+
+describe('test-craft command — option parsing', () => {
+  it('passes the resolved --cwd through as the engine input path', async () => {
+    await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(capturedInput().path).toBe(PROJECT);
+  });
+
+  it('falls back to the process working directory when --cwd is not given', async () => {
+    await runCraftCommand(createTestCraftCommand());
+
+    expect(capturedInput().path).toBe(process.cwd());
+  });
+
+  it('parses --max-files into a number, not the raw string', async () => {
+    await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-files', '7'],
+    });
+
+    expect(capturedInput().maxFiles).toBe(7);
+  });
+
+  it('parses --max-tests-per-file into a number', async () => {
+    await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--max-tests-per-file', '9'],
+    });
+
+    expect(capturedInput().maxTestsPerFile).toBe(9);
+  });
+
+  it('collects repeated values for the variadic --files scope', async () => {
+    await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--files', 'tests/a.test.ts', 'tests/b.test.ts'],
+    });
+
+    expect(capturedInput().files).toEqual(['tests/a.test.ts', 'tests/b.test.ts']);
+  });
+
+  it('forwards --frameworks as the framework restriction list', async () => {
+    await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--frameworks', 'vitest', 'pytest'],
+    });
+
+    expect(capturedInput().frameworks).toEqual(['vitest', 'pytest']);
+  });
+
+  it('maps --emit onto the engine’s emitTo report path', async () => {
+    await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--emit', 'reports/test-craft.json'],
+    });
+
+    expect(capturedInput().emitTo).toBe('reports/test-craft.json');
+  });
+
+  it('omits unsupplied flags from the input entirely rather than setting them undefined', async () => {
+    await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(Object.keys(capturedInput())).toEqual(['path']);
+  });
+
+  it('does not reach the engine with --no-source-pair (characterizes a live defect)', async () => {
+    // CHARACTERIZATION, NOT ENDORSEMENT. Commander stores a `--no-x` flag under
+    // key `x` (false when passed, true by default) — it never populates
+    // `noSourcePair`, which is the key `buildInput` reads. So the documented
+    // "Skip source-pairing resolution" flag is inert: `sourcePair` never
+    // reaches the engine. This test pins the CURRENT behavior and is expected
+    // to fail — loudly, by design — the moment the flag is wired correctly.
+    await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--cwd', PROJECT],
+      args: ['--no-source-pair'],
+    });
+
+    expect(capturedInput()).not.toHaveProperty('sourcePair');
+  });
+});
+
+describe('test-craft command — JSON output mode', () => {
+  it('emits the engine result as parseable JSON', async () => {
+    const result = output();
+    runTestCraft.mockResolvedValue(result);
+
+    const run = await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual(result);
+  });
+
+  it('suppresses the human report when --json is set', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(run.stdoutText).not.toContain('Summary:');
+  });
+});
+
+describe('test-craft command — human report', () => {
+  it('groups findings under the test file that produced them', async () => {
+    runTestCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding(),
+          finding({
+            target: {
+              file: 'tests/b.test.ts',
+              line: 7,
+              testName: 'handles empties',
+              nesting: [],
+              framework: 'jest',
+            },
+          }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('tests/a.test.ts');
+    expect(run.stdout).toContain('tests/b.test.ts');
+  });
+
+  it('renders a finding as code, axes, and framework:line', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('  TEST-R007 [polish/medium/high] vitest:42');
+  });
+
+  it('prefixes the test name with its describe chain', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('    cart > totals > returns the total');
+  });
+
+  it('prints a top-level test name with no chain prefix', async () => {
+    runTestCraft.mockResolvedValue(
+      output({
+        findings: [
+          finding({
+            target: {
+              file: 'tests/a.test.ts',
+              line: 3,
+              testName: 'stands alone',
+              nesting: [],
+              framework: 'vitest',
+            },
+          }),
+        ],
+      })
+    );
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('    stands alone');
+  });
+
+  it('adds the rubric citation under --verbose', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--verbose', '--cwd', PROJECT],
+    });
+
+    expect(run.stdout).toContain('    source: Beck, Test Desiderata');
+  });
+
+  it('withholds the rubric citation outside verbose mode', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('source:');
+  });
+
+  it('summarises findings, tests, files, frameworks, pairing, calls, cost, and duration', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'Summary: 1 findings across 20 tests (5 files, frameworks: vitest=4, jest=1, ' +
+        'paired: 4, 6 LLM calls, $0.5000, 900ms)'
+    );
+  });
+
+  it('reports "none" for frameworks when nothing was detected', async () => {
+    const none = output();
+    none.summary.frameworksDetected = {
+      vitest: 0,
+      jest: 0,
+      mocha: 0,
+      playwright: 0,
+      pytest: 0,
+      unknown: 0,
+    };
+    runTestCraft.mockResolvedValue(none);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).toContain('frameworks: none,');
+  });
+});
+
+describe('test-craft command — honesty of an empty result', () => {
+  it('says no tests were found when nothing was extracted', async () => {
+    const empty = output({ findings: [] });
+    empty.summary.counts = counts({ testsExtracted: 0, filesScanned: 0, sourcePaired: 0 });
+    empty.summary.llmCalls = llmCalls({ count: 0, costUsd: 0 });
+    runTestCraft.mockResolvedValue(empty);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('No tests found to critique.');
+  });
+
+  it('declares an ABSTAINED run when tests existed but no critique ran', async () => {
+    const abstained = output({ findings: [] });
+    abstained.summary.counts = counts({ testsExtracted: 12 });
+    abstained.summary.llmCalls = llmCalls({ count: 0, costUsd: 0 });
+    runTestCraft.mockResolvedValue(abstained);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'ABSTAINED: 12 test(s) extracted but 0 critiques ran — this is not a pass. ' +
+        'Check the LLM backend configuration.'
+    );
+  });
+
+  it('refuses to call an abstained run clean', async () => {
+    const abstained = output({ findings: [] });
+    abstained.summary.counts = counts({ testsExtracted: 12 });
+    abstained.summary.llmCalls = llmCalls({ count: 0, costUsd: 0 });
+    runTestCraft.mockResolvedValue(abstained);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('No test findings.');
+  });
+
+  it('reports a genuinely clean run when critiques ran and found nothing', async () => {
+    const clean = output({ findings: [] });
+    runTestCraft.mockResolvedValue(clean);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain('No test findings.');
+  });
+});
+
+describe('test-craft command — coverage-narrowing warnings', () => {
+  it('warns that discarded critiques leave pairs unmeasured', async () => {
+    const partial = output();
+    partial.summary.counts = counts({ critiqueErrors: 3 });
+    runTestCraft.mockResolvedValue(partial);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'WARNING: 3 critique(s) failed and were discarded; those (test, rubric) pairs are unmeasured.'
+    );
+  });
+
+  it('warns that a truncated run reports a cap rather than the population', async () => {
+    const truncated = output();
+    truncated.summary.counts = counts({ testsTruncated: 8, testsExtracted: 20 });
+    runTestCraft.mockResolvedValue(truncated);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'WARNING: 8 test(s) dropped by --max-tests-per-file; "20 tests" is a cap, not the population.'
+    );
+  });
+
+  it('notes that the contract rubric had nothing to compare against when nothing paired', async () => {
+    const unpaired = output();
+    unpaired.summary.counts = counts({ filesScanned: 5, sourcePaired: 0 });
+    runTestCraft.mockResolvedValue(unpaired);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdout).toContain(
+      'NOTE: no test file resolved to a source file, so TEST-R007 ' +
+        '(contract-not-implementation) had no contract to compare against.'
+    );
+  });
+
+  it('stays silent about pairing when some files did pair', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('NOTE: no test file resolved');
+  });
+
+  it('stays silent about pairing when no files were scanned at all', async () => {
+    const nothing = output();
+    nothing.summary.counts = counts({ filesScanned: 0, sourcePaired: 0 });
+    runTestCraft.mockResolvedValue(nothing);
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('NOTE: no test file resolved');
+  });
+
+  it('emits no warnings for a full, uneventful run', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stdoutText).not.toContain('WARNING:');
+  });
+});
+
+describe('test-craft command — exit codes', () => {
+  it('exits VALIDATION_FAILED when any finding is foundational', async () => {
+    runTestCraft.mockResolvedValue(
+      output({ findings: [finding({ tier: 'polish' }), finding({ tier: 'foundational' })] })
+    );
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(1);
+  });
+
+  it('exits SUCCESS when findings exist but none are foundational', async () => {
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(0);
+  });
+});
+
+describe('test-craft command — engine failure', () => {
+  it('exits ERROR when the engine throws', async () => {
+    runTestCraft.mockRejectedValue(new Error('parser crashed'));
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.exitCode).toBe(2);
+  });
+
+  it('reports the failure on stderr in human mode', async () => {
+    runTestCraft.mockRejectedValue(new Error('parser crashed'));
+
+    const run = await runCraftCommand(createTestCraftCommand(), { globalArgs: ['--cwd', PROJECT] });
+
+    expect(run.stderrText).toContain('test-craft failed: parser crashed');
+  });
+
+  it('emits a machine-readable error envelope on stdout in JSON mode', async () => {
+    runTestCraft.mockRejectedValue(new Error('parser crashed'));
+
+    const run = await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'parser crashed' });
+  });
+
+  it('stringifies a non-Error rejection rather than reporting "undefined"', async () => {
+    runTestCraft.mockRejectedValue({ toString: () => 'weird failure' });
+
+    const run = await runCraftCommand(createTestCraftCommand(), {
+      globalArgs: ['--json', '--cwd', PROJECT],
+    });
+
+    expect(JSON.parse(run.stdoutText)).toEqual({ error: 'weird failure' });
+  });
+});


### PR DESCRIPTION
## What

The five craft CLI command modules had **no test reaching them**. The many suites under `packages/cli/tests/<x>-craft/` all exercise the underlying *engine* modules (`src/<x>-craft/`). A symbol-level cross-check found zero references to `createCopyCraftCommand` / `createTestCraftCommand` / `createSecurityCraftCommand` / `createNamingCraftCommand` / `createSpecCraftCommand` anywhere in the repo, and no test importing `src/commands/<x>-craft`. The command layer was entirely unmeasured.

These are not thin Commander wrappers. Each carries real inline logic worth covering:

- `parseInt` of the numeric caps (`--max-files`, `--max-items-per-file`, `--pr-limit`, …) and the conditional-assignment pattern that must leave an unsupplied flag **absent** from the engine input rather than `undefined`-valued
- `resolveOutputMode(globalOpts)` and the JSON-vs-human branch
- the catch branch: on engine throw, JSON mode prints `{"error": message}` while human mode routes through `logger.error(...)`, then `process.exit(ExitCode.ERROR)`
- exit-code mapping: any `foundational`-tier finding exits `VALIDATION_FAILED`, otherwise `SUCCESS`
- the module-private printers/formatters (`printResult`, the per-surface/per-file tally builders, `truncate`) reached through the command action
- LLM-config resolution via `resolveCraftLlmConfig` rendered by `formatCraftDiagnostic`

## How

One test file per command under `packages/cli/tests/commands/`, plus a small local harness (`craft-command-harness.ts`) shared by the five rather than repeated:

- mounts the subcommand under a parent `Command` carrying the real global flags (`--json`, `--quiet`, `--verbose`, `--cwd`) so `optsWithGlobals()` resolves as it does in production
- turns `process.exit` into a throw so the exit code is an assertable value instead of killing the worker
- captures ANSI-stripped stdout/stderr, so assertions are made against the text a user actually sees

Each engine module is `vi.mock`ed to return a controlled fixture (and to throw for the error path), so the command's own behavior is the only thing under test.

Every test asserts behavior — the parsed input handed to the engine (`--max-files 7` arrives as the number `7`; an unsupplied flag is absent from the object), the rendered report (grouping, `truncate` ellipsis at the 80/81 boundary, the summary line, the scan diagnostic, the zero-finding message), both exit-code branches, and both error-output branches. There are no import-only or "it constructs a Command" smoke tests.

Authored via `harness:tdd`, then critiqued and raised via `harness:test-craft`. Assertion strength was verified by mutation: each perturbed expectation was confirmed to fail, and only the perturbed ones.

**No source file was changed.**

## Assumptions made

Recommended defaults taken without asking, all reversible in review:

1. **Characterized the current output format as-is.** The rendered human report (exact prefixes, `[tier/impact/confidence]` axis triple, summary and `Diagnostic:` line wording) is asserted verbatim. For a CLI the rendered output *is* the user-facing contract, so this is deliberate — but it does mean a future intentional reformat updates these tests.
2. **Mocked the engine at the module boundary** (`src/<x>-craft/index.js`) rather than exercising real engines, to keep the cohort fast, deterministic, and scoped to the command layer. The engines keep their own existing suites.
3. **Factored one local helper** (`craft-command-harness.ts`) instead of repeating the parent-Command builder and exit capture five times. It is deliberately local to `tests/commands/` and encodes the craft command shell, not a repo-wide convention; no existing shared helper was modified.
4. **`provider=mock` in the diagnostic** comes from `HARNESS_CRAFT_LLM=mock`, set globally by `tests/setup.ts`. One test stubs it to `in-session` to prove the command genuinely resolves the provider rather than hardcoding the label.
5. **Pinned a live defect rather than fixing it** (see below), per the no-source-changes rule.
6. **No changeset.** `scripts/check-changesets.mjs` skips `*.test.ts` and `/tests/`; the gate did not ask for one.

## Parked: a live defect this PR documents but does not fix

`--no-source-pair` on `test-craft` is **inert**. Commander stores a negated flag under its positive key (`sourcePair`: `false` when passed, `true` by default) and never populates `noSourcePair` — which is the key `buildInput` reads:

```ts
if (opts.noSourcePair === true) input.sourcePair = false;  // never true
```

So the documented "Skip source-pairing resolution" flag never reaches the engine; that line is dead (it is why `test-craft.ts` sits at 98.5% statements rather than 100%). The test `does not reach the engine with --no-source-pair (characterizes a live defect)` pins the **current** behavior with an explicit comment, and is written to fail loudly the moment the flag is wired correctly. Filing/fixing is deliberately left out of this test-only PR.

## Coverage delta

v8 coverage of the five target files, measured over `packages/cli/tests/commands/` before and after:

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `copy-craft.ts` | 1.49% → **100%** | 0% → **100%** | 11.11% → **100%** | 1.69% → **100%** |
| `test-craft.ts` | 1.49% → **98.5%** | 0% → **97.72%** | 14.28% → **100%** | 1.66% → **100%** |
| `security-craft.ts` | 1.85% → **100%** | 0% → **96.66%** | 20% → **100%** | 2.08% → **100%** |
| `naming-craft.ts` | 1.88% → **100%** | 0% → **97.22%** | 20% → **100%** | 2.08% → **100%** |
| `spec-craft.ts` | 1.88% → **100%** | 0% → **96.42%** | 20% → **100%** | 2.12% → **100%** |

Command: `vitest run --coverage.enabled --coverage.include='src/commands/*-craft.ts' tests/commands/`

The residual uncovered branches are the unreachable `return` after `process.exit(...)` and, in `test-craft.ts`, the dead `--no-source-pair` line described above.

## Test run

`packages/cli` → `vitest run tests/commands/`: **152 files, 1953 tests, all passing** (up from 147 files / 1802 tests; **+151 new tests** across 5 new files: copy 41, test 35, naming 26, security 25, spec 24). No existing test was modified.

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
