### PR TITLE
fix(orchestrator): scope InteractionQueue.list's ENOENT guard to the readdir

### DIFF
--- a/.changeset/bugfleet-interaction-queue-list-swallows.md
+++ b/.changeset/bugfleet-interaction-queue-list-swallows.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Scope `InteractionQueue.list`'s ENOENT guard to the `readdir` instead of wrapping the per-file read loop too. One entry vanishing mid-scan discarded every interaction already read and reported the queue as empty, silently breaking `push()`'s dedup pass and hiding pending human escalations.

--- a/packages/orchestrator/src/core/interaction-queue.ts
+++ b/packages/orchestrator/src/core/interaction-queue.ts
@@ -132,24 +132,37 @@ export class InteractionQueue {
    * List all interactions (regardless of status).
    */
   async list(): Promise<PendingInteraction[]> {
+    let files: string[];
     try {
-      const files = await fs.readdir(this.dir);
-      const jsonFiles = files.filter((f) => f.endsWith('.json'));
-      const interactions: PendingInteraction[] = [];
-
-      for (const file of jsonFiles) {
-        const filePath = path.join(this.dir, file);
-        const raw = await fs.readFile(filePath, 'utf-8');
-        interactions.push(JSON.parse(raw) as PendingInteraction);
-      }
-
-      return interactions;
+      files = await fs.readdir(this.dir);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         return [];
       }
       throw err;
     }
+
+    const jsonFiles = files.filter((f) => f.endsWith('.json'));
+    const interactions: PendingInteraction[] = [];
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(this.dir, file);
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, 'utf-8');
+      } catch (err) {
+        // The entry was listed by `readdir` but is gone by the time we read it
+        // (a concurrent `push()` unlinks the superseded pending file for an
+        // issue). Skip just that entry -- the ENOENT guard above is for a
+        // missing DIRECTORY, and letting it also catch a single vanished file
+        // discarded every interaction already read and reported an empty queue.
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw err;
+      }
+      interactions.push(JSON.parse(raw) as PendingInteraction);
+    }
+
+    return interactions;
   }
 
   /**

--- a/packages/orchestrator/tests/core/bugfleet-interaction-queue-list-swallows.test.ts
+++ b/packages/orchestrator/tests/core/bugfleet-interaction-queue-list-swallows.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { InteractionQueue } from '../../src/core/interaction-queue';
+import type { PendingInteraction } from '../../src/core/interaction-queue';
+
+function makeInteraction(overrides: Partial<PendingInteraction> = {}): PendingInteraction {
+  return {
+    id: 'int-1',
+    issueId: 'issue-1',
+    type: 'needs-human',
+    reasons: ['full-exploration tier always requires human'],
+    context: {
+      issueTitle: 'Needs a human',
+      issueDescription: null,
+      specPath: null,
+      planPath: null,
+      relatedFiles: [],
+    },
+    createdAt: '2026-01-01T00:00:00Z',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+describe('InteractionQueue.list with an entry that disappears mid-scan', () => {
+  let tmpDir: string;
+  let queue: InteractionQueue;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bugfleet-iq-'));
+    queue = new InteractionQueue(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * `list()` reads the directory, then reads every `*.json` entry inside ONE
+   * try/catch whose ENOENT branch returns `[]`. So a single entry that is
+   * listed by `readdir` but gone by the time `readFile` reaches it does not
+   * merely get skipped — it discards every interaction already read and
+   * reports the queue as EMPTY.
+   *
+   * A file vanishing between `readdir` and `readFile` is exactly what a reader
+   * observes when `push()` (which unlinks the superseded pending file for an
+   * issue) interleaves with it. Here that same ENOENT is produced
+   * deterministically with a dangling symlink instead of a scheduled race.
+   */
+  async function seedSurvivorPlusVanishedEntry(): Promise<void> {
+    await queue.push(makeInteraction({ id: 'int-live', issueId: 'issue-live' }));
+    await fs.symlink(path.join(tmpDir, 'gone.json'), path.join(tmpDir, 'int-vanished.json'));
+  }
+
+  it('still returns the interactions it successfully read', async () => {
+    await seedSurvivorPlusVanishedEntry();
+
+    const result = await queue.list();
+
+    expect(result.map((i) => i.id)).toEqual(['int-live']);
+  });
+
+  it('still reports the surviving pending escalation via listPending', async () => {
+    await seedSurvivorPlusVanishedEntry();
+
+    const pending = await queue.listPending();
+
+    expect(pending).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
fix(orchestrator): scope InteractionQueue.list's ENOENT guard to the readdir

`InteractionQueue.list` wrapped the `readdir` AND the per-file `readFile` loop in
ONE try/catch whose ENOENT branch returns `[]`. That guard was written for a
missing DIRECTORY, but it also catches ENOENT from an individual `readFile` — so
a single entry that is listed by `readdir` and gone by the time it is read
discards every interaction already accumulated and reports the queue as EMPTY.

Two consequences:
- `push()` calls `list()` for its dedup pass, so its documented promise that
  "the directory never accumulates duplicates" silently breaks.
- The authenticated read path serving pending human escalations reports zero
  pending items while the files are still on disk.

The mid-scan disappearance is reachable in production because `push()` itself
unlinks the superseded pending file for an issue while a reader may be mid-scan.

The fix splits the single try/catch into a readdir guard (ENOENT => [],
unchanged) plus a per-file guard (ENOENT => skip that entry, else rethrow).
Non-ENOENT errors and JSON.parse errors still propagate exactly as before; no
signature or contract change. `updateStatus` in the same file already scopes its
ENOENT guard this way — the correct pattern was two methods away.

Reproducing test: packages/orchestrator/tests/core/bugfleet-interaction-queue-list-swallows.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.
Deterministic: real tmpdir + dangling symlink, no timing dependence.

Companion PR: the byte-identical defect shape in `AnalysisArchive.list` is fixed
separately so each is independently reviewable and revertible.

Assumptions made: area ranked by churn x blast-radius x inverse-coverage
(packages/orchestrator/src/core, churn 127, 16 external dependents). Fix-class
bounded-safe: same file, same method, no signature/contract/schema change, all
pre-existing error propagation preserved.

Found by bug-fleet proactive sweep (area: packages/orchestrator/src/core).
