### PR TITLE
fix(roadmap): say why a tracker kind is rejected instead of denying the block exists (#1863)

### DIFF
--- a/.changeset/tracker-kind-rejection-honest-1863.md
+++ b/.changeset/tracker-kind-rejection-honest-1863.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/cli': patch
+---
+
+Say why a tracker kind is rejected instead of denying the block exists (#1863)
+
+`harness roadmap sync` with a well-formed `roadmap.tracker` block whose kind is
+`pnyon` reported "harness.config.json has no `roadmap.tracker` block" — for a
+block that was present, well-formed, and sitting right there. The message sent
+readers hunting for something they already had.
+
+`loadTrackerSyncConfig` returns a bare `null` for four different situations (no
+config file, unparseable config, no tracker block, and a kind the shape guard
+rejects) and the CLI rendered all four as the missing-block sentence. The new
+`diagnoseTrackerSyncConfig` / `explainTrackerSyncConfig` pair distinguishes
+them, naming the supported kinds when the kind is the problem. Both are
+additive — `loadTrackerSyncConfig`'s contract is unchanged — and the accepted
+list is stated once, shared by the guard and the diagnosis, so they cannot
+drift apart.
+
+Sync remains GitHub-only; this makes the refusal true rather than changing what
+is accepted. Driving Waypoint from `roadmap sync` additionally needs a
+`TrackerSyncAdapter` for it: #1816 implemented the `RoadmapTrackerClient` seam,
+which is a different interface that `roadmap sync` does not consume.

--- a/.harness/comprehension/packages/cli/src/commands/roadmap/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands/roadmap'
-sourceHash: '820c271975e6ca13562ccba3e168261408d490414ba7959c0a5195561a443f5a'
+sourceHash: '1eae05ca49bdf4b43c84c62e45ea22a4f9d90218befe76e35b93389c577adecc'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -66,7 +66,7 @@ import { PoolSnapshotStore, resolvePreferredLocalModel } from './triage-pool.js'
 import { TriageProviderConfig, resolveTriageProvider } from './triage-provider.js'
 import { BrainstormReportRow, runApproveCommand } from './triage.js'
 import { createRoadmapUnshardCommand } from './unshard'
-import { DenominatedMetric, Err, ExternalSyncOptions, ExternalTicketState, GitHubIssuesSyncAdapter, Ok, Result, Roadmap, RoadmapFeature, RoadmapMeta, RoadmapStore, RoadmapTrackerClient, Shard, ShardIO, SuppressedInbound, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, assertRegeneratedRoundTrip, assertSemanticRoundTrip, buildExternalId, census, createTrackerClient, eventSourcing, fullSync, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, migrate, parseReferencedIssues, parseRoadmap, reconcileDoneFromClosedIssues, regenerate, resolveRoadmapStore, resolveRoadmapStoreForFile, roadmapSourceExists, roadmapToShards, serializeMeta, serializeRoadmap, serializeShard, unknownPopulation, verdictForMetrics, writeRegeneratedRoadmap } from '@harness-engineering/core'
+import { DenominatedMetric, Err, ExternalSyncOptions, ExternalTicketState, GitHubIssuesSyncAdapter, Ok, Result, Roadmap, RoadmapFeature, RoadmapMeta, RoadmapStore, RoadmapTrackerClient, Shard, ShardIO, SuppressedInbound, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, assertRegeneratedRoundTrip, assertSemanticRoundTrip, buildExternalId, census, createTrackerClient, diagnoseTrackerSyncConfig, eventSourcing, explainTrackerSyncConfig, fullSync, loadProjectRoadmapMode, loadTrackerClientConfigFromProject, loadTrackerSyncConfig, migrate, parseReferencedIssues, parseRoadmap, reconcileDoneFromClosedIssues, regenerate, resolveRoadmapStore, resolveRoadmapStoreForFile, roadmapSourceExists, roadmapToShards, serializeMeta, serializeRoadmap, serializeShard, unknownPopulation, verdictForMetrics, writeRegeneratedRoadmap } from '@harness-engineering/core'
 import { GraphNode, GraphStore } from '@harness-engineering/graph'
 import { AnalysisProvider, AnthropicAnalysisProvider, ForkGenerator, OpenAICompatibleAnalysisProvider, PrecedentLookup, RatchetOutcome, RatchetStage, StagedGoNoGoCandidate, V1_MAX_STAGE, dispatchableShapeKey, resolveGoNoGoStaged, resolveStage, shapeKey } from '@harness-engineering/intelligence'
 import { BrainstormWiringDeps, PoolState, PoolStateStore, RankProfile, RankableCandidate, TriageMarkItem, TriageVerdict, WiredBrainstormResult, artifactPresenceFromIssue, detectScopeTier, markApprovedForDispatch, poolStateToCandidates, precedentLookupFromStored, rankTriageCandidates, runBrainstormForIssue, triageIssue } from '@harness-engineering/orchestrator'

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '4c61914f56c6b8ae13338b9417230e83301ce88caa3f3cb20d036d473d07c839'
+sourceHash: '930e672c0143b2d801fea85e2cfdc81ea65c6c53434a24ffb68128770258fff8'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -77,6 +77,7 @@ export RoadmapPromoteTransition
 export RoadmapStorageMode
 export RoadmapTrackerClient
 export STATUS_RANK
+export SYNC_SUPPORTED_TRACKER_KINDS
 export ScoredCandidate
 export SyncChange
 export SyncOptions
@@ -84,6 +85,7 @@ export TicketWriteOptions
 export TrackedFeature
 export TrackerClientConfig
 export TrackerConfig
+export TrackerConfigDiagnosis
 export TrackerConflictBody
 export TrackerKindRegistration
 export TrackerSyncAdapter
@@ -106,6 +108,8 @@ export decidePromotionForRow
 export defaultIsArchive
 export deriveRepoFromGitRemote
 export detectRoadmapStorageMode
+export diagnoseTrackerSyncConfig
+export explainTrackerSyncConfig
 export fullSync
 export getRoadmapMode
 export getTrackerKindRegistration

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '8c924a05853c748c2179480a84acf9673779217f23ffb2a3883f843c297770f3'
+sourceHash: '3a094409cce9039ee51bc1a440a6c4c84c9b2b6f462f2ccf8901e9ee8b2c2df7'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -42,6 +42,7 @@ members:
     'sync-engine-guards.test.ts',
     'sync-engine.test.ts',
     'sync.test.ts',
+    'tracker-config-diagnosis.test.ts',
     'tracker-sync.test.ts',
   ]
 ---
@@ -98,7 +99,7 @@ import { decodeSummaryField, encodeSummaryField } from '../../src/roadmap/summar
 import { syncRoadmap } from '../../src/roadmap/sync'
 import { _resetSyncMutex, fullSync, syncFromExternal, syncRowToExternal, syncToExternal } from '../../src/roadmap/sync-engine'
 import { TrackedFeature } from '../../src/roadmap/tracker'
-import { loadTrackerSyncConfig } from '../../src/roadmap/tracker-config'
+import { SYNC_SUPPORTED_TRACKER_KINDS, diagnoseTrackerSyncConfig, explainTrackerSyncConfig, loadTrackerSyncConfig } from '../../src/roadmap/tracker-config'
 import { ExternalSyncOptions, TrackerSyncAdapter, resolveReverseStatus } from '../../src/roadmap/tracker-sync'
 import { GitHubIssuesTrackerAdapter } from '../../src/roadmap/tracker/adapters/github-issues'
 import { emitEvent } from '../../src/state/event-sourcing'

--- a/packages/cli/src/commands/roadmap/reconcile.ts
+++ b/packages/cli/src/commands/roadmap/reconcile.ts
@@ -7,6 +7,8 @@ import {
   resolveRoadmapStore,
   roadmapSourceExists,
   loadTrackerSyncConfig,
+  diagnoseTrackerSyncConfig,
+  explainTrackerSyncConfig,
   reconcileDoneFromClosedIssues,
   buildExternalId,
   GitHubIssuesSyncAdapter,
@@ -180,7 +182,9 @@ async function resolveAdapter(
   if (!config) {
     return Err(
       new CLIError(
-        'No tracker configured in harness.config.json; cannot fetch issue state offline',
+        // Same distinction as sync-deps: name WHICH problem, not just "not
+        // configured" (issue #1863).
+        `Cannot fetch issue state: ${explainTrackerSyncConfig(diagnoseTrackerSyncConfig(cwd))}`,
         ExitCode.ERROR
       )
     );

--- a/packages/cli/src/commands/roadmap/sync-deps.ts
+++ b/packages/cli/src/commands/roadmap/sync-deps.ts
@@ -1,6 +1,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Ok, Err, loadTrackerSyncConfig, GitHubIssuesSyncAdapter } from '@harness-engineering/core';
+import {
+  Ok,
+  Err,
+  loadTrackerSyncConfig,
+  diagnoseTrackerSyncConfig,
+  explainTrackerSyncConfig,
+  GitHubIssuesSyncAdapter,
+} from '@harness-engineering/core';
 import type { Result, TrackerSyncConfig, TrackerSyncAdapter } from '@harness-engineering/core';
 import { CLIError, ExitCode } from '../../utils/errors';
 
@@ -31,11 +38,13 @@ export function resolveConfig(
 ): Result<TrackerSyncConfig, CLIError> {
   const config = opts.config ?? loadTrackerSyncConfig(cwd) ?? undefined;
   if (!config) {
+    // Say which of the four reasons applied. The loader returns a bare null for
+    // all of them, and reporting every one as "no `roadmap.tracker` block" sent
+    // readers hunting for a block that was present and well-formed — it just
+    // named a kind sync cannot drive (issue #1863).
     return Err(
       new CLIError(
-        'No tracker configured: harness.config.json has no `roadmap.tracker` block. ' +
-          'Add one (kind, repo, labels, statusMap) before running `harness roadmap sync` — ' +
-          'without it there is nothing to sync to.',
+        `Cannot sync: ${explainTrackerSyncConfig(diagnoseTrackerSyncConfig(cwd))}`,
         ExitCode.ERROR
       )
     );

--- a/packages/core/src/roadmap/index.ts
+++ b/packages/core/src/roadmap/index.ts
@@ -70,7 +70,13 @@ export { parseExternalId, buildExternalId, githubRepoPath } from './external-id'
 /**
  * Shared tracker config loader for harness.config.json.
  */
-export { loadTrackerSyncConfig } from './tracker-config';
+export {
+  loadTrackerSyncConfig,
+  diagnoseTrackerSyncConfig,
+  explainTrackerSyncConfig,
+  SYNC_SUPPORTED_TRACKER_KINDS,
+} from './tracker-config';
+export type { TrackerConfigDiagnosis } from './tracker-config';
 
 /**
  * Default `roadmap.tracker.repo` derivation from the git origin remote.

--- a/packages/core/src/roadmap/tracker-config.ts
+++ b/packages/core/src/roadmap/tracker-config.ts
@@ -3,11 +3,109 @@ import * as path from 'node:path';
 import type { TrackerSyncConfig } from '@harness-engineering/types';
 import { deriveRepoFromGitRemote } from './derive-repo';
 
+/** The kinds `roadmap sync` can drive. Sync is GitHub-only (issue #1863). */
+export const SYNC_SUPPORTED_TRACKER_KINDS = ['github'] as const;
+
+/**
+ * Why `loadTrackerSyncConfig` returned null — the distinction its `null` throws
+ * away.
+ *
+ * `null` collapses four different situations into one, and the CLI rendered all
+ * of them as "harness.config.json has no `roadmap.tracker` block". For a config
+ * that HAS a well-formed block naming an unsupported kind, that message sends
+ * the reader looking for a missing block that is sitting right in front of them
+ * (issue #1863). Sync stays GitHub-only either way; this only makes the refusal
+ * say what is actually true.
+ */
+export type TrackerConfigDiagnosis =
+  | { readonly problem: 'none' }
+  | { readonly problem: 'no-config-file' }
+  | { readonly problem: 'unreadable-config-file' }
+  | { readonly problem: 'no-tracker-block' }
+  | { readonly problem: 'unsupported-kind'; readonly kind: string }
+  | { readonly problem: 'malformed-status-map' };
+
+/**
+ * Explain what (if anything) stops `loadTrackerSyncConfig` from returning a
+ * config. Additive and side-effect-free: the loader's own contract is
+ * unchanged, so no existing caller shifts behaviour.
+ */
+export function diagnoseTrackerSyncConfig(projectRoot: string): TrackerConfigDiagnosis {
+  const configPath = path.join(projectRoot, 'harness.config.json');
+  if (!fs.existsSync(configPath)) return { problem: 'no-config-file' };
+
+  let parsed: { roadmap?: { tracker?: unknown } };
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as typeof parsed;
+  } catch {
+    return { problem: 'unreadable-config-file' };
+  }
+
+  const tracker = parsed.roadmap?.tracker;
+  if (!tracker || typeof tracker !== 'object') return { problem: 'no-tracker-block' };
+
+  const t = tracker as Record<string, unknown>;
+  const kind = typeof t.kind === 'string' ? t.kind : '';
+  if (!(SYNC_SUPPORTED_TRACKER_KINDS as readonly string[]).includes(kind)) {
+    return { problem: 'unsupported-kind', kind };
+  }
+  if (typeof t.statusMap !== 'object' || t.statusMap === null) {
+    return { problem: 'malformed-status-map' };
+  }
+  const allStrings = Object.values(t.statusMap as Record<string, unknown>).every(
+    (val) => typeof val === 'string'
+  );
+  return allStrings ? { problem: 'none' } : { problem: 'malformed-status-map' };
+}
+
+/**
+ * A reader-facing sentence for each diagnosis, naming the supported kinds when
+ * the kind is the problem so the next step is obvious from the message alone.
+ */
+export function explainTrackerSyncConfig(diagnosis: TrackerConfigDiagnosis): string {
+  const supported = SYNC_SUPPORTED_TRACKER_KINDS.join(', ');
+  switch (diagnosis.problem) {
+    case 'none':
+      return 'Tracker config is usable.';
+    case 'no-config-file':
+      return (
+        'No harness.config.json at the project root — `roadmap sync` needs one ' +
+        'carrying a `roadmap.tracker` block (kind, repo, labels, statusMap).'
+      );
+    case 'unreadable-config-file':
+      return (
+        'harness.config.json could not be parsed as JSON, so its ' +
+        '`roadmap.tracker` block could not be read.'
+      );
+    case 'no-tracker-block':
+      return (
+        'harness.config.json has no `roadmap.tracker` block. Add one (kind, repo, ' +
+        'labels, statusMap) before running `harness roadmap sync` — without it ' +
+        'there is nothing to sync to.'
+      );
+    case 'unsupported-kind':
+      return (
+        `roadmap.tracker.kind ${JSON.stringify(diagnosis.kind)} is not supported by ` +
+        `\`harness roadmap sync\` (supported: ${supported}). The block IS present — ` +
+        'sync is GitHub-only, so a tracker registered for the client seam is not ' +
+        'usable here yet (issue #1863).'
+      );
+    case 'malformed-status-map':
+      return (
+        'roadmap.tracker.statusMap is missing or is not a map of strings — every ' +
+        'roadmap status must map to an external status string.'
+      );
+  }
+}
+
 function isValidTrackerShape(tracker: unknown): tracker is TrackerSyncConfig {
   if (!tracker || typeof tracker !== 'object') return false;
 
   const t = tracker as Record<string, unknown>;
-  if (t.kind !== 'github') return false;
+  // Stated once, in SYNC_SUPPORTED_TRACKER_KINDS, so the guard and the
+  // diagnosis can never disagree about which kinds sync accepts.
+  const kind = typeof t.kind === 'string' ? t.kind : '';
+  if (!(SYNC_SUPPORTED_TRACKER_KINDS as readonly string[]).includes(kind)) return false;
   if (typeof t.statusMap !== 'object' || t.statusMap === null) return false;
 
   const allStrings = Object.values(t.statusMap as Record<string, unknown>).every(

--- a/packages/core/tests/roadmap/tracker-config-diagnosis.test.ts
+++ b/packages/core/tests/roadmap/tracker-config-diagnosis.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the tracker-config diagnosis (issue #1863).
+ *
+ * `loadTrackerSyncConfig` returns a bare `null` for four different situations,
+ * and the CLI rendered all of them as "harness.config.json has no
+ * `roadmap.tracker` block". For a config that HAS a well-formed block naming a
+ * kind sync cannot drive, that message is false and sends the reader hunting
+ * for something that is sitting in front of them. These pin the distinction.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  diagnoseTrackerSyncConfig,
+  explainTrackerSyncConfig,
+  loadTrackerSyncConfig,
+  SYNC_SUPPORTED_TRACKER_KINDS,
+} from '../../src/roadmap/tracker-config';
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-tracker-diag-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function writeConfig(tracker: unknown): void {
+  const body = tracker === undefined ? { roadmap: {} } : { roadmap: { tracker } };
+  fs.writeFileSync(path.join(root, 'harness.config.json'), JSON.stringify(body), 'utf-8');
+}
+
+const GITHUB_TRACKER = {
+  kind: 'github',
+  repo: 'owner/repo',
+  labels: ['roadmap'],
+  statusMap: {
+    backlog: 'open',
+    planned: 'open',
+    'in-progress': 'open',
+    done: 'closed',
+    blocked: 'open',
+  },
+};
+
+describe('diagnoseTrackerSyncConfig', () => {
+  it('reports a usable github config as having no problem', () => {
+    writeConfig(GITHUB_TRACKER);
+    expect(diagnoseTrackerSyncConfig(root)).toEqual({ problem: 'none' });
+    expect(loadTrackerSyncConfig(root)).not.toBeNull();
+  });
+
+  it('distinguishes a missing config file from a missing tracker block', () => {
+    expect(diagnoseTrackerSyncConfig(root)).toEqual({ problem: 'no-config-file' });
+    writeConfig(undefined);
+    expect(diagnoseTrackerSyncConfig(root)).toEqual({ problem: 'no-tracker-block' });
+  });
+
+  /**
+   * The bug in #1863. A well-formed block naming an unsupported kind is NOT a
+   * missing block, and must not be reported as one.
+   */
+  it('names an unsupported kind rather than claiming the block is absent', () => {
+    writeConfig({ ...GITHUB_TRACKER, kind: 'pnyon', url: 'https://waypoint.example' });
+
+    const diagnosis = diagnoseTrackerSyncConfig(root);
+    expect(diagnosis).toEqual({ problem: 'unsupported-kind', kind: 'pnyon' });
+
+    const message = explainTrackerSyncConfig(diagnosis);
+    expect(message).toContain('pnyon');
+    expect(message).toContain('The block IS present');
+    // The reader is told what they COULD use, so the next step is in the message.
+    for (const kind of SYNC_SUPPORTED_TRACKER_KINDS) expect(message).toContain(kind);
+    // And it must never claim the block is missing.
+    expect(message).not.toContain('has no `roadmap.tracker` block');
+  });
+
+  it('reports a malformed statusMap distinctly from a bad kind', () => {
+    writeConfig({ ...GITHUB_TRACKER, statusMap: { backlog: 7 } });
+    expect(diagnoseTrackerSyncConfig(root)).toEqual({ problem: 'malformed-status-map' });
+
+    writeConfig({ kind: 'github', repo: 'o/r' });
+    expect(diagnoseTrackerSyncConfig(root)).toEqual({ problem: 'malformed-status-map' });
+  });
+
+  it('reports unparseable JSON rather than treating it as absent', () => {
+    fs.writeFileSync(path.join(root, 'harness.config.json'), '{ not json', 'utf-8');
+    expect(diagnoseTrackerSyncConfig(root)).toEqual({ problem: 'unreadable-config-file' });
+  });
+
+  /**
+   * The guard and the diagnosis read the same list, so they cannot drift into
+   * disagreeing about which kinds sync accepts — which is how the two config
+   * loaders diverged in the first place.
+   */
+  it('agrees with the loader for every diagnosis', () => {
+    const cases: unknown[] = [
+      GITHUB_TRACKER,
+      { ...GITHUB_TRACKER, kind: 'pnyon' },
+      { ...GITHUB_TRACKER, kind: 'linear' },
+      { kind: 'github' },
+    ];
+    for (const tracker of cases) {
+      writeConfig(tracker);
+      const usable = loadTrackerSyncConfig(root) !== null;
+      expect(usable).toBe(diagnoseTrackerSyncConfig(root).problem === 'none');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1863 (the message half — see **Scope** below).

## The bug

`roadmap sync` with a well-formed `roadmap.tracker` block whose kind is `pnyon`:

```
x No tracker configured: harness.config.json has no `roadmap.tracker` block.
  Add one (kind, repo, labels, statusMap)...
```

The block was present, well-formed, and sitting right there. The message sends you hunting for something you already have.

## Cause

`loadTrackerSyncConfig` returns a bare `null` for **four** different situations — no config file, unparseable config, no tracker block, and a kind `isValidTrackerShape` rejects (`t.kind !== 'github'`) — and the CLI rendered all four as the missing-block sentence.

## What this changes

`diagnoseTrackerSyncConfig` distinguishes the four; `explainTrackerSyncConfig` renders each, naming the supported kinds when the kind is the problem:

```
x Cannot sync: roadmap.tracker.kind "pnyon" is not supported by
  `harness roadmap sync` (supported: github). The block IS present — sync is
  GitHub-only, so a tracker registered for the client seam is not usable here
  yet (issue #1863).
```

Both functions are **additive** — `loadTrackerSyncConfig`'s contract is unchanged, so no existing caller shifts behaviour. The accepted-kind list is stated **once** (`SYNC_SUPPORTED_TRACKER_KINDS`), shared by the guard and the diagnosis, so those two cannot drift apart the way the two config loaders already did.

Applied at both sites that produced the message: `roadmap sync` and `roadmap reconcile`.

## Scope — this does not make sync accept `pnyon`

Worth stating plainly, because the issue title implies otherwise. There are **two adapter families**:

| interface | directory | pnyon impl |
|---|---|---|
| `RoadmapTrackerClient` | `roadmap/tracker/adapters/` | ✅ from #1816 |
| `TrackerSyncAdapter` | `roadmap/adapters/` | ❌ github only |

`roadmap sync` consumes the **second**. `TrackerSyncConfig.kind` is literally typed `'github'` ("narrowed to GitHub-only for now") and `sync-deps.ts` hardcodes `new GitHubIssuesSyncAdapter(...)` with no kind dispatch. So #1816 opened the client seam and sync was never wired to it.

Making sync actually drive Waypoint needs a `TrackerSyncAdapter` for it. Live usage across core+cli is `fetchAllTickets` ×4, `createTicket` ×2, `addComment` ×2, `updateTicket` ×1, `fetchComments` ×1 (`fetchTicketState`/`assignTicket` are dead) — tractable, except two of those need semantics that don't exist yet:

- **`addComment` / `fetchComments`** — Waypoint has no comment concept. Override notes? No-ops? Refusals?
- **`createTicket`** — does sync creating an item mean appending `intent.created`? That makes the roadmap a *writer* to the evidence ledger, which cuts against "the board is computed, not typed."

Those are design questions, so I've left them for a spec rather than guessing.

## A note on one existing test

`sync.test.ts` asserts the error mentions `roadmap.tracker`. My first no-config-file message didn't, so I widened the message to name what the file must contain rather than relaxing the assertion — knowing the file is missing is more useful when you're also told what belongs in it.

## Verification

- New: 6 tests over the diagnosis, including that the unsupported-kind message never claims the block is missing, and that the guard and diagnosis agree for every case.
- Existing: 836 core roadmap tests, 118 CLI roadmap tests — all pass.
- End-to-end against a real project fixture with the built CLI, producing the message quoted above.

Changeset included (patch: core + cli).
