### PR TITLE
fix(orchestrator): scope AnalysisArchive.list's ENOENT guard to the readdir

### DIFF
--- a/.changeset/bugfleet-analysis-archive-list-swallows.md
+++ b/.changeset/bugfleet-analysis-archive-list-swallows.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Scope `AnalysisArchive.list`'s ENOENT guard to the `readdir` instead of wrapping the per-file read loop too. One entry vanishing mid-scan discarded every record already read and reported the archive as empty, so the auto-publish and `publish-analyses` paths silently published nothing.

--- a/packages/orchestrator/src/core/analysis-archive.ts
+++ b/packages/orchestrator/src/core/analysis-archive.ts
@@ -76,23 +76,36 @@ export class AnalysisArchive {
    * List all archived analysis records.
    */
   async list(): Promise<AnalysisRecord[]> {
+    let files: string[];
     try {
-      const files = await fs.readdir(this.dir);
-      const jsonFiles = files.filter((f) => f.endsWith('.json'));
-      const records: AnalysisRecord[] = [];
-
-      for (const file of jsonFiles) {
-        const filePath = path.join(this.dir, file);
-        const raw = await fs.readFile(filePath, 'utf-8');
-        const record = JSON.parse(raw) as AnalysisRecord;
-        record.externalId ??= null;
-        records.push(record);
-      }
-
-      return records;
+      files = await fs.readdir(this.dir);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw err;
     }
+
+    const jsonFiles = files.filter((f) => f.endsWith('.json'));
+    const records: AnalysisRecord[] = [];
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(this.dir, file);
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, 'utf-8');
+      } catch (err) {
+        // The entry was listed by `readdir` but is gone by the time we read it
+        // (`save` overwrites concurrently). Skip just that entry -- the ENOENT
+        // guard above is for a missing DIRECTORY, and letting it also catch a
+        // single vanished file discarded every record already read and
+        // reported an empty archive. `get()` already scopes its guard this way.
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw err;
+      }
+      const record = JSON.parse(raw) as AnalysisRecord;
+      record.externalId ??= null;
+      records.push(record);
+    }
+
+    return records;
   }
 }

--- a/packages/orchestrator/tests/core/bugfleet-analysis-archive-list-swallows.test.ts
+++ b/packages/orchestrator/tests/core/bugfleet-analysis-archive-list-swallows.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { AnalysisArchive } from '../../src/core/analysis-archive';
+import type { AnalysisRecord } from '../../src/core/analysis-archive';
+
+function makeRecord(overrides: Partial<AnalysisRecord> = {}): AnalysisRecord {
+  return {
+    issueId: 'issue-1',
+    identifier: 'TEST-1',
+    spec: null,
+    score: null,
+    simulation: null,
+    analyzedAt: '2026-01-01T00:00:00Z',
+    externalId: null,
+    ...overrides,
+  };
+}
+
+describe('AnalysisArchive.list with an entry that disappears mid-scan', () => {
+  let tmpDir: string;
+  let archive: AnalysisArchive;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bugfleet-aa-'));
+    archive = new AnalysisArchive(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * `list()` reads the directory, then reads every `*.json` entry inside ONE
+   * try/catch whose ENOENT branch returns `[]`. So a single entry that is
+   * listed by `readdir` but gone by the time `readFile` reaches it does not
+   * merely get skipped — it discards every record already read and reports the
+   * archive as EMPTY, so the publish path sees no analyses to publish.
+   *
+   * `AnalysisArchive.get()` in the same file already scopes its ENOENT guard to
+   * the single `readFile` it guards; `list()` does not. Here the mid-scan
+   * disappearance is produced deterministically with a dangling symlink instead
+   * of a scheduled race.
+   */
+  async function seedSurvivorPlusVanishedEntry(): Promise<void> {
+    await archive.save(makeRecord({ issueId: 'issue-live', identifier: 'LIVE-1' }));
+    await fs.symlink(path.join(tmpDir, 'gone.json'), path.join(tmpDir, 'issue-vanished.json'));
+  }
+
+  it('still returns the records it successfully read', async () => {
+    await seedSurvivorPlusVanishedEntry();
+
+    const result = await archive.list();
+
+    expect(result.map((r) => r.issueId)).toEqual(['issue-live']);
+  });
+});


### PR DESCRIPTION
fix(orchestrator): scope AnalysisArchive.list's ENOENT guard to the readdir

`AnalysisArchive.list` had the byte-for-byte same defect shape as
`InteractionQueue.list`: the `readdir` and the per-file `readFile` loop shared
one try/catch whose ENOENT branch returns `[]`. A single entry listed by
`readdir` and gone by the time it is read therefore discarded every record
already accumulated and reported the archive as EMPTY.

Consequence: the auto-publish and `publish-analyses` paths see an empty archive
and silently publish nothing.

The fix applies the same minimal split — a readdir guard (ENOENT => [],
unchanged) plus a per-file guard (ENOENT => skip that entry, else rethrow). The
`record.externalId ??= null` normalization and all non-ENOENT / parse error
propagation are preserved. `AnalysisArchive.get()` twenty lines above already
scopes its ENOENT guard this way.

Reproducing test: packages/orchestrator/tests/core/bugfleet-analysis-archive-list-swallows.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch.
Deterministic: real tmpdir + dangling symlink, no timing dependence.

Companion PR: the same defect shape in `InteractionQueue.list` is fixed
separately so each is independently reviewable and revertible. They share a root
cause but are two distinct defects with two distinct failing tests.

Assumptions made: area ranked by churn x blast-radius x inverse-coverage
(packages/orchestrator/src/core, churn 127, 16 external dependents). Fix-class
bounded-safe: same file, same method, no signature/contract/schema change.

Found by bug-fleet proactive sweep (area: packages/orchestrator/src/core).
