### PR TITLE
fix(roadmap): scope #1811 history-only field keys to the Assignment History section

### DIFF
--- a/.changeset/bugfleet-preservation-history-keys.md
+++ b/.changeset/bugfleet-preservation-history-keys.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+Scope the #1811 Assignment History field keys (`Feature`, `Action`, `Date`) to the `## Assignment History` section instead of declaring them preservable document-wide. A hand-authored `- **Date:** ...` bullet inside a feature block was reported as preservable while a `serializeRoadmap` rewrite really does drop it, letting the monolith store accept the destructive write the #839 guard exists to refuse.

--- a/packages/core/src/roadmap/preservation.ts
+++ b/packages/core/src/roadmap/preservation.ts
@@ -9,6 +9,9 @@
  * prose. This module detects that unpreservable content so the monolith store can
  * refuse the destructive write instead of losing it.
  */
+// The `## Assignment History` heading is owned by `./assignment-history`, the
+// single source of truth shared with that section's emitter and both readers.
+import { ASSIGNMENT_HISTORY_HEADING } from './assignment-history';
 
 /**
  * Field keys the roadmap model round-trips. Source of truth is
@@ -30,14 +33,22 @@ const MODELED_FIELD_KEYS: ReadonlySet<string> = new Set([
   'Priority',
   'External-ID',
   'Updated-At',
-  // `## Assignment History` record bullets (#1811). The section stopped being a
-  // pipe table and became four `- **Key:** value` bullets per record, reusing the
-  // same line grammar, so its lines are preservable for the same reason a feature
-  // row's are. `Assignee` above is shared with the feature block.
-  'Feature',
-  'Action',
-  'Date',
 ]);
+
+/**
+ * Field keys modeled ONLY inside the `## Assignment History` section (#1811),
+ * where a record is four `- **Key:** value` bullets reusing the feature-row line
+ * grammar. (`Assignee` is the fourth; it is already modeled document-wide above
+ * because a feature row carries it too.)
+ *
+ * These are deliberately section-scoped rather than merged into
+ * {@link MODELED_FIELD_KEYS}: `parseFeatureBlock` does NOT read `Feature`,
+ * `Action` or `Date`, so a hand-authored `- **Date:** …` bullet inside a FEATURE
+ * block is dropped by a `serializeRoadmap` rewrite exactly like the `- **Issue:**`
+ * bullet this guard was built to catch (#839). Declaring them preservable
+ * everywhere let that loss through silently.
+ */
+const HISTORY_ONLY_FIELD_KEYS: ReadonlySet<string> = new Set(['Feature', 'Action', 'Date']);
 
 /** A source line whose content a monolith rewrite would drop. */
 export interface UnpreservedLine {
@@ -78,6 +89,8 @@ export function findUnpreservedLines(markdown: string): UnpreservedLine[] {
   let frontmatterDone = false;
   /** Past the first `## ` heading — before it the lines are the modeled preamble. */
   let inBody = false;
+  /** Inside the `## Assignment History` section, where the record bullets live. */
+  let inHistory = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
@@ -111,14 +124,25 @@ export function findUnpreservedLines(markdown: string): UnpreservedLine[] {
       inBody = true;
     }
 
-    if (!isPreservableBodyLine(text)) lost.push({ line: i + 1, text });
+    // Every H2 opens a new section; only the history heading opens the one whose
+    // record bullets are modeled. Trailing whitespace is already stripped from
+    // `text`, so an exact compare matches the reader's `[ \t]*` tolerance.
+    if (/^## /.test(text)) inHistory = text === ASSIGNMENT_HISTORY_HEADING;
+
+    if (!isPreservableBodyLine(text, inHistory)) lost.push({ line: i + 1, text });
   }
 
   return lost;
 }
 
-/** Does a post-preamble body line survive a `serializeRoadmap` rewrite? */
-function isPreservableBodyLine(text: string): boolean {
+/**
+ * Does a post-preamble body line survive a `serializeRoadmap` rewrite?
+ *
+ * `inHistory` reports whether the line sits under the `## Assignment History`
+ * heading, which is where — and only where — the record-only field keys are
+ * modeled.
+ */
+function isPreservableBodyLine(text: string, inHistory: boolean): boolean {
   if (text.trim() === '') return true; // blank lines carry no content
   if (/^# /.test(text)) return true; // H1 title (serializer canonicalizes it to `# Roadmap`)
   if (/^## /.test(text)) return true; // milestone / Backlog / Assignment History heading
@@ -130,5 +154,7 @@ function isPreservableBodyLine(text: string): boolean {
   // it carries a value. A modeled key with a MULTI-line body still surfaces its
   // continuation lines here — they fail every pattern above and are reported.
   const field = text.match(/^- \*\*(.+?):\*\*/);
-  return Boolean(field && MODELED_FIELD_KEYS.has(field[1]!));
+  if (!field) return false;
+  const key = field[1]!;
+  return MODELED_FIELD_KEYS.has(key) || (inHistory && HISTORY_ONLY_FIELD_KEYS.has(key));
 }

--- a/packages/core/tests/roadmap/bugfleet-preservation-history-keys-leak.test.ts
+++ b/packages/core/tests/roadmap/bugfleet-preservation-history-keys-leak.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { findUnpreservedLines } from '../../src/roadmap/preservation';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+
+/**
+ * bug-fleet A1 reproduction.
+ *
+ * `findUnpreservedLines` is the #839 monolith write-preservation guard: it exists
+ * to refuse a whole-file rewrite that would silently discard hand-authored content
+ * `serializeRoadmap` does not model.
+ *
+ * #1811 moved the `## Assignment History` section from a pipe table to four
+ * `- **Key:** value` bullets and added `Feature`, `Action` and `Date` to
+ * `MODELED_FIELD_KEYS` so those bullets stay preservable. The key set is GLOBAL,
+ * but those three keys are only modeled inside the history section — a feature
+ * block that carries a `- **Date:** …` (or `- **Feature:** …` / `- **Action:** …`)
+ * bullet is now declared preservable while `parseFeatureBlock` still ignores it,
+ * so the rewrite drops it with the guard reporting nothing.
+ *
+ * Before #1811 that same line WAS reported, exactly like the `- **Issue:**` bullet
+ * the guard's own test pins. This is the guard's core failure mode: silent loss it
+ * promised to catch.
+ */
+const ROADMAP_WITH_UNMODELED_DATE_BULLET = [
+  '---',
+  'project: demo',
+  'version: 1',
+  'last_synced: 2026-07-17T00:00:00.000Z',
+  'last_manual_edit: 2026-07-17T00:00:00.000Z',
+  '---',
+  '',
+  '# Roadmap',
+  '',
+  '## Current Work',
+  '',
+  '### A feature',
+  '',
+  '- **Status:** planned',
+  '- **Spec:** —',
+  '- **Summary:** x',
+  '- **Date:** 2026-03-01',
+  '- **Blockers:** —',
+  '- **Plan:** —',
+  '',
+].join('\n');
+
+describe('findUnpreservedLines — #1811 history keys leak into feature blocks', () => {
+  it('reports the unmodeled `- **Date:**` bullet a monolith rewrite would drop', () => {
+    // The rewrite really does lose the line — that is the loss the guard must catch.
+    const parsed = parseRoadmap(ROADMAP_WITH_UNMODELED_DATE_BULLET);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(serializeRoadmap(parsed.value)).not.toContain('- **Date:** 2026-03-01');
+
+    // …so the guard must report it, exactly as it reports `- **Issue:** …`.
+    expect(findUnpreservedLines(ROADMAP_WITH_UNMODELED_DATE_BULLET).map((l) => l.text)).toContain(
+      '- **Date:** 2026-03-01'
+    );
+  });
+});


### PR DESCRIPTION
fix(roadmap): scope #1811 history-only field keys to the Assignment History section

`findUnpreservedLines` is the guard that stops a monolith rewrite from silently
dropping hand-authored content (#839). #1811 added `Feature`, `Action` and `Date`
to the GLOBAL `MODELED_FIELD_KEYS` so the new `## Assignment History` record
bullets would stay preservable — but those three keys are modeled ONLY inside
that section. `parseFeatureBlock` never reads them.

The result was a regression in the guard itself: a hand-authored
`- **Date:** 2026-03-01` bullet inside a FEATURE block was reported as
preservable while `serializeRoadmap(parseRoadmap(md))` really does drop it, so
the store would accept exactly the destructive write the guard exists to refuse.
Pre-#1811 that line WAS reported.

The fix moves the three keys into a section-scoped `HISTORY_ONLY_FIELD_KEYS` set
and tracks whether the walk is inside the `## Assignment History` section, so the
bullets stay preservable where they are modeled and are reported everywhere else.

Reproducing test: packages/core/tests/roadmap/bugfleet-preservation-history-keys-leak.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.

Assumptions made: area ranked by churn x blast-radius x inverse-coverage;
fix-class bounded-safe (one private key set + one private helper signature, no
exported signature, no schema, no cross-module reach).

Found by bug-fleet proactive sweep (area: packages/core/src/roadmap).
