### PR TITLE
fix(orchestrator): do not re-arm the poll timer after stop()

### DIFF
--- a/.changeset/bugfleet-stop-rearms-poll-timer.md
+++ b/.changeset/bugfleet-stop-rearms-poll-timer.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Add a shutdown latch so `stop()` cannot be undone by an in-flight tick. The polling loop re-arms itself from inside the tick's own `.finally`, so a `stop()` that landed after the poll timer fired but before that tick settled armed a new timer on a stopped orchestrator — the loop kept polling, and the refed timer kept the Node event loop alive, forever after shutdown.

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -784,6 +784,17 @@ export class Orchestrator extends EventEmitter {
   private stageCheckpoints = new Map<string, Map<number, StageRun>>();
   private server?: OrchestratorServer;
   private interval?: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * Shutdown latch for the self-rearming polling loop. `stop()` clears
+   * {@link interval}, but the loop re-arms itself from INSIDE the tick's own
+   * `.finally` (see `scheduleNextTick` in {@link start}) — so a `stop()` that lands
+   * after the poll timer fired but before that tick settles was silently undone and
+   * a NEW timer was armed on a stopped orchestrator (the loop kept polling, and the
+   * refed timer kept the event loop alive, forever after shutdown). `stop()` raises
+   * this latch and `scheduleNextTick` refuses to re-arm while it is up; `start()`
+   * lowers it so a restart still polls.
+   */
+  private stopRequested = false;
   private heartbeatInterval?: ReturnType<typeof setInterval> | undefined;
   private logger: StructuredLogger;
   private interactionQueue: InteractionQueue;
@@ -5032,6 +5043,9 @@ export class Orchestrator extends EventEmitter {
     const jitterMs = this.config.polling.jitterMs ?? 0;
 
     const scheduleNextTick = () => {
+      // Never re-arm a stopped orchestrator: this runs from the in-flight tick's
+      // own `.finally`, which can settle AFTER `stop()` already cleared the timer.
+      if (this.stopRequested) return;
       const jitter = jitterMs > 0 ? Math.round((Math.random() * 2 - 1) * jitterMs) : 0;
       const delay = Math.max(0, intervalMs + jitter);
       this.interval = setTimeout(() => {
@@ -5039,6 +5053,7 @@ export class Orchestrator extends EventEmitter {
       }, delay);
     };
 
+    this.stopRequested = false;
     scheduleNextTick();
     void this.tick(); // Initial tick (no jitter)
 
@@ -5068,6 +5083,9 @@ export class Orchestrator extends EventEmitter {
   public async stop(): Promise<void> {
     // Seal the black-box first so an abrupt teardown still leaves a stamped record.
     this.flightRecorder?.finishRun();
+    // Raise the shutdown latch BEFORE clearing the timer, so an in-flight tick's
+    // `.finally` cannot re-arm the polling loop behind this teardown.
+    this.stopRequested = true;
     if (this.interval) {
       clearTimeout(this.interval);
       this.interval = undefined;

--- a/packages/orchestrator/tests/core/bugfleet-stop-rearms-poll-timer.test.ts
+++ b/packages/orchestrator/tests/core/bugfleet-stop-rearms-poll-timer.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Orchestrator } from '../../src/orchestrator';
+import { WorkflowConfig, Ok } from '@harness-engineering/types';
+import { MockBackend } from '../../src/agent/backends/mock';
+import { WorkspaceManager } from '../../src/workspace/manager';
+import { noopExecFile } from '../helpers/noop-exec-file';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+// bug-fleet A5 (orchestrator.ts): `Orchestrator.stop()` clears `this.interval`,
+// but the polling loop re-arms itself from INSIDE the tick's own `.finally`
+// (start(): `this.interval = setTimeout(() => { void this.tick().finally(() =>
+// scheduleNextTick()); }, delay)`). There is no stopped flag, so a `stop()` that
+// lands after the poll timer fired but before that tick settles is undone: the
+// `.finally` calls `scheduleNextTick()` again and arms a NEW timer on a stopped
+// orchestrator. The polling loop keeps running (and keeps the event loop alive)
+// forever after shutdown.
+
+const INTERVAL_MS = 1000;
+let tmpDir: string;
+
+function createMockConfig(): WorkflowConfig {
+  return {
+    tracker: { kind: 'mock', activeStates: ['planned'], terminalStates: ['done'] },
+    polling: { intervalMs: INTERVAL_MS },
+    workspace: { root: path.join(tmpDir, '.harness', 'workspaces') },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 1000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 2,
+      maxTurns: 3,
+      maxRetryBackoffMs: 1000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: { planned: 1 },
+      turnTimeoutMs: 5000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 5000,
+    },
+    server: { port: null },
+  } as unknown as WorkflowConfig;
+}
+
+describe('Orchestrator.stop() vs the self-rearming poll timer', () => {
+  let orchestrator: Orchestrator;
+  // Never resolved: pins the very first tick in-flight for the whole test.
+  const pinned = new Promise<never>(() => {});
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-bf-a5-stop-'));
+    execSync(
+      'git init && git config user.email "test@test" && git config user.name "test" && git commit --allow-empty -m "init"',
+      { cwd: tmpDir, stdio: 'ignore' }
+    );
+    fs.mkdirSync(path.join(tmpDir, '.harness', 'workspaces'), { recursive: true });
+    vi.spyOn(WorkspaceManager.prototype, 'sweepStaleBranches').mockResolvedValue([]);
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
+    });
+
+    const tracker = {
+      // Pins every tick that reaches it, so `tickInProgress` stays true.
+      fetchCandidateIssues: vi.fn().mockReturnValue(pinned),
+      fetchIssuesByStates: vi.fn().mockResolvedValue(Ok([])),
+      fetchIssueStatesByIds: vi.fn().mockResolvedValue(Ok(new Map())),
+      markIssueComplete: vi.fn().mockResolvedValue(Ok(undefined)),
+      claimIssue: vi.fn().mockResolvedValue(Ok(undefined)),
+      releaseIssue: vi.fn().mockResolvedValue(Ok(undefined)),
+    } as unknown as import('@harness-engineering/core').IssueTrackerClient;
+
+    orchestrator = new Orchestrator(createMockConfig(), 'Prompt', {
+      tracker,
+      backend: new MockBackend(),
+      execFileFn: noopExecFile,
+    });
+  });
+
+  afterEach(async () => {
+    // Defuse any timer the defect left armed so the suite can exit.
+    const leaked = (orchestrator as unknown as { interval?: NodeJS.Timeout }).interval;
+    if (leaked) clearTimeout(leaked);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    for (let i = 0; i < 3; i++) {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        break;
+      } catch {
+        if (i < 2) await new Promise((r) => setTimeout(r, 200));
+      }
+    }
+  });
+
+  it('leaves no polling timer armed after stop()', async () => {
+    await orchestrator.start();
+
+    const priv = orchestrator as unknown as {
+      interval?: NodeJS.Timeout;
+      tickInProgress: boolean;
+    };
+
+    // Precondition: start() armed the poll timer and pinned the initial tick.
+    expect(priv.interval).toBeDefined();
+    expect(priv.tickInProgress).toBe(true);
+
+    // The poll timer fires. `tick()` short-circuits on `tickInProgress` and
+    // resolves on a microtask, so its `.finally(() => scheduleNextTick())` is
+    // now queued but has NOT run yet.
+    vi.advanceTimersByTime(INTERVAL_MS);
+
+    // Shut down. `stop()` clears `this.interval` synchronously, before its
+    // first await — i.e. strictly before that queued `.finally` can run.
+    await orchestrator.stop();
+
+    // Let the in-flight tick's `.finally` run.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
+    // A stopped orchestrator must not have a live polling timer.
+    expect(priv.interval).toBeUndefined();
+  }, 20000);
+});


### PR DESCRIPTION
fix(orchestrator): do not re-arm the poll timer after stop()

The polling loop re-arms itself from INSIDE the tick's own `.finally`:

    this.interval = setTimeout(() => {
      void this.tick().finally(() => scheduleNextTick());
    }, delay);

There was no shutdown latch. `stop()` clears `this.interval` synchronously at its
top, but any tick whose timer had already fired and whose promise had not yet
settled then ran `scheduleNextTick()` and armed a NEW timer on a stopped
orchestrator.

Reachable input: the poll timer fires while a prior tick is still in flight (so
`tick()` takes the `tickInProgress` skip path and resolves on a microtask), then
`stop()` is awaited. The orchestrator keeps polling forever after shutdown — and
because the handle is REFED, it also keeps the Node event loop alive, so a
process that shuts the orchestrator down never exits.

The fix adds a `stopRequested` latch: `scheduleNextTick` refuses to re-arm while
it is up, `stop()` raises it BEFORE clearing the timer, and `start()` lowers it so
a stop-then-start restart still polls. 15 added lines, no deletions, all inside
orchestrator.ts.

Reproducing test: packages/orchestrator/tests/core/bugfleet-stop-rearms-poll-timer.test.ts
Verified red by assertion at base 056e1a79d (3/3 runs), green on this branch. The
received value at base is a live `{ refed: true, ... }` Timeout object.
Deterministic: fake timers driven synchronously via `vi.advanceTimersByTime`, the
initial tick pinned in-flight by a never-resolving tracker promise — no
wall-clock, real-concurrency, or setTimeout-ordering dependence.

Assumptions made: this area is `packages/orchestrator/src/orchestrator.ts` alone
— a single indivisible 5,358-LOC file, 34% over the fleet's area bound, hunted
whole under an explicit human decision. Fix-class bounded-safe: the polling timer
is private to this file, no public API / schema / persisted-state change, and the
behavior change is strictly toward what `stop()`'s own docstring already promises.

Pre-existing at this base (PROVEN by re-running the file in an untouched worktree
at the same SHA, not assumed): 2 failures in tests/server/http.test.ts, unrelated
to the polling timer.

Found by bug-fleet proactive sweep (area: packages/orchestrator/src/orchestrator.ts).
