### PR TITLE
test(core): characterize tsconfig paths alias loader (50% -> 95% branch coverage)

### DIFF
--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,16 +1,162 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/commands"
-sourceHash: "fa510e8ad1573b6a8a5272857b7fffb5959e2534cb40f0cb23c14fd884fa699d"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/cli/tests/commands'
+sourceHash: '2bbde1cdd4e0752f28023eebb4be0eaa9357ade3e280146c337e1d96b9878b41'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["add-extra.test.ts", "add.test.ts", "adoption-retrospective.test.ts", "adoption.test.ts", "agent-review.test.ts", "agent-run-persona.test.ts", "agent-run.test.ts", "agent.test.ts", "align-design-system-command.test.ts", "audit-protected.test.ts", "backfill-skill-provenance.test.ts", "check-arch.test.ts", "check-deployment.test.ts", "check-deps.test.ts", "check-design.test.ts", "check-docs.test.ts", "check-harness-strength.test.ts", "check-perf.test.ts", "check-phase-gate.test.ts", "check-security.test.ts", "check-vocabulary.test.ts", "cleanup-sessions.test.ts", "cleanup.test.ts", "cli-command-harness.ts", "compound-scan-candidates.test.ts", "copy-craft-command.test.ts", "craft-command-harness.ts", "create-skill.test.ts", "cross-check.test.ts", "dashboard.test.ts", "deprecated-graph-aliases.test.ts", "design-command-harness.ts", "design-pipeline-command.test.ts", "distortion.test.ts", "doctor-hardening.test.ts", "doctor.test.ts", "fix-drift.test.ts", "generate-agent-definitions.test.ts", "generate-slash-commands.test.ts", "generate.test.ts", "golden-build-command.test.ts", "golden-build.test.ts", "graph-ingest-decisions.integration.test.ts", "graph-ingest.test.ts", "graph-integrity.test.ts", "graph.test.ts", "hooks.test.ts", "impact-preview.test.ts", "ingest-options.test.ts", "init-extra.test.ts", "init-minimal.test.ts", "init.test.ts", "insights.test.ts", "install-constraints.test.ts", "install.test.ts", "integrations-sync.test.ts", "integrations.test.ts", "learnings-prune.test.ts", "linter-generate.test.ts", "maintenance-command-shape.test.ts", "maintenance-run-check-runner.test.ts", "maintenance-run-integration.test.ts", "maintenance-run-selection.test.ts", "mcp-context-report.test.ts", "mcp-guard.test.ts", "mcp-list-capabilities.test.ts", "mcp-refinement-demand.test.ts", "migrate-backends.test.ts", "migrate.test.ts", "models-probe.test.ts", "models.test.ts", "naming-craft-command.test.ts", "outcome-eval-ci.test.ts", "perf.test.ts", "persona-list.test.ts", "persona.test.ts", "pre-merge-brief-guardian.test.ts", "pre-merge-brief.test.ts", "predict.test.ts", "proposals-status.test.ts", "proposals.test.ts", "publish-analyses.test.ts", "pulse-run.test.ts", "recommend.test.ts", "resolve-skill-sources.test.ts", "review-ci-local-adapter.test.ts", "review-ci.test.ts", "rollback.test.ts", "scan-config.test.ts", "search.test.ts", "security-craft-command.test.ts", "setup-mcp.picker-message.test.ts", "setup-mcp.test.ts", "setup.test.ts", "share.test.ts", "skill-create.test.ts", "skill-info.test.ts", "skill-list.test.ts", "skill-local-resolution.test.ts", "skill-publish.test.ts", "skill-run.test.ts", "skill-search.test.ts", "skill-update.test.ts", "skill-validate.test.ts", "skill.test.ts", "snapshot.test.ts", "spec-craft-command.test.ts", "stale-constraints.test.ts", "state-show.test.ts", "state-streams.test.ts", "state.test.ts", "sync-analyses-action.test.ts", "sync-analyses.test.ts", "sync-main.test.ts", "taint.test.ts", "telemetry-synthesize.test.ts", "telemetry-wizard-run.test.ts", "telemetry-wizard.test.ts", "telemetry.test.ts", "test-craft-command.test.ts", "traceability.test.ts", "uninstall-constraints.test.ts", "uninstall.test.ts", "update-integrations-sync.test.ts", "update-skill-providers.test.ts", "update.test.ts", "usage-pipeline.test.ts", "usage.test.ts", "validate-cross-check.test.ts", "validate-scope.test.ts", "validate.changed.test.ts", "validate.merge-driver.test.ts", "validate.roadmap-abstention.test.ts", "validate.roadmap-health.test.ts", "validate.roadmap-mode.test.ts", "validate.test.ts", "waypoint.test.ts"]
+members:
+  [
+    'add-extra.test.ts',
+    'add.test.ts',
+    'adoption-retrospective.test.ts',
+    'adoption.test.ts',
+    'agent-review.test.ts',
+    'agent-run-persona.test.ts',
+    'agent-run.test.ts',
+    'agent.test.ts',
+    'align-design-system-command.test.ts',
+    'api-craft-command.test.ts',
+    'audit-protected.test.ts',
+    'backfill-skill-provenance.test.ts',
+    'check-arch.test.ts',
+    'check-deployment.test.ts',
+    'check-deps.test.ts',
+    'check-design.test.ts',
+    'check-docs.test.ts',
+    'check-harness-strength.test.ts',
+    'check-perf.test.ts',
+    'check-phase-gate.test.ts',
+    'check-security.test.ts',
+    'check-vocabulary.test.ts',
+    'cleanup-sessions.test.ts',
+    'cleanup.test.ts',
+    'cli-command-harness.ts',
+    'cli-ergonomics-craft-command.test.ts',
+    'code-craft-command.test.ts',
+    'compound-scan-candidates.test.ts',
+    'copy-craft-command.test.ts',
+    'craft-command-harness-cohort-b.ts',
+    'craft-command-harness.ts',
+    'create-skill.test.ts',
+    'cross-check.test.ts',
+    'dashboard.test.ts',
+    'deprecated-graph-aliases.test.ts',
+    'design-command-harness.ts',
+    'design-pipeline-command.test.ts',
+    'distortion.test.ts',
+    'docs-craft-command.test.ts',
+    'doctor-hardening.test.ts',
+    'doctor.test.ts',
+    'fix-drift.test.ts',
+    'generate-agent-definitions.test.ts',
+    'generate-slash-commands.test.ts',
+    'generate.test.ts',
+    'golden-build-command.test.ts',
+    'golden-build.test.ts',
+    'graph-ingest-decisions.integration.test.ts',
+    'graph-ingest.test.ts',
+    'graph-integrity.test.ts',
+    'graph.test.ts',
+    'hooks.test.ts',
+    'impact-preview.test.ts',
+    'ingest-options.test.ts',
+    'init-extra.test.ts',
+    'init-minimal.test.ts',
+    'init.test.ts',
+    'insights.test.ts',
+    'install-constraints.test.ts',
+    'install.test.ts',
+    'integrations-sync.test.ts',
+    'integrations.test.ts',
+    'knowledge-craft-command.test.ts',
+    'learnings-prune.test.ts',
+    'linter-generate.test.ts',
+    'maintenance-command-shape.test.ts',
+    'maintenance-run-check-runner.test.ts',
+    'maintenance-run-integration.test.ts',
+    'maintenance-run-selection.test.ts',
+    'mcp-context-report.test.ts',
+    'mcp-guard.test.ts',
+    'mcp-list-capabilities.test.ts',
+    'mcp-refinement-demand.test.ts',
+    'migrate-backends.test.ts',
+    'migrate.test.ts',
+    'models-probe.test.ts',
+    'models.test.ts',
+    'naming-craft-command.test.ts',
+    'outcome-eval-ci.test.ts',
+    'perf.test.ts',
+    'persona-list.test.ts',
+    'persona.test.ts',
+    'pre-merge-brief-guardian.test.ts',
+    'pre-merge-brief.test.ts',
+    'predict.test.ts',
+    'proposals-status.test.ts',
+    'proposals.test.ts',
+    'publish-analyses.test.ts',
+    'pulse-run.test.ts',
+    'recommend.test.ts',
+    'resolve-skill-sources.test.ts',
+    'review-ci-local-adapter.test.ts',
+    'review-ci.test.ts',
+    'rollback.test.ts',
+    'scan-config.test.ts',
+    'search.test.ts',
+    'security-craft-command.test.ts',
+    'setup-mcp.picker-message.test.ts',
+    'setup-mcp.test.ts',
+    'setup.test.ts',
+    'share.test.ts',
+    'skill-create.test.ts',
+    'skill-info.test.ts',
+    'skill-list.test.ts',
+    'skill-local-resolution.test.ts',
+    'skill-publish.test.ts',
+    'skill-run.test.ts',
+    'skill-search.test.ts',
+    'skill-update.test.ts',
+    'skill-validate.test.ts',
+    'skill.test.ts',
+    'snapshot.test.ts',
+    'spec-craft-command.test.ts',
+    'stale-constraints.test.ts',
+    'state-show.test.ts',
+    'state-streams.test.ts',
+    'state.test.ts',
+    'sync-analyses-action.test.ts',
+    'sync-analyses.test.ts',
+    'sync-main.test.ts',
+    'taint.test.ts',
+    'telemetry-synthesize.test.ts',
+    'telemetry-wizard-run.test.ts',
+    'telemetry-wizard.test.ts',
+    'telemetry.test.ts',
+    'test-craft-command.test.ts',
+    'traceability.test.ts',
+    'uninstall-constraints.test.ts',
+    'uninstall.test.ts',
+    'update-integrations-sync.test.ts',
+    'update-skill-providers.test.ts',
+    'update.test.ts',
+    'usage-pipeline.test.ts',
+    'usage.test.ts',
+    'validate-cross-check.test.ts',
+    'validate-scope.test.ts',
+    'validate.changed.test.ts',
+    'validate.merge-driver.test.ts',
+    'validate.roadmap-abstention.test.ts',
+    'validate.roadmap-health.test.ts',
+    'validate.roadmap-mode.test.ts',
+    'validate.test.ts',
+    'waypoint.test.ts',
+  ]
 ---
 
 ## Interface Contract
 
 ```ts
+export DEFAULT_CWD
 export ProcessExitCalled
 export ProcessExitSignal
 export captureConsole
@@ -27,12 +173,19 @@ export stubProcessExit
 
 ```
 import { AlignDesignSystemOutput, runAlignDesignSystem } from '../../src/align/index.js'
+import { ApiCraftOutput, ApiFinding } from '../../src/api-craft/findings/schema.js'
+import { ApiCraftInput, runApiCraft } from '../../src/api-craft/index.js'
+import { CliErgonomicsCraftOutput, CliErgonomicsFinding } from '../../src/cli-ergonomics-craft/findings/schema.js'
+import { CliErgonomicsCraftInput, runCliErgonomicsCraft } from '../../src/cli-ergonomics-craft/index.js'
+import { CodeCraftOutput, CodeFinding } from '../../src/code-craft/findings/schema.js'
+import { CodeCraftInput, runCodeCraft } from '../../src/code-craft/index.js'
 import { createAddCommand, runAdd } from '../../src/commands/add'
 import { createAdoptionCommand } from '../../src/commands/adoption'
 import { createAgentCommand } from '../../src/commands/agent'
 import { createReviewCommand, runAgentReview } from '../../src/commands/agent/review'
 import { createRunCommand, runAgentTask } from '../../src/commands/agent/run'
 import { createAlignDesignSystemCommand } from '../../src/commands/align-design-system'
+import { createApiCraftCommand } from '../../src/commands/api-craft'
 import { createAuditProtectedCommand, runAuditProtected } from '../../src/commands/audit-protected'
 import { runBackfillSkillProvenance } from '../../src/commands/backfill-skill-provenance'
 import { createCheckArchCommand, runCheckArch } from '../../src/commands/check-arch'
@@ -47,6 +200,8 @@ import { runCheckSecurity } from '../../src/commands/check-security'
 import { createCheckVocabularyCommand, runCheckVocabulary } from '../../src/commands/check-vocabulary'
 import { createCleanupCommand, runCleanup } from '../../src/commands/cleanup'
 import { runCleanupAll, runCleanupSessions } from '../../src/commands/cleanup-sessions'
+import { createCliErgonomicsCraftCommand } from '../../src/commands/cli-ergonomics-craft'
+import { createCodeCraftCommand } from '../../src/commands/code-craft'
 import { runCompoundScanCandidatesCommand } from '../../src/commands/compound/scan-candidates'
 import from '../../src/commands/copy-craft.js'
 import { createCreateSkillCommand, generateSkillFiles } from '../../src/commands/create-skill'
@@ -54,6 +209,7 @@ import { createCrossCheckCommand } from '../../src/commands/cross-check'
 import { createDashboardCommand } from '../../src/commands/dashboard'
 import { createDesignPipelineCommand } from '../../src/commands/design-pipeline'
 import { createDistortionCommand } from '../../src/commands/distortion'
+import { createDocsCraftCommand } from '../../src/commands/docs-craft'
 import { checkBaselineFreshness, checkCatalogFreshness, checkHookValidity, checkLivePings, checkSessionCorruption, isCatalogStale, runDoctor } from '../../src/commands/doctor'
 import { createFixDriftCommand, runFixDrift } from '../../src/commands/fix-drift'
 import { createGenerateCommand } from '../../src/commands/generate'
@@ -86,6 +242,7 @@ import from '../../src/commands/integrations/dismiss'
 import from '../../src/commands/integrations/list'
 import from '../../src/commands/integrations/remove'
 import { SyncIO, runSyncIntegrations } from '../../src/commands/integrations/sync'
+import { createKnowledgeCraftCommand } from '../../src/commands/knowledge-craft'
 import { createGenerateCommand } from '../../src/commands/linter/generate'
 import { createMaintenanceCommand } from '../../src/commands/maintenance'
 import { MaintenanceRunDeps, aggregateReport, buildTaskRunner, createCheckRunner, createFixDispatcher, deriveExitCode, loadRunHistory, makeResolveBackend, parseConcurrency, renderTable, resolveHarnessSpawn, resolveSelection, runMaintenanceRun } from '../../src/commands/maintenance-run'
@@ -150,10 +307,14 @@ import { resolveConfig } from '../../src/config/loader'
 import { HarnessConfig } from '../../src/config/schema'
 import { CopyCraftInput, CopyCraftOutput } from '../../src/copy-craft/index.js'
 import { DesignPipelineContext, runDesignPipeline } from '../../src/design-pipeline/index.js'
+import { DocsCraftOutput, DocsFinding } from '../../src/docs-craft/findings/schema.js'
+import { DocsCraftInput, runDocsCraft } from '../../src/docs-craft/index.js'
 import { DriftFinding } from '../../src/drift/findings/finding.js'
 import { createProgram } from '../../src/index'
 import { readMcpConfig, writeMcpEntry, writeOpencodeMcpEntry } from '../../src/integrations/config'
 import { CATALOG_LAST_REVIEWED, INTEGRATION_REGISTRY } from '../../src/integrations/registry'
+import { KnowledgeCraftOutput, KnowledgeFinding } from '../../src/knowledge-craft/findings/schema.js'
+import { KnowledgeCraftInput, runKnowledgeCraft } from '../../src/knowledge-craft/index.js'
 import { getToolDefinitions } from '../../src/mcp/index'
 import { getToolDefinitions } from '../../src/mcp/server'
 import { NETWORK_TOOL_NAMES, deriveScope, deriveToolCapabilities, deriveToolCapability } from '../../src/mcp/tool-capabilities'
@@ -190,6 +351,7 @@ import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
 import { ConsoleCapture, captureConsole, runToExit, stubProcessExit } from './cli-command-harness'
+import { CraftCommandRun, DEFAULT_CWD, runCraftCommand } from './craft-command-harness-cohort-b'
 import { llmCalls, runCraftCommand } from './craft-command-harness.js'
 import { parseJsonStdout, runCommand } from './design-command-harness'
 import * as clack from '@clack/prompts'

--- a/.harness/comprehension/packages/core/tests/entropy/_module.md
+++ b/.harness/comprehension/packages/core/tests/entropy/_module.md
@@ -1,29 +1,19 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/entropy'
-sourceHash: '1ddc7a718c7385227602a723e2c84a08528e84a32a7d9237d9c9c4aa523c4603'
-compiledAt: '2026-08-28T01:22:10.811Z'
+sourceHash: '8983961fcd566ac94fc595351425adedd5c233dd4fc142c5fdc3a9ee213a7aad'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
-  ['analyzer.behavior.test.ts', 'analyzer.test.ts', 'graph-integration.test.ts', 'snapshot.test.ts']
+  [
+    'analyzer.behavior.test.ts',
+    'analyzer.test.ts',
+    'graph-integration.test.ts',
+    'path-aliases.test.ts',
+    'snapshot.test.ts',
+  ]
 ---
-
-## Summary
-
-This test suite validates **EntropyAnalyzer**, a unified tool for detecting codebase entropy across five dimensions: documentation drift, dead code, pattern violations, complexity, and coupling. The analyzer supports both standalone detector methods (detectDrift, detectDeadCode, detectPatterns) and integrated analyze() flow. A key optimization: when run in graph-enhanced mode with both `graphDriftData` and `graphDeadCodeData` supplied, it skips expensive snapshot building, relying on pre-computed reachability from the knowledge graph. Tests characterize accessor contracts, selective analyzer enablement (patterns/complexity/coupling/sizeBudget accept both boolean flags and object-form configs), snapshot reuse across detector calls, graph-skipped paths, and suggestion derivation. Every async operation returns a Result<T> envelope with an ok flag for type-safe error handling.
-
-## Invariants
-
-- Accessor idempotency: getReport() and getSnapshot() return undefined until analyze() completes; thereafter they return the exact same object instances that analyze() resolved with, not copies.
-- Analyzer selectivity: Only enabled analyzers (drift, deadCode, patterns, complexity, coupling, sizeBudget) produce reports attached to the result; disabled ones remain absent—never null or empty stubs.
-- Graph optimization gate: When both graphDriftData AND graphDeadCodeData are supplied to analyze(), snapshot building is bypassed entirely; result uses minimal empty snapshot (files: [], buildTime: 0). If only one is present, real snapshot is built.
-- Snapshot singleton: ensureSnapshot() short-circuits—the same snapshot instance is reused across multiple detector calls (drift, deadCode, patterns) rather than rebuilt, reducing I/O.
-- Configuration polymorphism: Analyzers (patterns, complexity, coupling, sizeBudget) accept both boolean-true (default config) and object forms (custom config); both branches must attach reports.
-- Detector independence: Standalone detectX() methods build snapshots on-demand and work without analyze() being called first; they populate the analyzer's internal snapshot state as a side effect.
-- Suggestions require analyzed state: getSuggestions() only produces output after analyze() has completed; calling it before analysis is a contract violation.
-- Result envelope consistency: All async operations (analyze, detectDrift, detectDeadCode) return Result<T> with an ok boolean; callers must guard on ok before accessing .value.
 
 ## Interface Contract
 
@@ -37,13 +27,16 @@ This test suite validates **EntropyAnalyzer**, a unified tool for detecting code
 import { EntropyAnalyzer } from '../../src/entropy/analyzer'
 import { detectDeadCode } from '../../src/entropy/detectors/dead-code'
 import { detectDocDrift } from '../../src/entropy/detectors/drift'
+import { PathAlias, loadPathAliases, resolveAliasCandidates } from '../../src/entropy/path-aliases'
 import { buildSnapshot, parseDocumentationFile, resolveEntryPoints } from '../../src/entropy/snapshot'
 import { CodebaseSnapshot, EntropyConfig } from '../../src/entropy/types'
 import { TypeScriptParser } from '../../src/shared/parsers'
 import { skipDirGlobs } from '@harness-engineering/graph'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import * as fs from 'node:fs'
 import from 'node:fs/promises'
 import * as os from 'node:os'
-import { join } from 'path'
+import { tmpdir } from 'os'
+import { dirname, join, resolve, sep } from 'path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ```

--- a/packages/core/tests/entropy/path-aliases.test.ts
+++ b/packages/core/tests/entropy/path-aliases.test.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join, resolve, sep } from 'path';
+import {
+  loadPathAliases,
+  resolveAliasCandidates,
+  type PathAlias,
+} from '../../src/entropy/path-aliases';
+
+/**
+ * Characterization tests for the currently-shipped behavior of the tsconfig
+ * `paths` alias loader (`loadPathAliases` / `resolveAliasCandidates`).
+ *
+ * The module exists to prevent the regression in issue #1759: before it, any
+ * file reached only through an alias import (`@lib/foo`) was falsely reported
+ * dead because the dead-code resolver treated every non-relative specifier as an
+ * external package. `tests/entropy/detectors/dead-code-path-alias.test.ts`
+ * covers the happy path indirectly through `buildSnapshot`; these tests pin the
+ * loader's own contract directly — the degenerate configs, the JSONC tolerance,
+ * the `extends` chain, the `baseUrl` semantics, and the match ordering.
+ *
+ * `loadPathAliases` reads the real filesystem, so every case builds a throwaway
+ * tsconfig tree under `os.tmpdir()`; nothing is written into the repo.
+ *
+ * Windows: `normalizeTargets` builds target prefixes with `path.resolve`, so
+ * they carry the platform separator, and `resolveAliasCandidates` converts the
+ * wildcard capture to the platform separator too. Every path assertion below
+ * therefore either compares `toPosix(...)` on both sides or builds the expected
+ * value with `path.resolve` — never a hardcoded `/`.
+ */
+describe('entropy/path-aliases', () => {
+  const tempRoots: string[] = [];
+
+  /** Normalize to POSIX separators so assertions match on Windows too. */
+  const toPosix = (p: string): string => p.replaceAll('\\', '/');
+
+  /** Compare two absolute paths separator-independently. */
+  const expectSamePath = (actual: string, expected: string): void => {
+    expect(toPosix(actual)).toBe(toPosix(expected));
+  };
+
+  async function makeRoot(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'path-aliases-'));
+    tempRoots.push(dir);
+    return dir;
+  }
+
+  /** Write a config file (creating parent dirs) at `relPath` under `root`. */
+  async function writeConfig(root: string, relPath: string, contents: string): Promise<void> {
+    const full = join(root, relPath);
+    await mkdir(dirname(full), { recursive: true });
+    await writeFile(full, contents, 'utf8');
+  }
+
+  afterEach(async () => {
+    await Promise.all(tempRoots.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempRoots.length = 0;
+  });
+
+  describe('loadPathAliases — configurations that yield no aliases', () => {
+    it('returns an empty list when the root has no tsconfig.json', async () => {
+      const root = await makeRoot();
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when tsconfig declares no compilerOptions.paths', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: '.', strict: true } })
+      );
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when tsconfig has no compilerOptions block at all', async () => {
+      const root = await makeRoot();
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ include: ['src'] }));
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when the tsconfig path exists but cannot be read', async () => {
+      const root = await makeRoot();
+      // A directory at the tsconfig path passes the existence check but fails the
+      // read, exercising the unreadable-config branch deterministically.
+      await mkdir(join(root, 'tsconfig.json'), { recursive: true });
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+
+    it('falls back to an empty list — silently — when tsconfig is unparseable', async () => {
+      // Deliberate silent fallback, not an oversight: the docblock frames alias
+      // support as "opt-in with zero configuration", so a broken tsconfig must
+      // degrade to "no aliases" rather than throwing and taking down the whole
+      // entropy scan. This test pins that contract; a future change that starts
+      // throwing (or logging-and-throwing) here should fail this test on purpose.
+      const root = await makeRoot();
+      await writeConfig(root, 'tsconfig.json', '{ "compilerOptions": { "paths": { oops');
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+  });
+
+  describe('loadPathAliases — JSONC tolerance', () => {
+    it('parses a tsconfig with line comments, block comments and trailing commas', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        `{
+  // Line comment before compilerOptions.
+  /*
+   * Block comment spanning
+   * several lines.
+   */
+  "compilerOptions": {
+    "baseUrl": ".", // trailing line comment
+    "paths": {
+      "@lib/*": ["src/lib/*",], // trailing comma inside the target array
+    },
+  },
+}`
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases).toHaveLength(1);
+      expect(aliases[0]?.prefix).toBe('@lib/');
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'src/lib/widget'),
+      ]);
+    });
+
+    it('preserves a `//` sequence inside a string literal instead of stripping it as a comment', async () => {
+      // Strings are the first alternative in the JSONC token regex. If they were
+      // not, `//keep/*": [...]` would be eaten to end-of-line, leaving an
+      // unterminated string, and the whole config would silently parse to `[]`.
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@lib//keep/*": ["src/keep/*"]
+    }
+  }
+}`
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases).toHaveLength(1);
+      expect(aliases[0]?.prefix).toBe('@lib//keep/');
+      expect(resolveAliasCandidates('@lib//keep/thing', aliases)).toEqual([
+        resolve(root, 'src/keep/thing'),
+      ]);
+    });
+
+    it('preserves a `/*` … `*/` pair that only exists inside string literals', async () => {
+      // `"@a/*"` opens a `/*` and `"src/*/deep"` closes it with `*/`. Unprotected
+      // strings would let the block-comment rule swallow everything between them.
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@a/*": ["src/*/deep"]
+    }
+  }
+}`
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases).toHaveLength(1);
+      expect(aliases[0]?.prefix).toBe('@a/');
+      // The target's own wildcard sits mid-path, so the capture is spliced into
+      // the middle and the target suffix is preserved.
+      expect(resolveAliasCandidates('@a/foo', aliases)).toEqual([resolve(root, 'src/foo/deep')]);
+    });
+  });
+
+  describe('loadPathAliases — extends chain', () => {
+    it('inherits paths from a relative `./base.json` extends', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'base.json',
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@lib/*': ['src/lib/*'] } } })
+      );
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: './base.json' }));
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases.map((a) => a.prefix)).toEqual(['@lib/']);
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'src/lib/widget'),
+      ]);
+    });
+
+    it('appends `.json` to an extends value that has no suffix', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.base.json',
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@lib/*': ['src/lib/*'] } } })
+      );
+      // No `.json` suffix — the loader must append one to find the file.
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: './tsconfig.base' }));
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases.map((a) => a.prefix)).toEqual(['@lib/']);
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'src/lib/widget'),
+      ]);
+    });
+
+    it('follows an absolute extends path', async () => {
+      const root = await makeRoot();
+      const basePath = join(root, 'cfgs', 'base.json');
+      await writeConfig(
+        root,
+        join('cfgs', 'base.json'),
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@lib/*': ['src/lib/*'] } } })
+      );
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: basePath }));
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases.map((a) => a.prefix)).toEqual(['@lib/']);
+      // baseUrl "." came from the base config, so it resolves against cfgs/.
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'cfgs/src/lib/widget'),
+      ]);
+    });
+
+    it('skips a bare package extends, inheriting nothing from it', async () => {
+      const root = await makeRoot();
+      // A real file at the bare specifier's node_modules location. It must NOT be
+      // read: bare extends resolution is deliberately unimplemented.
+      await writeConfig(
+        root,
+        join('node_modules', '@tsconfig', 'node20', 'tsconfig.json'),
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@pkg/*': ['pkg/*'] } } })
+      );
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({ extends: '@tsconfig/node20/tsconfig.json' })
+      );
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+
+    it('lets the nearer config replace — not merge — the extended config paths', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'base.json',
+        JSON.stringify({
+          compilerOptions: { paths: { '@base/*': ['base-src/*'], '@lib/*': ['base-lib/*'] } },
+        })
+      );
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          extends: './base.json',
+          compilerOptions: { baseUrl: '.', paths: { '@lib/*': ['child-lib/*'] } },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      // The child's `paths` object wins wholesale, so `@base/*` disappears
+      // entirely rather than being merged in (matching TS's own semantics).
+      expect(aliases.map((a) => a.prefix)).toEqual(['@lib/']);
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'child-lib/widget'),
+      ]);
+      expect(resolveAliasCandidates('@base/thing', aliases)).toEqual([]);
+    });
+
+    it('follows a multi-level extends chain that stays within the bound', async () => {
+      const root = await makeRoot();
+      const depth = 8;
+      for (let level = 0; level < depth; level += 1) {
+        await writeConfig(
+          root,
+          `base${level}.json`,
+          JSON.stringify({ extends: `./base${level + 1}.json` })
+        );
+      }
+      await writeConfig(
+        root,
+        `base${depth}.json`,
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@deep/*': ['deep/*'] } } })
+      );
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: './base0.json' }));
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases.map((a) => a.prefix)).toEqual(['@deep/']);
+      expect(resolveAliasCandidates('@deep/widget', aliases)).toEqual([
+        resolve(root, 'deep/widget'),
+      ]);
+    });
+
+    it('stops following a chain deeper than the bound instead of inheriting from it', async () => {
+      const root = await makeRoot();
+      const depth = 12;
+      for (let level = 0; level < depth; level += 1) {
+        await writeConfig(
+          root,
+          `base${level}.json`,
+          JSON.stringify({ extends: `./base${level + 1}.json` })
+        );
+      }
+      // Only the config past the bound declares paths.
+      await writeConfig(
+        root,
+        `base${depth}.json`,
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@deep/*': ['deep/*'] } } })
+      );
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: './base0.json' }));
+
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+
+    it('terminates on a circular extends chain', async () => {
+      const root = await makeRoot();
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: './a.json' }));
+      await writeConfig(root, 'a.json', JSON.stringify({ extends: './b.json' }));
+      await writeConfig(root, 'b.json', JSON.stringify({ extends: './a.json' }));
+
+      // The depth bound is what makes this terminate at all; without it the test
+      // would hang rather than fail.
+      await expect(loadPathAliases(root)).resolves.toEqual([]);
+    });
+  });
+
+  describe('loadPathAliases — baseUrl semantics', () => {
+    it('resolves targets against the baseUrl declared by a parent config', async () => {
+      const root = await makeRoot();
+      // baseUrl lives in cfgs/base.json, so it resolves relative to cfgs/ …
+      await writeConfig(
+        root,
+        join('cfgs', 'base.json'),
+        JSON.stringify({ compilerOptions: { baseUrl: './src' } })
+      );
+      // … while `paths` is declared by the child at the root.
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          extends: './cfgs/base.json',
+          compilerOptions: { paths: { '@lib/*': ['lib/*'] } },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      // Parent's baseUrlDir (cfgs/) + parent's baseUrl (src) wins over the
+      // child's own directory.
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'cfgs/src/lib/widget'),
+      ]);
+    });
+
+    it('resolves targets against the declaring config directory when no baseUrl is set (TS5)', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        join('config', 'base.json'),
+        JSON.stringify({ compilerOptions: { paths: { '@lib/*': ['lib/*'] } } })
+      );
+      await writeConfig(root, 'tsconfig.json', JSON.stringify({ extends: './config/base.json' }));
+
+      const aliases = await loadPathAliases(root);
+
+      // baseUrl is absent everywhere, so targets are relative to the directory of
+      // the config that declared `paths` — config/, not the project root.
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'config/lib/widget'),
+      ]);
+    });
+
+    it('keeps an absolute target as-is rather than re-resolving it against baseUrl', async () => {
+      const root = await makeRoot();
+      const absoluteTarget = join(root, 'elsewhere', '*');
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { baseUrl: './src', paths: { '@abs/*': [absoluteTarget] } },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expectSamePath(
+        resolveAliasCandidates('@abs/widget', aliases)[0] ?? '',
+        resolve(root, 'elsewhere', 'widget')
+      );
+    });
+  });
+
+  describe('loadPathAliases — malformed paths entries', () => {
+    it('skips patterns whose target list is empty or not an array, keeping the valid ones', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            paths: {
+              '@empty/*': [],
+              '@notarray/*': 'src/notarray/*',
+              '@ok/*': ['src/ok/*'],
+            },
+          },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases.map((a) => a.prefix)).toEqual(['@ok/']);
+      expect(resolveAliasCandidates('@empty/thing', aliases)).toEqual([]);
+      expect(resolveAliasCandidates('@notarray/thing', aliases)).toEqual([]);
+      expect(resolveAliasCandidates('@ok/thing', aliases)).toEqual([resolve(root, 'src/ok/thing')]);
+    });
+  });
+
+  describe('loadPathAliases — pattern and target shapes', () => {
+    it('marks a pattern without a `*` as non-wildcard and matches it only on an exact specifier', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { baseUrl: '.', paths: { '@app/config': ['src/config.ts'] } },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases).toHaveLength(1);
+      expect(aliases[0]?.isWildcard).toBe(false);
+      expect(aliases[0]?.prefix).toBe('@app/config');
+      expect(aliases[0]?.suffix).toBe('');
+      expect(resolveAliasCandidates('@app/config', aliases)).toEqual([
+        resolve(root, 'src/config.ts'),
+      ]);
+      // A longer specifier sharing the prefix must not match a non-wildcard alias.
+      expect(resolveAliasCandidates('@app/config/nested', aliases)).toEqual([]);
+      expect(resolveAliasCandidates('@app/confi', aliases)).toEqual([]);
+    });
+
+    it('emits one candidate per target, in declaration order', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            paths: { '@lib/*': ['src/first/*', 'src/second/*', 'src/third/*'] },
+          },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(aliases[0]?.targets).toHaveLength(3);
+      expect(resolveAliasCandidates('@lib/widget', aliases)).toEqual([
+        resolve(root, 'src/first/widget'),
+        resolve(root, 'src/second/widget'),
+        resolve(root, 'src/third/widget'),
+      ]);
+    });
+
+    it('ignores the captured segment when the target itself has no wildcard', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { baseUrl: '.', paths: { '@barrel/*': ['src/barrel/index.ts'] } },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(resolveAliasCandidates('@barrel/anything/at/all', aliases)).toEqual([
+        resolve(root, 'src/barrel/index.ts'),
+      ]);
+    });
+
+    it('splices a multi-segment capture using the platform separator', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { baseUrl: '.', paths: { '@lib/*': ['src/lib/*'] } },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+      const [candidate] = resolveAliasCandidates('@lib/nested/deep', aliases);
+
+      // The specifier always uses `/`; the emitted candidate must use the
+      // platform separator so it lines up with snapshot file keys on Windows.
+      expect(candidate).toBe(resolve(root, 'src/lib/nested/deep'));
+      expect(candidate).toContain(`lib${sep}nested${sep}deep`);
+    });
+  });
+
+  describe('resolveAliasCandidates — matching and ordering', () => {
+    const wildcardAlias = (prefix: string, targetPrefix: string, suffix = ''): PathAlias => ({
+      prefix,
+      suffix,
+      isWildcard: true,
+      targets: [{ prefix: targetPrefix, suffix: '', isWildcard: true }],
+    });
+
+    it('returns an empty list when the specifier matches no alias', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@lib/*': ['src/lib/*'] } } })
+      );
+
+      const aliases = await loadPathAliases(root);
+
+      expect(resolveAliasCandidates('react', aliases)).toEqual([]);
+      expect(resolveAliasCandidates('./relative', aliases)).toEqual([]);
+      expect(resolveAliasCandidates('@other/widget', aliases)).toEqual([]);
+    });
+
+    it('returns an empty list when the alias table itself is empty', () => {
+      expect(resolveAliasCandidates('@lib/widget', [])).toEqual([]);
+    });
+
+    it('orders the more specific alias first when several match (longest prefix wins)', async () => {
+      const root = await makeRoot();
+      await writeConfig(
+        root,
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            // Declaration order puts the *less* specific alias first on purpose,
+            // so ordering can only come from the longest-prefix sort.
+            paths: { '@lib/*': ['src/lib/*'], '@lib/nested/*': ['src/nested-override/*'] },
+          },
+        })
+      );
+
+      const aliases = await loadPathAliases(root);
+      expect(aliases.map((a) => a.prefix)).toEqual(['@lib/', '@lib/nested/']);
+
+      expect(resolveAliasCandidates('@lib/nested/deep', aliases)).toEqual([
+        resolve(root, 'src/nested-override/deep'),
+        resolve(root, 'src/lib/nested/deep'),
+      ]);
+      // A specifier that only the broad alias matches is unaffected.
+      expect(resolveAliasCandidates('@lib/plain', aliases)).toEqual([
+        resolve(root, 'src/lib/plain'),
+      ]);
+    });
+
+    it('requires the specifier to be long enough to hold both the prefix and the suffix', () => {
+      const targetPrefix = resolve('/gen') + sep;
+      const alias: PathAlias = {
+        prefix: '@gen/',
+        suffix: '/index',
+        isWildcard: true,
+        targets: [{ prefix: targetPrefix, suffix: `${sep}index`, isWildcard: true }],
+      };
+
+      // '@gen/index' starts with the prefix AND ends with the suffix, but the two
+      // overlap — there is no room left for a capture, so it must not match.
+      expect(resolveAliasCandidates('@gen/index', [alias])).toEqual([]);
+      expectSamePath(
+        resolveAliasCandidates('@gen/widget/index', [alias])[0] ?? '',
+        resolve('/gen', 'widget', 'index')
+      );
+    });
+
+    it('matches every alias whose prefix the specifier shares, not just the best one', () => {
+      const first = wildcardAlias('@lib/', resolve('/a') + sep);
+      const second = wildcardAlias('@lib/deep/', resolve('/b') + sep);
+
+      const candidates = resolveAliasCandidates('@lib/deep/thing', [first, second]);
+
+      expect(candidates).toHaveLength(2);
+      expectSamePath(candidates[0] ?? '', resolve('/b', 'thing'));
+      expectSamePath(candidates[1] ?? '', resolve('/a', 'deep', 'thing'));
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds 29 characterization tests for `packages/core/src/entropy/path-aliases.ts`, the tsconfig `paths` alias loader used by the dead-code detector.

Tests only — **no production source is modified.**

## Why this module

It had no direct tests. Its only coverage arrived *indirectly* through `dead-code-path-alias.test.ts`, which exercises exactly one config shape (`baseUrl: "."`, a single `@lib/*` wildcard). That left **half the module's branches unexercised** on the code that decides whether an alias-imported file is reachable — and a wrong answer there resurfaces the #1759 false-dead-code regression this module exists to prevent.

## Coverage delta

Measured with v8 over `packages/core/tests/entropy`, before and after:

| Metric | Before | After |
| --- | --- | --- |
| Statements | 75% (54/72) | **100% (72/72)** |
| Branches | 50% (32/64) | **95.31% (61/64)** |
| Functions | 87.5% (14/16) | **100% (16/16)** |
| Lines | 82.53% (52/63) | **100% (63/63)** |

The 3 residual branches are structurally unreachable rather than gaps: the two `?? rootDir` fallbacks in `effectivePathsBaseDir` (`baseUrlDir`/`pathsDir` are always assigned alongside `baseUrl`/`paths`), and the `sep === '/'` ternary in `resolveAliasCandidates` (only one arm is reachable per platform).

## What is covered

- **Degenerate configs** — absent, `paths`-less, unreadable, and unparseable tsconfig all return an empty list
- **JSONC handling** — line comments, block comments, trailing commas, and `//` / `/* */` sequences *inside string literals* being preserved rather than stripped
- **`extends`** — relative, suffix-less (`.json` appended), absolute, bare-package (skipped), multi-level chains, the depth bound, and circular chains terminating
- **Precedence** — a nearer config's `paths` *replacing* rather than merging the extended base's
- **baseUrl semantics** — declared in a parent config, vs TS5 baseUrl-optional resolution against the declaring config's directory
- **Malformed `paths` entries** — empty-array and non-array target lists skipped while valid siblings survive
- **Non-wildcard patterns** — matched only on exact specifier equality
- **`resolveAliasCandidates`** — declaration order, longest-prefix-wins ordering, multi-segment captures, no-match and empty-table cases

## Assumptions made

These are characterizations of current behavior, not endorsements:

- **The silent empty-list fallback on an unparseable tsconfig is pinned AS-IS.** The module documents itself as "opt-in with zero configuration", so silent degradation is the stated contract. The test says so explicitly, and a future decision to surface the parse error should fail it *on purpose*.
- **A child config's `paths` replacing rather than merging the extended base's** is treated as correct — it matches TypeScript's own `compilerOptions` override semantics.
- **A bare package `extends` inheriting nothing** is treated as deliberate; the source comment states it.
- **The `extends` depth bound is asserted behaviorally** ("does not inherit past the bound" / "terminates on a cycle") rather than against the literal constant, to avoid coupling the test to the number.

### Noted limitation, not fixed here

`quoteYamlScalar`-style control-character escaping is out of scope for this module, but worth recording for the reviewer: nothing here changes production behavior, so any latent defect the characterization pins remains exactly as it was on `main`. Where a pinned behavior is arguably wrong rather than merely undocumented, it is called out in the test's own comments.

## Cross-check note

Two sibling targets originally queued alongside this one were **dropped as already-covered** after measurement, rather than re-swept:

- `src/roadmap/status-rank.ts` — measures 100% via `tests/roadmap/sync.test.ts` and `sync-engine-guards.test.ts`
- `src/roadmap/store/yaml-scalar.ts` — measures 100% via `tests/roadmap/store/meta.test.ts` ("B1: round-trips milestone names with colons, booleans, numbers, and escapes")

## Portability

Fixtures are built in `os.tmpdir()` mkdtemp directories and removed in `afterEach` — nothing is written under `tests/fixtures/`. Every path assertion normalizes separators (or builds expectations with `path.resolve`/`join`), so the suite passes on the windows leg of the CI matrix as well as ubuntu and macOS.

## Verification

- `packages/core` full suite: **5279 passed**, 1 skipped, 0 failed (475 files)
- Coverage delta independently re-measured, not taken from the authoring agent's report
