### PR TITLE
fix(skill): fold tierOverrides into the skills-index cache key

### DIFF
--- a/.changeset/bugfleet-index-tier-overrides-cache.md
+++ b/.changeset/bugfleet-index-tier-overrides-cache.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fold `tierOverrides` into the skills-index cache key. The on-disk index was keyed on skill.yaml mtimes alone, so a changed override map was invisible to the cache: editing `tierOverrides` in harness config was inert until an unrelated skill.yaml mtime changed, and the first caller's overrides were served to callers that passed none.

--- a/packages/cli/src/skill/index-builder.ts
+++ b/packages/cli/src/skill/index-builder.ts
@@ -31,10 +31,19 @@ export interface SkillsIndex {
 }
 
 /**
- * Compute a hash of all skill.yaml mtimes across the given directories.
+ * Compute a hash of all skill.yaml mtimes across the given directories, plus the
+ * tier overrides applied on top of them.
  * Used for staleness detection — if the hash changes, the index needs rebuilding.
+ *
+ * `tierOverrides` participates because it materially changes the built index
+ * (parseSkillEntry applies it to every entry's `tier`). Keyed on mtimes alone,
+ * a changed override map was invisible to the cache and the previous caller's
+ * tiers were served indefinitely.
  */
-export function computeSkillsDirHash(skillsDirs: string[]): string {
+export function computeSkillsDirHash(
+  skillsDirs: string[],
+  tierOverrides?: Record<string, number>
+): string {
   const hash = crypto.createHash('sha256');
   for (const dir of skillsDirs) {
     if (!fs.existsSync(dir)) continue;
@@ -45,6 +54,12 @@ export function computeSkillsDirHash(skillsDirs: string[]): string {
       const stat = fs.statSync(yamlPath);
       hash.update(`${yamlPath}:${stat.mtimeMs}`);
     }
+  }
+  const overrideEntries = Object.entries(tierOverrides ?? {}).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (const [name, tier] of overrideEntries) {
+    hash.update(`tier:${name}=${tier}`);
   }
   return hash.digest('hex');
 }
@@ -133,7 +148,10 @@ export function buildIndex(
   const skillsDirs = resolveAllSkillsDirsWithSource(platform, projectRoot);
   const index: SkillsIndex = {
     version: 1,
-    hash: computeSkillsDirHash(skillsDirs.map((d) => d.dir)),
+    hash: computeSkillsDirHash(
+      skillsDirs.map((d) => d.dir),
+      tierOverrides
+    ),
     generatedAt: new Date().toISOString(),
     skills: {},
   };
@@ -156,7 +174,7 @@ export function loadOrRebuildIndex(
 ): SkillsIndex {
   const indexPath = path.join(projectRoot, '.harness', 'skills-index.json');
   const skillsDirs = resolveAllSkillsDirsWithSource(platform, projectRoot).map((d) => d.dir);
-  const currentHash = computeSkillsDirHash(skillsDirs);
+  const currentHash = computeSkillsDirHash(skillsDirs, tierOverrides);
 
   if (fs.existsSync(indexPath)) {
     try {

--- a/packages/cli/tests/skill/bugfleet-index-tier-overrides-cache.test.ts
+++ b/packages/cli/tests/skill/bugfleet-index-tier-overrides-cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { stringify } from 'yaml';
+import { loadOrRebuildIndex } from '../../src/skill/index-builder';
+import { resolveAllSkillsDirsWithSource } from '../../src/utils/paths';
+import type { SkillsDirWithSource } from '../../src/utils/paths';
+
+vi.mock('../../src/utils/paths', () => ({
+  resolveAllSkillsDirsWithSource: vi.fn(() => []),
+}));
+
+const mockedResolveDirs = vi.mocked(resolveAllSkillsDirsWithSource);
+
+/**
+ * index-builder.loadOrRebuildIndex keys its cache purely on skill.yaml mtimes
+ * (computeSkillsDirHash). `tierOverrides` is a THIRD input that materially
+ * changes the built index (parseSkillEntry applies it to every entry's `tier`)
+ * but never reaches the hash, so the cached index is served with the tiers of
+ * whichever caller happened to build it first.
+ *
+ * Every production caller passes tierOverrides read from harness config
+ * (mcp/tools/skill.ts, mcp/tools/search-skills.ts, mcp/tools/recommend-skills.ts,
+ * commands/recommend.ts, commands/advise-skills.ts), so editing that config has
+ * no effect until an unrelated skill.yaml mtime happens to change.
+ */
+describe('bugfleet: loadOrRebuildIndex ignores tierOverrides changes', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bugfleet-tier-'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSkillYaml(dir: string, name: string): void {
+    const skillDir = path.join(dir, name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, 'skill.yaml'),
+      stringify({
+        name,
+        version: '1.0.0',
+        description: `Test skill ${name}`,
+        triggers: ['manual'],
+        platforms: ['claude-code'],
+        tools: ['Read'],
+        type: 'flexible',
+        tier: 3,
+      })
+    );
+  }
+
+  it('applies a changed tierOverrides map instead of serving the cached tiers', () => {
+    const skillsDir = path.join(tmpDir, 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+    writeSkillYaml(skillsDir, 'test-skill');
+    const dirs: SkillsDirWithSource[] = [{ dir: skillsDir, source: 'project' }];
+    mockedResolveDirs.mockReturnValue(dirs);
+
+    // First caller overrides the skill to tier 1 and warms the on-disk cache.
+    const first = loadOrRebuildIndex('claude-code', tmpDir, { 'test-skill': 1 });
+    expect(first.skills['test-skill']!.tier).toBe(1);
+
+    // Config now says tier 2. Nothing on disk changed, so the mtime hash matches
+    // and the stale tier-1 index is returned.
+    const second = loadOrRebuildIndex('claude-code', tmpDir, { 'test-skill': 2 });
+    expect(second.skills['test-skill']!.tier).toBe(2);
+  });
+});


### PR DESCRIPTION
fix(skill): fold tierOverrides into the skills-index cache key

`loadOrRebuildIndex` keyed its on-disk cache (`.harness/skills-index.json`)
purely on skill.yaml mtimes via `computeSkillsDirHash`. `tierOverrides` is a
third input that materially changes the built index — `parseSkillEntry` applies
it to every entry's tier — but never reached the hash.

So editing `tierOverrides` in harness config was INERT until an unrelated
skill.yaml mtime happened to change, and worse, the first caller's overrides were
baked into the cache file and then served to callers that pass none. Every
production caller passes config-derived overrides (mcp/tools/skill.ts,
search-skills.ts, recommend-skills.ts, commands/recommend.ts,
commands/advise-skills.ts).

The fix gives `computeSkillsDirHash` an optional second `tierOverrides`
parameter and folds the sorted `name=tier` pairs into the same sha256;
`buildIndex` and `loadOrRebuildIndex` both pass it.

Reproducing test: packages/cli/tests/skill/bugfleet-index-tier-overrides-cache.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.

Assumptions made: fix-class bounded-safe — the signature is backward-compatible,
the `SkillsIndex` shape is unchanged, there is no migration, callers passing no
overrides produce a byte-identical hash to today (so existing on-disk caches stay
valid), and a hash mismatch simply triggers the rebuild that is already the
designed recovery path.

REVIEWER JUDGEMENT CALL, flagged rather than buried: the hunting agent noted that
`tier` feeds catalog and slash-command loading in other modules, so if you read
"corrects a stale tier that another module consumes" as cross-module reach, this
should be downgraded to risky-large and the test taken alone. The fix is a clean
single-file revert if you make that call.

Found by bug-fleet proactive sweep (area: packages/cli/src/skill).
