### PR TITLE
test(cli): cover the golden-build, mcp context-report, and telemetry-wizard command layer

### DIFF
--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '4fd8cee931904f68676859d2876dfa148c3e9524e309bde8e640c07060501124'
+sourceHash: '9c62390c1f24ef76809468d40ea2947fc31b4310f1668d3faf01c5132f833f9d'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -29,6 +29,7 @@ members:
     'check-vocabulary.test.ts',
     'cleanup-sessions.test.ts',
     'cleanup.test.ts',
+    'cli-command-harness.ts',
     'compound-scan-candidates.test.ts',
     'create-skill.test.ts',
     'cross-check.test.ts',
@@ -41,6 +42,7 @@ members:
     'generate-agent-definitions.test.ts',
     'generate-slash-commands.test.ts',
     'generate.test.ts',
+    'golden-build-command.test.ts',
     'golden-build.test.ts',
     'graph-ingest-decisions.integration.test.ts',
     'graph-ingest.test.ts',
@@ -63,6 +65,7 @@ members:
     'maintenance-run-check-runner.test.ts',
     'maintenance-run-integration.test.ts',
     'maintenance-run-selection.test.ts',
+    'mcp-context-report.test.ts',
     'mcp-guard.test.ts',
     'mcp-list-capabilities.test.ts',
     'mcp-refinement-demand.test.ts',
@@ -112,6 +115,7 @@ members:
     'sync-main.test.ts',
     'taint.test.ts',
     'telemetry-synthesize.test.ts',
+    'telemetry-wizard-run.test.ts',
     'telemetry-wizard.test.ts',
     'telemetry.test.ts',
     'traceability.test.ts',
@@ -137,7 +141,11 @@ members:
 ## Interface Contract
 
 ```ts
-
+export ProcessExitSignal
+export captureConsole
+export runToExit
+export stripAnsi
+export stubProcessExit
 ```
 
 ## Dependency Slice
@@ -172,7 +180,8 @@ import { createFixDriftCommand, runFixDrift } from '../../src/commands/fix-drift
 import { createGenerateCommand } from '../../src/commands/generate'
 import { createGenerateAgentDefinitionsCommand, generateAgentDefinitions } from '../../src/commands/generate-agent-definitions'
 import { GenerateResult, createGenerateSlashCommandsCommand, generateSlashCommands, handleOrphanDeletion, resolveSkillSources } from '../../src/commands/generate-slash-commands'
-import { runGoldenDiff, runGoldenPromote, runGoldenVerify } from '../../src/commands/golden-build'
+import { createGoldenBuildCommand, runGoldenDiff, runGoldenPromote, runGoldenVerify } from '../../src/commands/golden-build'
+import { runGoldenDiff, runGoldenPromote, runGoldenVerify } from '../../src/commands/golden-build/runners'
 import { registerDeprecatedGraphAliases } from '../../src/commands/graph/deprecated-aliases'
 import { runGraphExport } from '../../src/commands/graph/export'
 import { createGraphCommand } from '../../src/commands/graph/index'
@@ -201,7 +210,7 @@ import { SyncIO, runSyncIntegrations } from '../../src/commands/integrations/syn
 import { createGenerateCommand } from '../../src/commands/linter/generate'
 import { createMaintenanceCommand } from '../../src/commands/maintenance'
 import { MaintenanceRunDeps, aggregateReport, buildTaskRunner, createCheckRunner, createFixDispatcher, deriveExitCode, loadRunHistory, makeResolveBackend, parseConcurrency, renderTable, resolveHarnessSpawn, resolveSelection, runMaintenanceRun } from '../../src/commands/maintenance-run'
-import { createMcpRefinementDemandCommand, formatCapabilitiesByPermission, formatCapabilitiesTable, formatRefinementDemand } from '../../src/commands/mcp'
+import { createMcpCommand, createMcpContextReportCommand, createMcpListCapabilitiesCommand, createMcpRefinementDemandCommand, formatCapabilitiesByPermission, formatCapabilitiesTable, formatContextReport, formatRefinementDemand } from '../../src/commands/mcp'
 import { extractNpmPackages, parseNpmSpec, runMcpGuardCheck } from '../../src/commands/mcp-guard'
 import { detectLegacyArtifacts, runMigrate } from '../../src/commands/migrate'
 import { runMigrateBackends } from '../../src/commands/migrate-backends'
@@ -243,7 +252,7 @@ import { createSyncAnalysesCommand, extractAnalysisFromComments } from '../../sr
 import { runSyncMain } from '../../src/commands/sync-main'
 import { createTaintCommand } from '../../src/commands/taint'
 import { createTelemetryCommand } from '../../src/commands/telemetry'
-import { ensureTelemetryConfigured, isTelemetryConfigured, writeTelemetryConfig } from '../../src/commands/telemetry-wizard'
+import { ensureTelemetryConfigured, isTelemetryConfigured, runTelemetryWizard, writeTelemetryConfig } from '../../src/commands/telemetry-wizard'
 import { createTelemetryCommand } from '../../src/commands/telemetry/index'
 import { createTraceabilityCommand } from '../../src/commands/traceability'
 import { createUninstallCommand, runUninstall } from '../../src/commands/uninstall'
@@ -290,8 +299,9 @@ import { CLIError, ExitCode } from '../../src/utils/errors'
 import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
+import { ConsoleCapture, captureConsole, runToExit, stubProcessExit } from './cli-command-harness'
 import * as clack from '@clack/prompts'
-import { CiReviewResult, DiffInfo, Err, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
+import { CiReviewResult, DiffInfo, Err, GoldenFileChange, GoldenSnapshot, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateKnowledgeMap, writeConfig } from '@harness-engineering/core'
 import from '@harness-engineering/graph'
 import { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION, GuardianAnalysis, OutcomeVerdict } from '@harness-engineering/intelligence'
 import { AnalysisRecord, MockBackend, RunMode, RunResult, SyncMainResult, TaskDefinition, renderAnalysisComment } from '@harness-engineering/orchestrator'
@@ -310,6 +320,6 @@ import { mockedSetTimeout } from 'node:timers'
 import { fileURLToPath } from 'node:url'
 import * as os from 'os'
 import * as path, { join } from 'path'
-import { MockedFunction, afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Mock, MockedFunction, afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import YAML, { parseYaml, yamlParse } from 'yaml'
 ```

--- a/packages/cli/tests/commands/cli-command-harness.ts
+++ b/packages/cli/tests/commands/cli-command-harness.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared fixtures for exercising commander command trees end-to-end.
+ *
+ * CLI command modules are only observable through three side channels: what
+ * they print, what exit code they hand the shell, and what they pass to the
+ * runners underneath. These helpers capture the first two so a test can assert
+ * on the *user-visible* contract instead of reaching into module internals.
+ */
+import { vi } from 'vitest';
+
+// Built from a char code rather than a literal escape so the source stays free
+// of control characters (and of an eslint `no-control-regex` suppression).
+const ANSI_ESCAPE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+/** Strip SGR colour codes so assertions survive a colour-capable terminal. */
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE, '');
+}
+
+export interface ConsoleCapture {
+  /** Each `console.log` call, ANSI-stripped and argument-joined. */
+  readonly stdoutLines: string[];
+  /** Each `console.error` / `console.warn` call, ANSI-stripped. */
+  readonly stderrLines: string[];
+  /** All stdout lines joined by newline — the text a user would read. */
+  stdout(): string;
+  /** All stderr lines joined by newline. */
+  stderr(): string;
+  restore(): void;
+}
+
+/**
+ * Redirect console output into arrays. Callers must `restore()` (an
+ * `afterEach` is the usual home) or later tests inherit the spies.
+ */
+export function captureConsole(): ConsoleCapture {
+  const stdoutLines: string[] = [];
+  const stderrLines: string[] = [];
+  const render = (args: unknown[]): string =>
+    stripAnsi(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+
+  const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    stdoutLines.push(render(args));
+  });
+  const error = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    stderrLines.push(render(args));
+  });
+  const warn = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    stderrLines.push(render(args));
+  });
+
+  return {
+    stdoutLines,
+    stderrLines,
+    stdout: () => stdoutLines.join('\n'),
+    stderr: () => stderrLines.join('\n'),
+    restore: () => {
+      log.mockRestore();
+      error.mockRestore();
+      warn.mockRestore();
+    },
+  };
+}
+
+/**
+ * Thrown by the stubbed `process.exit`. Throwing (rather than returning) is the
+ * faithful stand-in: the real `process.exit` never returns, so a stub that
+ * *does* return would let the command run code that could never execute in
+ * production — e.g. dereferencing `result.value` after an error exit.
+ */
+export class ProcessExitSignal extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+    this.name = 'ProcessExitSignal';
+  }
+}
+
+/** Replace `process.exit` with a throw so the test process survives. */
+export function stubProcessExit(): { restore(): void } {
+  const spy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ProcessExitSignal(code ?? 0);
+  }) as never);
+  return { restore: () => spy.mockRestore() };
+}
+
+/**
+ * Run a command and return the exit code it requested. Fails loudly if the
+ * command returned without exiting — a command that forgets to exit is a bug,
+ * not a silent pass.
+ */
+export async function runToExit(run: () => Promise<unknown>): Promise<number> {
+  try {
+    await run();
+  } catch (err) {
+    if (err instanceof ProcessExitSignal) return err.code;
+    throw err;
+  }
+  throw new Error('Expected the command to call process.exit(), but it returned normally.');
+}

--- a/packages/cli/tests/commands/golden-build-command.test.ts
+++ b/packages/cli/tests/commands/golden-build-command.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Command-wiring tests for `harness golden-build`.
+ *
+ * The runners themselves are covered by `golden-build.test.ts`; this file
+ * covers the layer above them — option accumulation, human-readable rendering,
+ * and above all the exit-code mapping. `golden-build verify` is a verification
+ * gate, so a wrong exit code turns a red gate green in CI without any visible
+ * symptom. The runners are mocked so each exit branch can be driven directly.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { Command } from 'commander';
+import type { GoldenSnapshot, GoldenFileChange } from '@harness-engineering/core';
+import { ExitCode } from '../../src/utils/errors';
+import {
+  captureConsole,
+  runToExit,
+  stubProcessExit,
+  type ConsoleCapture,
+} from './cli-command-harness';
+
+vi.mock('../../src/commands/golden-build/runners', () => ({
+  runGoldenPromote: vi.fn(),
+  runGoldenVerify: vi.fn(),
+  runGoldenDiff: vi.fn(),
+}));
+
+import { createGoldenBuildCommand } from '../../src/commands/golden-build';
+import {
+  runGoldenPromote,
+  runGoldenVerify,
+  runGoldenDiff,
+} from '../../src/commands/golden-build/runners';
+
+const promoteMock = runGoldenPromote as unknown as Mock;
+const verifyMock = runGoldenVerify as unknown as Mock;
+const diffMock = runGoldenDiff as unknown as Mock;
+
+/** A root program mirroring `harness`: the real CLI owns `--json`/`--config`. */
+function rootProgram(): Command {
+  const program = new Command('harness')
+    .option('--json', 'Emit machine-readable JSON')
+    .option('-c, --config <path>', 'Config file path')
+    .exitOverride();
+  program.addCommand(createGoldenBuildCommand());
+  return program;
+}
+
+/**
+ * The options object a runner was invoked with. Fails with a readable message
+ * when the command never reached the runner at all — otherwise a wiring
+ * regression surfaces as "cannot read property of undefined".
+ */
+function runnerOptions(mock: Mock): { configPath?: string; paths?: string[] } {
+  const [firstCall] = mock.mock.calls;
+  if (!firstCall) throw new Error('Expected the runner to be invoked, but it never was.');
+  return firstCall[0] as { configPath?: string; paths?: string[] };
+}
+
+/** Run `harness golden-build <argv...>` and return the requested exit code. */
+function run(...argv: string[]): Promise<number> {
+  return runToExit(() => rootProgram().parseAsync(argv, { from: 'user' }));
+}
+
+const GOLDEN: GoldenSnapshot = {
+  version: 1,
+  promotedAt: '2026-01-02T03:04:05.000Z',
+  commit: 'abc1234',
+  branch: 'main',
+  files: [],
+};
+
+function change(over: Partial<GoldenFileChange> & { path: string }): GoldenFileChange {
+  return { status: 'changed', ...over } as GoldenFileChange;
+}
+
+function verifyValue(over: {
+  clean?: boolean;
+  changed?: GoldenFileChange[];
+  missing?: GoldenFileChange[];
+  added?: GoldenFileChange[];
+  golden?: GoldenSnapshot | null;
+}) {
+  const changed = over.changed ?? [];
+  const missing = over.missing ?? [];
+  const added = over.added ?? [];
+  const clean = over.clean ?? changed.length + missing.length + added.length === 0;
+  return {
+    clean,
+    diff: { clean, changed, missing, added },
+    golden: over.golden === undefined ? GOLDEN : over.golden,
+  };
+}
+
+let out: ConsoleCapture;
+let exitStub: { restore(): void };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  out = captureConsole();
+  exitStub = stubProcessExit();
+});
+
+afterEach(() => {
+  out.restore();
+  exitStub.restore();
+});
+
+describe('--path accumulation (collectPath)', () => {
+  it('accumulates every repeated --path into one ordered array', async () => {
+    promoteMock.mockResolvedValue({
+      ok: true,
+      value: { changed: true, fileCount: 2, commit: 'c', branch: 'b', manifestPath: 'm' },
+    });
+
+    await run('golden-build', 'promote', '--path', 'a.json', '--path', 'b.json');
+
+    expect(runnerOptions(promoteMock).paths).toEqual(['a.json', 'b.json']);
+  });
+
+  it('preserves duplicate --path values verbatim rather than de-duplicating them', async () => {
+    // The accumulator is a plain append, not a set: `--path a --path b --path a`
+    // must survive as three entries so the runner — not the CLI — owns any
+    // normalisation of the reference list.
+    verifyMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    await run('golden-build', 'verify', '--path', 'a.json', '--path', 'b.json', '--path', 'a.json');
+
+    expect(runnerOptions(verifyMock).paths).toEqual(['a.json', 'b.json', 'a.json']);
+  });
+
+  it('passes an empty path list through when --path is never given', async () => {
+    verifyMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    await run('golden-build', 'verify');
+
+    expect(runnerOptions(verifyMock).paths).toEqual([]);
+  });
+});
+
+describe('global option resolution (isJson / --config)', () => {
+  it('honours --json when it lands on the root program', async () => {
+    verifyMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    await run('--json', 'golden-build', 'verify');
+
+    expect(JSON.parse(out.stdout()).clean).toBe(true);
+  });
+
+  it('honours --json when it lands on the subcommand', async () => {
+    verifyMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    await run('golden-build', 'verify', '--json');
+
+    expect(JSON.parse(out.stdout()).clean).toBe(true);
+  });
+
+  it('forwards the root --config down to the runner as configPath', async () => {
+    diffMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    await run('-c', './ci.harness.config.json', 'golden-build', 'diff');
+
+    expect(runnerOptions(diffMock).configPath).toBe('./ci.harness.config.json');
+  });
+});
+
+describe('human-readable diff rendering (printDiffHuman / shortHash)', () => {
+  it('prints the golden provenance line when a golden snapshot is present', async () => {
+    verifyMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).toContain(
+      'Golden promoted from abc1234 (main) at 2026-01-02T03:04:05.000Z'
+    );
+  });
+
+  it('omits the golden provenance line when no snapshot is attached', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({ clean: true, golden: null }),
+    });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).not.toContain('Golden promoted from');
+  });
+
+  it('reports a clean tree and skips the per-entry lines entirely', async () => {
+    // `diff.clean` short-circuits the renderer, so the (contradictory) entries
+    // below must never be printed. This pins the early return, not the message.
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: {
+        clean: true,
+        diff: {
+          clean: true,
+          changed: [change({ path: 'never-printed.json' })],
+          missing: [],
+          added: [],
+        },
+        golden: GOLDEN,
+      },
+    });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).toContain('Working tree matches the golden build. No drift.');
+    expect(out.stdout()).not.toContain('never-printed.json');
+  });
+
+  it('renders a changed entry with both hashes truncated to 12 characters', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        changed: [
+          change({
+            path: 'coverage-baselines.json',
+            goldenHash: 'aaaaaaaaaaaabbbbbbbbbbbbcccc',
+            currentHash: 'ddddddddddddeeeeeeeeeeeeffff',
+          }),
+        ],
+      }),
+    });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).toContain(
+      'changed  coverage-baselines.json  aaaaaaaaaaaa -> dddddddddddd'
+    );
+  });
+
+  it('renders a missing entry with its former hash and an absence note', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        missing: [change({ path: 'gone.json', status: 'missing', goldenHash: '0123456789abcdef' })],
+      }),
+    });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).toContain('missing  gone.json  (was 0123456789ab, now absent)');
+  });
+
+  it('renders an added entry as not-in-golden', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        added: [change({ path: 'new.json', status: 'added', currentHash: 'fedcba9876543210' })],
+      }),
+    });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).toContain('added    new.json  fedcba987654 (not in golden)');
+  });
+
+  it('substitutes an em-dash placeholder for an absent hash', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        // A `missing` entry has no currentHash by construction; rendering it
+        // through the `changed` template exposes the placeholder branch.
+        changed: [change({ path: 'vanished.json', goldenHash: 'aaaaaaaaaaaabbbb' })],
+      }),
+    });
+
+    await run('golden-build', 'verify');
+
+    expect(out.stdout()).toContain('changed  vanished.json  aaaaaaaaaaaa -> —');
+  });
+
+  it('prints one line per entry across all three change categories', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        changed: [
+          change({ path: 'c1.json', goldenHash: 'g1', currentHash: 'n1' }),
+          change({ path: 'c2.json', goldenHash: 'g2', currentHash: 'n2' }),
+        ],
+        missing: [change({ path: 'm1.json', status: 'missing', goldenHash: 'g3' })],
+        added: [change({ path: 'a1.json', status: 'added', currentHash: 'n4' })],
+      }),
+    });
+
+    await run('golden-build', 'verify');
+
+    const entryLines = out.stdoutLines.filter((l) => /^\S\s+(changed|missing|added)\s/.test(l));
+    expect(entryLines).toHaveLength(4);
+  });
+});
+
+describe('promote exit-code mapping', () => {
+  it('exits SUCCESS and names the promoted file count on a changed promote', async () => {
+    promoteMock.mockResolvedValue({
+      ok: true,
+      value: {
+        changed: true,
+        fileCount: 3,
+        commit: 'deadbee',
+        branch: 'main',
+        manifestPath: '.harness/golden.json',
+      },
+    });
+
+    const code = await run('golden-build', 'promote');
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(out.stdout()).toContain(
+      'Golden build promoted: 3 reference file(s) from deadbee (main).'
+    );
+    expect(out.stdout()).toContain('Manifest written to .harness/golden.json');
+  });
+
+  it('reports a byte-stable manifest instead of a promotion on an unchanged promote', async () => {
+    promoteMock.mockResolvedValue({
+      ok: true,
+      value: {
+        changed: false,
+        fileCount: 3,
+        commit: 'deadbee',
+        branch: 'main',
+        manifestPath: '.harness/golden.json',
+      },
+    });
+
+    const code = await run('golden-build', 'promote');
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(out.stdout()).toContain(
+      'Golden build unchanged (fingerprint identical) — manifest left byte-stable.'
+    );
+    expect(out.stdout()).not.toContain('Golden build promoted');
+  });
+
+  it('emits the promote result as JSON instead of prose when --json is set', async () => {
+    promoteMock.mockResolvedValue({
+      ok: true,
+      value: {
+        changed: true,
+        fileCount: 3,
+        commit: 'deadbee',
+        branch: 'main',
+        manifestPath: '.harness/golden.json',
+      },
+    });
+
+    const code = await run('golden-build', 'promote', '--json');
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(JSON.parse(out.stdout())).toMatchObject({ changed: true, fileCount: 3 });
+    expect(out.stdout()).not.toContain('Golden build promoted');
+  });
+
+  it('exits with ERROR when the runner reports an unexpected failure', async () => {
+    promoteMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'config unreadable', exitCode: ExitCode.ERROR },
+    });
+
+    expect(await run('golden-build', 'promote')).toBe(ExitCode.ERROR);
+  });
+
+  it('exits with ZERO_DENOMINATOR when the runner reports one', async () => {
+    // Paired with the ERROR case above: two different runner codes reaching the
+    // shell prove the command forwards `error.exitCode` rather than collapsing
+    // every failure onto one constant.
+    promoteMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'nothing to fingerprint', exitCode: ExitCode.ZERO_DENOMINATOR },
+    });
+
+    expect(await run('golden-build', 'promote')).toBe(ExitCode.ZERO_DENOMINATOR);
+  });
+
+  it('routes a failure to stderr in human mode', async () => {
+    promoteMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'config unreadable', exitCode: ExitCode.ERROR },
+    });
+
+    await run('golden-build', 'promote');
+
+    expect(out.stderr()).toContain('config unreadable');
+    expect(out.stdout()).toBe('');
+  });
+
+  it('routes a failure to a JSON error envelope on stdout in --json mode', async () => {
+    promoteMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'config unreadable', exitCode: ExitCode.ERROR },
+    });
+
+    await run('golden-build', 'promote', '--json');
+
+    expect(JSON.parse(out.stdout())).toEqual({ error: 'config unreadable' });
+    expect(out.stderr()).toBe('');
+  });
+});
+
+describe('verify exit-code mapping', () => {
+  it('exits SUCCESS when the working tree matches the golden', async () => {
+    verifyMock.mockResolvedValue({ ok: true, value: verifyValue({ clean: true }) });
+
+    expect(await run('golden-build', 'verify')).toBe(ExitCode.SUCCESS);
+  });
+
+  it('exits VALIDATION_FAILED when the working tree has drifted', async () => {
+    verifyMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        changed: [change({ path: 'x.json', goldenHash: 'a', currentHash: 'b' })],
+      }),
+    });
+
+    expect(await run('golden-build', 'verify')).toBe(ExitCode.VALIDATION_FAILED);
+  });
+
+  it('forwards the runner error exit code when verification cannot run', async () => {
+    verifyMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'no golden build found', exitCode: ExitCode.ERROR },
+    });
+
+    expect(await run('golden-build', 'verify')).toBe(ExitCode.ERROR);
+    expect(out.stderr()).toContain('no golden build found');
+  });
+});
+
+describe('diff exit-code mapping', () => {
+  it('exits SUCCESS even when the tree has drifted, because diff is advisory', async () => {
+    diffMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({
+        changed: [change({ path: 'x.json', goldenHash: 'a', currentHash: 'b' })],
+      }),
+    });
+
+    const code = await run('golden-build', 'diff');
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(out.stdout()).toContain('changed  x.json');
+  });
+
+  it('suggests promoting instead of rendering a diff when no golden exists', async () => {
+    diffMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({ clean: true, golden: null }),
+    });
+
+    const code = await run('golden-build', 'diff');
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(out.stdout()).toContain(
+      'No golden build has been promoted yet. Run `harness golden-build promote`.'
+    );
+    expect(out.stdout()).not.toContain('Working tree matches the golden build');
+  });
+
+  it('emits the raw result instead of the hint when --json is set and no golden exists', async () => {
+    diffMock.mockResolvedValue({
+      ok: true,
+      value: verifyValue({ clean: true, golden: null }),
+    });
+
+    await run('golden-build', 'diff', '--json');
+
+    expect(JSON.parse(out.stdout()).golden).toBeNull();
+    expect(out.stdout()).not.toContain('No golden build has been promoted yet');
+  });
+
+  it('forwards the runner error exit code when the diff itself fails', async () => {
+    diffMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'config unreadable', exitCode: ExitCode.ERROR },
+    });
+
+    expect(await run('golden-build', 'diff')).toBe(ExitCode.ERROR);
+  });
+});

--- a/packages/cli/tests/commands/mcp-context-report.test.ts
+++ b/packages/cli/tests/commands/mcp-context-report.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Covers the `harness mcp` surfaces that the existing mcp tests leave untouched:
+ * the `formatContextReport` attribution renderer, the option parsers that guard
+ * `--tier` / `--budget-tokens` / `--window` / `--top`, and the
+ * `list-capabilities` JSON envelope and formatter selection.
+ *
+ * The formatter internals of `formatCapabilitiesTable` /
+ * `formatCapabilitiesByPermission` are covered by `mcp-list-capabilities.test.ts`
+ * and are deliberately not re-asserted here — only which of the two the command
+ * chooses.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { captureConsole, type ConsoleCapture } from './cli-command-harness';
+
+// Only the two entry points the context-report action reaches for are replaced;
+// everything else in `@harness-engineering/core` (and the rest of the MCP tree)
+// stays real so `list-capabilities` still exercises the production tool list.
+const gatherContextSurface = vi.fn(() => [] as unknown[]);
+const buildAttributionReport = vi.fn();
+const startServer = vi.fn(async () => undefined);
+const selectTier = vi.fn();
+
+vi.mock('../../src/mcp/context-surface.js', () => ({ gatherContextSurface }));
+
+vi.mock('@harness-engineering/core', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  buildAttributionReport,
+}));
+
+vi.mock('../../src/mcp/index.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  startServer,
+}));
+
+vi.mock('../../src/mcp/tool-tiers.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    selectTier: (...args: unknown[]) => {
+      selectTier(...args);
+      return (actual.selectTier as (...a: unknown[]) => unknown)(...args);
+    },
+  };
+});
+
+import {
+  formatContextReport,
+  createMcpContextReportCommand,
+  createMcpListCapabilitiesCommand,
+  createMcpCommand,
+} from '../../src/commands/mcp';
+
+/**
+ * The options argument a collaborator was invoked with. Fails with a readable
+ * message when the command never reached the collaborator.
+ */
+function optionsPassedTo(mock: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  const [firstCall] = mock.mock.calls;
+  if (!firstCall) throw new Error('Expected the collaborator to be invoked, but it never was.');
+  return firstCall[1] as Record<string, unknown>;
+}
+
+type ReportArg = Parameters<typeof formatContextReport>[0];
+
+function report(over: Partial<ReportArg> = {}): ReportArg {
+  return {
+    windowTokens: 200_000,
+    totalTokens: 1_234,
+    counterMode: 'heuristic',
+    degraded: false,
+    byClass: [],
+    topContributors: [],
+    ...over,
+  };
+}
+
+let out: ConsoleCapture;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gatherContextSurface.mockReturnValue([]);
+  buildAttributionReport.mockResolvedValue(report());
+  out = captureConsole();
+});
+
+afterEach(() => {
+  out.restore();
+});
+
+describe('formatContextReport', () => {
+  it('names the tier the measurement was taken at in the header', () => {
+    expect(formatContextReport(report(), 'core')).toContain(
+      '# Context-surface attribution (tier: core)'
+    );
+  });
+
+  it('reports the budgeting window and the counter mode on the provenance line', () => {
+    const text = formatContextReport(
+      report({ windowTokens: 50_000, counterMode: 'exact' }),
+      'full'
+    );
+
+    expect(text).toContain('# window=50000 tokens · counts=exact');
+  });
+
+  it('warns that some entries fell back to the heuristic when the report is degraded', () => {
+    const text = formatContextReport(report({ degraded: true }), 'full');
+
+    expect(text).toContain('(some entries fell back to the chars/4 heuristic)');
+  });
+
+  it('stays silent about the heuristic fallback when nothing was degraded', () => {
+    expect(formatContextReport(report({ degraded: false }), 'full')).not.toContain(
+      'fell back to the chars/4 heuristic'
+    );
+  });
+
+  it('flags only the class that exceeded its budget', () => {
+    const text = formatContextReport(
+      report({
+        byClass: [
+          {
+            contextClass: 'always-loaded',
+            tokens: 90_000,
+            count: 12,
+            budgetTokens: 40_000,
+            overBudget: true,
+          },
+          {
+            contextClass: 'invoked-only',
+            tokens: 500,
+            count: 3,
+            budgetTokens: 40_000,
+            overBudget: false,
+          },
+        ],
+      }),
+      'full'
+    );
+
+    const flagged = text.split('\n').filter((l) => l.includes('OVER BUDGET'));
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0]).toContain('always-loaded');
+  });
+
+  it('shows each class with its token total, budget, and contributor count', () => {
+    const text = formatContextReport(
+      report({
+        byClass: [
+          {
+            contextClass: 'path-scoped',
+            tokens: 1_500,
+            count: 7,
+            budgetTokens: 20_000,
+            overBudget: false,
+          },
+        ],
+      }),
+      'full'
+    );
+
+    expect(text).toContain('path-scoped');
+    expect(text).toMatch(/1500\s+tok\s+budget 20000\s+\(7 contributors\)/);
+  });
+
+  it('marks only the estimated contributors as [heuristic]', () => {
+    const text = formatContextReport(
+      report({
+        topContributors: [
+          { label: 'AGENTS.md', contextClass: 'always-loaded', tokens: 900, degraded: true },
+          { label: 'hooks', contextClass: 'always-loaded', tokens: 300, degraded: false },
+        ],
+      }),
+      'full'
+    );
+
+    const marked = text.split('\n').filter((l) => l.includes('[heuristic]'));
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain('AGENTS.md');
+  });
+
+  it('closes with the measured-surface total', () => {
+    expect(formatContextReport(report({ totalTokens: 98_765 }), 'full')).toContain(
+      'Total: 98765 tokens across the measured surface.'
+    );
+  });
+});
+
+// The rejection tests below assert the exact message text on purpose: for a CLI
+// the message *is* the contract, because it is the only place the user learns
+// which values are accepted. A silent or vague rejection is the regression.
+describe('context-report option parsing', () => {
+  const parse = (...argv: string[]) =>
+    createMcpContextReportCommand().parseAsync(argv, { from: 'user' });
+
+  it('rejects an unrecognised tier and names the accepted values', async () => {
+    await expect(parse('--tier', 'bogus')).rejects.toThrow(
+      'Invalid tier "bogus". Expected one of: core, standard, full.'
+    );
+  });
+
+  it('accepts a tier in any casing and normalises it to lower case', async () => {
+    await parse('--tier', 'CORE');
+
+    expect(optionsPassedTo(gatherContextSurface)).toMatchObject({ tier: 'core' });
+  });
+
+  it('defaults to the full tier when --tier is omitted', async () => {
+    await parse();
+
+    expect(optionsPassedTo(gatherContextSurface)).toMatchObject({ tier: 'full' });
+  });
+
+  it('rejects a zero --window because the budget denominator must be positive', async () => {
+    await expect(parse('--window', '0')).rejects.toThrow(
+      'Invalid --window "0". Expected a positive integer.'
+    );
+  });
+
+  it('names the offending flag when --top is not positive', async () => {
+    await expect(parse('--top', '-3')).rejects.toThrow(
+      'Invalid --top "-3". Expected a positive integer.'
+    );
+  });
+
+  it('rejects a non-numeric --window', async () => {
+    await expect(parse('--window', 'lots')).rejects.toThrow(
+      'Invalid --window "lots". Expected a positive integer.'
+    );
+  });
+
+  it('forwards an accepted --window and --top into the attribution report', async () => {
+    await parse('--window', '50000', '--top', '3');
+
+    expect(optionsPassedTo(buildAttributionReport)).toMatchObject({
+      windowTokens: 50_000,
+      topN: 3,
+    });
+  });
+
+  it('budgets against a 200k window and 10 contributors by default', async () => {
+    await parse();
+
+    expect(optionsPassedTo(buildAttributionReport)).toMatchObject({
+      windowTokens: 200_000,
+      topN: 10,
+    });
+  });
+
+  it('includes the platform skill trees by default', async () => {
+    await parse();
+
+    expect(optionsPassedTo(gatherContextSurface)).toMatchObject({ includeSkills: true });
+  });
+
+  it('excludes the platform skill trees when --no-skills is passed', async () => {
+    await parse('--no-skills');
+
+    expect(optionsPassedTo(gatherContextSurface)).toMatchObject({ includeSkills: false });
+  });
+
+  it('counts with the heuristic — not exact counts — unless --exact is given', async () => {
+    await parse();
+
+    expect(optionsPassedTo(buildAttributionReport)).toMatchObject({ exact: false });
+  });
+
+  it('emits the report as JSON tagged with the measured tier when --json is set', async () => {
+    buildAttributionReport.mockResolvedValue(report({ totalTokens: 42 }));
+
+    await parse('--tier', 'standard', '--json');
+
+    const parsed = JSON.parse(out.stdout());
+    expect(parsed.tier).toBe('standard');
+    expect(parsed.totalTokens).toBe(42);
+  });
+
+  it('renders the human report instead of JSON by default', async () => {
+    buildAttributionReport.mockResolvedValue(report({ totalTokens: 42 }));
+
+    await parse('--tier', 'standard');
+
+    expect(out.stdout()).toContain('# Context-surface attribution (tier: standard)');
+  });
+});
+
+describe('mcp root option parsing', () => {
+  const parse = (...argv: string[]) => createMcpCommand().parseAsync(argv, { from: 'user' });
+
+  it('rejects a non-numeric --budget-tokens', async () => {
+    await expect(parse('--budget-tokens', 'plenty')).rejects.toThrow(
+      'Invalid --budget-tokens "plenty". Expected a non-negative integer.'
+    );
+  });
+
+  it('rejects a negative --budget-tokens', async () => {
+    await expect(parse('--budget-tokens', '-1')).rejects.toThrow(
+      'Invalid --budget-tokens "-1". Expected a non-negative integer.'
+    );
+  });
+
+  it('accepts a zero --budget-tokens as a real (most restrictive) budget', async () => {
+    // Zero is a legitimate budget, not "unset" — it must reach tier selection
+    // rather than being rejected alongside the negatives.
+    await parse('--budget-tokens', '0');
+
+    expect(selectTier).toHaveBeenCalledWith(expect.anything(), { tokenBudget: 0 });
+    expect(startServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('lower-cases an explicit --tier before handing it to tier selection', async () => {
+    await parse('--tier', 'STANDARD');
+
+    expect(selectTier).toHaveBeenCalledWith(expect.anything(), { overrideTier: 'standard' });
+  });
+
+  it('lets an explicit --tools list win over tier selection', async () => {
+    await parse('--tools', 'code_search', 'query_graph');
+
+    expect(startServer).toHaveBeenCalledWith(['code_search', 'query_graph']);
+    expect(selectTier).not.toHaveBeenCalled();
+  });
+
+  it('starts the server with no filter when neither tier nor budget is given', async () => {
+    await parse();
+
+    expect(startServer).toHaveBeenCalledWith();
+    expect(selectTier).not.toHaveBeenCalled();
+  });
+});
+
+describe('list-capabilities output selection', () => {
+  const parse = (...argv: string[]) =>
+    createMcpListCapabilitiesCommand().parseAsync(argv, { from: 'user' });
+
+  it('partitions the tool count into declared and heuristic sources in the JSON envelope', async () => {
+    await parse('--json');
+
+    const parsed = JSON.parse(out.stdout());
+    expect(parsed.scopeSource).toBe('declared-with-heuristic-fallback');
+    expect(parsed.count).toBe(parsed.capabilities.length);
+    expect(parsed.declaredCount).toBe(
+      parsed.capabilities.filter((c: { source: string }) => c.source === 'declared').length
+    );
+    expect(parsed.heuristicCount).toBe(
+      parsed.capabilities.filter((c: { source: string }) => c.source === 'heuristic').length
+    );
+    expect(parsed.declaredCount + parsed.heuristicCount).toBe(parsed.count);
+  });
+
+  it('reports a non-empty tool surface so the envelope is not vacuously consistent', async () => {
+    await parse('--json');
+
+    expect(JSON.parse(out.stdout()).count).toBeGreaterThan(0);
+  });
+
+  it('prints the flat table by default', async () => {
+    await parse();
+
+    expect(out.stdout()).toMatch(/TOOL\s+SCOPES\s+NETWORK\s+TRUST\s+SOURCE/);
+    expect(out.stdout()).not.toContain('## READ (');
+  });
+
+  it('prints the permission-grouped view when --by-permission is set', async () => {
+    await parse('--by-permission');
+
+    expect(out.stdout()).toContain('## READ (');
+    expect(out.stdout()).toContain('## NETWORK (');
+    expect(out.stdout()).not.toMatch(/TOOL\s+SCOPES\s+NETWORK\s+TRUST\s+SOURCE/);
+  });
+
+  it('lets --json win over --by-permission', async () => {
+    await parse('--json', '--by-permission');
+
+    expect(JSON.parse(out.stdout()).scopeSource).toBe('declared-with-heuristic-fallback');
+    expect(out.stdout()).not.toContain('## READ (');
+  });
+});

--- a/packages/cli/tests/commands/telemetry-wizard-run.test.ts
+++ b/packages/cli/tests/commands/telemetry-wizard-run.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Covers `runTelemetryWizard` — the interactive driver.
+ *
+ * `isTelemetryConfigured` / `writeTelemetryConfig` / `ensureTelemetryConfigured`
+ * are covered by `telemetry-wizard.test.ts`; this file covers only the prompt
+ * loop. Its consent semantics are the point: both telemetry questions are
+ * default-ON (`!isNo(answer)`), so a user who just presses Enter opts IN. That
+ * is exactly the kind of default a silent regression could invert.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { captureConsole, type ConsoleCapture } from './cli-command-harness';
+
+const script = vi.hoisted(() => ({
+  /** Answers handed to `rl.question`, in order. */
+  answers: [] as string[],
+  /** Every question string the wizard asked, in order. */
+  asked: [] as string[],
+  /** How many readline interfaces were opened and closed. */
+  opened: 0,
+  closed: 0,
+}));
+
+vi.mock('node:readline', () => {
+  const createInterface = () => {
+    script.opened += 1;
+    return {
+      question: (query: string, callback: (answer: string) => void) => {
+        script.asked.push(query);
+        callback(script.answers.shift() ?? '');
+      },
+      close: () => {
+        script.closed += 1;
+      },
+    };
+  };
+  return { default: { createInterface }, createInterface };
+});
+
+import { runTelemetryWizard } from '../../src/commands/telemetry-wizard';
+
+const ENTER = '';
+
+let out: ConsoleCapture;
+let originalIsTTY: boolean | undefined;
+
+/** Script the answers and run the wizard as an interactive session. */
+async function wizardWith(...answers: string[]) {
+  script.answers = [...answers];
+  process.stdin.isTTY = true;
+  return runTelemetryWizard();
+}
+
+beforeEach(() => {
+  script.answers = [];
+  script.asked = [];
+  script.opened = 0;
+  script.closed = 0;
+  originalIsTTY = process.stdin.isTTY;
+  out = captureConsole();
+});
+
+afterEach(() => {
+  process.stdin.isTTY = originalIsTTY as boolean;
+  out.restore();
+});
+
+describe('non-interactive guard', () => {
+  it('returns null without prompting when stdin is not a TTY', async () => {
+    process.stdin.isTTY = false;
+
+    expect(await runTelemetryWizard()).toBeNull();
+  });
+
+  it('opens no readline interface at all in non-interactive mode', async () => {
+    process.stdin.isTTY = false;
+
+    await runTelemetryWizard();
+
+    expect(script.opened).toBe(0);
+  });
+
+  it('returns null when isTTY is undefined rather than explicitly false', async () => {
+    // `process.stdin.isTTY` is `undefined` — not `false` — on a piped stdin.
+    process.stdin.isTTY = undefined as unknown as boolean;
+
+    expect(await runTelemetryWizard()).toBeNull();
+  });
+});
+
+describe('consent defaults', () => {
+  it('enables both telemetry and adoption when the user just presses Enter', async () => {
+    const result = await wizardWith(ENTER, ENTER, ENTER);
+
+    expect(result).toEqual({
+      telemetryEnabled: true,
+      adoptionEnabled: true,
+      identity: {},
+    });
+  });
+
+  it('offers telemetry and adoption as (Y/n) — default yes', async () => {
+    await wizardWith(ENTER, ENTER, ENTER);
+
+    expect(script.asked[0]).toContain('(Y/n)');
+    expect(script.asked[1]).toContain('(Y/n)');
+  });
+
+  it('disables telemetry on "n"', async () => {
+    const result = await wizardWith('n', ENTER, ENTER);
+
+    expect(result?.telemetryEnabled).toBe(false);
+  });
+
+  it('disables telemetry on the spelled-out "no"', async () => {
+    const result = await wizardWith('no', ENTER, ENTER);
+
+    expect(result?.telemetryEnabled).toBe(false);
+  });
+
+  it('treats an unrecognised answer as consent, since only n/no decline', async () => {
+    const result = await wizardWith('maybe', ENTER, ENTER);
+
+    expect(result?.telemetryEnabled).toBe(true);
+  });
+
+  it('normalises case and surrounding whitespace before reading a decline', async () => {
+    const result = await wizardWith('  N  ', ENTER, ENTER);
+
+    expect(result?.telemetryEnabled).toBe(false);
+  });
+
+  it('decides adoption independently of the telemetry answer', async () => {
+    const result = await wizardWith('n', ENTER, ENTER);
+
+    expect(result?.adoptionEnabled).toBe(true);
+  });
+
+  it('disables adoption without disabling telemetry', async () => {
+    const result = await wizardWith('y', 'no', ENTER);
+
+    expect(result).toMatchObject({ telemetryEnabled: true, adoptionEnabled: false });
+  });
+
+  it('asks exactly three questions when identity is declined', async () => {
+    await wizardWith(ENTER, ENTER, ENTER);
+
+    expect(script.asked).toHaveLength(3);
+  });
+});
+
+describe('optional identity', () => {
+  it('skips the identity fields unless the user opts in explicitly', async () => {
+    // Identity is (y/N): unlike the consent prompts, blank means "no".
+    const result = await wizardWith(ENTER, ENTER, ENTER);
+
+    expect(result?.identity).toEqual({});
+    expect(script.asked[2]).toContain('(y/N)');
+  });
+
+  it('does not prompt for identity fields on an unrecognised answer', async () => {
+    const result = await wizardWith(ENTER, ENTER, 'sure');
+
+    expect(result?.identity).toEqual({});
+    expect(script.asked).toHaveLength(3);
+  });
+
+  it('collects project, team, and alias when the user opts in with "y"', async () => {
+    const result = await wizardWith(ENTER, ENTER, 'y', 'checkout', 'payments', 'cw');
+
+    expect(result?.identity).toEqual({ project: 'checkout', team: 'payments', alias: 'cw' });
+  });
+
+  it('accepts the spelled-out "yes" and any casing to open the identity prompts', async () => {
+    const result = await wizardWith(ENTER, ENTER, 'YES', 'checkout', 'payments', 'cw');
+
+    expect(result?.identity).toEqual({ project: 'checkout', team: 'payments', alias: 'cw' });
+  });
+
+  it('preserves the original casing of identity values', async () => {
+    const result = await wizardWith(ENTER, ENTER, 'y', 'Checkout API', 'Platform Team', 'CWarner');
+
+    expect(result?.identity).toEqual({
+      project: 'Checkout API',
+      team: 'Platform Team',
+      alias: 'CWarner',
+    });
+  });
+
+  it('trims surrounding whitespace from identity values without lowercasing them', async () => {
+    const result = await wizardWith(ENTER, ENTER, 'y', '  MiXeD Case  ', ENTER, ENTER);
+
+    expect(result?.identity.project).toBe('MiXeD Case');
+  });
+
+  it('omits a blank identity field entirely instead of storing an empty string', async () => {
+    const result = await wizardWith(ENTER, ENTER, 'y', 'checkout', ENTER, 'cw');
+
+    expect(result?.identity).toEqual({ project: 'checkout', alias: 'cw' });
+    // `toEqual` treats an explicit `team: undefined` as equal to an absent key,
+    // so the key check is what actually pins "omitted", not "set to nothing".
+    expect('team' in (result?.identity ?? {})).toBe(false);
+  });
+
+  it('asks six questions in total once identity is opted into', async () => {
+    await wizardWith(ENTER, ENTER, 'y', 'checkout', 'payments', 'cw');
+
+    expect(script.asked).toHaveLength(6);
+  });
+});
+
+describe('readline lifecycle', () => {
+  it('closes every readline interface it opens on the short path', async () => {
+    await wizardWith(ENTER, ENTER, ENTER);
+
+    expect(script.opened).toBe(3);
+    expect(script.closed).toBe(3);
+  });
+
+  it('closes every readline interface it opens on the identity path', async () => {
+    await wizardWith(ENTER, ENTER, 'y', 'checkout', 'payments', 'cw');
+
+    expect(script.opened).toBe(6);
+    expect(script.closed).toBe(6);
+  });
+});


### PR DESCRIPTION
Three CLI command modules had untested wiring. The runners and formatters *underneath* them were already covered; the layer that maps argv to runner options and runner results to **exit codes** was not. `golden-build verify` is a verification gate, so a wrong exit code turns a red gate green in CI with no visible symptom — that is the highest-value part of this diff.

Test-only change. No production code was modified.

## What is covered

**`packages/cli/src/commands/golden-build/index.ts`** — `createGoldenBuildCommand` had *zero* test references. `golden-build.test.ts` covers only the re-exported runners.
- `collectPath` — repeated `--path` accumulates in argv order; duplicates survive verbatim; empty when omitted.
- `shortHash` — 12-character truncation and the `—` placeholder for an absent hash.
- `isJson` — resolves `--json` via `optsWithGlobals()` whether the flag lands on the subcommand or the root program.
- `printDiffHuman` — promoted-from line only when `golden` is present; `diff.clean` logs the success line and **returns early** (pinned by feeding it contradictory non-empty entries that must not print); otherwise one `changed`/`missing`/`added` line per entry.
- Exit-code mapping — `promote` forwards `result.error.exitCode` (proved with two different codes, ERROR and ZERO_DENOMINATOR, not one constant); `verify` maps `clean` to `SUCCESS` and drift to `VALIDATION_FAILED`; `diff` always exits `SUCCESS` even when drifted, and prints the "No golden build has been promoted yet" hint when `!v.golden`. All three route failures to a `{"error": ...}` envelope on stdout in JSON mode vs `logger.error` on stderr otherwise.

**`packages/cli/src/commands/mcp.ts`** — narrowed to the genuinely uncovered symbols. `formatCapabilitiesTable`, `formatCapabilitiesByPermission`, `formatRefinementDemand`, and `createMcpRefinementDemandCommand` are covered by `mcp-list-capabilities.test.ts` / `mcp-refinement-demand.test.ts` and are **not** re-tested here.
- `formatContextReport` — tier in the header, window/counterMode provenance line, the degraded suffix only when `report.degraded`, `OVER BUDGET` on exactly the over-budget class, `[heuristic]` on exactly the degraded contributor, and the trailing Total.
- `parseTier` / `parseBudget` / `parsePositiveInt` — module-private, so reached through the commands' option parsing. Casing normalisation is asserted behaviourally (`--tier STANDARD` reaches `selectTier` as `overrideTier: 'standard'`). `--budget-tokens 0` is accepted as a real budget while `-1` and non-numerics are rejected; `parsePositiveInt` rejects `0` and names the offending flag.
- `createMcpListCapabilitiesCommand` — the `--json` envelope (`scopeSource`, `count`, and `declaredCount`/`heuristicCount` partitioning by `source`), and the flat-table vs `--by-permission` **selection** (not the formatter internals).

**`packages/cli/src/commands/telemetry-wizard.ts`** — `runTelemetryWizard` only. `isTelemetryConfigured` / `writeTelemetryConfig` / `ensureTelemetryConfigured` are covered by `telemetry-wizard.test.ts` and are not re-tested.
- Returns `null` and opens no readline interface when `process.stdin.isTTY` is falsy (both `false` and `undefined`).
- **Default-ON consent**: `telemetryEnabled` / `adoptionEnabled` are `!isNo(answer)`, so a blank Enter, `y`, and any unrecognised answer all opt the user **in**; only `n` / `no` decline. Asserted explicitly because a silent inversion here is a privacy regression.
- Identity: prompted only on `y`/`yes`, blank sub-answers are omitted from the object rather than stored as `''`, and casing is preserved for identity fields (`promptRaw`) while the yes/no prompts are lower-cased (`prompt`).
- `rl.close()` is called once per prompt on both the 3-prompt and 6-prompt paths.

## Method

Authored via `harness:tdd`, then critiqued and revised via `harness:test-craft` (in-session mode, runId `b690d911`; its 8-rubric catalog drove the pass). test-craft findings applied: two multi-act tests split into single-responsibility tests (TEST-R003/R005), a `not.toThrow()` assertion strengthened to assert the actual JSON envelope (TEST-R002), and indexed `mock.calls[0][0]` access replaced with helpers that fail with a readable message when the collaborator was never invoked (TEST-R008).

Because the code under test already exists, RED discipline was satisfied by **mutation verification** rather than by watching a new test fail: 20 mutations were applied across the three source files (exit-code constants collapsed, `optsWithGlobals` narrowed to `opts`, the `diff.clean` early return removed, hash truncation length changed, the `—` placeholder changed, comparison operators flipped in the parsers, formatter selection inverted, `isNo` inverted, the `prompt` lower-casing dropped, the blank-field guards removed, `rl.close()` dropped). **Every one was caught**, then reverted. `git status` is clean of any source change — the diff is test files only.

## Assumptions made

- **`collectPath`'s "returns a new array" property is not observable through the command surface.** Commander does not reset `_optionValues` between parses, and the `[]` default is constructed per `createGoldenBuildCommand()` call, so a mutating `previous.push(value)` accumulator is behaviourally indistinguishable from `[...previous, value]` from outside. I verified this empirically against commander before dropping the test — a "does not leak into the next invocation" assertion passed under the mutation and was therefore coverage theater. It was replaced with the accumulation properties that *are* observable (argv order preserved, duplicates not de-duplicated, empty by default). Flagged rather than silently dropped.
- **Exact error-message text is asserted for the option parsers on purpose.** TEST-R007 generally warns against pinning message wording, but for a CLI the message *is* the contract — it is the only place the user learns which values are accepted. Noted in a comment at the assertion site.
- The runner boundary is treated as the command's contract: `golden-build`'s tests assert what reaches `runGoldenPromote`/`Verify`/`Diff`, because translating argv into runner options is precisely what the command layer is for.
- `process.exit` is stubbed to **throw** rather than return. A returning stub would let the command execute code that can never run in production (e.g. dereferencing `result.value` after an error exit), so the throw is the faithful stand-in.
- Shared fixtures live in a new non-test helper, `packages/cli/tests/commands/cli-command-harness.ts` (not collected by vitest, whose `include` is `tests/**/*.test.ts`). Named to avoid collision with the `craft-command-harness*.ts` / `design-command-harness.ts` helpers landing in sibling PRs.

## Coverage delta

Measured with `vitest run --coverage` over `tests/commands/`, identical file set before and after (`search.test.ts` excluded from both runs — see the note below).

| File | Metric | Before | After |
| --- | --- | ---: | ---: |
| `src/commands/golden-build/index.ts` | Stmts | 12.50% | **96.87%** |
| | Branch | 0.00% | **93.33%** |
| | Funcs | 36.36% | **100%** |
| | Lines | 13.33% | **100%** |
| `src/commands/mcp.ts` | Stmts | 41.96% | **93.75%** |
| | Branch | 13.04% | **93.47%** |
| | Funcs | 53.84% | **96.15%** |
| | Lines | 39.81% | **93.51%** |
| `src/commands/telemetry-wizard.ts` | Stmts | 37.97% | **93.67%** |
| | Branch | 42.10% | **73.68%** |
| | Funcs | 33.33% | **100%** |
| | Lines | 38.66% | **93.33%** |
| **All three combined** | Stmts | 33.33% | **94.50%** |
| | Branch | 19.29% | **86.84%** |
| | Funcs | 44.89% | **97.95%** |
| | Lines | 32.92% | **95.06%** |

Remaining uncovered is out of scope for this PR: `mcp.ts:309-317` is the `refinement-demand` action body (that command's existing test covers its formatter), and `telemetry-wizard.ts:166-174` is the `ensureTelemetryConfigured` summary tail (owned by `telemetry-wizard.test.ts`).

## Test run

`packages/cli` `tests/commands/`: **149 files / 1876 tests passed**, including the 82 new tests, with every pre-existing suite still green.

`tests/commands/search.test.ts` (4 tests) fails *in-session only* and is unrelated to this diff: `better-sqlite3` is compiled for the Node 22 ABI that the pre-push gate pins (`NODE_MODULE_VERSION 127`) while the authoring session runs Node 24 (`137`). The pre-push gate ran the full suite under Node 22 and passed — this branch pushed clean through it, no bypass.
