### PR TITLE
test(cli): cover the api/code/docs/knowledge/cli-ergonomics craft command layer

### DIFF
--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '4fd8cee931904f68676859d2876dfa148c3e9524e309bde8e640c07060501124'
+sourceHash: '3ccacc976e5d94509e858d7df0d604864e16b7a8441a2d7cf249bf2794e4ac7d'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -15,6 +15,7 @@ members:
     'agent-run-persona.test.ts',
     'agent-run.test.ts',
     'agent.test.ts',
+    'api-craft-command.test.ts',
     'audit-protected.test.ts',
     'backfill-skill-provenance.test.ts',
     'check-arch.test.ts',
@@ -29,12 +30,16 @@ members:
     'check-vocabulary.test.ts',
     'cleanup-sessions.test.ts',
     'cleanup.test.ts',
+    'cli-ergonomics-craft-command.test.ts',
+    'code-craft-command.test.ts',
     'compound-scan-candidates.test.ts',
+    'craft-command-harness-cohort-b.ts',
     'create-skill.test.ts',
     'cross-check.test.ts',
     'dashboard.test.ts',
     'deprecated-graph-aliases.test.ts',
     'distortion.test.ts',
+    'docs-craft-command.test.ts',
     'doctor-hardening.test.ts',
     'doctor.test.ts',
     'fix-drift.test.ts',
@@ -57,6 +62,7 @@ members:
     'install.test.ts',
     'integrations-sync.test.ts',
     'integrations.test.ts',
+    'knowledge-craft-command.test.ts',
     'learnings-prune.test.ts',
     'linter-generate.test.ts',
     'maintenance-command-shape.test.ts',
@@ -137,17 +143,25 @@ members:
 ## Interface Contract
 
 ```ts
-
+export DEFAULT_CWD
+export runCraftCommand
 ```
 
 ## Dependency Slice
 
 ```
+import { ApiCraftOutput, ApiFinding } from '../../src/api-craft/findings/schema.js'
+import { ApiCraftInput, runApiCraft } from '../../src/api-craft/index.js'
+import { CliErgonomicsCraftOutput, CliErgonomicsFinding } from '../../src/cli-ergonomics-craft/findings/schema.js'
+import { CliErgonomicsCraftInput, runCliErgonomicsCraft } from '../../src/cli-ergonomics-craft/index.js'
+import { CodeCraftOutput, CodeFinding } from '../../src/code-craft/findings/schema.js'
+import { CodeCraftInput, runCodeCraft } from '../../src/code-craft/index.js'
 import { createAddCommand, runAdd } from '../../src/commands/add'
 import { createAdoptionCommand } from '../../src/commands/adoption'
 import { createAgentCommand } from '../../src/commands/agent'
 import { createReviewCommand, runAgentReview } from '../../src/commands/agent/review'
 import { createRunCommand, runAgentTask } from '../../src/commands/agent/run'
+import { createApiCraftCommand } from '../../src/commands/api-craft'
 import { createAuditProtectedCommand, runAuditProtected } from '../../src/commands/audit-protected'
 import { runBackfillSkillProvenance } from '../../src/commands/backfill-skill-provenance'
 import { createCheckArchCommand, runCheckArch } from '../../src/commands/check-arch'
@@ -162,11 +176,14 @@ import { runCheckSecurity } from '../../src/commands/check-security'
 import { createCheckVocabularyCommand, runCheckVocabulary } from '../../src/commands/check-vocabulary'
 import { createCleanupCommand, runCleanup } from '../../src/commands/cleanup'
 import { runCleanupAll, runCleanupSessions } from '../../src/commands/cleanup-sessions'
+import { createCliErgonomicsCraftCommand } from '../../src/commands/cli-ergonomics-craft'
+import { createCodeCraftCommand } from '../../src/commands/code-craft'
 import { runCompoundScanCandidatesCommand } from '../../src/commands/compound/scan-candidates'
 import { createCreateSkillCommand, generateSkillFiles } from '../../src/commands/create-skill'
 import { createCrossCheckCommand } from '../../src/commands/cross-check'
 import { createDashboardCommand } from '../../src/commands/dashboard'
 import { createDistortionCommand } from '../../src/commands/distortion'
+import { createDocsCraftCommand } from '../../src/commands/docs-craft'
 import { checkBaselineFreshness, checkCatalogFreshness, checkHookValidity, checkLivePings, checkSessionCorruption, isCatalogStale, runDoctor } from '../../src/commands/doctor'
 import { createFixDriftCommand, runFixDrift } from '../../src/commands/fix-drift'
 import { createGenerateCommand } from '../../src/commands/generate'
@@ -198,6 +215,7 @@ import from '../../src/commands/integrations/dismiss'
 import from '../../src/commands/integrations/list'
 import from '../../src/commands/integrations/remove'
 import { SyncIO, runSyncIntegrations } from '../../src/commands/integrations/sync'
+import { createKnowledgeCraftCommand } from '../../src/commands/knowledge-craft'
 import { createGenerateCommand } from '../../src/commands/linter/generate'
 import { createMaintenanceCommand } from '../../src/commands/maintenance'
 import { MaintenanceRunDeps, aggregateReport, buildTaskRunner, createCheckRunner, createFixDispatcher, deriveExitCode, loadRunHistory, makeResolveBackend, parseConcurrency, renderTable, resolveHarnessSpawn, resolveSelection, runMaintenanceRun } from '../../src/commands/maintenance-run'
@@ -256,9 +274,13 @@ import { SCOPED_WALKERS, deriveChangedSurface, filterToDesignSurface } from '../
 import { createWaypointCommand } from '../../src/commands/waypoint'
 import { resolveConfig } from '../../src/config/loader'
 import { HarnessConfig } from '../../src/config/schema'
+import { DocsCraftOutput, DocsFinding } from '../../src/docs-craft/findings/schema.js'
+import { DocsCraftInput, runDocsCraft } from '../../src/docs-craft/index.js'
 import { createProgram } from '../../src/index'
 import { readMcpConfig, writeMcpEntry, writeOpencodeMcpEntry } from '../../src/integrations/config'
 import { CATALOG_LAST_REVIEWED, INTEGRATION_REGISTRY } from '../../src/integrations/registry'
+import { KnowledgeCraftOutput, KnowledgeFinding } from '../../src/knowledge-craft/findings/schema.js'
+import { KnowledgeCraftInput, runKnowledgeCraft } from '../../src/knowledge-craft/index.js'
 import { getToolDefinitions } from '../../src/mcp/index'
 import { getToolDefinitions } from '../../src/mcp/server'
 import { NETWORK_TOOL_NAMES, deriveScope, deriveToolCapabilities, deriveToolCapability } from '../../src/mcp/tool-capabilities'
@@ -290,6 +312,7 @@ import { CLIError, ExitCode } from '../../src/utils/errors'
 import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
+import { CraftCommandRun, DEFAULT_CWD, runCraftCommand } from './craft-command-harness-cohort-b'
 import * as clack from '@clack/prompts'
 import { CiReviewResult, DiffInfo, Err, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
 import from '@harness-engineering/graph'

--- a/packages/cli/tests/commands/api-craft-command.test.ts
+++ b/packages/cli/tests/commands/api-craft-command.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Contract tests for the `harness api-craft` command layer.
+ *
+ * Scope is the command module only: flag parsing into `ApiCraftInput`, the
+ * JSON-vs-human output branch, the rendered human report, and the exit-code
+ * mapping. The engine (`src/api-craft/`) is mocked — it has its own suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createApiCraftCommand } from '../../src/commands/api-craft';
+import { runApiCraft } from '../../src/api-craft/index.js';
+import type { ApiCraftInput } from '../../src/api-craft/index.js';
+import type { ApiCraftOutput, ApiFinding } from '../../src/api-craft/findings/schema.js';
+import {
+  runCraftCommand,
+  DEFAULT_CWD,
+  type CraftCommandRun,
+} from './craft-command-harness-cohort-b';
+
+vi.mock('../../src/api-craft/index.js', () => ({ runApiCraft: vi.fn() }));
+
+const ROUTES_FILE = '/repo/src/routes/users.ts';
+const SPEC_FILE = '/repo/openapi.yaml';
+
+function finding(over: Partial<ApiFinding> = {}): ApiFinding {
+  return {
+    code: 'API-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: { file: ROUTES_FILE, relative: 'src/routes/users.ts', kind: 'route' },
+    message: 'GET /users returns an unpaginated array.',
+    cite: { rubricId: 'collections-paginate-and-filter', source: 'seed:api/collections' },
+    derived: { priority: 6 },
+    ...over,
+  };
+}
+
+function output(findings: ApiFinding[]): ApiCraftOutput {
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: 1234,
+      llmCalls: { provider: 'mock', model: 'mock-1', count: 3, costUsd: 0.123456 },
+      catalog: {
+        rubricsApplied: ['naming-is-predictable', 'verbs-are-honest'],
+        exemplarsAvailable: 4,
+      },
+      counts: { filesScanned: 5, filesSkipped: 2 },
+      runId: 'run-1',
+    },
+  };
+}
+
+/** The engine resolves `result` for the next run. */
+function engineReturns(result: ApiCraftOutput): void {
+  vi.mocked(runApiCraft).mockResolvedValue(result);
+}
+
+/** The input object the command handed the engine on its only call. */
+function inputPassedToEngine(): ApiCraftInput {
+  expect(runApiCraft).toHaveBeenCalledTimes(1);
+  return vi.mocked(runApiCraft).mock.calls[0]![0]!;
+}
+
+function run(argv: string[], globals: string[] = []): Promise<CraftCommandRun> {
+  return runCraftCommand(createApiCraftCommand, ['api-craft', ...argv], { globals });
+}
+
+describe('api-craft command', () => {
+  beforeEach(() => {
+    vi.mocked(runApiCraft).mockReset();
+    engineReturns(output([]));
+  });
+
+  describe('flag parsing into the engine input', () => {
+    it('scopes the run to the process cwd when no --cwd is given', async () => {
+      await run([]);
+      expect(inputPassedToEngine().path).toBe(DEFAULT_CWD);
+    });
+
+    it('scopes the run to --cwd when the root command supplies it', async () => {
+      await run([], ['--cwd', '/elsewhere/repo']);
+      expect(inputPassedToEngine().path).toBe('/elsewhere/repo');
+    });
+
+    it('omits every optional field when no flag was supplied', async () => {
+      // Absence, not `undefined`: the engine distinguishes "caller said nothing"
+      // (apply the documented default) from "caller passed undefined".
+      await run([]);
+      // toStrictEqual, not toEqual: an `undefined`-valued key would satisfy
+      // toEqual and defeat the very absence this test exists to pin.
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD });
+    });
+
+    it('parses --max-files into a number, not the raw string', async () => {
+      await run(['--max-files', '7']);
+      expect(inputPassedToEngine().maxFiles).toBe(7);
+    });
+
+    it('collects --files as a variadic list', async () => {
+      await run(['--files', 'a/openapi.yaml', 'b/routes.ts']);
+      expect(inputPassedToEngine().files).toEqual(['a/openapi.yaml', 'b/routes.ts']);
+    });
+
+    it('collects --exclude-dirs as a variadic list', async () => {
+      await run(['--exclude-dirs', 'fixtures', 'vendor']);
+      expect(inputPassedToEngine().excludeDirs).toEqual(['fixtures', 'vendor']);
+    });
+
+    it('forwards --routes-dir and --spec-file as the API-surface overrides', async () => {
+      await run(['--routes-dir', 'src/api', '--spec-file', 'spec/openapi.yaml']);
+      const input = inputPassedToEngine();
+      expect(input.routesDir).toBe('src/api');
+      expect(input.specFile).toBe('spec/openapi.yaml');
+    });
+
+    it('leaves unrelated fields absent when only one flag is supplied', async () => {
+      await run(['--max-files', '3']);
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD, maxFiles: 3 });
+    });
+  });
+
+  describe('human-readable report', () => {
+    it('groups findings by file, regrouping non-adjacent findings, and closes with a summary', async () => {
+      engineReturns(
+        output([
+          finding({ code: 'API-R001' }),
+          finding({
+            code: 'API-R009',
+            target: { file: SPEC_FILE, relative: 'openapi.yaml', kind: 'openapi' },
+            tier: 'aspirational',
+            impact: 'small',
+            confidence: 'low',
+            message: 'No deprecation policy is documented.',
+          }),
+          finding({
+            code: 'API-R004',
+            tier: 'foundational',
+            impact: 'large',
+            message: 'DELETE /users/:id returns 200 with a body on a missing id.',
+          }),
+        ])
+      );
+
+      const result = await run([]);
+
+      expect(result.stdout).toEqual([
+        `\n${ROUTES_FILE}`,
+        '  API-R001 [polish/medium/high] src/routes/users.ts (route)',
+        '    GET /users returns an unpaginated array.',
+        '  API-R004 [foundational/large/high] src/routes/users.ts (route)',
+        '    DELETE /users/:id returns 200 with a body on a missing id.',
+        `\n${SPEC_FILE}`,
+        '  API-R009 [aspirational/small/low] openapi.yaml (openapi)',
+        '    No deprecation policy is documented.',
+        '',
+        'Summary: 3 findings across 5 API surfaces (2 skipped, 2 rubrics, 4 exemplars, ' +
+          '3 LLM calls, $0.1235, 1234ms)',
+      ]);
+    });
+
+    it('reports the clean run instead of an empty grouping when there are no findings', async () => {
+      engineReturns(output([]));
+
+      const result = await run([]);
+
+      expect(result.stdout[0]).toBe('No API-craft findings.');
+      expect(result.stdoutText).toContain('Summary: 0 findings across 5 API surfaces');
+    });
+
+    it('withholds the rubric citation unless --verbose is set', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([]);
+
+      // Paired with a presence assertion: on its own the negative would also
+      // pass against an empty report, proving nothing about the verbose gate.
+      expect(result.stdoutText).toContain('  API-R001 [polish/medium/high]');
+      expect(result.stdoutText).not.toContain('source:');
+    });
+
+    it('adds the rubric citation under --verbose', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--verbose']);
+
+      expect(result.stdoutText).toContain('    source: seed:api/collections');
+    });
+
+    it('still renders the full report under --quiet', async () => {
+      // Characterization: `--quiet` resolves to OutputMode.QUIET, which the
+      // printer treats exactly like TEXT — it only branches on VERBOSE.
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--quiet']);
+
+      expect(result.stdoutText).toContain(
+        '  API-R001 [polish/medium/high] src/routes/users.ts (route)'
+      );
+      expect(result.stdoutText).toContain('Summary: 1 findings across 5 API surfaces');
+    });
+  });
+
+  describe('--json output', () => {
+    it('emits the engine result verbatim as pretty-printed JSON', async () => {
+      const engineOutput = output([finding()]);
+      engineReturns(engineOutput);
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(JSON.parse(result.stdout[0]!)).toEqual(engineOutput);
+      // JSON.parse is blind to formatting; assert the 2-space indent directly.
+      expect(result.stdout[0]).toContain('\n  "findings"');
+    });
+
+    it('suppresses the human report entirely', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(result.stdoutText).not.toContain('Summary:');
+    });
+  });
+
+  describe('exit codes', () => {
+    it('fails the run when any finding is foundational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'foundational' })]));
+
+      expect((await run([])).exitCode).toBe(1);
+    });
+
+    it('succeeds when the worst finding is only polish or aspirational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'aspirational' })]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('succeeds on a clean run', async () => {
+      engineReturns(output([]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('applies the same tier rule under --json', async () => {
+      engineReturns(output([finding({ tier: 'foundational' })]));
+
+      expect((await run([], ['--json'])).exitCode).toBe(1);
+    });
+  });
+
+  describe('engine failure', () => {
+    it('reports the failure on stderr and exits with the error code', async () => {
+      vi.mocked(runApiCraft).mockRejectedValue(new Error('no API surface found'));
+
+      const result = await run([]);
+
+      expect(result.stderrText).toContain('api-craft failed: no API surface found');
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('keeps stdout clean when it fails in human mode', async () => {
+      vi.mocked(runApiCraft).mockRejectedValue(new Error('no API surface found'));
+
+      expect((await run([])).stdout).toEqual([]);
+    });
+
+    it('emits a machine-readable error envelope under --json', async () => {
+      vi.mocked(runApiCraft).mockRejectedValue(new Error('no API surface found'));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toEqual(['{"error":"no API surface found"}']);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('does not duplicate the JSON envelope onto stderr', async () => {
+      vi.mocked(runApiCraft).mockRejectedValue(new Error('no API surface found'));
+
+      expect((await run([], ['--json'])).stderr).toEqual([]);
+    });
+
+    it('stringifies a non-Error rejection rather than dropping it', async () => {
+      vi.mocked(runApiCraft).mockRejectedValue('provider quota exhausted');
+
+      const result = await run([], ['--json']);
+
+      expect(JSON.parse(result.stdout[0]!)).toEqual({ error: 'provider quota exhausted' });
+    });
+  });
+});

--- a/packages/cli/tests/commands/cli-ergonomics-craft-command.test.ts
+++ b/packages/cli/tests/commands/cli-ergonomics-craft-command.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Contract tests for the `harness cli-ergonomics-craft` command layer.
+ *
+ * Scope is the command module only: flag parsing into `CliErgonomicsCraftInput`,
+ * the JSON-vs-human output branch, the rendered human report, and the exit-code
+ * mapping. The engine (`src/cli-ergonomics-craft/`) is mocked — it has its own
+ * suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCliErgonomicsCraftCommand } from '../../src/commands/cli-ergonomics-craft';
+import { runCliErgonomicsCraft } from '../../src/cli-ergonomics-craft/index.js';
+import type { CliErgonomicsCraftInput } from '../../src/cli-ergonomics-craft/index.js';
+import type {
+  CliErgonomicsCraftOutput,
+  CliErgonomicsFinding,
+} from '../../src/cli-ergonomics-craft/findings/schema.js';
+import {
+  runCraftCommand,
+  DEFAULT_CWD,
+  type CraftCommandRun,
+} from './craft-command-harness-cohort-b';
+
+vi.mock('../../src/cli-ergonomics-craft/index.js', () => ({ runCliErgonomicsCraft: vi.fn() }));
+
+const LEAF_FILE = '/repo/packages/cli/src/commands/scan.ts';
+const GROUP_FILE = '/repo/packages/cli/src/commands/graph.ts';
+
+function finding(over: Partial<CliErgonomicsFinding> = {}): CliErgonomicsFinding {
+  return {
+    code: 'CLI-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: { file: LEAF_FILE, relative: 'packages/cli/src/commands/scan.ts', kind: 'leaf' },
+    message: '--force is unguarded on a destructive re-index.',
+    cite: { rubricId: 'destructive-actions-are-guarded', source: 'seed:cli/destructive' },
+    derived: { priority: 6 },
+    ...over,
+  };
+}
+
+function output(findings: CliErgonomicsFinding[]): CliErgonomicsCraftOutput {
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: 320,
+      llmCalls: { provider: 'mock', model: 'mock-1', count: 7, costUsd: 0.123456 },
+      catalog: {
+        rubricsApplied: ['names-are-predictable', 'output-is-scannable'],
+        exemplarsAvailable: 5,
+      },
+      counts: { filesScanned: 11, filesSkipped: 6 },
+      runId: 'run-cli-1',
+    },
+  };
+}
+
+function engineReturns(result: CliErgonomicsCraftOutput): void {
+  vi.mocked(runCliErgonomicsCraft).mockResolvedValue(result);
+}
+
+function inputPassedToEngine(): CliErgonomicsCraftInput {
+  expect(runCliErgonomicsCraft).toHaveBeenCalledTimes(1);
+  return vi.mocked(runCliErgonomicsCraft).mock.calls[0]![0]!;
+}
+
+function run(argv: string[], globals: string[] = []): Promise<CraftCommandRun> {
+  return runCraftCommand(createCliErgonomicsCraftCommand, ['cli-ergonomics-craft', ...argv], {
+    globals,
+  });
+}
+
+describe('cli-ergonomics-craft command', () => {
+  beforeEach(() => {
+    vi.mocked(runCliErgonomicsCraft).mockReset();
+    engineReturns(output([]));
+  });
+
+  describe('flag parsing into the engine input', () => {
+    it('scopes the run to the process cwd when no --cwd is given', async () => {
+      await run([]);
+      expect(inputPassedToEngine().path).toBe(DEFAULT_CWD);
+    });
+
+    it('scopes the run to --cwd when the root command supplies it', async () => {
+      await run([], ['--cwd', '/elsewhere/repo']);
+      expect(inputPassedToEngine().path).toBe('/elsewhere/repo');
+    });
+
+    it('omits every optional field when no flag was supplied', async () => {
+      await run([]);
+      // toStrictEqual, not toEqual: an `undefined`-valued key would satisfy
+      // toEqual and defeat the very absence this test exists to pin.
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD });
+    });
+
+    it('parses --max-files into a number, not the raw string', async () => {
+      await run(['--max-files', '15']);
+      expect(inputPassedToEngine().maxFiles).toBe(15);
+    });
+
+    it('collects --files as a variadic list', async () => {
+      await run(['--files', 'src/commands/a.ts', 'src/commands/b.ts']);
+      expect(inputPassedToEngine().files).toEqual(['src/commands/a.ts', 'src/commands/b.ts']);
+    });
+
+    it('collects --exclude-dirs as a variadic list', async () => {
+      await run(['--exclude-dirs', 'fixtures', '__mocks__']);
+      expect(inputPassedToEngine().excludeDirs).toEqual(['fixtures', '__mocks__']);
+    });
+
+    it('forwards --commands-dir as the command-definition override', async () => {
+      await run(['--commands-dir', 'src/commands']);
+      expect(inputPassedToEngine().commandsDir).toBe('src/commands');
+    });
+
+    it('leaves unrelated fields absent when only one flag is supplied', async () => {
+      await run(['--commands-dir', 'src/commands']);
+      expect(inputPassedToEngine()).toStrictEqual({
+        path: DEFAULT_CWD,
+        commandsDir: 'src/commands',
+      });
+    });
+  });
+
+  describe('human-readable report', () => {
+    it('groups findings by file, regrouping non-adjacent findings, and closes with a summary', async () => {
+      engineReturns(
+        output([
+          finding({ code: 'CLI-R001' }),
+          finding({
+            code: 'CLI-R002',
+            target: {
+              file: GROUP_FILE,
+              relative: 'packages/cli/src/commands/graph.ts',
+              kind: 'group',
+            },
+            tier: 'aspirational',
+            impact: 'small',
+            confidence: 'low',
+            message: 'The group help lists subcommands without saying when to reach for each.',
+          }),
+          finding({
+            code: 'CLI-R003',
+            tier: 'foundational',
+            impact: 'large',
+            message: 'The failure message names no next action.',
+          }),
+        ])
+      );
+
+      const result = await run([]);
+
+      expect(result.stdout).toEqual([
+        `\n${LEAF_FILE}`,
+        '  CLI-R001 [polish/medium/high] packages/cli/src/commands/scan.ts (leaf)',
+        '    --force is unguarded on a destructive re-index.',
+        '  CLI-R003 [foundational/large/high] packages/cli/src/commands/scan.ts (leaf)',
+        '    The failure message names no next action.',
+        `\n${GROUP_FILE}`,
+        '  CLI-R002 [aspirational/small/low] packages/cli/src/commands/graph.ts (group)',
+        '    The group help lists subcommands without saying when to reach for each.',
+        '',
+        'Summary: 3 findings across 11 commands (6 skipped, 2 rubrics, 5 exemplars, ' +
+          '7 LLM calls, $0.1235, 320ms)',
+      ]);
+    });
+
+    it('reports the clean run instead of an empty grouping when there are no findings', async () => {
+      engineReturns(output([]));
+
+      const result = await run([]);
+
+      expect(result.stdout[0]).toBe('No CLI-ergonomics-craft findings.');
+      expect(result.stdoutText).toContain('Summary: 0 findings across 11 commands');
+    });
+
+    it('withholds the rubric citation unless --verbose is set', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([]);
+
+      // Paired with a presence assertion: on its own the negative would also
+      // pass against an empty report, proving nothing about the verbose gate.
+      expect(result.stdoutText).toContain('  CLI-R001 [polish/medium/high]');
+      expect(result.stdoutText).not.toContain('source:');
+    });
+
+    it('adds the rubric citation under --verbose', async () => {
+      engineReturns(output([finding()]));
+
+      expect((await run([], ['--verbose'])).stdoutText).toContain(
+        '    source: seed:cli/destructive'
+      );
+    });
+  });
+
+  describe('--json output', () => {
+    it('emits the engine result verbatim as pretty-printed JSON', async () => {
+      const engineOutput = output([finding()]);
+      engineReturns(engineOutput);
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(JSON.parse(result.stdout[0]!)).toEqual(engineOutput);
+      // JSON.parse is blind to formatting; assert the 2-space indent directly.
+      expect(result.stdout[0]).toContain('\n  "findings"');
+    });
+
+    it('suppresses the human report entirely', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(result.stdoutText).not.toContain('Summary:');
+    });
+  });
+
+  describe('exit codes', () => {
+    it('fails the run when any finding is foundational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'foundational' })]));
+
+      expect((await run([])).exitCode).toBe(1);
+    });
+
+    it('succeeds when the worst finding is only polish or aspirational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'aspirational' })]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('succeeds on a clean run', async () => {
+      engineReturns(output([]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('applies the same tier rule under --json', async () => {
+      engineReturns(output([finding({ tier: 'foundational' })]));
+
+      expect((await run([], ['--json'])).exitCode).toBe(1);
+    });
+  });
+
+  describe('engine failure', () => {
+    it('reports the failure on stderr and exits with the error code', async () => {
+      vi.mocked(runCliErgonomicsCraft).mockRejectedValue(new Error('no command definitions found'));
+
+      const result = await run([]);
+
+      expect(result.stderrText).toContain(
+        'cli-ergonomics-craft failed: no command definitions found'
+      );
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('keeps stdout clean when it fails in human mode', async () => {
+      vi.mocked(runCliErgonomicsCraft).mockRejectedValue(new Error('no command definitions found'));
+
+      expect((await run([])).stdout).toEqual([]);
+    });
+
+    it('emits a machine-readable error envelope under --json', async () => {
+      vi.mocked(runCliErgonomicsCraft).mockRejectedValue(new Error('no command definitions found'));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toEqual(['{"error":"no command definitions found"}']);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('does not duplicate the JSON envelope onto stderr', async () => {
+      vi.mocked(runCliErgonomicsCraft).mockRejectedValue(new Error('no command definitions found'));
+
+      expect((await run([], ['--json'])).stderr).toEqual([]);
+    });
+
+    it('stringifies a non-Error rejection rather than dropping it', async () => {
+      vi.mocked(runCliErgonomicsCraft).mockRejectedValue('provider quota exhausted');
+
+      expect(JSON.parse((await run([], ['--json'])).stdout[0]!)).toEqual({
+        error: 'provider quota exhausted',
+      });
+    });
+  });
+});

--- a/packages/cli/tests/commands/code-craft-command.test.ts
+++ b/packages/cli/tests/commands/code-craft-command.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Contract tests for the `harness code-craft` command layer.
+ *
+ * Scope is the command module only: flag parsing into `CodeCraftInput`, the
+ * JSON-vs-human output branch, the per-unit human report, and the exit-code
+ * mapping. The engine (`src/code-craft/`) is mocked — it has its own suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCodeCraftCommand } from '../../src/commands/code-craft';
+import { runCodeCraft } from '../../src/code-craft/index.js';
+import type { CodeCraftInput } from '../../src/code-craft/index.js';
+import type { CodeCraftOutput, CodeFinding } from '../../src/code-craft/findings/schema.js';
+import {
+  runCraftCommand,
+  DEFAULT_CWD,
+  type CraftCommandRun,
+} from './craft-command-harness-cohort-b';
+
+vi.mock('../../src/code-craft/index.js', () => ({ runCodeCraft: vi.fn() }));
+
+const STORE_FILE = '/repo/packages/core/src/store.ts';
+const PARSER_FILE = '/repo/packages/core/src/parser.ts';
+
+function finding(over: Partial<CodeFinding> = {}): CodeFinding {
+  return {
+    code: 'CODE-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: { file: STORE_FILE, unit: 'saveRunState', kind: 'function', line: 42 },
+    message: 'The name promises a save; the body also prunes.',
+    cite: { rubricId: 'signature-keeps-promise', source: 'seed:code/promise' },
+    derived: { priority: 6 },
+    ...over,
+  };
+}
+
+function output(findings: CodeFinding[]): CodeCraftOutput {
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: 900,
+      llmCalls: { provider: 'mock', model: 'mock-1', count: 11, costUsd: 0.123456 },
+      catalog: {
+        rubricsApplied: ['reveals-intent', 'simplest-it-could-be'],
+        exemplarsAvailable: 3,
+      },
+      counts: { filesScanned: 8, filesSkippedNoUnit: 4, unitsDetected: 19 },
+      runId: 'run-code-1',
+    },
+  };
+}
+
+function engineReturns(result: CodeCraftOutput): void {
+  vi.mocked(runCodeCraft).mockResolvedValue(result);
+}
+
+function inputPassedToEngine(): CodeCraftInput {
+  expect(runCodeCraft).toHaveBeenCalledTimes(1);
+  return vi.mocked(runCodeCraft).mock.calls[0]![0]!;
+}
+
+function run(argv: string[], globals: string[] = []): Promise<CraftCommandRun> {
+  return runCraftCommand(createCodeCraftCommand, ['code-craft', ...argv], { globals });
+}
+
+describe('code-craft command', () => {
+  beforeEach(() => {
+    vi.mocked(runCodeCraft).mockReset();
+    engineReturns(output([]));
+  });
+
+  describe('flag parsing into the engine input', () => {
+    it('scopes the run to the process cwd when no --cwd is given', async () => {
+      await run([]);
+      expect(inputPassedToEngine().path).toBe(DEFAULT_CWD);
+    });
+
+    it('scopes the run to --cwd when the root command supplies it', async () => {
+      await run([], ['--cwd', '/elsewhere/repo']);
+      expect(inputPassedToEngine().path).toBe('/elsewhere/repo');
+    });
+
+    it('omits every optional field when no flag was supplied', async () => {
+      await run([]);
+      // toStrictEqual, not toEqual: an `undefined`-valued key would satisfy
+      // toEqual and defeat the very absence this test exists to pin.
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD });
+    });
+
+    it('parses --max-files into a number, not the raw string', async () => {
+      await run(['--max-files', '12']);
+      expect(inputPassedToEngine().maxFiles).toBe(12);
+    });
+
+    it('parses --max-units-per-file into a number, not the raw string', async () => {
+      await run(['--max-units-per-file', '5']);
+      expect(inputPassedToEngine().maxUnitsPerFile).toBe(5);
+    });
+
+    it('leaves the other cap absent when only one cap is supplied', async () => {
+      // The two caps are independent: supplying one must not synthesize the other,
+      // or the engine's documented default for the unsupplied cap is overridden.
+      await run(['--max-files', '12']);
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD, maxFiles: 12 });
+    });
+
+    it('collects --files as a variadic list', async () => {
+      await run(['--files', 'src/a.ts', 'src/b.ts']);
+      expect(inputPassedToEngine().files).toEqual(['src/a.ts', 'src/b.ts']);
+    });
+
+    it('collects --packages as a variadic list', async () => {
+      await run(['--packages', 'core', 'cli']);
+      expect(inputPassedToEngine().packages).toEqual(['core', 'cli']);
+    });
+  });
+
+  describe('human-readable report', () => {
+    it('groups findings by file, regrouping non-adjacent findings, and closes with a summary', async () => {
+      engineReturns(
+        output([
+          finding({ code: 'CODE-R001' }),
+          finding({
+            code: 'CODE-R005',
+            target: { file: PARSER_FILE, unit: 'Parser', kind: 'class', line: 7 },
+            tier: 'aspirational',
+            impact: 'small',
+            confidence: 'low',
+            message: 'The class is a namespace for three unrelated helpers.',
+          }),
+          finding({
+            code: 'CODE-R002',
+            tier: 'foundational',
+            impact: 'large',
+            target: { file: STORE_FILE, unit: 'load', kind: 'method', line: 88 },
+            message: 'Control flow hides an early return behind a mutated flag.',
+          }),
+        ])
+      );
+
+      const result = await run([]);
+
+      expect(result.stdout).toEqual([
+        `\n${STORE_FILE}`,
+        '  CODE-R001 [polish/medium/high] function saveRunState:42',
+        '    The name promises a save; the body also prunes.',
+        '  CODE-R002 [foundational/large/high] method load:88',
+        '    Control flow hides an early return behind a mutated flag.',
+        `\n${PARSER_FILE}`,
+        '  CODE-R005 [aspirational/small/low] class Parser:7',
+        '    The class is a namespace for three unrelated helpers.',
+        '',
+        'Summary: 3 findings across 8 files (4 skipped, 19 units, 2 rubrics, 3 exemplars, ' +
+          '11 LLM calls, $0.1235, 900ms)',
+      ]);
+    });
+
+    it('reports the clean run instead of an empty grouping when there are no findings', async () => {
+      engineReturns(output([]));
+
+      const result = await run([]);
+
+      expect(result.stdout[0]).toBe('No code-craft findings.');
+      expect(result.stdoutText).toContain(
+        'Summary: 0 findings across 8 files (4 skipped, 19 units'
+      );
+    });
+
+    it('withholds the rubric citation unless --verbose is set', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([]);
+
+      // Paired with a presence assertion: on its own the negative would also
+      // pass against an empty report, proving nothing about the verbose gate.
+      expect(result.stdoutText).toContain('  CODE-R001 [polish/medium/high]');
+      expect(result.stdoutText).not.toContain('source:');
+    });
+
+    it('adds the rubric citation under --verbose', async () => {
+      engineReturns(output([finding()]));
+
+      expect((await run([], ['--verbose'])).stdoutText).toContain('    source: seed:code/promise');
+    });
+  });
+
+  describe('--json output', () => {
+    it('emits the engine result verbatim as pretty-printed JSON', async () => {
+      const engineOutput = output([finding()]);
+      engineReturns(engineOutput);
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(JSON.parse(result.stdout[0]!)).toEqual(engineOutput);
+      // JSON.parse is blind to formatting; assert the 2-space indent directly.
+      expect(result.stdout[0]).toContain('\n  "findings"');
+    });
+
+    it('suppresses the human report entirely', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(result.stdoutText).not.toContain('Summary:');
+    });
+  });
+
+  describe('exit codes', () => {
+    it('fails the run when any finding is foundational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'foundational' })]));
+
+      expect((await run([])).exitCode).toBe(1);
+    });
+
+    it('succeeds when the worst finding is only polish or aspirational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'aspirational' })]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('succeeds on a clean run', async () => {
+      engineReturns(output([]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('applies the same tier rule under --json', async () => {
+      engineReturns(output([finding({ tier: 'foundational' })]));
+
+      expect((await run([], ['--json'])).exitCode).toBe(1);
+    });
+  });
+
+  describe('engine failure', () => {
+    it('reports the failure on stderr and exits with the error code', async () => {
+      vi.mocked(runCodeCraft).mockRejectedValue(new Error('no source units detected'));
+
+      const result = await run([]);
+
+      expect(result.stderrText).toContain('code-craft failed: no source units detected');
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('keeps stdout clean when it fails in human mode', async () => {
+      vi.mocked(runCodeCraft).mockRejectedValue(new Error('no source units detected'));
+
+      expect((await run([])).stdout).toEqual([]);
+    });
+
+    it('emits a machine-readable error envelope under --json', async () => {
+      vi.mocked(runCodeCraft).mockRejectedValue(new Error('no source units detected'));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toEqual(['{"error":"no source units detected"}']);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('does not duplicate the JSON envelope onto stderr', async () => {
+      vi.mocked(runCodeCraft).mockRejectedValue(new Error('no source units detected'));
+
+      expect((await run([], ['--json'])).stderr).toEqual([]);
+    });
+
+    it('stringifies a non-Error rejection rather than dropping it', async () => {
+      vi.mocked(runCodeCraft).mockRejectedValue('provider quota exhausted');
+
+      expect(JSON.parse((await run([], ['--json'])).stdout[0]!)).toEqual({
+        error: 'provider quota exhausted',
+      });
+    });
+  });
+});

--- a/packages/cli/tests/commands/craft-command-harness-cohort-b.ts
+++ b/packages/cli/tests/commands/craft-command-harness-cohort-b.ts
@@ -1,0 +1,116 @@
+/**
+ * Driving harness for the craft CLI command layer (cohort B: api / code / docs
+ * / knowledge / cli-ergonomics).
+ *
+ * Every craft command ends its action by calling `process.exit(...)` on both the
+ * success and the failure path, so a test that drives one must replace
+ * `process.exit` or it tears down the vitest worker. This harness swaps it for a
+ * throw of a private sentinel, mounts the command under a parent that supplies
+ * the global flags `optsWithGlobals()` reads (`--json`, `--quiet`, `--verbose`,
+ * `--cwd`), captures the real rendered stdout/stderr, and hands back the exit
+ * code the command chose.
+ *
+ * Only the driving machinery lives here. Output fixtures stay in each command's
+ * own test file because the five engines emit structurally different findings
+ * and summaries — sharing them would hide exactly the differences worth pinning.
+ *
+ * NOTE: sibling PR #1876 (`test/craft-commands-cohort-a`) adds a
+ * `craft-command-harness.ts` for the other craft cohort. The two are deliberately
+ * separate files so the PRs do not collide; consolidate them in a follow-up once
+ * both have landed.
+ */
+
+import { Command } from 'commander';
+import { vi } from 'vitest';
+
+/** Thrown by the stubbed `process.exit` so the action unwinds instead of exiting. */
+const EXIT_SENTINEL = Symbol('craft-command-harness:process.exit');
+
+export interface CraftCommandRun {
+  /** The code the command passed to `process.exit()`. */
+  exitCode: number;
+  /** Lines written to stdout through `console.log`, in emission order. */
+  stdout: string[];
+  /** Lines written to stderr through `console.error` (the logger's error channel). */
+  stderr: string[];
+  /** `stdout` joined with newlines, for substring/regex assertions. */
+  stdoutText: string;
+  /** `stderr` joined with newlines, for substring/regex assertions. */
+  stderrText: string;
+}
+
+export interface RunCraftCommandOptions {
+  /** Root-level flags, e.g. `['--json']` or `['--cwd', '/elsewhere']`. */
+  globals?: string[];
+  /** Value `process.cwd()` reports during the run. */
+  cwd?: string;
+}
+
+/** The cwd a run reports unless the caller overrides it. */
+export const DEFAULT_CWD = '/fixture/project';
+
+/**
+ * Parse `argv` through `factory()`'s command and return what the user would have
+ * seen plus the exit code the command chose.
+ *
+ * Fails loudly if the command returns without exiting: "always terminates the
+ * process" is part of these commands' contract, and a silent return would make
+ * every `exitCode` assertion below vacuous.
+ */
+export async function runCraftCommand(
+  factory: () => Command,
+  argv: string[],
+  options: RunCraftCommandOptions = {}
+): Promise<CraftCommandRun> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    stdout.push(args.map(String).join(' '));
+  });
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    stderr.push(args.map(String).join(' '));
+  });
+  const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(options.cwd ?? DEFAULT_CWD);
+
+  let exitCode: number | undefined;
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCode = code;
+    throw EXIT_SENTINEL;
+  }) as never);
+
+  const parent = new Command();
+  parent.exitOverride();
+  parent
+    .option('--json', 'JSON output')
+    .option('--quiet', 'Quiet output')
+    .option('--verbose', 'Verbose output')
+    .option('--cwd <dir>', 'Project root');
+  parent.addCommand(factory());
+
+  try {
+    await parent.parseAsync([...(options.globals ?? []), ...argv], { from: 'user' });
+    throw new Error(
+      'craft command returned without calling process.exit() — the exit contract is broken'
+    );
+  } catch (err) {
+    if (err !== EXIT_SENTINEL) throw err;
+  } finally {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    cwdSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+
+  if (exitCode === undefined) {
+    throw new Error('process.exit() was called without an exit code');
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    stdoutText: stdout.join('\n'),
+    stderrText: stderr.join('\n'),
+  };
+}

--- a/packages/cli/tests/commands/docs-craft-command.test.ts
+++ b/packages/cli/tests/commands/docs-craft-command.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Contract tests for the `harness docs-craft` command layer.
+ *
+ * Scope is the command module only: flag parsing into `DocsCraftInput`, the
+ * JSON-vs-human output branch, the rendered human report, and the exit-code
+ * mapping. The engine (`src/docs-craft/`) is mocked — it has its own suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createDocsCraftCommand } from '../../src/commands/docs-craft';
+import { runDocsCraft } from '../../src/docs-craft/index.js';
+import type { DocsCraftInput } from '../../src/docs-craft/index.js';
+import type { DocsCraftOutput, DocsFinding } from '../../src/docs-craft/findings/schema.js';
+import {
+  runCraftCommand,
+  DEFAULT_CWD,
+  type CraftCommandRun,
+} from './craft-command-harness-cohort-b';
+
+vi.mock('../../src/docs-craft/index.js', () => ({ runDocsCraft: vi.fn() }));
+
+const GUIDE_FILE = '/repo/docs/guides/getting-started.md';
+const README_FILE = '/repo/README.md';
+
+function finding(over: Partial<DocsFinding> = {}): DocsFinding {
+  return {
+    code: 'DOCS-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: { file: GUIDE_FILE, relative: 'docs/guides/getting-started.md', kind: 'guide' },
+    message: 'The page describes the flags but never walks a first run.',
+    cite: { rubricId: 'teaches-not-describes', source: 'seed:docs/teaches' },
+    derived: { priority: 6 },
+    ...over,
+  };
+}
+
+function output(findings: DocsFinding[]): DocsCraftOutput {
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: 4200,
+      llmCalls: { provider: 'mock', model: 'mock-1', count: 6, costUsd: 0.123456 },
+      catalog: {
+        rubricsApplied: ['teaches-not-describes', 'prose-is-alive'],
+        exemplarsAvailable: 2,
+      },
+      counts: { filesScanned: 9, filesSkipped: 1 },
+      runId: 'run-docs-1',
+    },
+  };
+}
+
+function engineReturns(result: DocsCraftOutput): void {
+  vi.mocked(runDocsCraft).mockResolvedValue(result);
+}
+
+function inputPassedToEngine(): DocsCraftInput {
+  expect(runDocsCraft).toHaveBeenCalledTimes(1);
+  return vi.mocked(runDocsCraft).mock.calls[0]![0]!;
+}
+
+function run(argv: string[], globals: string[] = []): Promise<CraftCommandRun> {
+  return runCraftCommand(createDocsCraftCommand, ['docs-craft', ...argv], { globals });
+}
+
+describe('docs-craft command', () => {
+  beforeEach(() => {
+    vi.mocked(runDocsCraft).mockReset();
+    engineReturns(output([]));
+  });
+
+  describe('flag parsing into the engine input', () => {
+    it('scopes the run to the process cwd when no --cwd is given', async () => {
+      await run([]);
+      expect(inputPassedToEngine().path).toBe(DEFAULT_CWD);
+    });
+
+    it('scopes the run to --cwd when the root command supplies it', async () => {
+      await run([], ['--cwd', '/elsewhere/repo']);
+      expect(inputPassedToEngine().path).toBe('/elsewhere/repo');
+    });
+
+    it('omits every optional field when no flag was supplied', async () => {
+      await run([]);
+      // toStrictEqual, not toEqual: an `undefined`-valued key would satisfy
+      // toEqual and defeat the very absence this test exists to pin.
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD });
+    });
+
+    it('parses --max-files into a number, not the raw string', async () => {
+      await run(['--max-files', '25']);
+      expect(inputPassedToEngine().maxFiles).toBe(25);
+    });
+
+    it('collects --files as a variadic list', async () => {
+      await run(['--files', 'docs/a.md', 'docs/b.md']);
+      expect(inputPassedToEngine().files).toEqual(['docs/a.md', 'docs/b.md']);
+    });
+
+    it('collects --exclude-dirs as a variadic list', async () => {
+      await run(['--exclude-dirs', 'reference', 'archive']);
+      expect(inputPassedToEngine().excludeDirs).toEqual(['reference', 'archive']);
+    });
+
+    it('leaves unrelated fields absent when only one flag is supplied', async () => {
+      await run(['--exclude-dirs', 'archive']);
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD, excludeDirs: ['archive'] });
+    });
+  });
+
+  describe('human-readable report', () => {
+    it('groups findings by file, regrouping non-adjacent findings, and closes with a summary', async () => {
+      engineReturns(
+        output([
+          finding({ code: 'DOCS-R001' }),
+          finding({
+            code: 'DOCS-R007',
+            target: { file: README_FILE, relative: 'README.md', kind: 'readme' },
+            tier: 'aspirational',
+            impact: 'small',
+            confidence: 'low',
+            message: 'No headings; the reader cannot scan for the install step.',
+          }),
+          finding({
+            code: 'DOCS-R005',
+            tier: 'foundational',
+            impact: 'large',
+            message: 'The response shape shown does not match the documented endpoint.',
+          }),
+        ])
+      );
+
+      const result = await run([]);
+
+      expect(result.stdout).toEqual([
+        `\n${GUIDE_FILE}`,
+        '  DOCS-R001 [polish/medium/high] docs/guides/getting-started.md (guide)',
+        '    The page describes the flags but never walks a first run.',
+        '  DOCS-R005 [foundational/large/high] docs/guides/getting-started.md (guide)',
+        '    The response shape shown does not match the documented endpoint.',
+        `\n${README_FILE}`,
+        '  DOCS-R007 [aspirational/small/low] README.md (readme)',
+        '    No headings; the reader cannot scan for the install step.',
+        '',
+        'Summary: 3 findings across 9 docs (1 skipped, 2 rubrics, 2 exemplars, ' +
+          '6 LLM calls, $0.1235, 4200ms)',
+      ]);
+    });
+
+    it('reports the clean run instead of an empty grouping when there are no findings', async () => {
+      engineReturns(output([]));
+
+      const result = await run([]);
+
+      expect(result.stdout[0]).toBe('No documentation-craft findings.');
+      expect(result.stdoutText).toContain('Summary: 0 findings across 9 docs');
+    });
+
+    it('withholds the rubric citation unless --verbose is set', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([]);
+
+      // Paired with a presence assertion: on its own the negative would also
+      // pass against an empty report, proving nothing about the verbose gate.
+      expect(result.stdoutText).toContain('  DOCS-R001 [polish/medium/high]');
+      expect(result.stdoutText).not.toContain('source:');
+    });
+
+    it('adds the rubric citation under --verbose', async () => {
+      engineReturns(output([finding()]));
+
+      expect((await run([], ['--verbose'])).stdoutText).toContain('    source: seed:docs/teaches');
+    });
+  });
+
+  describe('--json output', () => {
+    it('emits the engine result verbatim as pretty-printed JSON', async () => {
+      const engineOutput = output([finding()]);
+      engineReturns(engineOutput);
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(JSON.parse(result.stdout[0]!)).toEqual(engineOutput);
+      // JSON.parse is blind to formatting; assert the 2-space indent directly.
+      expect(result.stdout[0]).toContain('\n  "findings"');
+    });
+
+    it('suppresses the human report entirely', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(result.stdoutText).not.toContain('Summary:');
+    });
+  });
+
+  describe('exit codes', () => {
+    it('fails the run when any finding is foundational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'foundational' })]));
+
+      expect((await run([])).exitCode).toBe(1);
+    });
+
+    it('succeeds when the worst finding is only polish or aspirational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'aspirational' })]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('succeeds on a clean run', async () => {
+      engineReturns(output([]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('applies the same tier rule under --json', async () => {
+      engineReturns(output([finding({ tier: 'foundational' })]));
+
+      expect((await run([], ['--json'])).exitCode).toBe(1);
+    });
+  });
+
+  describe('engine failure', () => {
+    it('reports the failure on stderr and exits with the error code', async () => {
+      vi.mocked(runDocsCraft).mockRejectedValue(new Error('docs/ not found'));
+
+      const result = await run([]);
+
+      expect(result.stderrText).toContain('docs-craft failed: docs/ not found');
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('keeps stdout clean when it fails in human mode', async () => {
+      vi.mocked(runDocsCraft).mockRejectedValue(new Error('docs/ not found'));
+
+      expect((await run([])).stdout).toEqual([]);
+    });
+
+    it('emits a machine-readable error envelope under --json', async () => {
+      vi.mocked(runDocsCraft).mockRejectedValue(new Error('docs/ not found'));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toEqual(['{"error":"docs/ not found"}']);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('does not duplicate the JSON envelope onto stderr', async () => {
+      vi.mocked(runDocsCraft).mockRejectedValue(new Error('docs/ not found'));
+
+      expect((await run([], ['--json'])).stderr).toEqual([]);
+    });
+
+    it('stringifies a non-Error rejection rather than dropping it', async () => {
+      vi.mocked(runDocsCraft).mockRejectedValue('provider quota exhausted');
+
+      expect(JSON.parse((await run([], ['--json'])).stdout[0]!)).toEqual({
+        error: 'provider quota exhausted',
+      });
+    });
+  });
+});

--- a/packages/cli/tests/commands/knowledge-craft-command.test.ts
+++ b/packages/cli/tests/commands/knowledge-craft-command.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Contract tests for the `harness knowledge-craft` command layer.
+ *
+ * Scope is the command module only: flag parsing into `KnowledgeCraftInput`
+ * (built inline in the action rather than in a `buildInput` helper), the
+ * JSON-vs-human output branch, the rendered human report, and the exit-code
+ * mapping. The engine (`src/knowledge-craft/`) is mocked — it has its own suite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKnowledgeCraftCommand } from '../../src/commands/knowledge-craft';
+import { runKnowledgeCraft } from '../../src/knowledge-craft/index.js';
+import type { KnowledgeCraftInput } from '../../src/knowledge-craft/index.js';
+import type {
+  KnowledgeCraftOutput,
+  KnowledgeFinding,
+} from '../../src/knowledge-craft/findings/schema.js';
+import {
+  runCraftCommand,
+  DEFAULT_CWD,
+  type CraftCommandRun,
+} from './craft-command-harness-cohort-b';
+
+vi.mock('../../src/knowledge-craft/index.js', () => ({ runKnowledgeCraft: vi.fn() }));
+
+const PATTERN_FILE = '/repo/docs/knowledge/patterns/retry.md';
+const GLOSSARY_FILE = '/repo/docs/knowledge/glossary.md';
+
+function finding(over: Partial<KnowledgeFinding> = {}): KnowledgeFinding {
+  return {
+    code: 'KNOW-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'medium',
+    confidence: 'high',
+    target: { file: PATTERN_FILE, relative: 'patterns/retry.md' },
+    message: 'The entry restates the code without carrying the decision forward.',
+    cite: { rubricId: 'carries-forward-decision', source: 'seed:knowledge/decision' },
+    derived: { priority: 6 },
+    ...over,
+  };
+}
+
+function output(findings: KnowledgeFinding[]): KnowledgeCraftOutput {
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: 777,
+      llmCalls: { provider: 'mock', model: 'mock-1', count: 4, costUsd: 0.123456 },
+      catalog: { rubricsApplied: ['load-bearing-fact', 'earns-graph-place'] },
+      counts: { filesScanned: 6, filesSkipped: 3 },
+      runId: 'run-knowledge-1',
+    },
+  };
+}
+
+function engineReturns(result: KnowledgeCraftOutput): void {
+  vi.mocked(runKnowledgeCraft).mockResolvedValue(result);
+}
+
+function inputPassedToEngine(): KnowledgeCraftInput {
+  expect(runKnowledgeCraft).toHaveBeenCalledTimes(1);
+  return vi.mocked(runKnowledgeCraft).mock.calls[0]![0]!;
+}
+
+function run(argv: string[], globals: string[] = []): Promise<CraftCommandRun> {
+  return runCraftCommand(createKnowledgeCraftCommand, ['knowledge-craft', ...argv], { globals });
+}
+
+describe('knowledge-craft command', () => {
+  beforeEach(() => {
+    vi.mocked(runKnowledgeCraft).mockReset();
+    engineReturns(output([]));
+  });
+
+  describe('flag parsing into the engine input', () => {
+    it('scopes the run to the process cwd when no --cwd is given', async () => {
+      await run([]);
+      expect(inputPassedToEngine().path).toBe(DEFAULT_CWD);
+    });
+
+    it('scopes the run to --cwd when the root command supplies it', async () => {
+      await run([], ['--cwd', '/elsewhere/repo']);
+      expect(inputPassedToEngine().path).toBe('/elsewhere/repo');
+    });
+
+    it('omits every optional field when no flag was supplied', async () => {
+      await run([]);
+      // toStrictEqual, not toEqual: an `undefined`-valued key would satisfy
+      // toEqual and defeat the very absence this test exists to pin.
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD });
+    });
+
+    it('parses --max-files into a number, not the raw string', async () => {
+      await run(['--max-files', '9']);
+      expect(inputPassedToEngine().maxFiles).toBe(9);
+    });
+
+    it('collects --files as a variadic list', async () => {
+      await run(['--files', 'docs/knowledge/a.md', 'docs/knowledge/b.md']);
+      expect(inputPassedToEngine().files).toEqual(['docs/knowledge/a.md', 'docs/knowledge/b.md']);
+    });
+
+    it('forwards --exclude-dirs on top of the always-excluded decisions dir', async () => {
+      await run(['--exclude-dirs', 'drafts']);
+      expect(inputPassedToEngine().excludeDirs).toEqual(['drafts']);
+    });
+
+    it('leaves unrelated fields absent when only one flag is supplied', async () => {
+      await run(['--max-files', '9']);
+      expect(inputPassedToEngine()).toStrictEqual({ path: DEFAULT_CWD, maxFiles: 9 });
+    });
+  });
+
+  describe('human-readable report', () => {
+    it('groups findings by file, regrouping non-adjacent findings, and closes with a summary', async () => {
+      engineReturns(
+        output([
+          finding({ code: 'KNOW-R001' }),
+          finding({
+            code: 'KNOW-R006',
+            target: { file: GLOSSARY_FILE, relative: 'glossary.md' },
+            tier: 'aspirational',
+            impact: 'small',
+            confidence: 'low',
+            message: 'Three terms are defined by restating the term.',
+          }),
+          finding({
+            code: 'KNOW-R003',
+            tier: 'foundational',
+            impact: 'large',
+            message: 'The load-bearing fact is asserted with no source.',
+          }),
+        ])
+      );
+
+      const result = await run([]);
+
+      // The knowledge report is deliberately kind-less: entries have no kind axis,
+      // so the line ends at the relative path where the docs/api reports print a kind.
+      expect(result.stdout).toEqual([
+        `\n${PATTERN_FILE}`,
+        '  KNOW-R001 [polish/medium/high] patterns/retry.md',
+        '    The entry restates the code without carrying the decision forward.',
+        '  KNOW-R003 [foundational/large/high] patterns/retry.md',
+        '    The load-bearing fact is asserted with no source.',
+        `\n${GLOSSARY_FILE}`,
+        '  KNOW-R006 [aspirational/small/low] glossary.md',
+        '    Three terms are defined by restating the term.',
+        '',
+        'Summary: 3 findings across 6 entries (3 skipped, 2 rubrics, 4 LLM calls, $0.1235, 777ms)',
+      ]);
+    });
+
+    it('reports the clean run instead of an empty grouping when there are no findings', async () => {
+      engineReturns(output([]));
+
+      const result = await run([]);
+
+      expect(result.stdout[0]).toBe('No knowledge-entry findings.');
+      expect(result.stdoutText).toContain('Summary: 0 findings across 6 entries');
+    });
+
+    it('withholds the rubric citation unless --verbose is set', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([]);
+
+      // Paired with a presence assertion: on its own the negative would also
+      // pass against an empty report, proving nothing about the verbose gate.
+      expect(result.stdoutText).toContain('  KNOW-R001 [polish/medium/high]');
+      expect(result.stdoutText).not.toContain('source:');
+    });
+
+    it('adds the rubric citation under --verbose', async () => {
+      engineReturns(output([finding()]));
+
+      expect((await run([], ['--verbose'])).stdoutText).toContain(
+        '    source: seed:knowledge/decision'
+      );
+    });
+  });
+
+  describe('--json output', () => {
+    it('emits the engine result verbatim as pretty-printed JSON', async () => {
+      const engineOutput = output([finding()]);
+      engineReturns(engineOutput);
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(JSON.parse(result.stdout[0]!)).toEqual(engineOutput);
+      // JSON.parse is blind to formatting; assert the 2-space indent directly.
+      expect(result.stdout[0]).toContain('\n  "findings"');
+    });
+
+    it('suppresses the human report entirely', async () => {
+      engineReturns(output([finding()]));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toHaveLength(1);
+      expect(result.stdoutText).not.toContain('Summary:');
+    });
+  });
+
+  describe('exit codes', () => {
+    it('fails the run when any finding is foundational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'foundational' })]));
+
+      expect((await run([])).exitCode).toBe(1);
+    });
+
+    it('succeeds when the worst finding is only polish or aspirational', async () => {
+      engineReturns(output([finding({ tier: 'polish' }), finding({ tier: 'aspirational' })]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('succeeds on a clean run', async () => {
+      engineReturns(output([]));
+
+      expect((await run([])).exitCode).toBe(0);
+    });
+
+    it('applies the same tier rule under --json', async () => {
+      engineReturns(output([finding({ tier: 'foundational' })]));
+
+      expect((await run([], ['--json'])).exitCode).toBe(1);
+    });
+  });
+
+  describe('engine failure', () => {
+    it('reports the failure on stderr and exits with the error code', async () => {
+      vi.mocked(runKnowledgeCraft).mockRejectedValue(new Error('docs/knowledge/ is empty'));
+
+      const result = await run([]);
+
+      expect(result.stderrText).toContain('knowledge-craft failed: docs/knowledge/ is empty');
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('keeps stdout clean when it fails in human mode', async () => {
+      vi.mocked(runKnowledgeCraft).mockRejectedValue(new Error('docs/knowledge/ is empty'));
+
+      expect((await run([])).stdout).toEqual([]);
+    });
+
+    it('emits a machine-readable error envelope under --json', async () => {
+      vi.mocked(runKnowledgeCraft).mockRejectedValue(new Error('docs/knowledge/ is empty'));
+
+      const result = await run([], ['--json']);
+
+      expect(result.stdout).toEqual(['{"error":"docs/knowledge/ is empty"}']);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('does not duplicate the JSON envelope onto stderr', async () => {
+      vi.mocked(runKnowledgeCraft).mockRejectedValue(new Error('docs/knowledge/ is empty'));
+
+      expect((await run([], ['--json'])).stderr).toEqual([]);
+    });
+
+    it('stringifies a non-Error rejection rather than dropping it', async () => {
+      vi.mocked(runKnowledgeCraft).mockRejectedValue('provider quota exhausted');
+
+      expect(JSON.parse((await run([], ['--json'])).stdout[0]!)).toEqual({
+        error: 'provider quota exhausted',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

The five craft CLI **command** modules had zero direct coverage. The existing `packages/cli/tests/<x>-craft/*.test.ts` suites all exercise the underlying `packages/cli/src/<x>-craft/` **engines**; a symbol-level cross-check found zero references to `createApiCraftCommand`, `createCodeCraftCommand`, `createDocsCraftCommand`, `createKnowledgeCraftCommand`, or `createCliErgonomicsCraftCommand` in any `*.test.ts`, and no test importing `src/commands/<x>-craft`.

These are not thin Commander wrappers — the command layer owns flag-to-input parsing, the JSON-vs-human output branch, the whole rendered human report, and the exit-code mapping.

New files (tests only, no source changed):

- `packages/cli/tests/commands/craft-command-harness-cohort-b.ts` — driving harness
- `packages/cli/tests/commands/api-craft-command.test.ts`
- `packages/cli/tests/commands/code-craft-command.test.ts`
- `packages/cli/tests/commands/docs-craft-command.test.ts`
- `packages/cli/tests/commands/knowledge-craft-command.test.ts`
- `packages/cli/tests/commands/cli-ergonomics-craft-command.test.ts`

Each engine is `vi.mock`ed so `runXCraft` returns a controlled fixture or throws; the harness stubs `process.exit` (all five commands exit on **both** the success and the failure path) so the exit code is asserted rather than killing the worker, mounts the command under a parent supplying `--json` / `--quiet` / `--verbose` / `--cwd` so `optsWithGlobals()` resolves, and captures the real rendered stdout/stderr.

## Contracts pinned, per command

- **Flag → input.** An unsupplied flag is **absent** from the engine input, not `undefined`-valued — that absence is what the conditional-assignment pattern in `buildInput` encodes, and it is what lets the engine apply its documented default. Asserted with `toStrictEqual` (`toEqual` would accept an `undefined`-valued key and defeat the point).
- **`--max-files 7` arrives as the number `7`**, not the raw string. Same for `code-craft`'s second cap, `--max-units-per-file`, plus a test that supplying one cap does not synthesize the other.
- **`--cwd` vs `process.cwd()`** both reach `input.path`.
- **Human report.** Exact rendered output: grouping by file including *regrouping non-adjacent findings* (the fixture interleaves file A, file B, file A), the per-finding line — which differs per command (`relative (kind)` for api/docs/cli-ergonomics, `kind unit:line` for code, bare `relative` for knowledge) — the `--verbose`-only `source:` citation, the zero-findings line, and the exact summary line with its per-command noun ("API surfaces" / "files" / "docs" / "entries" / "commands") and 4-dp cost formatting.
- **`--json`.** The engine result verbatim, and actually pretty-printed (`JSON.parse` is blind to formatting, so the 2-space indent is asserted directly); the human report is fully suppressed.
- **Exit codes.** A `foundational`-tier finding → `ExitCode.VALIDATION_FAILED` (1); polish/aspirational only, or zero findings → `ExitCode.SUCCESS` (0). Asserted in both output modes, so the mapping is proven independent of the render branch. (The rule is the same for all five — I read each file rather than assuming.)
- **Failure branch.** Engine throw → under `--json` a single compact `{"error":"..."}` line on stdout (asserted as an exact string, since that is what a pipe consumes) with stderr empty; in human mode `<name> failed: <message>` on stderr with stdout empty. Exit `ExitCode.ERROR` (2) either way. A non-`Error` rejection is stringified rather than dropped.

Negative assertions are paired with a positive one (e.g. the no-`--verbose` test asserts the finding line *is* rendered and the `source:` line is not) so none of them can pass vacuously against an empty report.

## Coverage delta

`pnpm vitest run --coverage --coverage.include='src/commands/*-craft.ts' tests/commands/`, before vs. after this branch's test files:

| File | Before (stmt / branch / func / line) | After |
| --- | --- | --- |
| `src/commands/api-craft.ts` | 2.04 / 0 / 20 / 2.38 | **100 / 100 / 100 / 100** |
| `src/commands/code-craft.ts` | 2.12 / 0 / 20 / 2.38 | **100 / 100 / 100 / 100** |
| `src/commands/docs-craft.ts` | 2.22 / 0 / 20 / 2.50 | **100 / 100 / 100 / 100** |
| `src/commands/knowledge-craft.ts` | 2.27 / 0 / 25 / 2.56 | **100 / 100 / 100 / 100** |
| `src/commands/cli-ergonomics-craft.ts` | 2.12 / 0 / 20 / 2.43 | **100 / 100 / 100 / 100** |

Suite: `tests/commands/` went from 147 files / 1802 tests to **152 files / 1916 tests**, all passing. `tsc --noEmit` clean.

## Assumptions made

- **The engines are out of scope.** Each `runXCraft` is mocked. These tests assert what the *command* does with an engine result, not what the engine computes — the engines have their own suites under `tests/<x>-craft/`.
- **The rendered human output is a contract worth pinning exactly.** One test per command compares the full stdout line array. If a formatter changes deliberately, that test is meant to fail and be updated; that is the point of pinning it.
- **`--quiet` currently renders the full human report.** `resolveOutputMode` maps `--quiet` to `OutputMode.QUIET`, but `printResult` only branches on `VERBOSE`, so QUIET renders identically to TEXT. This is asserted as **characterization** (in `api-craft-command.test.ts`, with a comment saying so) — it is the behavior on `main`, not an endorsement. Arguably `--quiet` should suppress the per-finding lines and keep the summary; that would be a behavior change and is deliberately not made here.
- **Fixture cost `0.123456`** is used so the `$${cost.toFixed(4)}` rounding-to-4-dp is actually exercised (`$0.1235`) rather than trivially matched.
- **Tests were mutation-checked, not just watched green.** Perturbing a fixture (`filesScanned`) and a finding tier turned the corresponding output and exit-code assertions red, then reverted — the assertions are load-bearing, not coverage theater.
- **No changeset.** `scripts/check-changesets.mjs` skips `*.test.ts` and `/tests/`; the pre-push gate passed without one.

## Note on the sibling PR

Sibling PR #1876 (`test/craft-commands-cohort-a`), which is not in this branch's base, adds `packages/cli/tests/commands/craft-command-harness.ts` for the other craft cohort. This PR's harness is deliberately named `craft-command-harness-cohort-b.ts` so the two branches do not collide on the same path. **The two harnesses should be consolidated into one in a follow-up once both have landed.**

## Authoring flow

Authored via `harness:tdd` (assertions mutation-verified before being accepted), then critiqued and raised via `harness:test-craft`. The test-craft pass produced six applied changes: `toStrictEqual` instead of key-order-coupled `Object.keys(...).toEqual([...])`; pairing every vacuous-capable negative assertion with a presence assertion; asserting the JSON indentation the test name claims; pinning that `--json` emits exactly one line; and asserting the error envelope as an exact compact string rather than a parsed object.

Tests only. No source file was modified.