### PR TITLE
fix(skill): keep interior blank cells when parsing a SKILLS.md table row

### DIFF
--- a/.changeset/bugfleet-skills-md-empty-reason-row.md
+++ b/.changeset/bugfleet-skills-md-empty-reason-row.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Keep interior blank cells when parsing a SKILLS.md table row. The blanket empty-cell filter also shed legitimate interior blanks, so a match with no `matchReasons` rendered a row that `parseSkillsMd` then silently discarded, breaking the round-trip fidelity the module promises.

--- a/packages/cli/src/skill/skills-md-writer.ts
+++ b/packages/cli/src/skill/skills-md-writer.ts
@@ -97,10 +97,13 @@ function detectTier(line: string): SkillMatchTier | undefined {
 
 /** Parse a single table row into a SkillMatch, or return undefined if it cannot be parsed. */
 function parseTableRow(line: string, tier: SkillMatchTier): SkillMatch | undefined {
-  const cells = line
-    .split('|')
-    .map((c) => c.trim())
-    .filter((c) => c.length > 0);
+  // `split('|')` on a pipe-delimited row yields an empty leading and trailing
+  // element. Drop exactly those two — filtering every empty cell also drops
+  // legitimate interior blanks (a match with no matchReasons renders an empty
+  // Purpose column), which shifted the columns and silently discarded the row.
+  const cells = line.split('|').map((c) => c.trim());
+  if (cells[0] === '') cells.shift();
+  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
 
   if (cells.length < 4) return undefined;
 

--- a/packages/cli/tests/skill/bugfleet-skills-md-empty-reason-row.test.ts
+++ b/packages/cli/tests/skill/bugfleet-skills-md-empty-reason-row.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { generateSkillsMd, parseSkillsMd } from '../../src/skill/skills-md-writer.js';
+import type { ContentMatchResult } from '../../src/skill/content-matcher-types.js';
+
+/**
+ * skills-md-writer declares round-trip fidelity ("Generates markdown output and
+ * parses it back for round-trip fidelity"). A match whose matchReasons array is
+ * empty renders an empty Purpose cell; parseTableRow's
+ * `.filter((c) => c.length > 0)` drops that INTERIOR empty cell along with the
+ * two leading/trailing empties from `split('|')`, leaving 3 cells, which trips
+ * the `cells.length < 4` guard and silently discards the row.
+ *
+ * Empty matchReasons is reachable from the real engine: buildMatchReasons()
+ * returns [] when a skill matched on description term-overlap alone (no keyword
+ * hit, no stack hit, no feature domain), which alone clears the consider tier.
+ */
+function makeResult(matchReasons: string[]): ContentMatchResult {
+  return {
+    matches: [
+      {
+        skillName: 'term-overlap-only',
+        score: 0.42,
+        tier: 'reference',
+        matchReasons,
+        category: 'patterns',
+        when: 'During implementation',
+      },
+    ],
+    signalsUsed: {
+      specKeywords: [],
+      specText: 'some spec body',
+      stackSignals: [],
+      featureDomain: [],
+    },
+    scanDuration: 1,
+  };
+}
+
+describe('bugfleet: SKILLS.md round-trip drops reason-less rows', () => {
+  it('round-trips a match that has no matchReasons', () => {
+    const md = generateSkillsMd('Some Feature', makeResult([]), 1);
+
+    // The row IS written to the markdown...
+    expect(md).toContain('`term-overlap-only`');
+
+    // ...but parsing it back loses it entirely.
+    const parsed = parseSkillsMd(md);
+    expect(parsed.map((m) => m.skillName)).toEqual(['term-overlap-only']);
+  });
+
+  it('control: the same match round-trips fine once it has a reason', () => {
+    const md = generateSkillsMd('Some Feature', makeResult(['Keywords: layout']), 1);
+    const parsed = parseSkillsMd(md);
+    expect(parsed.map((m) => m.skillName)).toEqual(['term-overlap-only']);
+  });
+});


### PR DESCRIPTION
fix(skill): keep interior blank cells when parsing a SKILLS.md table row

`parseTableRow` shed the two empty elements `split('|')` produces at the ends of
a pipe-delimited row with a blanket `.filter((c) => c.length > 0)`. That also
shed legitimate INTERIOR empty cells.

A `SkillMatch` with `matchReasons: []` renders `| \`name\` |  | When | 0.42 |`.
The blank Purpose cell was filtered out, leaving 3 cells, which trips the
`cells.length < 4` guard — so `parseSkillsMd` silently DISCARDED a row that
`generateSkillsMd` had just written, breaking the round-trip fidelity the
module's own docstring promises.

Empty `matchReasons` is reachable from the real engine: `buildMatchReasons()`
returns `[]` when a skill matches on description term-overlap alone (weight
0.25, so 0.6 term overlap clears `TIER_THRESHOLDS.consider` = 0.15) with no
keyword hit, no stack hit and no featureDomain.

The fix drops exactly the leading and trailing empty elements instead of every
empty cell.

Reproducing test: packages/cli/tests/skill/bugfleet-skills-md-empty-reason-row.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.
The test carries a control case — the same match WITH a reason — which passes at
base, isolating the defect to the empty cell.

Assumptions made: area ranked by churn x blast-radius x inverse-coverage
(packages/cli/src/skill, coverage 0.76 — the thinnest in the batch). Two existing
round-trip tests enforce this contract but both fixtures give every match at
least one reason, so the reason-less case was uncovered. Fix-class bounded-safe:
`parseSkillsMd` has no production caller (test-only import), the row grammar is
unchanged, and no schema or exported signature moves.

Found by bug-fleet proactive sweep (area: packages/cli/src/skill).
