### PR TITLE
fix(orchestrator): route PRDetector External-ID parsing through the core authority (#1857)

### DIFF
--- a/.changeset/pr-detector-shared-external-id-1857.md
+++ b/.changeset/pr-detector-shared-external-id-1857.md
@@ -1,0 +1,30 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): route PRDetector External-ID parsing through the core authority (#1857)
+
+`PRDetector` defined its own `parseExternalId` around a verbatim copy of the
+**pre-#1843** pattern `/^github:([^/]+)\/([^#]+)#(\d+)$/`, so the two-layer hardening
+that #1854 landed in `@harness-engineering/core` never reached this consumer. That file
+documents itself as the "single source of truth ... so the `github:owner/repo#NNN` shape
+can never drift" — a claim that was already false at this call site.
+
+The parsed `owner`/`repo` are interpolated into an authenticated
+`gh pr list --repo <owner>/<repo>`. Two things bound the exposure and are stated rather
+than overstated: the value travels through `execFile` **argv**, not a shell string, so
+this is not command injection, and `gh` performs its own `--repo` validation. This is a
+drift defect with a latent security dimension, not a second exploitable instance of
+#1843.
+
+`parseExternalId` now delegates to core's, and `githubRepoPath` is applied at both
+`--repo` argv sinks — `hasOpenPRForExternalId` and the public `fetchOpenPRClosures` —
+immediately before the value is built, because core's sink check deliberately never
+consults the regex, so loosening it again cannot silently re-open the traversal.
+
+The tightening is deliberately BREAKING for External-IDs GitHub itself could never have
+issued; that trade was made and accepted in #1843/#1854 and is propagated here rather
+than re-decided. `PRDetector`'s documented fail-open contract is unchanged: a rejected
+External-ID degrades on exactly the path an unparseable one already took — `false` from
+`hasOpenPRForExternalId`, `null` from `fetchOpenPRClosures`, a `logger.debug` line at the
+pre-existing level, no throw, and no candidate newly blocked.

--- a/.harness/comprehension/packages/orchestrator/src/core/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/core/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src/core'
-sourceHash: '83382f6bd97ebb80b615ee07bed6961d35a26f5c71e989cddede60b8e117d56a'
+sourceHash: 'ddcb706d0bbdd81b5ccf8a778379c0a4eec77ad2ca746c0984a6bbc255d1ab5a'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -24,6 +24,7 @@ members:
     'lane-persistence.ts',
     'model-router.ts',
     'orchestrator-identity.ts',
+    'pr-detector.external-id-1857.test.ts',
     'pr-detector.ts',
     'published-index.ts',
     'rate-limit-events.ts',
@@ -126,11 +127,12 @@ import { assertIssueWithinContextBudget, buildLeafContextEstimate, estimateIssue
 import { FlightRecorder, RunRecord, gatherProvenance } from './flight-recorder'
 import { InteractionQueue, PendingInteraction } from './interaction-queue'
 import { artifactPresenceFromIssue, detectScopeTier, routeIssue } from './model-router'
+import { PRDetector, PRDetectorLogger } from './pr-detector'
 import { extractRateLimitReset } from './rate-limit-events'
 import { reconcile } from './reconciliation'
 import { calculateRetryDelay } from './retry'
 import { AttemptStats, Highlight } from './stream-recorder'
-import { CHARS_PER_TOKEN, ComprehensionSourceFile, ComprehensionUnit, ContextBudgetExceededError, Issue, IssueTrackerClient, assertLeafWithinBudget, computeSourceHash, coreIsFleetAllocationExhausted, coreIsGlobalEnvelopeExhausted, eventSourcing, renderServedUnit } from '@harness-engineering/core'
+import { CHARS_PER_TOKEN, ComprehensionSourceFile, ComprehensionUnit, ContextBudgetExceededError, Issue, IssueTrackerClient, assertLeafWithinBudget, computeSourceHash, coreIsFleetAllocationExhausted, coreIsGlobalEnvelopeExhausted, eventSourcing, githubRepoPath, parseCanonicalExternalId, renderServedUnit } from '@harness-engineering/core'
 import { ComplexityScore, EnrichedSpec, SimulationResult } from '@harness-engineering/intelligence'
 import { AgentBudgetConfig, AgentEvent, BudgetEnvelopeStatus, ConcernSignal, Err, EscalationConfig, FleetBudgetStatus, Issue, IssueRoutingDecision, LeafContextEstimate, LeafContextSource, Ok, Result, ScopeTier, WorkflowConfig } from '@harness-engineering/types'
 import { execFile, execFileSync } from 'node:child_process'
@@ -141,5 +143,5 @@ import * as fs from 'node:fs/promises'
 import * as os, { tmpdir } from 'node:os'
 import * as path, { join } from 'node:path'
 import { promisify } from 'node:util'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/docs/changes/pr-detector-shared-external-id-1857/debug-session.md
+++ b/docs/changes/pr-detector-shared-external-id-1857/debug-session.md
@@ -1,0 +1,140 @@
+# Debug Session: pr-detector inlines a third copy of the External-ID regex
+
+Status: resolved
+Started: 2026-09-06
+Issue: https://github.com/Intense-Visions/harness-engineering/issues/1857
+Base SHA: c1ca02ba2
+Error/symptom: `packages/orchestrator/src/core/pr-detector.ts` defines its own
+`parseExternalId` around the **pre-#1843** pattern `/^github:([^/]+)\/([^#]+)#(\d+)$/`,
+so the hardening PR #1854 landed in `packages/core/src/roadmap/external-id.ts` does not
+reach this consumer. `github:x/../../../user/emails?#1` still parses here to
+`owner="x"`, `repo="../../../user/emails?"`.
+
+## Investigation Log
+
+### Phase 1 — INVESTIGATE (read-only)
+
+**What failed, exactly.** Not a crash — a silently divergent validator. The core file's
+own docblock (`external-id.ts:2-8`) claims it is the "Single source of truth for the
+format ... consumers import these instead of inlining the regex, so the
+`github:owner/repo#NNN` shape can never drift". That claim is false on `main` today:
+`pr-detector.ts:43` is a fourth consumer that was never brought under the rule.
+
+**Divergence, verified at base SHA `c1ca02ba2`:**
+
+    core/src/roadmap/external-id.ts:36 (post-#1854, authoritative)
+      /^github:([A-Za-z0-9][A-Za-z0-9-]{0,38})\/([A-Za-z0-9._-]{1,100})#(\d+)$/
+      + isDotSegment() guard          (layer 1)
+      + githubRepoPath(owner, repo)   (layer 2, sink-side, never consults the regex)
+
+    orchestrator/src/core/pr-detector.ts:44 (pre-#1843, stale copy)
+      /^github:([^/]+)\/([^#]+)#(\d+)$/
+      (no dot-segment guard, no sink defence)
+
+**Where the parsed values go.** Traced forward from the parser to every consumer.
+`parseExternalId` has four usages in the file — `:81`, `:234`, `:248`, `:269` — feeding
+two distinct argv sinks, both AUTHENTICATED `gh` invocations:
+
+- `hasOpenPRForExternalId` (`:81` → `:85-87`)
+  `exec('gh', ['pr','list','--repo', ` + "`${parsed.owner}/${parsed.repo}`" + `, ...])`
+- `fetchOpenPRClosures(owner, repo)` (`:185` → `:193-195`)
+  `exec('gh', ['pr','list','--repo', ` + "`${owner}/${repo}`" + `, ...])`
+  This one is PUBLIC and takes raw `owner`/`repo`, so it is a sink in its own right
+  and cannot assume the caller parsed the pair.
+
+**Bounding the security claim (recorded so it is not overstated).** The value travels
+through `execFile` **argv**, not a shell string — this is not command injection. `gh`
+also performs its own `--repo` validation downstream. So this is a **drift defect with a
+latent security dimension**, not a second exploitable instance of #1843.
+
+**Reproduced consistently** (3/3 runs) — see Phase 4.
+
+**Recent changes.** `git log` confirms this is not a regression introduced by #1854;
+`pr-detector.ts` carried the inlined copy since it was written. #1854 tightened the
+authority and thereby _created_ the divergence rather than causing a behaviour change
+here.
+
+**Assumption (surfaced, not buried).** `parseExternalId` is part of `PRDetector`'s
+public surface: `packages/orchestrator/tests/orchestrator-pr-guard.test.ts:319-330`
+calls `detector.parseExternalId(...)` directly. Deleting the method outright would break
+an external caller, so a thin delegating wrapper is kept.
+
+**Deferrable (noted, NOT in scope).** Two further divergent copies exist on `main`:
+`packages/dashboard/src/server/routes/actions.ts:301` and
+`packages/dashboard/src/client/components/roadmap/utils.ts:30`. A third, unrelated-format
+inline lives at `packages/cli/src/commands/install.ts:102`. Out of scope for #1857.
+
+### Phase 2 — ANALYZE
+
+**Working examples.** Five call sites in
+`packages/core/src/roadmap/adapters/github-issues.ts` and five more in
+`.../tracker/adapters/github-issues.ts` all `import { parseExternalId, githubRepoPath }`
+and apply BOTH layers: parse, then assert at the sink immediately before building the
+path. `packages/core/src/rework/rework.ts:14` does the same for the parse layer.
+Read in full. The pattern is uniform: parse → null-check → `githubRepoPath` at the
+argv/URL construction point → null-check → build.
+
+**The difference.** `pr-detector.ts` differs from every working example in exactly one
+structural respect: it owns a private validator instead of importing the shared one, and
+consequently has no layer-2 sink assertion at all. Nothing else differs — same format,
+same intent, same downstream shape.
+
+**Wiring pre-checked.** `packages/orchestrator/package.json` already depends on
+`@harness-engineering/core` (`workspace:*`) and `src/` already imports from it
+(`orchestrator.ts:18`, `types/orchestrator-context.ts:2`, …), so no new dependency and
+no architecture-layer violation. `parseExternalId` / `githubRepoPath` are already
+exported (`core/src/roadmap/index.ts:68`, re-exported by `core/src/index.ts:134`), so no
+`scripts/generate-core-barrel.mjs` allowlist edit is needed.
+
+## Hypotheses
+
+**H1 (single, falsifiable).** The permissive behaviour is caused solely by the inlined
+stale regex and the absence of a sink assertion — not by anything else in the class.
+
+_Prediction:_ replacing the method body with a delegation to core's `parseExternalId`,
+and inserting `githubRepoPath` at both `--repo` argv sinks, makes the traversal payload
+rejected at both layers while every currently-accepted legitimate External-ID still
+parses and still produces byte-identical argv.
+
+_Test:_ write the regression suite first, run it against the UNMODIFIED file (must
+FAIL), then apply the change and re-run (must PASS), and separately re-run the
+pre-existing `tests/orchestrator-pr-guard.test.ts` (must stay green, proving no
+false rejection and no contract break).
+
+_Result:_ **confirmed.** 7 failed / 6 passed before; 13/13 after; pre-existing suite
+26/26 both before and after.
+
+## Resolution
+
+Root cause: `PRDetector.parseExternalId` inlined a verbatim copy of the pre-#1843
+External-ID regex instead of importing the `@harness-engineering/core` authority, so
+the two-layer hardening added by #1854 was never applied at this consumer, and the
+class had no sink-side assertion before interpolating `owner`/`repo` into an
+authenticated `gh pr list --repo` argv.
+
+Fix (one change, both of core's stated defences, matching the working examples):
+
+1. `parseExternalId` now delegates to core's `parseExternalId`. Kept as a thin instance
+   method rather than deleted, because it is a public surface with an existing external
+   caller (`tests/orchestrator-pr-guard.test.ts`).
+2. `githubRepoPath(owner, repo)` is applied at BOTH `--repo` argv construction points —
+   `hasOpenPRForExternalId` and the public `fetchOpenPRClosures` — immediately before the
+   value is built, per the core docblock's instruction that the sink check "deliberately
+   never consults `EXTERNAL_ID_RE` ... so that loosening the regex again cannot silently
+   re-open the traversal".
+
+Fail-open contract preserved. A now-rejected External-ID degrades on exactly the path an
+unparseable one already took: `hasOpenPRForExternalId` returns `false`,
+`fetchOpenPRClosures` returns `null` (its existing "check failed" signal, which
+`filterCandidatesWithOpenPRs` already treats as fail-open), each logs at the pre-existing
+`logger.debug` level. Nothing throws; no candidate is newly blocked. Pinned by tests.
+
+Regression test: `packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts`
+(colocated in `src/` — `packages/orchestrator/tests/**` is region-locked by a sibling
+unmerged PR in this fleet run; colocated `*.test.ts` under `src/` is an established
+convention here, cf. `src/agent/adaptive-router.*.test.ts`, and `vitest.config.mts`
+already includes `src/**/*.test.ts`).
+
+Learnings: a "single source of truth" asserted only in a docblock is not enforced. The
+claim in `external-id.ts` was already false when it was written. Grep for the format's
+shape — not for the helper's name — when auditing whether an authority actually holds.

--- a/docs/changes/pr-detector-shared-external-id-1857/provenance.json
+++ b/docs/changes/pr-detector-shared-external-id-1857/provenance.json
@@ -1,0 +1,51 @@
+{
+  "issues": [1857],
+  "issueUrl": "https://github.com/Intense-Visions/harness-engineering/issues/1857",
+  "title": "pr-detector inlines a third copy of the External-ID regex and will silently miss the #1843 hardening",
+  "route": "bug",
+  "fleet": "roadmap-fleet",
+  "stages": ["debugging"],
+  "pipelineStages": ["debugging"],
+  "branch": "fix/pr-detector-shared-external-id-parser-1857",
+  "baseSha": "c1ca02ba2",
+  "debugSession": "docs/changes/pr-detector-shared-external-id-1857/debug-session.md",
+  "reproducingTest": "packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts",
+  "reproducingTestCommand": "pnpm --filter @harness-engineering/orchestrator exec vitest run src/core/pr-detector.external-id-1857.test.ts",
+  "reproducingTestResult": {
+    "beforeFix": "FAIL — 7 failed | 6 passed (13). Traversal case: AssertionError: expected { owner: 'x', …(2) } to be null",
+    "afterFix": "PASS — 13 passed (13)",
+    "revertVerification": "suite authored and executed against the UNMODIFIED pr-detector.ts at base c1ca02ba2 -> 7 failed; fix applied, suite unchanged -> 13 passed"
+  },
+  "closingKeyword": "Closes #1857",
+  "rootCause": "PRDetector.parseExternalId inlined a verbatim copy of the pre-#1843 External-ID regex (/^github:([^/]+)\\/([^#]+)#(\\d+)$/) instead of importing the @harness-engineering/core authority, so the two-layer hardening landed by #1854 never applied at this consumer, and the class had no sink-side assertion before interpolating owner/repo into an authenticated `gh pr list --repo` argv.",
+  "fix": "parseExternalId now delegates to core's parseExternalId (kept as a thin instance method because it is public surface with an existing external caller). githubRepoPath(owner, repo) is applied at BOTH --repo argv construction sinks — hasOpenPRForExternalId and the public fetchOpenPRClosures — immediately before the value is built.",
+  "filesChanged": [
+    "packages/orchestrator/src/core/pr-detector.ts",
+    "packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts"
+  ],
+  "securityFraming": "Drift defect with a latent security dimension, NOT a second exploitable instance of #1843. The parsed values do reach an authenticated `gh` invocation, but via execFile ARGV rather than a shell string (so not command injection), and `gh` performs its own --repo validation downstream.",
+  "assumptions": [
+    "parseExternalId is part of PRDetector's PUBLIC surface — packages/orchestrator/tests/orchestrator-pr-guard.test.ts:319-330 calls detector.parseExternalId(...) directly. The method was therefore NOT deleted; it is kept as a thin wrapper delegating to core. That pre-existing suite passes unchanged (26/26), which also demonstrates no false rejection of the ids it asserts.",
+    "githubRepoPath is applied at BOTH --repo argv sinks, not only the one named in the issue. fetchOpenPRClosures is public and takes raw owner/repo, so it is a sink in its own right and cannot assume its caller parsed the pair; the core docblock explicitly instructs the sink check be applied at the sink and never derived from the regex.",
+    "Applying githubRepoPath changes no argv for any legitimate External-ID: every character the tightened regex admits (A-Za-z0-9._-) is unreserved for encodeURIComponent, so the encoded value is byte-identical. Pinned by tests asserting the exact --repo argument for a legitimate id at both sinks.",
+    "PRDetector's documented fail-open contract is preserved verbatim rather than tightened. A rejected External-ID degrades on the path an unparseable one already took: hasOpenPRForExternalId returns false, fetchOpenPRClosures returns null (its existing 'check failed' signal, which filterCandidatesWithOpenPRs already treats as fail-open), each logging at the pre-existing logger.debug level. Nothing throws and no candidate is newly blocked — pinned by three explicit fail-open tests.",
+    "The tightening is deliberately BREAKING for External-IDs GitHub itself could never have issued. That trade was made and accepted in #1843/#1854; it is propagated here, not re-decided.",
+    "The regression test is colocated at packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts rather than under packages/orchestrator/tests/, because that directory is region-locked by a sibling unmerged PR in this fleet run. Colocated *.test.ts under src/ is an established convention in this package (cf. src/agent/adaptive-router.*.test.ts) and vitest.config.mts already includes 'src/**/*.test.ts'.",
+    "No scripts/generate-core-barrel.mjs allowlist edit was needed: parseExternalId and githubRepoPath are pre-existing exports (core/src/roadmap/index.ts:68, re-exported via core/src/index.ts:134). No new dependency was added — packages/orchestrator already depends on @harness-engineering/core (workspace:*) and src/ already imports from it.",
+    "packages/core/src/roadmap/external-id.ts was NOT modified. It is the authority and is already correct."
+  ],
+  "outOfScope": [
+    "packages/dashboard/src/server/routes/actions.ts:301 — a further divergent inline copy of the External-ID regex on main. Named as follow-up, deliberately not touched (scope for #1857 is pr-detector.ts only).",
+    "packages/dashboard/src/client/components/roadmap/utils.ts:30 — same, a further divergent inline copy. Named as follow-up, not touched.",
+    "packages/cli/src/commands/install.ts:102 — an unrelated-format inline match, not an External-ID parser. Not touched.",
+    "A lint/architecture rule forbidding a second inlined `github:` regex, which the issue raises as an optional hardening. That is new enforcement machinery, not the reported defect."
+  ],
+  "verification": {
+    "reproducingTest": "13 passed (13)",
+    "preExistingSuite": "pnpm --filter @harness-engineering/orchestrator exec vitest run tests/orchestrator-pr-guard.test.ts -> 26 passed (26)",
+    "packageTests": "pnpm --filter @harness-engineering/orchestrator test -> 261 files passed | 1 skipped; 2896 tests passed | 1 skipped",
+    "typecheck": "pnpm --filter @harness-engineering/orchestrator typecheck -> clean",
+    "lint": "pnpm --filter @harness-engineering/orchestrator lint -> clean"
+  },
+  "debugSessionNote": "The harness-debugging pipeline writes its session under .harness/debug/, which is gitignored. A verbatim copy is committed at docs/changes/pr-detector-shared-external-id-1857/debug-session.md so the investigation record is durable and reviewable."
+}

--- a/packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts
+++ b/packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Issue } from '@harness-engineering/types';
+import { PRDetector, type PRDetectorLogger } from './pr-detector';
+
+/**
+ * Regression suite for #1857 — `PRDetector` inlined its own pre-#1843 copy of the
+ * External-ID regex (`/^github:([^/]+)\/([^#]+)#(\d+)$/`) instead of importing the
+ * `@harness-engineering/core` authority, so the hardening landed by #1854 (for
+ * #1843) did not reach this consumer.
+ *
+ * The parsed `owner`/`repo` are interpolated into `gh pr list --repo <owner>/<repo>`,
+ * an AUTHENTICATED invocation. Two things bound the exposure and are stated here so
+ * the tests are not read as claiming more than they prove: the value travels through
+ * `execFile` ARGV rather than a shell string, so this is not command injection; and
+ * `gh` performs its own `--repo` validation downstream. This is a drift defect with a
+ * latent security dimension, not a second exploitable instance of #1843.
+ *
+ * Both of core's defences are exercised independently:
+ *   layer 1 — the tightened regex, via `parseExternalId`
+ *   layer 2 — the sink assertion `githubRepoPath`, via `fetchOpenPRClosures`, which
+ *             is public, takes raw `owner`/`repo`, and never consults the regex.
+ *
+ * `PRDetector` is documented fail-open. Every rejection below must therefore degrade
+ * exactly as an unparseable External-ID already did — candidates pass through, no
+ * throw, no hard block.
+ */
+
+/** The #1843 payload. Under the old permissive regex this parsed to
+ *  `owner="x"`, `repo="../../../user/emails?"` and resolved to
+ *  `POST https://api.github.com/user/emails`. */
+const TRAVERSAL_ID = 'github:x/../../../user/emails?#1';
+
+const LEGIT_ID = 'github:Intense-Visions/harness-engineering#1857';
+
+function makeMockLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } satisfies Record<
+    keyof PRDetectorLogger,
+    unknown
+  >;
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'id-1',
+    identifier: 'issue-abc12345',
+    title: 'Test issue',
+    description: null,
+    state: 'Todo',
+    externalId: null,
+    url: null,
+    ...overrides,
+  } as Issue;
+}
+
+describe('#1857 PRDetector routes External-ID parsing through the core authority', () => {
+  let detector: PRDetector;
+  let execFileFn: ReturnType<typeof vi.fn>;
+  let logger: ReturnType<typeof makeMockLogger>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = makeMockLogger();
+    execFileFn = vi.fn(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, r: unknown) => void) => {
+        cb(null, { stdout: '0\n', stderr: '' });
+      }
+    );
+    detector = new PRDetector({
+      logger: logger as unknown as PRDetectorLogger,
+      execFileFn: execFileFn as never,
+      projectRoot: '/tmp',
+    });
+  });
+
+  describe('layer 1 — parseExternalId (the tightened core regex)', () => {
+    it('rejects the #1843 path-traversing External-ID', () => {
+      expect(detector.parseExternalId(TRAVERSAL_ID)).toBeNull();
+    });
+
+    it('rejects a bare dot-segment owner or repo', () => {
+      expect(detector.parseExternalId('github:./repo#1')).toBeNull();
+      expect(detector.parseExternalId('github:../repo#1')).toBeNull();
+      expect(detector.parseExternalId('github:owner/.#1')).toBeNull();
+      expect(detector.parseExternalId('github:owner/..#1')).toBeNull();
+    });
+
+    it('rejects owner/repo values carrying a path or query delimiter', () => {
+      expect(detector.parseExternalId('github:x/a/b#1')).toBeNull();
+      expect(detector.parseExternalId('github:x/repo?#1')).toBeNull();
+    });
+
+    it('still parses a legitimate External-ID (no false rejection)', () => {
+      expect(detector.parseExternalId(LEGIT_ID)).toEqual({
+        owner: 'Intense-Visions',
+        repo: 'harness-engineering',
+        number: 1857,
+      });
+    });
+
+    it('still parses the punctuation GitHub actually permits in a repo name', () => {
+      expect(detector.parseExternalId('github:a-b/c.d_e-f#7')).toEqual({
+        owner: 'a-b',
+        repo: 'c.d_e-f',
+        number: 7,
+      });
+    });
+  });
+
+  describe('layer 2 — githubRepoPath at the authenticated `gh --repo` sink', () => {
+    it('never issues a gh call for a traversing External-ID', async () => {
+      const result = await detector.hasOpenPRForExternalId(TRAVERSAL_ID);
+      expect(result).toBe(false);
+      expect(execFileFn).not.toHaveBeenCalled();
+    });
+
+    it('rejects a traversing owner/repo handed straight to the sink, bypassing the regex', async () => {
+      // `fetchOpenPRClosures` is public and takes raw owner/repo, so it exercises the
+      // sink defence on its own. This is the case a regressed regex would re-open.
+      const result = await detector.fetchOpenPRClosures('x', '../../../user/emails?');
+      expect(result).toBeNull();
+      expect(execFileFn).not.toHaveBeenCalled();
+    });
+
+    it('rejects a bare dot segment at the sink', async () => {
+      expect(await detector.fetchOpenPRClosures('owner', '..')).toBeNull();
+      expect(await detector.fetchOpenPRClosures('.', 'repo')).toBeNull();
+      expect(execFileFn).not.toHaveBeenCalled();
+    });
+
+    it('passes a legitimate owner/repo through the sink unchanged', async () => {
+      execFileFn.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, r: unknown) => void) => {
+          cb(null, { stdout: '[]', stderr: '' });
+        }
+      );
+      const result = await detector.fetchOpenPRClosures('Intense-Visions', 'harness-engineering');
+      expect(result).toEqual(new Set());
+      expect(execFileFn).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['--repo', 'Intense-Visions/harness-engineering']),
+        expect.objectContaining({ timeout: 15_000 }),
+        expect.any(Function)
+      );
+    });
+
+    it('builds the same --repo argv as before for a legitimate External-ID', async () => {
+      execFileFn.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, r: unknown) => void) => {
+          cb(null, { stdout: '1\n', stderr: '' });
+        }
+      );
+      expect(await detector.hasOpenPRForExternalId(LEGIT_ID)).toBe(true);
+      expect(execFileFn).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['--repo', 'Intense-Visions/harness-engineering']),
+        expect.objectContaining({ timeout: 10_000 }),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('fail-open contract is preserved', () => {
+    it('keeps a candidate whose External-ID is now rejected, rather than blocking it', async () => {
+      const candidate = makeIssue({ identifier: 'traversal-1', externalId: TRAVERSAL_ID });
+      const filtered = await detector.filterCandidatesWithOpenPRs([candidate]);
+      expect(filtered).toEqual([candidate]);
+      // No repo-scoped list is attempted; it degrades to the `feat/<identifier>`
+      // branch lookup exactly as an unparseable External-ID always did.
+      for (const call of execFileFn.mock.calls) {
+        expect(call[1]).not.toContain('--repo');
+      }
+    });
+
+    it('degrades an unparseable External-ID exactly as before', async () => {
+      const result = await detector.hasOpenPRForExternalId('linear:TEAM-123');
+      expect(result).toBe(false);
+      expect(execFileFn).not.toHaveBeenCalled();
+    });
+
+    it('does not throw on a rejected External-ID', async () => {
+      await expect(detector.hasOpenPRForExternalId(TRAVERSAL_ID)).resolves.toBe(false);
+      await expect(
+        detector.filterCandidatesWithOpenPRs([makeIssue({ externalId: 'github:owner/..#3' })])
+      ).resolves.toHaveLength(1);
+    });
+  });
+});

--- a/packages/orchestrator/src/core/pr-detector.ts
+++ b/packages/orchestrator/src/core/pr-detector.ts
@@ -1,6 +1,10 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { Issue } from '@harness-engineering/types';
+import {
+  parseExternalId as parseCanonicalExternalId,
+  githubRepoPath,
+} from '@harness-engineering/core';
 
 /**
  * Minimal logger interface for PR detection.
@@ -39,11 +43,21 @@ export class PRDetector {
   /**
    * Parse a `github:owner/repo#N` externalId into its parts.
    * Returns null for invalid or non-GitHub formats.
+   *
+   * Delegates to the `@harness-engineering/core` authority rather than inlining
+   * the regex, which is the rule `roadmap/external-id.ts` states about itself and
+   * which this class was violating (#1857). The copy that lived here was the
+   * verbatim PRE-#1843 pattern `/^github:([^/]+)\/([^#]+)#(\d+)$/`, so the
+   * hardening landed by #1854 never reached this consumer and
+   * `github:x/../../../user/emails?#1` still parsed to
+   * `owner="x"`, `repo="../../../user/emails?"`.
+   *
+   * Kept as a thin instance method because it is part of this class's public
+   * surface — `tests/orchestrator-pr-guard.test.ts` calls
+   * `detector.parseExternalId(...)` directly.
    */
   parseExternalId(externalId: string): { owner: string; repo: string; number: number } | null {
-    const match = externalId.match(/^github:([^/]+)\/([^#]+)#(\d+)$/);
-    if (!match) return null;
-    return { owner: match[1]!, repo: match[2]!, number: parseInt(match[3]!, 10) };
+    return parseCanonicalExternalId(externalId);
   }
 
   /**
@@ -80,6 +94,15 @@ export class PRDetector {
   async hasOpenPRForExternalId(externalId: string): Promise<boolean> {
     const parsed = this.parseExternalId(externalId);
     if (!parsed) return false;
+    // Second, independent defence (#1843/#1857): assert at the sink, immediately
+    // before the argv is built, so loosening the regex again cannot silently
+    // re-open the traversal. A rejection degrades exactly as an unparseable
+    // External-ID does — fail open, never block a candidate.
+    const repoPath = githubRepoPath(parsed.owner, parsed.repo);
+    if (!repoPath) {
+      this.logger.debug(`Refusing to query gh for unsafe externalId ${externalId}`);
+      return false;
+    }
 
     try {
       const exec = promisify(this.execFileFn);
@@ -89,7 +112,7 @@ export class PRDetector {
           'pr',
           'list',
           '--repo',
-          `${parsed.owner}/${parsed.repo}`,
+          repoPath,
           '--search',
           `closes #${parsed.number}`,
           '--state',
@@ -183,22 +206,20 @@ export class PRDetector {
    * network error) so callers can fail open rather than block real work.
    */
   async fetchOpenPRClosures(owner: string, repo: string): Promise<Set<number> | null> {
+    // This method is public and takes raw `owner`/`repo`, so it is a sink in its
+    // own right and cannot rely on the caller having parsed the pair. Assert here
+    // (#1843/#1857). Returning null is the existing "check failed" signal, which
+    // callers already treat as fail-open.
+    const repoPath = githubRepoPath(owner, repo);
+    if (!repoPath) {
+      this.logger.debug(`Refusing to list PRs for unsafe repo reference ${owner}/${repo}`);
+      return null;
+    }
     try {
       const exec = promisify(this.execFileFn);
       const { stdout } = await exec(
         'gh',
-        [
-          'pr',
-          'list',
-          '--repo',
-          `${owner}/${repo}`,
-          '--state',
-          'open',
-          '--json',
-          'body',
-          '--limit',
-          '200',
-        ],
+        ['pr', 'list', '--repo', repoPath, '--state', 'open', '--json', 'body', '--limit', '200'],
         {
           cwd: this.projectRoot,
           timeout: 15_000,


### PR DESCRIPTION
## Summary

`packages/orchestrator/src/core/pr-detector.ts` re-implemented External-ID parsing with its own inlined copy of the **pre-#1843 permissive regex** instead of importing the `packages/core` authority:

```ts
// pr-detector.ts:44 (before)
const match = externalId.match(/^github:([^/]+)\/([^#]+)#(\d+)$/);
```

PR #1854 landed the #1843 hardening in `packages/core/src/roadmap/external-id.ts:36`, but this consumer was never brought under it. The core file's own docblock claims it is the "Single source of truth ... instead of inlining the regex, so the shape can never drift" — **that claim was false on `main` today**, not prospectively. This PR makes it true at this sink.

## Change

**Layer 1 — route parsing through the authority.** `parseExternalId` now delegates to core's `parseExternalId`. It is kept as a thin instance method rather than deleted, because it is **public surface**: `packages/orchestrator/tests/orchestrator-pr-guard.test.ts:319-330` calls `detector.parseExternalId(...)` directly. That pre-existing suite passes unchanged (26/26), which also demonstrates no false rejection of the IDs it asserts.

**Layer 2 — assert at the sink.** `githubRepoPath(owner, repo)` is applied at **both** `--repo` argv-construction sinks, immediately before the value is built:

- `hasOpenPRForExternalId` — the sink the issue names.
- `fetchOpenPRClosures(owner, repo)` — **found during the fix and not named in the issue.** It is public and takes *raw* `owner`/`repo`, so it is a sink in its own right and cannot assume its caller parsed the pair.

Applying the sink check at the sink (rather than deriving it from the regex) is what the core docblock explicitly instructs, so that loosening the regex again cannot silently re-open the traversal.

## Security framing — precise, and deliberately not overstated

This is a **drift defect with a latent security dimension**, **not** a second exploitable instance of #1843.

The parsed values *do* reach an authenticated `gh` invocation, but:

- they are passed via **`execFile` argv, not a shell string** — so this is **not command injection**;
- `gh` performs its own `--repo` validation, so a traversing value was likely rejected downstream rather than silently followed.

What was actually wrong: the #1854 hardening did not apply here, and any future consumer of this copy inherited the permissive behaviour with no signal.

The tightening is **deliberately BREAKING** for External-IDs GitHub itself could never have issued. That trade was made and accepted in #1843/#1854 — it is propagated here, not re-decided.

## Fail-open contract preserved

`PRDetector` is documented fail-open. A rejected External-ID degrades on exactly the path an unparseable one already took — `hasOpenPRForExternalId` returns `false`, `fetchOpenPRClosures` returns `null` (its existing "check failed" signal, which `filterCandidatesWithOpenPRs` already treats as fail-open) — each logging at the pre-existing `logger.debug` level. Nothing throws, and **no candidate is newly blocked**. Pinned by three explicit fail-open tests.

Applying `githubRepoPath` also changes **no argv for any legitimate External-ID**: every character the tightened regex admits (`A-Za-z0-9._-`) is unreserved for `encodeURIComponent`, so the encoded value is byte-identical. Pinned by assertions on the exact `--repo` argument at both sinks.

## Reproducing test — before / after

Regression test written first, against the unmodified file at base `c1ca02ba2`. Colocated at `packages/orchestrator/src/core/pr-detector.external-id-1857.test.ts` because `packages/orchestrator/tests/**` is region-locked by a sibling unmerged PR in this fleet run; colocated `*.test.ts` under `src/` is an established convention in this package (cf. `src/agent/adaptive-router.*.test.ts`) and `vitest.config.mts` already includes `src/**/*.test.ts`.

The traversal payload is the exact one from #1843 — `github:x/../../../user/emails?#1`, which under the old regex parsed to `owner="x"`, `repo="../../../user/emails?"` and resolved to `POST https://api.github.com/user/emails`.

**BEFORE the fix:**

```
7 failed | 6 passed (13)
AssertionError: expected { owner: 'x', …(2) } to be null
```

**AFTER the fix:**

```
13 passed (13)
```

Suite authored and executed against the UNMODIFIED `pr-detector.ts`, then the fix applied with the suite unchanged.

## Verification

- Reproducing suite **13/13**.
- Pre-existing region-locked `tests/orchestrator-pr-guard.test.ts` **26/26**, before and after.
- Full package suite **2896 passed | 1 skipped** (261 files).
- `typecheck` clean · `lint` clean.
- No `scripts/generate-core-barrel.mjs` allowlist edit needed — `parseExternalId` / `githubRepoPath` are pre-existing exports (`core/src/roadmap/index.ts:68`, re-exported via `core/src/index.ts:134`). No new dependency: `packages/orchestrator` already depends on `@harness-engineering/core` and `src/` already imports from it.
- `packages/core/src/roadmap/external-id.ts` was **not** modified — it is the authority and is already correct.

## Assumptions made

- **`parseExternalId` kept as a thin delegating wrapper, not deleted** — it is public surface with an existing external caller (`orchestrator-pr-guard.test.ts:319-330`), and that file is region-locked.
- **`githubRepoPath` applied at BOTH sinks, not just the one the issue names.** `fetchOpenPRClosures` is public and takes raw values, so it is an independent sink.
- **No argv change for legitimate IDs** — verified by construction (unreserved characters) and pinned by tests.
- **Fail-open preserved verbatim rather than tightened** — a rejection reuses the existing null/false degradation paths and the existing `logger.debug` level.
- **The breaking tightening is propagated, not re-decided** — that call belongs to #1843/#1854.
- **Test colocated in `src/`** rather than `tests/`, due to the region lock.

## Out of scope — named so they are not lost

- `packages/dashboard/src/server/routes/actions.ts:301` — a further divergent inline copy of the External-ID regex on `main`. Not touched.
- `packages/dashboard/src/client/components/roadmap/utils.ts:30` — same. Not touched.
- `packages/cli/src/commands/install.ts:102` — an unrelated-format inline match, not an External-ID parser. Not touched.
- A lint/architecture rule forbidding a second inlined `github:` regex, which the issue raises as optional hardening. That is new enforcement machinery, not the reported defect — it would make the "single source of truth" claim *enforced* rather than aspirational.

Route: `bug` → `harness-debugging`. Provenance: `docs/changes/pr-detector-shared-external-id-1857/provenance.json` · Debug session: `docs/changes/pr-detector-shared-external-id-1857/debug-session.md` (a `bug` route leaves no `plans/` directory, as expected).

Closes #1857
Refs #1843 #1854
