### PR TITLE
fix(config): use an own-property lookup when walking the config schema

### DIFF
--- a/.changeset/bugfleet-stripped-keys-prototype-key.md
+++ b/.changeset/bugfleet-stripped-keys-prototype-key.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Use an own-property lookup when walking the config schema for unknown-key detection. A config key colliding with an `Object.prototype` member (`__proto__`, `constructor`, `toString`, ...) resolved to the inherited value, so the walk recursed into a non-zod object and threw; the throw is swallowed upstream, silently discarding the unknown-key warnings for the entire config file.

--- a/packages/cli/src/config/stripped-keys.ts
+++ b/packages/cli/src/config/stripped-keys.ts
@@ -168,7 +168,13 @@ function walkObject(def: ZodDef, value: unknown, prefix: string, out: StrippedKe
   const knownKeys = Object.keys(shape);
   const passthrough = def.unknownKeys === 'passthrough';
   for (const key of Object.keys(value)) {
-    const child = shape[key];
+    // Own-property lookup only: a config key that collides with an
+    // `Object.prototype` member (`__proto__`, `constructor`, `toString`, …)
+    // would otherwise resolve to the inherited value instead of `undefined`,
+    // and the walk would recurse into a non-schema object and throw. That throw
+    // is swallowed upstream, silently dropping the warnings for every OTHER key
+    // in the same config — the exact silent no-op #862 exists to prevent.
+    const child = Object.prototype.hasOwnProperty.call(shape, key) ? shape[key] : undefined;
     const childPath = join(prefix, key);
     if (child) {
       walk(child, value[key], childPath, out);

--- a/packages/cli/tests/config/bugfleet-stripped-keys-prototype-key.test.ts
+++ b/packages/cli/tests/config/bugfleet-stripped-keys-prototype-key.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadConfig } from '../../src/config/loader';
+
+/**
+ * Regression guard: the #862 stripped-key warning walk indexes the zod shape with
+ * a bare `shape[key]` truthiness test. For any config key that collides with an
+ * `Object.prototype` member (`__proto__`, `constructor`, `toString`,
+ * `hasOwnProperty`, …) that lookup returns an inherited value instead of
+ * `undefined`, so the walk recurses into a non-schema object and throws
+ * `TypeError: Cannot read properties of undefined (reading 'typeName')`.
+ *
+ * `warnStrippedKeys` swallows the throw ("detection is best-effort"), so the
+ * entire file's unknown-key diagnostics vanish — reinstating exactly the silent
+ * no-op that #862 exists to prevent, for every other key in the same config.
+ */
+describe('loadConfig — stripped-key warnings survive a prototype-named config key', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function writeRawConfig(json: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-bugfleet-cfg-'));
+    dirs.push(dir);
+    const configPath = path.join(dir, 'harness.config.json');
+    fs.writeFileSync(configPath, json);
+    return configPath;
+  }
+
+  it("warns about the typo'd 'securty' key even when the config also carries a '__proto__' key", () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    // Raw JSON text on purpose: `JSON.stringify({ __proto__: ... })` would drop
+    // the key, while `JSON.parse` defines it as a genuine own property — which is
+    // what a tool-generated or hand-merged harness.config.json actually contains.
+    const configPath = writeRawConfig(
+      '{"version":1,"__proto__":{"note":"x"},"securty":{"enabled":true}}'
+    );
+
+    const result = loadConfig(configPath);
+
+    expect(result.ok).toBe(true); // precondition: the load itself is unaffected
+    const output = stderr.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain("ignored unknown key 'securty'");
+  });
+});


### PR DESCRIPTION
fix(config): use an own-property lookup when walking the config schema

`walkObject` resolved the child schema with a bare truthiness lookup
`const child = shape[key]`. For any config key colliding with an
`Object.prototype` member (`__proto__`, `constructor`, `toString`,
`hasOwnProperty`, `valueOf`, ...) that returns the INHERITED value instead of
`undefined`, so the walk recursed into a non-zod object and threw
`TypeError: Cannot read properties of undefined (reading 'typeName')`.

`warnStrippedKeys` swallows that throw ("detection is best-effort"), so ONE
prototype-named key silently discarded the unknown-key diagnostics for the
ENTIRE config file — reinstating precisely the silent no-op #862 exists to
prevent. Given `{"version":1,"__proto__":{...},"securty":{...}}`, the typo
warning for `securty` was never emitted. It fires at any nesting depth.

The fix guards the lookup with `Object.prototype.hasOwnProperty.call`.

Reproducing test: packages/cli/tests/config/bugfleet-stripped-keys-prototype-key.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.

Assumptions made: area ranked #2 by blast radius (48 external importers);
fix-class bounded-safe because `collectStrippedKeys` has exactly one non-test
importer (`loader.ts`) and is diagnostics-only and non-fatal — no config that
loads today stops loading, the only behavior change is that warnings are emitted
where they were previously discarded. No schema was tightened.

Found by bug-fleet proactive sweep (area: packages/cli/src/config).
