### PR TITLE
chore(roadmap): reconcile fleet-item-type-routing to done; two expected reconciliations rejected on evidence

### DIFF
--- a/docs/roadmap.d/fleet-item-type-routing.md
+++ b/docs/roadmap.d/fleet-item-type-routing.md
@@ -6,9 +6,9 @@ order: 20
 
 ### fleet-item-type-routing — build-shaped fleets route by item type (bug vs feature)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/fleet-item-type-routing/proposal.md
-- **Summary:** The build-shaped `-fleet` members (`roadmap-fleet`, `security-fleet`) forced every item through the design-first pipeline `harness-brainstorming → harness-autopilot`, so a bug tracked as a backlog/roadmap item got design ceremony it did not need and then stalled in autopilot for lack of an Implementation Order. This item makes those members classify each item by type and route it: `bug` → `harness-debugging`, approved-spec → `harness-autopilot`, new-feature/ambiguous → `harness-brainstorming → harness-autopilot`. The rubric is stated once in `docs/reference/fleet-family.md` (§Item-type routing, ADR 0103) and referenced by both fleets; classification happens at SELECT (metadata-first, router-rubric fallback), is human-overridable at CONFIRM, and VERIFY checks route-appropriate artifacts. `bug-fleet` / `cicd-fleet` already route to debugging and are unchanged.
+- **Summary:** DELIVERED (PR #1506, merged 2026-08-26; ADR 0103). The build-shaped `-fleet` members (`roadmap-fleet`, `security-fleet`) forced every item through the design-first pipeline `harness-brainstorming → harness-autopilot`, so a bug tracked as a backlog/roadmap item got design ceremony it did not need and then stalled in autopilot for lack of an Implementation Order. This item makes those members classify each item by type and route it: `bug` → `harness-debugging`, approved-spec → `harness-autopilot`, new-feature/ambiguous → `harness-brainstorming → harness-autopilot`. The rubric is stated once in `docs/reference/fleet-family.md` (§Item-type routing, ADR 0103) and referenced by both fleets; classification happens at SELECT (metadata-first, router-rubric fallback), is human-overridable at CONFIRM, and VERIFY checks route-appropriate artifacts. `bug-fleet` / `cicd-fleet` already route to debugging and are unchanged.
 - **Blockers:** —
 - **Assignee:** —
 - **Priority:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -741,9 +741,9 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### fleet-item-type-routing — build-shaped fleets route by item type (bug vs feature)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/fleet-item-type-routing/proposal.md
-- **Summary:** The build-shaped `-fleet` members (`roadmap-fleet`, `security-fleet`) forced every item through the design-first pipeline `harness-brainstorming → harness-autopilot`, so a bug tracked as a backlog/roadmap item got design ceremony it did not need and then stalled in autopilot for lack of an Implementation Order. This item makes those members classify each item by type and route it: `bug` → `harness-debugging`, approved-spec → `harness-autopilot`, new-feature/ambiguous → `harness-brainstorming → harness-autopilot`. The rubric is stated once in `docs/reference/fleet-family.md` (§Item-type routing, ADR 0103) and referenced by both fleets; classification happens at SELECT (metadata-first, router-rubric fallback), is human-overridable at CONFIRM, and VERIFY checks route-appropriate artifacts. `bug-fleet` / `cicd-fleet` already route to debugging and are unchanged.
+- **Summary:** DELIVERED (PR #1506, merged 2026-08-26; ADR 0103). The build-shaped `-fleet` members (`roadmap-fleet`, `security-fleet`) forced every item through the design-first pipeline `harness-brainstorming → harness-autopilot`, so a bug tracked as a backlog/roadmap item got design ceremony it did not need and then stalled in autopilot for lack of an Implementation Order. This item makes those members classify each item by type and route it: `bug` → `harness-debugging`, approved-spec → `harness-autopilot`, new-feature/ambiguous → `harness-brainstorming → harness-autopilot`. The rubric is stated once in `docs/reference/fleet-family.md` (§Item-type routing, ADR 0103) and referenced by both fleets; classification happens at SELECT (metadata-first, router-rubric fallback), is human-overridable at CONFIRM, and VERIFY checks route-appropriate artifacts. `bug-fleet` / `cicd-fleet` already route to debugging and are unchanged.
 - **Blockers:** —
 - **Plan:** —
 


### PR DESCRIPTION
## What

Reconciles **one** shipped-but-stale roadmap shard to `done`, following the precedent of PR #1850.

`docs/roadmap.d/fleet-item-type-routing.md` — **`planned` → `done`**, resolving citation **PR #1506** (merged 2026-08-26, ADR 0103).

This shard's `External-ID` is `—`, which is exactly why routine reconciliation has never caught it: the merge-triggered reconciler keys on the External-ID, so a shard without one is invisible to it forever regardless of what ships.

### Evidence re-derived on `origin/main` (not taken on report)

- `docs/knowledge/decisions/0103-fleet-item-type-routing.md` exists with `status: accepted`, `source: docs/changes/fleet-item-type-routing/proposal.md`.
- `docs/reference/fleet-family.md:40` carries `## Item-type routing (build-shaped members)`; `:227` routes `roadmap-fleet` per that section; `:263` names ADR 0103.
- Both build-shaped members reference the section (5 hits each in `roadmap-fleet/SKILL.md` and `security-fleet/SKILL.md`), and roadmap-fleet's SELECT phase implements the metadata → spec-presence → rubric-fallback precedence the ADR defines.
- PR #1506 is `MERGED`, and the shard's Summary describes exactly what that PR delivered.

That is EXISTS + SUBSTANTIVE + **WIRED** — the consumers actually read it.

## Two shards were investigated and deliberately NOT reconciled

Both were expected to be reconciled here. Independent re-derivation says otherwise, and marking them `done` would have destroyed tracking for real, un-built work.

### `denominator-declaration-in-metric-outputs` (#1530) — left `planned`

PR #1858 (merged 2026-09-06) is **slice 1 of 5**, not the whole item. Its body reads `Refs #1530 — deliberately not Closes`, and states verbatim: *"closing it here would strand the remaining tranches with no tracking row. The roadmap row stays open until the ledger burns down."*

`docs/conventions/metric-denominator-ledger.md` on `main` names ~255 remaining sites across tranches 2–5 — including tranche 4, the dashboard render sites, of which the PR says the adopter-facing goal **"is not delivered"**. Issue #1530 is still `OPEN`.

Flipping this row to `done` would have deleted the tracking for four undelivered tranches. This is the single highest-priority row in the backlog (P0, order 98) — it must stay `planned`.

### `content-addressed-gate-memoization` (#1639) — left `planned`

Same shape. PR #1798 (merged 2026-09-01) says `Refs #1639` — *"first correct-by-construction slice; remainder deferred"* — and names four deferred deliverables (per-gate input-closure declaration + access-recorder audit, distributed cache backend, basal-metabolism savings telemetry, and the `harness cache stats` / `explain` CLI surface). Issue #1639 is still `OPEN`.

Additionally: the expectation that reconciling this slug would **release other rows is false**. `git grep` across `docs/roadmap.d/` finds *zero* other shards naming `content-addressed-gate-memoization` in `Blockers:`. That shard is itself blocked (on `basal-token-metabolism`, `model-update-regression-sentinel`, `scope-harness-validate-to-changed-surface`) — it is downstream, not upstream.

The slug that *does* appear widely in `Blockers:` is `denominator-declaration-in-metric-outputs`, in **7** shards: `adoption-funnel-telemetry`, `autonomy-ratio-self-hosting-benchmark`, `basal-token-metabolism`, `controlled-experiment-harness-for-its-own-effect`, `counterfactual-shadow-trial`, `observational-causal-inference-toolkit`, `toulmin-structured-justifications`. Since #1530 is **not** done, **none of them are released by this PR.**

## Rows unblocked by this PR

**None.** `fleet-item-type-routing` appears in no other shard's `Blockers:`.

## Why the aggregate was hand-edited

`docs/roadmap.md` was updated surgically (2 lines) rather than by regenerating wholesale.

The `harness` binary on `PATH` is the globally-installed published CLI, not this repo's build. Its `roadmap regen` is **lossy** — it emitted a 354,353-byte aggregate that silently dropped the entire 92-line `## Assignment History` section. The repo-local build (`node packages/cli/dist/bin/harness.js roadmap regen`) emits 356,908 bytes and preserves it.

Verification: after the surgical edit, running the **repo-local** regen produces a **zero-byte diff**. The aggregate here is therefore byte-identical to a correct regeneration — it just never passed through the stale global binary. `manage_roadmap` MCP write actions were not used (known to flip unrelated rows `planned` → `blocked`).

## Assumptions made

- **Citation style follows the repo's own `done`-shard convention** (`DELIVERED (PR #NNNN, merged …)` prefixed to the Summary), which is slightly richer than PR #1850's bare status flip. Chosen so the shard is self-documenting for the next reconciliation pass rather than relying on this PR description surviving.
- **`Refs #1506`, not `Closes`** — #1506 is already merged; there is no open issue for this PR to close. The shard carries no External-ID, so no reconciler behavior is triggered either way.
- **Scope held to one shard.** The two rejected shards were left completely untouched rather than annotated with partial-progress notes — an annotation is a content edit that belongs with whoever burns the ledger down, and touching them here would have muddied a pure reconciliation diff.

## Verification

- Only 2 files changed, 4 insertions, 4 deletions.
- All pre-push gates passed on the **first** attempt (format:check, coverage-ratchet, reference-docs freshness, tool/skill catalog).
- No source change, so no changeset is required.
