### PR TITLE
fix(roadmap): anchor autopilot plan-path matching to a path separator

### DIFF
--- a/.changeset/bugfleet-plan-path-suffix-crosstalk.md
+++ b/.changeset/bugfleet-plan-path-suffix-crosstalk.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+Anchor autopilot plan-path matching to a path separator. The unanchored `endsWith` suffix test linked a phase for `docs/changes/multi-auth/plan.md` to a roadmap row whose plan is `auth/plan.md`, carrying an unrelated feature's completion into that row's inferred status.

--- a/packages/core/src/roadmap/sync.ts
+++ b/packages/core/src/roadmap/sync.ts
@@ -39,6 +39,19 @@ interface AutopilotState {
 }
 
 /**
+ * Is `planPath` the same plan as `featurePlan`, allowing for the relative-vs-
+ * repo-rooted forms the two sources write?
+ *
+ * The suffix test MUST break on a path separator. A bare `endsWith` matched
+ * mid-segment, so a phase for `docs/changes/multi-auth/plan.md` linked itself to
+ * a row whose plan is `auth/plan.md` and carried that unrelated phase's
+ * completion into the row's inferred status.
+ */
+function isSamePlan(planPath: string, featurePlan: string): boolean {
+  return planPath === featurePlan || planPath.endsWith(`/${featurePlan}`);
+}
+
+/**
  * Read an autopilot-state.json file and push normalized task statuses for phases
  * linked to the given plan paths. Ignores malformed files.
  */
@@ -53,9 +66,7 @@ function collectAutopilotStatuses(
     if (!autopilot.phases) return;
 
     const linkedPhases = autopilot.phases.filter((phase) =>
-      phase.planPath
-        ? featurePlans.some((p) => p === phase.planPath || phase.planPath!.endsWith(p))
-        : false
+      phase.planPath ? featurePlans.some((p) => isSamePlan(phase.planPath!, p)) : false
     );
 
     for (const phase of linkedPhases) {

--- a/packages/core/tests/roadmap/bugfleet-plan-path-suffix-crosstalk.test.ts
+++ b/packages/core/tests/roadmap/bugfleet-plan-path-suffix-crosstalk.test.ts
@@ -32,7 +32,9 @@ beforeAll(() => {
   fs.writeFileSync(
     path.join(sessionDir, 'autopilot-state.json'),
     JSON.stringify({
-      phases: [{ name: 'phase-1', planPath: 'docs/changes/multi-auth/plan.md', status: 'complete' }],
+      phases: [
+        { name: 'phase-1', planPath: 'docs/changes/multi-auth/plan.md', status: 'complete' },
+      ],
     })
   );
 });

--- a/packages/core/tests/roadmap/bugfleet-plan-path-suffix-crosstalk.test.ts
+++ b/packages/core/tests/roadmap/bugfleet-plan-path-suffix-crosstalk.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { syncRoadmap } from '../../src/roadmap/sync';
+import type { Roadmap } from '@harness-engineering/types';
+
+/**
+ * bug-fleet A1 reproduction.
+ *
+ * `collectAutopilotStatuses` (roadmap/sync.ts) links an autopilot phase to a
+ * roadmap row with an UNANCHORED suffix test:
+ *
+ *   featurePlans.some((p) => p === phase.planPath || phase.planPath!.endsWith(p))
+ *
+ * `endsWith` has no path-segment boundary, so a phase whose `planPath` merely ENDS
+ * with the feature's plan string as a substring is treated as that feature's phase.
+ * `'docs/changes/multi-auth/plan.md'.endsWith('auth/plan.md')` is true, so the
+ * completion of the unrelated `multi-auth` work is aggregated into the `Auth`
+ * row's task statuses and `inferStatus` proposes `planned → done` for a feature
+ * nothing was executed against.
+ *
+ * The intended tolerance is relative-vs-absolute path forms; matching must break
+ * on a path separator, not mid-segment.
+ */
+let projectPath: string;
+
+beforeAll(() => {
+  projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bugfleet-plan-suffix-'));
+  const sessionDir = path.join(projectPath, '.harness', 'sessions', 's1');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sessionDir, 'autopilot-state.json'),
+    JSON.stringify({
+      phases: [{ name: 'phase-1', planPath: 'docs/changes/multi-auth/plan.md', status: 'complete' }],
+    })
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(projectPath, { recursive: true, force: true });
+});
+
+function roadmapWithAuthRow(): Roadmap {
+  return {
+    frontmatter: { project: 'demo', version: 1, lastSynced: 'x', lastManualEdit: 'x' },
+    milestones: [
+      {
+        name: 'Theme',
+        isBacklog: false,
+        features: [
+          {
+            name: 'Auth',
+            status: 'planned',
+            spec: null,
+            // This row's OWN plan. No phase in the session state references it.
+            plans: ['auth/plan.md'],
+            blockedBy: [],
+            summary: '',
+            assignee: null,
+            priority: null,
+            externalId: null,
+            updatedAt: null,
+          },
+        ],
+      },
+    ],
+    assignmentHistory: [],
+  };
+}
+
+describe('syncRoadmap — autopilot plan-path linkage', () => {
+  it('does not link a phase whose planPath only shares a mid-segment suffix', async () => {
+    const result = await syncRoadmap({ projectPath, roadmap: roadmapWithAuthRow() });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+  });
+});


### PR DESCRIPTION
fix(roadmap): anchor autopilot plan-path matching to a path separator

`collectAutopilotStatuses` linked an autopilot phase to a roadmap row with an
UNANCHORED suffix test:

    featurePlans.some((p) => p === phase.planPath || phase.planPath!.endsWith(p))

`endsWith` has no path-segment boundary, so a phase for
`docs/changes/multi-auth/plan.md` matched a row whose plan is `auth/plan.md` and
carried that unrelated feature's completion into the row's inferred status — a
roadmap row marked shipped on the strength of a different feature's work.

The fix extracts `isSamePlan` and requires the suffix to break on `/`. Existing
sync tests use exact-equal planPaths, so the anchor does not narrow them.

Reproducing test: packages/core/tests/roadmap/bugfleet-plan-path-suffix-crosstalk.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.

Assumptions made: area ranked by churn x blast-radius x inverse-coverage;
fix-class bounded-safe (one private helper, no exported signature change, no
schema, no cross-module reach).

Found by bug-fleet proactive sweep (area: packages/core/src/roadmap).
