### PR TITLE
fix(cli): honour design.tokenPath in the drift token resolvers (#1855)

### DIFF
--- a/.changeset/design-tokenpath-wired-1855.md
+++ b/.changeset/design-tokenpath-wired-1855.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Honour `design.tokenPath` in the drift token resolvers (#1855)
+
+`design.tokenPath` was declared and type-validated by the config schema but
+never read — both token resolvers hardcoded `design-system/tokens.json`. An
+adopter whose tokens lived elsewhere got no error and watched the DRIFT-T001 /
+T002 / T003 token-bypass rules skip silently, which reads identically to "no
+drift found".
+
+`loadTokenSet` and `loadTokenPathIndex` now resolve the configured
+`design.tokenPath` relative to the project root (an absolute value is used
+as-is), falling back to `design-system/tokens.json` only when the key is unset.
+A blank or whitespace-only value is treated as unset.
+
+Missing-file behaviour is unchanged: a configured path that does not exist still
+yields `null`.

--- a/.harness/comprehension/packages/cli/src/config/_module.md
+++ b/.harness/comprehension/packages/cli/src/config/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/config'
-sourceHash: '87db0d593c4f7c483046a942a40fe86de0471ded0e0e8f1f689a5c0901121707'
+sourceHash: '3f3bf5ea1ee1dca8ee517bea76fab573543d5f72c707265b8d8d02da9a51418c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -81,6 +81,7 @@ export loadAnalysisExclude
 export loadConfig
 export loadDepsExclude
 export loadDesignExclude
+export loadDesignTokenPath
 export resolveConfig
 ```
 

--- a/.harness/comprehension/packages/cli/src/drift/resolvers/_module.md
+++ b/.harness/comprehension/packages/cli/src/drift/resolvers/_module.md
@@ -1,30 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/drift/resolvers'
-sourceHash: 'd1ec8fa0a69449cc0d67c0d12ee00b04e156a41f64c6857d12f3109852fd868b'
-compiledAt: '2026-08-28T01:22:09.220Z'
+sourceHash: 'bb2916fd7c3822f85d28ed9f36b4adbb96dbfef8ce542bb489a4ebf8b1615848'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['component-registry.ts', 'tokens.ts']
+model: null
+semantic: absent
+members: ['component-registry.ts', 'tokens.tokenpath-1855.test.ts', 'tokens.ts']
 ---
-
-## Summary
-
-This module loads and parses design system metadata (component registry and design tokens) from project files, providing normalized lookup structures for the detect-design-drift rules. It exports three loaders: loadComponentRegistry() parses design-system/DESIGN.md to map HTML primitives to registered component names; loadTokenSet() extracts colors, font families, spacing scales, and deprecated token paths from design-system/tokens.json (W3C DTCG format); and loadTokenPathIndex() creates a reverse index mapping token values back to their dotted paths. All loaders degrade gracefully when source files are missing or malformed, returning null to allow drift checks to skip silently.
-
-## Invariants
-
-- Loaders return null when source files don't exist or on I/O errors; null signals callers to skip that check, not to fail the build.
-- HTML_PRIMITIVE_MAP is the single source of truth for component type → primitive tag mappings; only known entries (Button→button, Input→input, etc.) are indexed.
-- Component registry map keys are always lowercased HTML primitive tags (button, input, textarea, a); component type names are preserved as values.
-- Token deprecation detection checks both standard $deprecated: true and harness-specific $extensions.harness.deprecated: true; either flag adds to deprecatedTokens set.
-- A DTCG token is identified by presence of $value field; all object entries with keys starting with $ are treated as metadata and skipped in walks.
-- Color, font-family, and spacing values are normalized: colors and font families lowercased; spacing values must be px units (rem/em/% are dropped).
-- TokenPathIndex and TokenSet use identical token classification logic (colorValues, fontFamilyValues, spacingValues); both must normalize the same way or reverse lookup fails.
-- Font families accept either string or array-of-strings values; both are normalized to lowercase strings in TokenSet and TokenPathIndex.
-- Component Registry section extraction is delimited by the next H2 heading; section stops immediately when another ## is encountered.
-- Spacing scale only captures numeric px values; non-px CSS units (rem, em, %, calc) are explicitly filtered out and not added to spacingPx.
 
 ## Interface Contract
 
@@ -37,6 +19,11 @@ export loadTokenSet
 ## Dependency Slice
 
 ```
+import { loadDesignTokenPath } from '../../config/analysis-schema.js'
+import { runDetectDrift } from '../index.js'
+import { loadTokenPathIndex, loadTokenSet } from './tokens.js'
 import * as fs from 'node:fs'
+import * as os from 'node:os'
 import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ```

--- a/docs/changes/design-tokenpath-wired-1855/debug-session.md
+++ b/docs/changes/design-tokenpath-wired-1855/debug-session.md
@@ -1,0 +1,264 @@
+# Debug Session: design.tokenPath declared but never read (#1855)
+
+Status: resolved
+Started: 2026-09-06
+Resolved: 2026-09-06
+Base SHA: c1ca02ba2
+
+Error: No thrown error. A **silent-skip** defect — setting `design.tokenPath` in
+`harness.config.json` has no effect; the token-bypass drift rules
+(DRIFT-T001/T002/T003) simply do not run, which reads identically to
+"no drift found".
+
+## Phase 1 — INVESTIGATE
+
+### Step 1: Entropy analysis
+
+`harness cleanup packages/cli/src/drift` → 5754 entropy issues, **all** of them
+repo-wide documentation drift (`docs/knowledge/decisions/**`,
+`docs/supply-chain-audit-*.md`, `docs/roadmap.md`). Nothing near the failure
+site; no dead code, no pattern violation, no dependency issue implicated in
+`packages/cli/src/drift/`. Entropy contributed nothing to this diagnosis —
+recorded so the negative result is not re-derived.
+
+### Step 2: Read the error
+
+There is no error. That IS the bug. The failure signature is an **absence**:
+
+- What failed: `loadTokenSet` / `loadTokenPathIndex` return `null`.
+- Where: `packages/cli/src/drift/resolvers/tokens.ts` lines 53 and 88.
+- Input: a project whose tokens are NOT at `design-system/tokens.json`, with
+  `design.tokenPath` pointing at their real location.
+- Expected: tokens load; DRIFT-T00x run.
+- Actual: `null`; `meta.tokensLoaded: false`; zero findings; **exit 0**.
+
+The issue text names the file as
+`packages/cli/src/design-craft/drift/resolvers/tokens.ts` — that path does not
+exist. The real path is `packages/cli/src/drift/resolvers/tokens.ts`. The issue
+also cites only line 53; there is a **second**, identical hardcoded site at line
+88 (`loadTokenPathIndex`, which feeds align-design-system's codemods). Fixing
+only the cited site would leave the defect half-live: detect would honour the
+config and align would not.
+
+### Step 3: Reproduce consistently
+
+Fixture project (scratchpad `repro-1855/`):
+
+```
+harness.config.json         { "design": { "enabled": true,
+                                          "tokenPath": "custom/design/my-tokens.json" } }
+custom/design/my-tokens.json  { color.brand.primary = #FF6600 }
+src/Button.tsx                style={{ color: '#FF6600' }}
+```
+
+Driving the real public entry point `runDetectDrift` plus both resolvers:
+
+```
+--- site :53 (loadTokenSet) ---
+loadTokenSet => null (tokens NOT loaded)
+--- site :88 (loadTokenPathIndex) ---
+loadTokenPathIndex => null (index NOT loaded)
+--- end-to-end runDetectDrift ---
+meta.tokensLoaded: false
+DRIFT-T001 findings: 0
+```
+
+Reproduces every run. Deterministic — no timing or ordering factor.
+
+### Step 4: Check recent changes
+
+Not a recent regression — an original wiring gap, and the history says so:
+
+| commit      | date       | what                                                     |
+| ----------- | ---------- | -------------------------------------------------------- |
+| `a049b3e51` | 2026-03-19 | design-system Phase 1-2 — declares `tokenPath` in schema |
+| `421532820` | 2026-05-24 | detect-design-drift verifier — **hardcodes** the path    |
+| `e4134d341` | 2026-05-24 | align-design-system — second **hardcoded** site          |
+
+The config key shipped **two months before** its only consumer existed. The
+consumer was then authored against a fixed literal and the loop back to the
+pre-existing key was never closed. That ordering is the root cause: a config key
+with no consumer at declaration time has nothing to hold it accountable.
+
+The documented intent was explicit all along —
+`docs/changes/design-system-skills/plans/2026-03-19-design-system-phase5-implementation-skills-plan.md:150`:
+
+> `design.tokenPath` — custom token path (default: `design-system/tokens.json`).
+
+So this is a plain contract violation, not an ambiguous design call. The fix
+restores the documented contract rather than inventing one.
+
+### Step 6: Trace data flow
+
+```
+harness.config.json  design.tokenPath
+        |
+        X   <-- severed here: NOTHING reads the key
+        |
+runDetectDrift(input)
+  -> resolveDriftConfig()            drift/index.ts:79
+       loadDesignExclude(root)       <-- config IS read here, for design.exclude
+       loadTokenSet(root)            drift/index.ts:97
+         -> path.join(root,'design-system','tokens.json')   <-- HARDCODED :53
+       -> null -> tokens:null -> rulesApplied omits 'token-bypass'
+       -> scanFile() skips runTokenBypassRule entirely
+
+runAlignDesignSystem(input)          align/index.ts:76
+  -> loadTokenPathIndex(root)
+       -> path.join(root,'design-system','tokens.json')   <-- HARDCODED :88
+       -> null -> T001/T002/T003 codemods cannot resolve token references
+```
+
+The severed edge is unambiguous: `design.tokenPath` has **zero** readers in the
+whole repo (verified by symbol sweep; the `tokenPath` hits in
+`packages/graph/src/ingest/DesignIngestor.ts` are an unrelated homonym — a
+token's dotted path like `space.md`).
+
+## Phase 2 — ANALYZE
+
+### Working example
+
+`loadDesignExclude` in `packages/cli/src/config/analysis-schema.ts:74`. It reads
+one `design.*` key from `harness.config.json` for this exact drift runner, and
+its own doc comment states the reason: kept out of `HarnessConfigSchema` so hot
+paths do not drag in the full schema's transitive imports. Sibling precedents in
+the same file: `loadAnalysisExclude`, `loadDepsExclude`.
+
+Critically, `resolveDriftConfig` **already calls** `loadDesignExclude(projectRoot)`
+two lines above its `loadTokenSet(projectRoot)` call. The mechanism to read
+config was already present and already in use in the same function — the token
+resolver just never used it.
+
+### Differences (working vs failing)
+
+|                                 | `design.exclude` (works)          | `design.tokenPath` (broken)   |
+| ------------------------------- | --------------------------------- | ----------------------------- |
+| config reader                   | `loadDesignExclude`               | **none**                      |
+| default when unset              | `[]`                              | `design-system/tokens.json`   |
+| failure mode when misconfigured | patterns ignored, scan still runs | **rules silently do not run** |
+
+Category: **missing setup** — the failing path skips a config read the working
+path performs. Not a wrong-argument or timing bug.
+
+### Why the existing tests do not catch it
+
+`packages/cli/tests/config/design-schema.test.ts:83` asserts `tokenPath must be
+a string if provided`. That is a test of the **schema shape**, not of the value
+being **honoured**. The key is covered by a passing test and still completely
+inert — false confidence. Any replacement test must assert behaviour.
+
+## Phase 3 — HYPOTHESIZE
+
+> The rules skip because `loadTokenSet` and `loadTokenPathIndex` build the tokens
+> path from a hardcoded literal and never consult `design.tokenPath`.
+> If correct, routing both through a config-aware resolver will make the SAME
+> fixture report `tokensLoaded: true` and emit a DRIFT-T001 finding for `#FF6600`.
+> Falsifiable by: one variable — replace only the path expression at :53 and :88.
+
+**Confirmed.** One variable changed (the path expression, via a single shared
+helper). Same fixture, after:
+
+```
+loadTokenSet => TokenSet loaded
+loadTokenPathIndex => TokenPathIndex loaded
+meta.tokensLoaded: true
+DRIFT-T001 findings: 1
+```
+
+### Uncertainty ledger
+
+- **Assumption (recorded, not blocking):** a configured `tokenPath` that escapes
+  `projectRoot` (`../../elsewhere.json`) is honoured. It is the project's own
+  config file naming its own tokens — same trust boundary as `projectRoot`
+  itself — so no traversal guard was added.
+- **Assumption:** `tokenPath` may name a `.css` file per the schema's doc
+  comment, but the resolver only parses DTCG JSON. Behaviour there is unchanged
+  (parse fails -> `null`). Not widened here.
+- **Deferrable (filed as PR follow-ups, not built):** three adjacent hardcoded
+  `design-system/tokens.json` sites outside this defect's scope.
+
+## Phase 4 — FIX
+
+### Regression test (written BEFORE the fix)
+
+`packages/cli/src/drift/resolvers/tokens.tokenpath-1855.test.ts` — 11 tests.
+Colocated in `src/` because `packages/cli/tests/**` is region-locked by a
+concurrent PR; `src/**/*.test.ts` is an established include in this package's
+vitest config.
+
+Asserts behaviour, not shape: both call sites read a configured path, the
+DRIFT-T00x rules genuinely run against custom-path tokens (checked via
+`meta.tokensLoaded` **and** `catalog.rulesApplied` **and** the palette-aware
+finding message — a silent skip and a clean scan are otherwise
+indistinguishable), the unset-key fallback is intact, and the deliberately
+unchanged missing-file contract is pinned.
+
+### Fix
+
+Root cause, minimal, one concept:
+
+- `loadDesignTokenPath()` added to `config/analysis-schema.ts`, mirroring the
+  `loadDesignExclude` sibling exactly. Blank/whitespace-only is treated as unset
+  (it cannot name a file, and honouring it literally would resolve to the
+  project root and silently disable the rules again).
+- `resolveTokensFilePath()` added to `tokens.ts` and used at **both** :53 and
+  :88, so the configured path cannot be honoured by one loader and ignored by
+  the other.
+
+No new config-plumbing mechanism, no widened signatures, no special-case branch.
+
+### Verify (Phase 4 Step 4 — revert-and-fail protocol)
+
+Identical test file, fix reverted then restored:
+
+|        | fix reverted                  | fix applied        |
+| ------ | ----------------------------- | ------------------ |
+| result | **5 failed** \| 6 passed (11) | **11 passed** (11) |
+
+The 6 that pass without the fix are precisely the unchanged-behaviour guards
+(unset-key fallback, missing-file `null`) — they are meant to pass in both
+states. Every custom-path assertion fails without the fix. The test provably
+catches the bug.
+
+Wider suites: `tests/drift tests/align tests/config src/drift src/align
+src/design-pipeline` → 38 files, 398 tests, all pass. `tsc --noEmit` clean.
+ESLint clean on all three changed files.
+
+## Resolution
+
+**Root cause:** `design.tokenPath` was declared in the config schema on
+2026-03-19, two months before its only consumer existed. When the drift token
+resolver was authored (2026-05-24) it hardcoded `design-system/tokens.json` at
+two sites and was never wired back to the pre-existing key. Schema validation
+gave the key the appearance of support; nothing read it.
+
+**Fix:** route both resolver sites through `resolveTokensFilePath`, which reads
+`design.tokenPath` via a new `loadDesignTokenPath` config reader (modelled on
+the `loadDesignExclude` sibling) and falls back to `design-system/tokens.json`
+only when the key is unset.
+
+**Regression test:** `packages/cli/src/drift/resolvers/tokens.tokenpath-1855.test.ts`
+
+**Deliberately NOT changed (F2):** an explicitly-configured-but-missing tokens
+file still returns `null` rather than failing loudly. The issue raises that
+"separately"; it is an adopter-visible behaviour change and belongs in its own
+change. The current contract is now pinned by a test so a future change to it is
+a visible, deliberate edit.
+
+**Out of scope (named as PR follow-ups):**
+`packages/cli/src/brand/resolvers/token-extensions.ts:31`,
+`packages/cli/src/design-pipeline/phases/fill.ts:92`,
+`packages/cli/src/design-pipeline/phases/freshen.ts:27`.
+
+## Learnings
+
+- **A config key declared before its consumer exists has nothing holding it
+  accountable.** Zod validation makes an inert key look supported. When adding a
+  schema key ahead of its reader, the schema test is not coverage — a behaviour
+  test that the value is honoured is.
+- **A silent skip and a clean result are indistinguishable from the finding list
+  alone.** Any test for a resource-gated rule must assert the rule _ran_
+  (`tokensLoaded` / `rulesApplied`), not just what it found. Same class as #1838.
+- **A fix scoped to the cited line can be half a fix.** The issue cited one
+  hardcoded site; there were two, feeding two different skills. Sweep for the
+  literal before scoping.

--- a/docs/changes/design-tokenpath-wired-1855/provenance.json
+++ b/docs/changes/design-tokenpath-wired-1855/provenance.json
@@ -1,0 +1,26 @@
+{
+  "issues": [1855],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/cli/src/drift/resolvers/tokens.tokenpath-1855.test.ts",
+  "closingKeyword": "Closes #1855",
+  "baseSha": "c1ca02ba2",
+  "debugSession": "docs/changes/design-tokenpath-wired-1855/debug-session.md",
+  "sitesWired": [
+    "packages/cli/src/drift/resolvers/tokens.ts:53 (loadTokenSet)",
+    "packages/cli/src/drift/resolvers/tokens.ts:88 (loadTokenPathIndex)"
+  ],
+  "assumptions": [
+    "The issue names the file as packages/cli/src/design-craft/drift/resolvers/tokens.ts; that path does not exist. The real path is packages/cli/src/drift/resolvers/tokens.ts.",
+    "The issue cites only line 53. A second identical hardcoded site exists at line 88 (loadTokenPathIndex, feeding align-design-system's codemods). Both were wired — fixing only the cited site would have left detect honouring the config while align ignored it.",
+    "A configured design.tokenPath is resolved relative to projectRoot; an absolute configured value is honoured as-is (path.resolve gives both behaviours).",
+    "A blank or whitespace-only configured value is treated as unset rather than as a real path — it cannot name a file, and honouring it literally would resolve to the project root and silently disable the token rules, reproducing the very defect being fixed.",
+    "The fallback to design-system/tokens.json applies only when the key is unset. When tokenPath IS configured, the default location is NOT also probed: a configured-but-missing file resolves to null rather than silently loading a different project's tokens.",
+    "Config is read via a new loadDesignTokenPath() in packages/cli/src/config/analysis-schema.ts, mirroring the loadDesignExclude sibling already called by resolveDriftConfig two lines above the loadTokenSet call. No new config-plumbing mechanism was invented and no function signature was widened.",
+    "F2 — missing-file behaviour is deliberately UNCHANGED. The issue raises loud-failure-on-missing 'separately'; it is a distinct adopter-visible behaviour change. The existing null-on-missing semantics are preserved and now pinned by a test.",
+    "A configured path that escapes projectRoot (e.g. ../../elsewhere.json) is honoured. The value comes from the project's own harness.config.json naming its own tokens — the same trust boundary as projectRoot — so no traversal guard was added.",
+    "The schema's doc comment says tokenPath may be 'JSON or CSS'; the resolver parses DTCG JSON only. That behaviour is unchanged (a CSS file fails to parse and yields null). Widening the parser was out of scope.",
+    "The regression test is colocated at packages/cli/src/drift/resolvers/ rather than under packages/cli/tests/ because that tree is region-locked by a concurrent PR. src/**/*.test.ts is an established include in packages/cli/vitest.config.mts.",
+    "F1 — three adjacent hardcoded design-system/tokens.json sites (brand/resolvers/token-extensions.ts:31, design-pipeline/phases/fill.ts:92, design-pipeline/phases/freshen.ts:27) were left untouched and are named as follow-ups in the PR body."
+  ]
+}

--- a/packages/cli/src/config/analysis-schema.ts
+++ b/packages/cli/src/config/analysis-schema.ts
@@ -90,6 +90,51 @@ export function loadDesignExclude(projectPath: string): string[] {
 }
 
 /**
+ * Schema fragment for the `design.tokenPath` override. Kept here alongside
+ * `design.exclude` for the same reason: the drift token resolver needs one
+ * `design.*` key and must not drag in the full `HarnessConfigSchema`. Mirrors
+ * the `DesignConfigSchema.tokenPath` field shape.
+ */
+const DesignTokenPathSchema = z.object({
+  tokenPath: z.string().optional(),
+});
+
+/**
+ * Best-effort load of `design.tokenPath` from `<projectPath>/harness.config.json`.
+ *
+ * Returns `undefined` on any miss (no config file, malformed JSON, a `design`
+ * block that fails validation, or the key simply being absent) so callers fall
+ * back to their built-in default location — the same degrade-gracefully contract
+ * `loadDesignExclude` uses. A blank or whitespace-only value is also treated as
+ * unset: it cannot name a real file, and honouring it literally would resolve to
+ * the project root and silently disable the token rules (#1855).
+ *
+ * The returned value is the raw configured string; resolving it against a project
+ * root is the caller's job (see `resolveTokensFilePath` in
+ * `drift/resolvers/tokens.ts`).
+ */
+export function loadDesignTokenPath(projectPath: string): string | undefined {
+  const configPath = path.join(projectPath, 'harness.config.json');
+  if (!fs.existsSync(configPath)) return undefined;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+
+  const designRaw = (raw as { design?: unknown } | null | undefined)?.design;
+  if (designRaw === undefined || designRaw === null || typeof designRaw !== 'object') {
+    return undefined;
+  }
+  const parsed = DesignTokenPathSchema.safeParse(designRaw);
+  if (!parsed.success) return undefined;
+  const configured = parsed.data.tokenPath?.trim();
+  return configured === undefined || configured === '' ? undefined : configured;
+}
+
+/**
  * Schema for the `deps.exclude` glob list (check-deps discovery scoping).
  * Kept here — alongside `analysis.exclude` / `design.exclude` — so check-deps
  * can load it without importing the full HarnessConfigSchema. Patterns are

--- a/packages/cli/src/drift/resolvers/tokens.tokenpath-1855.test.ts
+++ b/packages/cli/src/drift/resolvers/tokens.tokenpath-1855.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression test for #1855 — `design.tokenPath` is declared and type-validated
+ * by the config schema but was never read: both token resolvers hardcoded
+ * `design-system/tokens.json`.
+ *
+ * The pre-existing coverage (`tests/config/design-schema.test.ts`) asserts only
+ * that `tokenPath` *must be a string if provided* — that is a test of the schema
+ * shape, not of the value being honoured. The key was covered by a passing test
+ * and still completely inert. These tests therefore assert BEHAVIOUR: that a
+ * non-default configured path is actually read, that the DRIFT-T00x token-bypass
+ * rules run against tokens loaded from it, and that the unset-key fallback is
+ * unchanged.
+ *
+ * Both previously-hardcoded call sites are exercised:
+ *   - `loadTokenSet`       (was tokens.ts:53) — feeds runDetectDrift's DRIFT-T* rules
+ *   - `loadTokenPathIndex` (was tokens.ts:88) — feeds align-design-system's codemods
+ *
+ * Colocated in `src/` rather than under `packages/cli/tests/` because that tree is
+ * region-locked by a concurrent PR; `src/**\/*.test.ts` is an established include
+ * in this package's vitest config.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadTokenSet, loadTokenPathIndex } from './tokens.js';
+import { runDetectDrift } from '../index.js';
+
+const TOKENS = {
+  color: { brand: { primary: { $type: 'color', $value: '#FF6600' } } },
+  space: { md: { $type: 'dimension', $value: '16px' } },
+};
+
+describe('design.tokenPath is honoured by the drift token resolvers (#1855)', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tokenpath-1855-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  function writeConfig(design: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(projectRoot, 'harness.config.json'), JSON.stringify({ design }));
+  }
+
+  function writeTokensAt(relOrAbs: string, tokens: unknown = TOKENS): string {
+    const target = path.isAbsolute(relOrAbs) ? relOrAbs : path.join(projectRoot, relOrAbs);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(tokens));
+    return target;
+  }
+
+  describe('a configured non-default tokenPath IS read', () => {
+    // The failing-before / passing-after case. Before the fix both resolvers
+    // built `<root>/design-system/tokens.json` and returned null here.
+    beforeEach(() => {
+      writeConfig({ tokenPath: 'custom/design/my-tokens.json' });
+      writeTokensAt('custom/design/my-tokens.json');
+    });
+
+    it('loadTokenSet reads tokens from the configured path (site :53)', () => {
+      const tokens = loadTokenSet(projectRoot);
+      expect(tokens).not.toBeNull();
+      expect(tokens!.colors.has('#ff6600')).toBe(true);
+      expect(tokens!.spacingPx.has(16)).toBe(true);
+    });
+
+    it('loadTokenPathIndex reads tokens from the configured path (site :88)', () => {
+      const index = loadTokenPathIndex(projectRoot);
+      expect(index).not.toBeNull();
+      expect(index!.colorPath.get('#ff6600')).toEqual(['color.brand.primary']);
+      expect(index!.spacingPath.get(16)).toEqual(['space.md']);
+    });
+
+    it('the DRIFT-T00x token-bypass rules actually run against them', async () => {
+      fs.mkdirSync(path.join(projectRoot, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectRoot, 'src', 'Button.tsx'),
+        `export const Button = () => <button style={{ color: '#FF6600' }}>Go</button>;\n`
+      );
+
+      const result = await runDetectDrift({ path: projectRoot, mode: 'full' });
+
+      // A silent skip and a clean scan are indistinguishable from the finding
+      // list alone, so assert the rule *ran* as well as what it found.
+      expect(result.meta.tokensLoaded).toBe(true);
+      expect(result.catalog.rulesApplied).toContain('token-bypass');
+      const t001 = result.findings.filter((f) => f.code === 'DRIFT-T001');
+      expect(t001).toHaveLength(1);
+      // Palette-aware message proves the CUSTOM-PATH palette reached the rule:
+      // an empty/absent palette yields the "outside the design system" variant.
+      expect(t001[0]!.message).toContain('token reference');
+    });
+  });
+
+  it('honours an absolute configured tokenPath', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'tokenpath-1855-abs-'));
+    try {
+      const abs = writeTokensAt(path.join(outside, 'tokens.json'));
+      writeConfig({ tokenPath: abs });
+      expect(loadTokenSet(projectRoot)!.colors.has('#ff6600')).toBe(true);
+      expect(loadTokenPathIndex(projectRoot)!.colorPath.has('#ff6600')).toBe(true);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  describe('unset tokenPath still falls back to design-system/tokens.json', () => {
+    it('falls back when harness.config.json has no tokenPath key', () => {
+      writeConfig({ enabled: true });
+      writeTokensAt('design-system/tokens.json');
+      expect(loadTokenSet(projectRoot)!.colors.has('#ff6600')).toBe(true);
+      expect(loadTokenPathIndex(projectRoot)!.colorPath.has('#ff6600')).toBe(true);
+    });
+
+    it('falls back when there is no harness.config.json at all', () => {
+      writeTokensAt('design-system/tokens.json');
+      expect(loadTokenSet(projectRoot)!.colors.has('#ff6600')).toBe(true);
+      expect(loadTokenPathIndex(projectRoot)!.colorPath.has('#ff6600')).toBe(true);
+    });
+
+    it('treats a blank/whitespace-only tokenPath as unset', () => {
+      writeConfig({ tokenPath: '   ' });
+      writeTokensAt('design-system/tokens.json');
+      expect(loadTokenSet(projectRoot)!.colors.has('#ff6600')).toBe(true);
+      expect(loadTokenPathIndex(projectRoot)!.colorPath.has('#ff6600')).toBe(true);
+    });
+
+    it('does not fall back when tokenPath IS configured — the default path is ignored', () => {
+      writeConfig({ tokenPath: 'custom/tokens.json' });
+      writeTokensAt('design-system/tokens.json');
+      expect(loadTokenSet(projectRoot)).toBeNull();
+      expect(loadTokenPathIndex(projectRoot)).toBeNull();
+    });
+  });
+
+  describe('missing-file behaviour is deliberately unchanged (F2)', () => {
+    // #1855 suggests, *separately*, making an explicitly-configured-but-missing
+    // tokens file a loud failure. That is an adopter-visible behaviour change and
+    // is out of scope here; this test pins the current null-on-missing contract so
+    // a future change to it is a deliberate, visible edit rather than a drift.
+    it('returns null when the configured tokenPath does not exist', () => {
+      writeConfig({ tokenPath: 'custom/nope.json' });
+      expect(loadTokenSet(projectRoot)).toBeNull();
+      expect(loadTokenPathIndex(projectRoot)).toBeNull();
+    });
+
+    it('returns null when the configured tokenPath is not valid JSON', () => {
+      writeConfig({ tokenPath: 'custom/tokens.json' });
+      const target = path.join(projectRoot, 'custom', 'tokens.json');
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, '{ not: valid');
+      expect(loadTokenSet(projectRoot)).toBeNull();
+      expect(loadTokenPathIndex(projectRoot)).toBeNull();
+    });
+
+    it('falls back to the default path when harness.config.json is malformed', () => {
+      fs.writeFileSync(path.join(projectRoot, 'harness.config.json'), '{ not: valid');
+      writeTokensAt('design-system/tokens.json');
+      expect(loadTokenSet(projectRoot)!.colors.has('#ff6600')).toBe(true);
+      expect(loadTokenPathIndex(projectRoot)!.colorPath.has('#ff6600')).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/drift/resolvers/tokens.ts
+++ b/packages/cli/src/drift/resolvers/tokens.ts
@@ -1,5 +1,7 @@
 /**
- * Load and parse design-system/tokens.json (W3C DTCG format).
+ * Load and parse the project's design tokens file (W3C DTCG format) — the
+ * `design.tokenPath` configured in harness.config.json, or
+ * design-system/tokens.json when that key is unset.
  *
  * Extracts:
  *   - Color values (palette)
@@ -18,6 +20,28 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { loadDesignTokenPath } from '../../config/analysis-schema.js';
+
+/** Location used when `design.tokenPath` is not configured. */
+const DEFAULT_TOKENS_RELATIVE_PATH = path.join('design-system', 'tokens.json');
+
+/**
+ * Absolute path of the project's tokens file.
+ *
+ * Honours `design.tokenPath` from `harness.config.json`, resolved relative to
+ * `projectRoot` (an absolute configured value is used as-is). Falls back to
+ * `design-system/tokens.json` only when the key is unset — before #1855 the key
+ * was type-validated by the config schema but never read, so an adopter whose
+ * tokens lived elsewhere got no error and watched the DRIFT-T00x token-bypass
+ * rules skip silently, which reads identically to "no drift found".
+ *
+ * Shared by both loaders below so the configured path cannot be honoured by one
+ * and ignored by the other.
+ */
+function resolveTokensFilePath(projectRoot: string): string {
+  const configured = loadDesignTokenPath(projectRoot);
+  return path.resolve(projectRoot, configured ?? DEFAULT_TOKENS_RELATIVE_PATH);
+}
 
 export interface TokenSet {
   /** Lowercased hex color values from $type: 'color' tokens */
@@ -50,7 +74,7 @@ export interface TokenPathIndex {
  * file doesn't exist.
  */
 export function loadTokenSet(projectRoot: string): TokenSet | null {
-  const tokenPath = path.join(projectRoot, 'design-system', 'tokens.json');
+  const tokenPath = resolveTokensFilePath(projectRoot);
   if (!fs.existsSync(tokenPath)) return null;
   let raw: string;
   try {
@@ -85,7 +109,7 @@ function extractTokens(root: Record<string, unknown>): TokenSet {
  * tokens absence in the drift rules).
  */
 export function loadTokenPathIndex(projectRoot: string): TokenPathIndex | null {
-  const tokenPath = path.join(projectRoot, 'design-system', 'tokens.json');
+  const tokenPath = resolveTokensFilePath(projectRoot);
   if (!fs.existsSync(tokenPath)) return null;
   let raw: string;
   try {


### PR DESCRIPTION
## Summary

`design.tokenPath` was accepted and type-validated by the config schema, but **nothing ever read it**. The token resolver hardcoded the path, so setting the key in `harness.config.json` silently did nothing.

The failure signature is an **absence**, which is why it survived: `loadTokenSet` returns `null`, `rulesApplied` omits `token-bypass`, and `scanFile()` skips `runTokenBypassRule` entirely. An adopter whose tokens are not at `design-system/tokens.json` gets **no error** — the DRIFT-T001/T002/T003 rules simply never run, and a silent skip reads identically to "no drift found".

The config key shipped roughly two months before its only consumer existed.

## Both hardcoded sites were wired — the issue cites only one

This is the part worth reviewing carefully. The issue names `tokens.ts:53`. There is a **second, identical** hardcoded site:

| Site | Function | Feeds |
| --- | --- | --- |
| `packages/cli/src/drift/resolvers/tokens.ts:53` | `loadTokenSet` | detect-design-drift (the site the issue cites) |
| `packages/cli/src/drift/resolvers/tokens.ts:88` | `loadTokenPathIndex` | align-design-system's codemods |

Fixing only the cited site would have left **detect honouring the config while align ignored it** — a worse, harder-to-diagnose split than the original bug. Both are wired.

Note also: the issue names the file as `packages/cli/src/design-craft/drift/resolvers/tokens.ts`. **That path does not exist.** The real path is `packages/cli/src/drift/resolvers/tokens.ts`.

## How the config is read

Via a new `loadDesignTokenPath()` in `packages/cli/src/config/analysis-schema.ts`, mirroring the `loadDesignExclude` sibling that `resolveDriftConfig` already calls two lines above the `loadTokenSet` call. No new config-plumbing mechanism was invented and no function signature was widened.

Resolution semantics:
- A configured `design.tokenPath` resolves **relative to `projectRoot`**; an absolute value is honoured as-is (`path.resolve` gives both).
- A blank/whitespace-only value is treated as **unset** — it cannot name a file, and honouring it literally would resolve to the project root and silently disable the token rules, reproducing the very defect being fixed.
- The `design-system/tokens.json` fallback applies **only when the key is unset**. When `tokenPath` *is* configured, the default location is deliberately **not** also probed — a configured-but-missing file resolves to `null` rather than silently loading a different project's tokens.

## Why the existing tests did not catch it

`packages/cli/tests/config/design-schema.test.ts:83` asserts `tokenPath must be a string if provided` — that tests the **schema**, not that the value is **honoured**. Classic false-confidence: the key was covered by a passing test and still completely inert. The new test asserts **behaviour**.

## Reproducing test — before / after

Written **before** the fix, against the unmodified resolver, and verified by the revert-and-fail protocol:

| | without fix | with fix |
| --- | --- | --- |
| result | **5 failed** \| 6 passed (11) | **11 passed** (11) |

The 6 that pass in both states are precisely the unchanged-behaviour guards (unset-key fallback, missing-file `null`) — they are meant to pass either way. **Every custom-path assertion fails without the fix**, so the test provably discriminates.

Test is colocated at `packages/cli/src/drift/resolvers/tokens.tokenpath-1855.test.ts` rather than under `packages/cli/tests/`, because that tree is region-locked by a concurrent unmerged PR in this fleet run. `src/**/*.test.ts` is an established include in `packages/cli/vitest.config.mts`.

## Verification

- Reproducing suite **11/11**.
- `packages/cli/src/drift` + `src/align` + `src/design-pipeline` → **38 files, 398 tests, all pass**.
- `tsc --noEmit` clean.

## Assumptions made

- **Both sites (`:53` and `:88`) wired**, not just the cited one — see the table above.
- **Corrected the issue's file path** (`design-craft/drift/...` does not exist).
- Configured path resolves relative to `projectRoot`; absolute honoured as-is.
- **Blank/whitespace-only treated as unset**, not as a literal path.
- When `tokenPath` is configured, the default location is **not** additionally probed.
- Config read through a new `loadDesignTokenPath()` mirroring the existing `loadDesignExclude` sibling — no new mechanism, no widened signatures.
- **F2 — missing-file behaviour deliberately UNCHANGED.** The issue raises loud-failure-on-missing *"separately"*; it is a distinct, adopter-visible behaviour change. The existing `null`-on-missing semantics are preserved and now **pinned by a test** so a future change to them is deliberate. Recommended as a follow-up, not built here.
- **A configured path that escapes `projectRoot`** (e.g. `../../elsewhere.json`) is honoured. The value comes from the project's own `harness.config.json` naming its own tokens — the same trust boundary as `projectRoot` — so no traversal guard was added.
- **The schema doc comment says `tokenPath` may be "JSON or CSS"; the resolver parses DTCG JSON only.** That behaviour is unchanged (a CSS file fails to parse and yields `null`). Widening the parser was out of scope.
- Test colocated in `src/` due to the region lock.

## Out of scope — named so they are not lost

Three adjacent hardcoded `design-system/tokens.json` sites were left untouched and should be considered as follow-ups:

- `packages/cli/src/brand/resolvers/token-extensions.ts:31`
- `packages/cli/src/design-pipeline/phases/fill.ts:92`
- `packages/cli/src/design-pipeline/phases/freshen.ts:27`

Route: `bug` → `harness-debugging`. Provenance: `docs/changes/design-tokenpath-wired-1855/provenance.json` · Debug session: `docs/changes/design-tokenpath-wired-1855/debug-session.md` (a `bug` route leaves no `plans/` directory, as expected).

Closes #1855
Refs #1824 #1852
