### PR TITLE
fix(eslint-plugin): catch Playwright's test.describe.only() in no-focused-tests

### DIFF
--- a/.changeset/no-focused-tests-playwright-describe-only.md
+++ b/.changeset/no-focused-tests-playwright-describe-only.md
@@ -1,0 +1,28 @@
+---
+'@harness-engineering/eslint-plugin': patch
+---
+
+fix(eslint-plugin): no-focused-tests now catches Playwright's `test.describe.only()` (#1853)
+
+`no-focused-tests` gated focus detection on `node.callee.object.type === 'Identifier'`,
+which admits only a flat member expression. Playwright namespaces its API, so in
+`test.describe.only(...)` the callee's object is a `MemberExpression` (`test.describe`)
+and the guard never matched.
+
+That inverted severity in the worst possible direction: `.only` mutes every _other_
+test in the file, so a focused Playwright block silently reduced a suite to one case
+while lint stayed silent and CI reported green — even though the strictly-smaller
+`test.only(...)` was reported.
+
+The rule now delegates to the existing `isTestModifierCall(node, 'only')` helper, which
+walks the callee's dotted chain and matches any chain rooted at `describe`/`it`/`test`
+whose final link is the modifier. This is the same adoption `no-skipped-tests` and
+`no-disabled-tests` already made for `'skip'` in #1851; the helper was parameterised by
+modifier for exactly this.
+
+`test.describe.only`, `test.describe.serial.only` and `test.describe.parallel.only` are
+now reported. Every previously reported spelling still reports, including the
+`fdescribe` / `fit` bare-identifier forms, which the helper does not cover and which are
+unchanged. Computed access (`test.describe['only']()`) and optional chaining stay
+unreported, and the modifier must be the terminal chain link — the same documented
+boundaries as #1851, pinned by tests.

--- a/.harness/comprehension/packages/eslint-plugin/src/rules/_module.md
+++ b/.harness/comprehension/packages/eslint-plugin/src/rules/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/eslint-plugin/src/rules'
-sourceHash: '83dd3bcf2a4dca66b39981e8776fad77fe6aad6d42277af905f3f86b03b5b503'
+sourceHash: 'bff4f7af956b8475ba532de4a8edb518dce4ba0012e338053be6b3861bbedd29'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/eslint-plugin/tests/rules/_module.md
+++ b/.harness/comprehension/packages/eslint-plugin/tests/rules/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/eslint-plugin/tests/rules'
-sourceHash: 'cd07281f9ba0e2678d77ba358f78e37d264104345b41d57c0244bb82d0a4bd66'
+sourceHash: '37dfa6427bae186a1673b4d5e0c39df20096c9de048e5e17388df396241ca0bc'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/docs/changes/no-focused-tests-playwright-describe-only-1853/debug-session.md
+++ b/docs/changes/no-focused-tests-playwright-describe-only-1853/debug-session.md
@@ -1,0 +1,185 @@
+# Debug Session: `no-focused-tests` misses `test.describe.only()`
+
+Status: resolved
+Started: 2026-09-06
+Resolved: 2026-09-06
+Issue: https://github.com/Intense-Visions/harness-engineering/issues/1853
+Base SHA: c1ca02ba2
+Error: `test.describe.only('...', () => {})` (Playwright) produces NO lint error from
+`@harness-engineering/no-focused-tests`, while the strictly-smaller focus
+`test.only('...')` does report. `.only` mutes every _other_ test in the file, so the
+broader mute passes lint while CI still reports green.
+
+## Investigation Log
+
+### Phase 1 — INVESTIGATE (read-only)
+
+**Entropy analysis.** `harness cleanup` reports 5754 entropy issues repo-wide, all
+doc-drift `RENAMED` / `NOT_FOUND` symbol findings under `docs/`. Nothing at the failure
+site: no finding names `src/rules/no-focused-tests.ts` or `src/utils/ast-helpers.ts`.
+Entropy is not a contributing factor here.
+
+**What failed.** One rule under-reports.
+`packages/eslint-plugin/src/rules/no-focused-tests.ts:28-34` gates focus detection on:
+
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&                  // <-- the guard
+    (object.name === 'describe' | 'it' | 'test') &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'only'
+
+**Reproduced consistently** (3/3 identical runs) via a standalone `eslint`
+`Linter.verify()` over:
+
+     1 |
+     2 | test.describe.only('a whole describe, focused - mutes every OTHER test in the file', () => {
+     3 |   test('one', async () => {});
+     4 |   test('two', async () => {});
+     5 | });
+     6 | test.only('a single focused test', async () => {});
+     7 | test.describe.serial.only('serial chain, focused', () => {});
+     8 | describe.only('jest style', () => {});
+     9 | it.only('jest style single', () => {});
+    10 | fdescribe('jasmine style', () => {});
+    11 | fit('jasmine style single', () => {});
+
+Observed, every run:
+
+    --- no-focused-tests: 5 problems
+      6:1  Focused test - ...
+      8:1  Focused test - ...
+      9:1  Focused test - ...
+      10:1 Focused test - ...
+      11:1 Focused test - ...
+
+Lines **2** and **7** are silent. Line 2 focuses a whole block and therefore mutes
+every other test in the file; line 6 focuses one test and IS reported. Severity is
+inverted exactly as the issue describes.
+
+**Where it diverges.** For `test.describe.only(...)` the callee is a MemberExpression
+whose `.object` is itself a MemberExpression (`test.describe`), not an Identifier. The
+`object.type === 'Identifier'` guard is false, the first branch short-circuits, the
+`f`-prefix branch does not match, nothing is reported.
+
+**Recent changes.** Not a regression. `git log` on the rule shows a single commit
+(`938ba6f55`, "feat(eslint-plugin): add no-focused-tests rule (#868)"); the flat-member
+shape has been present since the rule was introduced. The bug is original, surfaced by
+Playwright's namespaced API.
+
+**External corroboration.** The vendored Playwright-lint ESTree bundle in the repo
+(`packages/cli/dist/estree-*.js`) enumerates `test.describe.only`,
+`test.describe.parallel.only`, and `test.describe.serial.only` among its known test
+spellings - independent confirmation that these are real, current Playwright forms and
+not a speculative shape.
+
+### Phase 2 — ANALYZE
+
+**Working example #1 (same file).** The flat spellings `describe.only` / `it.only` /
+`test.only` all satisfy the guard because their callee object is a bare Identifier. The
+ONLY difference between the working and failing input is the DEPTH of the callee chain -
+not the root name, not the terminal property, not the call shape. That isolates the
+guard as the sole cause.
+
+**Working example #2 (sibling rule, already fixed).** `no-skipped-tests` was repaired
+for the identical defect by #1812 / PR #1851 and now delegates to
+`isTestModifierCall(node, 'skip')`. Running the same standalone harness against it with
+`.only` swapped for `.skip` reports **7/7** problems, including the two nested lines
+that `no-focused-tests` misses. Same file structure, same node shapes, same call sites -
+the detection guard is the only difference.
+
+**The helper is already proven for this modifier.**
+`packages/eslint-plugin/tests/utils/ast-helpers.test.ts:145-150` already asserts
+`isTestModifierCall(firstCall("test.describe.only('s', () => {});"), 'only') === true`.
+The helper was parameterised by modifier precisely so this rule could adopt it. What is
+missing is only the rule's adoption.
+
+## Hypotheses
+
+**H1 (single, falsifiable).** The failure occurs because the detection guard requires
+`callee.object` to be an `Identifier`, which admits only a single-level member
+expression. Playwright namespaces its API, so the callee chain is deeper than one link.
+
+_Prediction:_ if detection instead walks the callee chain to its root Identifier and
+tests the terminal property (i.e. delegates to `isTestModifierCall(node, 'only')`), then
+`test.describe.only` and `test.describe.serial.only` are reported, and every
+currently-reported spelling stays reported.
+
+_Test:_ add the missing spellings as `invalid` RuleTester cases (must FAIL first), then
+replace the guard with the chain walk and re-run (must PASS), then revert the walk and
+confirm the new cases FAIL again.
+
+## Resolution
+
+**H1 CONFIRMED.**
+
+**Root cause.** `no-focused-tests.ts` gated focus detection on
+`node.callee.object.type === 'Identifier'`. That guard admits only a single-level member
+expression. Playwright namespaces its API, so `test.describe.only()` has a
+`MemberExpression` (`test.describe`) as its callee object and never matched. Not a
+regression - present since the rule was introduced in `938ba6f55`.
+
+**Fix.** The rule now delegates to the existing
+`isTestModifierCall(node, 'only')` from `src/utils/ast-helpers.ts` (added by PR #1851,
+already parameterised by modifier for exactly this adoption), mirroring
+`no-skipped-tests.ts` and `no-disabled-tests.ts` line for line. Chain depth is no longer
+assumed. The `f`-prefix branch (`fdescribe` / `fit`) is untouched - `isTestModifierCall`
+does not cover bare identifiers and the branch is still required.
+
+**Regression test.** `packages/eslint-plugin/tests/rules/no-focused-tests.test.ts` -
+three new `invalid` cases (`test.describe.only`, `test.describe.serial.only`,
+`test.describe.parallel.only`) plus nine new `valid` cases pinning the false-positive
+boundary: `test.describe(...)`, `test.describe.serial(...)`, `test.describe.parallel(...)`,
+`test.describe.skip(...)`, `test.skip(...)`, `describe.skip(...)`,
+`rateLimiter.only(...)`, `queue.batch.only()`, and bare `only(...)`. The `.skip` valid
+cases pin the rule-ownership boundary: `no-focused-tests` owns `.only` alone and must
+not start double-reporting skips that `no-skipped-tests` / `no-disabled-tests` already
+report.
+
+Command:
+`pnpm --filter @harness-engineering/eslint-plugin exec vitest run tests/rules/no-focused-tests.test.ts`
+
+**Revert-and-fail protocol (mandatory) - executed:**
+
+    --- BEFORE FIX (test written first, rule untouched) ---
+     Test Files  1 failed (1)
+          Tests  3 failed | 20 passed (23)
+     AssertionError: Should have 1 error but had 0: []
+
+    --- AFTER FIX ---
+     Test Files  1 passed (1)
+          Tests  23 passed (23)
+
+    --- FIX REVERTED (tests unchanged) ---
+     Test Files  1 failed (1)
+          Tests  3 failed | 20 passed (23)
+
+    --- FIX RESTORED ---
+     Test Files  1 passed (1)
+          Tests  23 passed (23)
+
+**Original issue scenario, re-run end to end** (standalone `Linter.verify()` over the
+snippet above): **5 problems before -> 7 after**. Lines 2 (`test.describe.only`) and 7
+(`test.describe.serial.only`) are now reported; lines 6, 8, 9, 10 and 11 still are.
+
+**Full verification.** Package suite **341/341 pass** (27 files); `typecheck` clean;
+`lint` clean. Repo-wide grep confirms no source file uses `test.describe.only` /
+`.serial.only` / `.parallel.only`, so the broadened matcher introduces no new lint
+failures anywhere in this repo. `harness check-deps` reports one pre-existing circular
+dependency in `packages/core/src/solutions/scan-candidates/` - untouched by this change
+and present at base SHA `c1ca02ba2`.
+
+**Learnings.**
+
+1. Matching a call by `callee.object.type === 'Identifier'` silently assumes the API is
+   flat. Any namespaced test API (Playwright is the common one) defeats it. When a rule
+   targets a _modifier_ on a test global, walk the callee chain and check the terminal
+   link - do not assume depth.
+2. `.only` inverts severity harder than `.skip` did. `test.describe.skip` mutes the
+   block it is attached to; `test.describe.only` mutes every OTHER test in the file
+   while CI still reports green. The rule that exists precisely to prevent that was
+   silent on the single most dangerous spelling.
+3. Fixing one instance of a shape is not fixing the shape. #1812 repaired two of the
+   three rules carrying the identical flat-member guard and explicitly logged the third
+   as a follow-up; without that logged note this defect would have stayed latent. When a
+   fix leaves a known sibling unrepaired, file it - the note is the only thing that
+   closes the loop.

--- a/docs/changes/no-focused-tests-playwright-describe-only-1853/provenance.json
+++ b/docs/changes/no-focused-tests-playwright-describe-only-1853/provenance.json
@@ -1,0 +1,54 @@
+{
+  "issues": [1853],
+  "issue": 1853,
+  "issueUrl": "https://github.com/Intense-Visions/harness-engineering/issues/1853",
+  "title": "no-focused-tests misses Playwright's test.describe.only() — same flat-member guard as #1812, and .only is the worse mute",
+  "route": "bug",
+  "fleet": "roadmap-fleet",
+  "stages": ["debugging"],
+  "pipelineStages": ["debugging"],
+  "branch": "fix/no-focused-tests-playwright-describe-only-1853",
+  "baseSha": "c1ca02ba2",
+  "closingKeyword": "Closes #1853",
+  "debugSession": "docs/changes/no-focused-tests-playwright-describe-only-1853/debug-session.md",
+  "reproducingTest": "packages/eslint-plugin/tests/rules/no-focused-tests.test.ts",
+  "reproducingTests": ["packages/eslint-plugin/tests/rules/no-focused-tests.test.ts"],
+  "reproducingTestCommand": "pnpm --filter @harness-engineering/eslint-plugin exec vitest run tests/rules/no-focused-tests.test.ts",
+  "reproducingTestResult": {
+    "beforeFix": "FAIL — 3 failed | 20 passed (23); AssertionError: Should have 1 error but had 0: []",
+    "afterFix": "PASS — 23 passed (23)",
+    "revertVerification": "fix reverted with tests unchanged -> 3 failed | 20 passed (23); fix restored -> 23 passed (23)",
+    "issueScenario": "standalone eslint Linter.verify() over the issue snippet: 5 problems before -> 7 after; lines 2 (test.describe.only) and 7 (test.describe.serial.only) newly reported"
+  },
+  "rootCause": "The rule gated focus detection on `node.callee.object.type === 'Identifier'`, which admits only a single-level member expression. Playwright namespaces its API, so `test.describe.only()` has a MemberExpression (`test.describe`) as its callee object and never matched. Not a regression — the flat-member shape has been present since the rule was introduced in 938ba6f55 (#868).",
+  "fix": "The rule now delegates to the pre-existing `isTestModifierCall(node, 'only')` in packages/eslint-plugin/src/utils/ast-helpers.ts (added by PR #1851 and parameterised by modifier for exactly this adoption), mirroring no-skipped-tests.ts and no-disabled-tests.ts. The `fdescribe`/`fit` bare-Identifier branch is preserved unchanged — isTestModifierCall does not cover it.",
+  "filesChanged": [
+    "packages/eslint-plugin/src/rules/no-focused-tests.ts",
+    "packages/eslint-plugin/tests/rules/no-focused-tests.test.ts"
+  ],
+  "assumptions": [
+    "Adopted the existing `isTestModifierCall` helper rather than writing new chain-walking logic in the rule. This is the recommended-option default: the helper already exists on main (PR #1851), is already parameterised by modifier, is already unit-tested for the 'only' modifier at tests/utils/ast-helpers.test.ts:145-150, and is already the shape both sibling rules use. A bespoke matcher would have re-introduced the divergence #1851 removed.",
+    "Rule ownership is NOT expanded beyond the `only` keyword. `.skip` / `.fixme` belong to no-skipped-tests and no-disabled-tests; three `.skip` valid cases (`test.describe.skip`, `test.skip`, `describe.skip`) are pinned so this rule cannot start double-reporting skips that the sibling rules already report.",
+    "The `fdescribe` / `fit` bare-Identifier branch is kept verbatim. `isTestModifierCall` requires a MemberExpression callee and so does not cover bare identifiers; removing the branch would have silently dropped the jasmine spellings. Both remain covered by pre-existing invalid cases.",
+    "The chain root must still be one of `describe` / `it` / `test`. `.only` on any other receiver (e.g. `rateLimiter.only()`, `queue.batch.only()`) stays unreported — pinned by new valid cases so it cannot regress into a false positive.",
+    "Only statically written, non-computed dotted paths are matched. Computed access (`test.describe['only']()`) and optional chaining (`test?.describe?.only()`) stay unreported. Per the issue's own scope note these are documented non-regressions with a different root cause, identical to the flat case (`describe['only']()` was never caught either), and are deliberately out of scope.",
+    "Matching requires `only` to be the FINAL link of the chain, exactly as the issue states. Jest's `describe.only.each([...])(...)` therefore stays unreported. Pre-existing and unchanged: the rule at base c1ca02ba2 also reported nothing for that form.",
+    "Added `test.describe.serial.only` and `test.describe.parallel.only` as invalid cases beyond the single form the issue names. These are real Playwright spellings (independently corroborated by the vendored Playwright ESTree bundle in packages/cli/dist, which enumerates all three) and they fall out of the same fix; covering them costs nothing and mirrors the #1851 test shape.",
+    "Rule message wording is unchanged. The existing message already names both the '.only' and 'f' prefix forms, so no copy change was warranted."
+  ],
+  "outOfScope": [
+    "Computed access `test.describe['only']()` and optional chaining `test?.describe?.only()` — documented non-regressions per the issue's scope note.",
+    "Jest's `describe.only.each([...])(...)` — `only` is not the terminal chain link; pre-existing gap, unchanged by this PR.",
+    "Deduplicating the overlapping rules — `test.describe.only` reports once here, but a form matched by multiple enabled rules still reports per rule, matching pre-existing behaviour. A separate design question, not a bug fix."
+  ],
+  "verification": {
+    "regressionTest": "pnpm --filter @harness-engineering/eslint-plugin exec vitest run tests/rules/no-focused-tests.test.ts -> 23 passed (23)",
+    "packageTests": "pnpm --filter @harness-engineering/eslint-plugin test -> 27 files, 341 passed (341)",
+    "typecheck": "pnpm --filter @harness-engineering/eslint-plugin typecheck -> clean",
+    "lint": "pnpm --filter @harness-engineering/eslint-plugin lint -> clean",
+    "harnessValidate": "harness validate -> exit 0 (findings are pre-existing design-token noise in unrelated packages/cli test fixtures)",
+    "harnessCheckDeps": "harness check-deps -> 1 pre-existing circular dependency in packages/core/src/solutions/scan-candidates/, untouched by this change and present at base c1ca02ba2",
+    "repoWideImpact": "grep across packages/ and scripts/ sources finds no use of test.describe.only / .serial.only / .parallel.only, so the broadened matcher introduces no new lint failures in this repo"
+  },
+  "debugSessionNote": "The harness-debugging pipeline writes its session to .harness/debug/resolved/1853-playwright-describe-only.md, which is gitignored (.harness/.gitignore line 4). A verbatim copy is committed here so the investigation record is durable and reviewable."
+}

--- a/packages/eslint-plugin/src/rules/no-focused-tests.ts
+++ b/packages/eslint-plugin/src/rules/no-focused-tests.ts
@@ -1,4 +1,6 @@
 import { ESLintUtils } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { isTestModifierCall } from '../utils/ast-helpers';
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://github.com/harness-engineering/eslint-plugin/blob/main/docs/rules/${name}.md`
@@ -21,29 +23,30 @@ export default createRule<[], MessageIds>({
   },
   defaultOptions: [],
   create(context) {
+    function isFocusedCall(node: TSESTree.CallExpression): boolean {
+      // Any dotted chain rooted at describe/it/test ending in `.only` —
+      // covers the flat Jest/Mocha spellings (describe.only, it.only,
+      // test.only) AND Playwright's namespaced ones (test.describe.only,
+      // test.describe.serial.only), which focus an entire block and so mute
+      // every OTHER test in the file.
+      if (isTestModifierCall(node, 'only')) {
+        return true;
+      }
+
+      // Check for fdescribe() and fit()
+      if (
+        node.callee.type === 'Identifier' &&
+        (node.callee.name === 'fdescribe' || node.callee.name === 'fit')
+      ) {
+        return true;
+      }
+
+      return false;
+    }
+
     return {
       CallExpression(node) {
-        // Check for describe.only(), it.only(), test.only()
-        if (
-          node.callee.type === 'MemberExpression' &&
-          node.callee.object.type === 'Identifier' &&
-          (node.callee.object.name === 'describe' ||
-            node.callee.object.name === 'it' ||
-            node.callee.object.name === 'test') &&
-          node.callee.property.type === 'Identifier' &&
-          node.callee.property.name === 'only'
-        ) {
-          context.report({
-            node,
-            messageId: 'focusedTest',
-          });
-        }
-
-        // Check for fdescribe() and fit()
-        if (
-          node.callee.type === 'Identifier' &&
-          (node.callee.name === 'fdescribe' || node.callee.name === 'fit')
-        ) {
+        if (isFocusedCall(node)) {
           context.report({
             node,
             messageId: 'focusedTest',

--- a/packages/eslint-plugin/tests/rules/no-focused-tests.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-focused-tests.test.ts
@@ -19,6 +19,21 @@ ruleTester.run('no-focused-tests', rule, {
     { code: `someFunction();` },
     // Nested calls with .only
     { code: `describe('suite', () => { it('test', () => {}); });` },
+    // Playwright's namespaced block API without a focus modifier — the
+    // false-positive boundary for the chain walk below.
+    { code: `test.describe('suite', () => {});` },
+    { code: `test.describe.serial('suite', () => {});` },
+    { code: `test.describe.parallel('suite', () => {});` },
+    // `.skip` belongs to no-skipped-tests / no-disabled-tests. This rule owns
+    // `.only` alone and must not start double-reporting skips.
+    { code: `test.describe.skip('suite', () => {});` },
+    { code: `test.skip('test', () => {});` },
+    { code: `describe.skip('suite', () => {});` },
+    // `only` on a receiver that is not a test global — someone else's API.
+    { code: `rateLimiter.only('token');` },
+    { code: `queue.batch.only();` },
+    // Bare identifier call, no chain at all
+    { code: `only('test', () => {});` },
   ],
   invalid: [
     // describe.only()
@@ -34,6 +49,23 @@ ruleTester.run('no-focused-tests', rule, {
     // test.only()
     {
       code: `test.only('test', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    // Playwright's test.describe.only() — focuses a whole block and therefore
+    // mutes every OTHER test in the file. The callee object is a
+    // MemberExpression (`test.describe`), not an Identifier, so the original
+    // flat-member guard never matched it (#1853).
+    {
+      code: `test.describe.only('suite', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    // Playwright modifier chains — `only` is still the terminal link.
+    {
+      code: `test.describe.serial.only('suite', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    {
+      code: `test.describe.parallel.only('suite', () => {});`,
       errors: [{ messageId: 'focusedTest' }],
     },
     // fdescribe()


### PR DESCRIPTION
## Summary

`no-focused-tests` carried the identical flat-member defect that #1812 reported (and PR #1851 fixed) in `no-skipped-tests` / `no-disabled-tests`, but for `.only`. `packages/eslint-plugin/src/rules/no-focused-tests.ts:28-34` gated detection on:

```ts
node.callee.object.type === 'Identifier'   // <-- admits only a FLAT member expression
```

Playwright namespaces its API, so in `test.describe.only(...)` the callee's *object* is a `MemberExpression` (`test.describe`), not an `Identifier`. The guard never matched and the rule stayed silent.

`.only` mutes every **other** test in the file, so this inverted severity in the worst direction: a focused Playwright block silently reduced a suite to one case while lint stayed quiet and CI reported green — even though the strictly-smaller `test.only(...)` *was* reported.

The rule now delegates to the pre-existing `isTestModifierCall(node, 'only')` in `packages/eslint-plugin/src/utils/ast-helpers.ts`, which walks the callee's dotted chain and matches any chain rooted at `describe`/`it`/`test` whose final link is the modifier. This is the same adoption `no-skipped-tests.ts` and `no-disabled-tests.ts` already made for `'skip'` — the helper was parameterised by modifier for exactly this, and its own tests already assert the `'only'` case (`tests/utils/ast-helpers.test.ts:145-150`).

The `fdescribe()` / `fit()` bare-identifier branch is preserved unchanged; `isTestModifierCall` requires a MemberExpression callee and does not cover it.

Not a regression — the flat-member shape has been present since the rule was introduced in `938ba6f55` (#868).

## Reproducing test — before / after

Regression test written first, against the unmodified rule.

**BEFORE the fix** (`pnpm --filter @harness-engineering/eslint-plugin exec vitest run tests/rules/no-focused-tests.test.ts`):

```
 ❯ tests/rules/no-focused-tests.test.ts (23 tests | 3 failed) 30ms
       × test.describe.only('suite', () => {});
       × test.describe.serial.only('suite', () => {});
       × test.describe.parallel.only('suite', () => {});

 FAIL  ... > invalid > test.describe.only('suite', () => {});
 AssertionError: Should have 1 error but had 0: []
 0 !== 1

 Test Files  1 failed (1)
      Tests  3 failed | 20 passed (23)
```

**AFTER the fix:**

```
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

**Revert-and-fail protocol** (fix reverted, tests unchanged):

```
--- FIX REVERTED (tests unchanged) ---
 Test Files  1 failed (1)
      Tests  3 failed | 20 passed (23)
--- FIX RESTORED ---
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

**Original issue scenario, end to end** — standalone `eslint` `Linter.verify()` over a file containing all seven spellings. Lines 2 (`test.describe.only`, focuses a whole block) and 7 (`test.describe.serial.only`) were silent; every flat form was reported:

```
BEFORE --- no-focused-tests: 5 problems
  6:1   test.only               8:1  describe.only     9:1  it.only
  10:1  fdescribe               11:1 fit
  (lines 2 and 7 SILENT)

AFTER  --- no-focused-tests: 7 problems
  2:1  test.describe.only          <-- newly reported
  6:1  test.only
  7:1  test.describe.serial.only   <-- newly reported
  8:1  describe.only   9:1 it.only   10:1 fdescribe   11:1 fit
```

Reproduced 3/3 identical runs before the fix.

## Test coverage added

`packages/eslint-plugin/tests/rules/no-focused-tests.test.ts` — 3 new `invalid` cases and 9 new `valid` cases:

- **Reports:** `test.describe.only`, `test.describe.serial.only`, `test.describe.parallel.only`
- **Still reports (no regression):** `describe.only`, `it.only`, `test.only`, `fdescribe()`, `fit()`
- **Stays silent:** `test.describe(...)`, `test.describe.serial(...)`, `test.describe.parallel(...)`, `rateLimiter.only(...)`, `queue.batch.only()`, bare `only(...)`
- **Rule-ownership boundary:** `test.describe.skip`, `test.skip`, `describe.skip` stay silent — this rule owns `.only` alone and must not start double-reporting skips that `no-skipped-tests` / `no-disabled-tests` already report

## Scope

Per the issue's own scope note, these are documented non-regressions and are **not** changed here: computed access (`test.describe['only']()`) and optional chaining stay unreported, and the modifier must be the terminal chain link (so Jest's `describe.only.each([...])(...)` stays unreported — pre-existing and identical at base).

## Assumptions made

Every recommended-option default taken, also recorded in the committed provenance:

1. **Adopted the existing `isTestModifierCall` helper** rather than writing new chain-walking logic in the rule. It already exists on main (#1851), is already parameterised by modifier, is already unit-tested for `'only'`, and is already the shape both sibling rules use. A bespoke matcher would have re-introduced the divergence #1851 removed.
2. **Rule ownership is not expanded beyond `only`.** `.skip` / `.fixme` belong to the sibling rules; three `.skip` valid cases pin that boundary.
3. **The `fdescribe` / `fit` bare-identifier branch is kept verbatim.** `isTestModifierCall` requires a MemberExpression callee, so removing the branch would have silently dropped the jasmine spellings.
4. **The chain root must still be `describe` / `it` / `test`.** `.only` on any other receiver stays unreported, pinned by new valid cases so it cannot regress into a false positive.
5. **Only statically written, non-computed dotted paths match** — computed access and optional chaining stay unreported (issue scope note).
6. **`only` must be the terminal chain link**, exactly as the issue states.
7. **Added `test.describe.serial.only` and `test.describe.parallel.only`** beyond the single form the issue names. These are real Playwright spellings (independently corroborated by the vendored Playwright ESTree bundle in `packages/cli/dist`, which enumerates all three), they fall out of the same fix, and covering them mirrors the #1851 test shape.
8. **Rule message wording unchanged** — it already names both the `.only` and `f` prefix forms.

## Verification

- Regression test: **23 passed (23)**
- Package suite: **341 passed (341)** across 27 files
- `typecheck` clean, `lint` clean
- `harness validate` exit 0 (findings are pre-existing design-token noise in unrelated `packages/cli` test fixtures)
- `harness check-deps`: 1 pre-existing circular dependency in `packages/core/src/solutions/scan-candidates/` — untouched by this change and present at base `c1ca02ba2`
- Repo-wide grep finds **no** source file using `test.describe.only` / `.serial.only` / `.parallel.only`, so the broadened matcher introduces no new lint failures in this repo

## Debugging artifacts

Route was `bug`, so the `harness-debugging` pipeline ran and there is no `plans/` directory (expected). Committed:

- `docs/changes/no-focused-tests-playwright-describe-only-1853/debug-session.md` — full 4-phase investigation record
- `docs/changes/no-focused-tests-playwright-describe-only-1853/provenance.json`

Base SHA: `c1ca02ba2`.

Closes #1853
Refs #1812 #1851

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
