### PR TITLE
craft(naming): name the hex pattern for the design property it matches

### DIFF
--- a/.changeset/hex-color-pattern-rename.md
+++ b/.changeset/hex-color-pattern-rename.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Rename the internal `HEX_PATTERN` constant in the DRIFT-T001 token-bypass rule to `HEX_COLOR_PATTERN`, matching its siblings `FONT_FAMILY_PATTERN` and `PX_VALUE_PATTERN` which each name the design property they match. Internal, non-exported identifier — no behavior or API change.

--- a/.harness/comprehension/packages/cli/src/drift/rules/_module.md
+++ b/.harness/comprehension/packages/cli/src/drift/rules/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/drift/rules'
-sourceHash: '031e5519195c8951e8114db7976ab7b3cce7d443dc9f82ce966a1f270018e351'
+sourceHash: 'c7446f49ae67181f297505e8136552fd1eca3a82038fea797499213fbfedc513'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/src/drift/rules/token-bypass-rule.ts
+++ b/packages/cli/src/drift/rules/token-bypass-rule.ts
@@ -28,7 +28,7 @@ import type { TokenSet } from '../resolvers/tokens.js';
 
 // #1824: only CSS-valid hex lengths (3, 4, 6, 8). `{3,8}` also admitted 5 and 7,
 // which can never be a colour. Longest alternative first so `#aabbccdd` matches as 8.
-const HEX_PATTERN = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b/g;
+const HEX_COLOR_PATTERN = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b/g;
 const FONT_FAMILY_PATTERN = /(?:fontFamily|font-family)\s*[:=]\s*['"`]([^'"`,]+)['"`]/g;
 const PX_VALUE_PATTERN =
   /\b(?:margin(?:Top|Right|Bottom|Left)?|padding(?:Top|Right|Bottom|Left)?|gap|top|right|bottom|left)\s*[:=]\s*['"`]?(\d+(?:\.\d+)?)px\b/g;
@@ -67,8 +67,8 @@ function detectHexBypass(
   const findings: DriftFinding[] = [];
   const seenAtLine = new Set<string>();
   let match: RegExpExecArray | null;
-  HEX_PATTERN.lastIndex = 0;
-  while ((match = HEX_PATTERN.exec(source)) !== null) {
+  HEX_COLOR_PATTERN.lastIndex = 0;
+  while ((match = HEX_COLOR_PATTERN.exec(source)) !== null) {
     const hex = match[0]!;
     if (!isHexColorContext(source, ctx, match.index, hex)) continue;
     const lc = hex.toLowerCase();


### PR DESCRIPTION
## Cite

- **runId:** `727d3807-4bf9-421c-9c18-f3bfa62dda22`
- **rubricId:** `NAME-R001`
- **location:** `packages/cli/src/drift/rules/token-bypass-rule.ts:31 (HEX_PATTERN)`
- **axes:** polish / small / high

### Verbatim finding

> `HEX_PATTERN` under-names what it matches: it is a CSS hex *colour* literal matcher, and the comment directly above it says so ('can never be a colour'). Its two siblings on the next lines are `FONT_FAMILY_PATTERN` and `PX_VALUE_PATTERN`, both of which name the design property. Rename to `HEX_COLOR_PATTERN`.

## Change

Renames the module-local constant `HEX_PATTERN` to `HEX_COLOR_PATTERN`. Three references, all inside the target file.

Blast radius was checked before touching anything: `HEX_PATTERN` is a **non-exported module local** — `grep` across the repo (excluding `node_modules`, `dist`, `.git`) returns only the declaration and its two use sites in this file, plus one historical mention in a `docs/changes/` investigation record, which is deliberately left alone (see below). No contract change, no consumer change.

Purely structural: no behavior change. The regex literal, its alternation order, and the `lastIndex` reset are all untouched.

## Count-flat gate

Measured in a clean worktree branched from the pinned base `056e1a79d`, before and after the change:

| Check | Before | After | Delta |
| --- | --- | --- | --- |
| `harness validate` | 430 issues | 430 issues | **0** |
| `harness check-deps` | 1 issue | 1 issue | **0** |

Both counts are **FLAT**. The baseline at the pinned base SHA is not clean, and this PR does not make it worse.

The single pre-existing `check-deps` issue is unrelated to this change: a two-node cycle where `packages/core/src/solutions/scan-candidates/read-commits.ts` imports `normalizeSince` from `./git-scan`, and `git-scan.ts` imports `readRawCommits` back from `./read-commits`. Left untouched.

## Tests

`packages/cli` drift + align + design-pipeline detect suites: **144 passed (16 files)** before the change and **144 passed (16 files)** after. Typecheck clean. Pushed through the full pre-push gate with no `--no-verify`.

## Assumptions made

- **Ranking basis.** Taken as given from the craft critique run: axes polish / small / high — a high-confidence, small-scope, low-risk naming defect. A rename of a file-local constant is about the cheapest possible elevation, and the finding is self-evidencing: the comment one line above the declaration already calls the thing a colour.
- **Routing call.** Routed *elevate* rather than *file* because the whole change is a single non-exported identifier with a three-reference blast radius, entirely inside one file — no contract surface, no cross-module coordination, nothing a reviewer needs context to judge.
- **Elevation scope taken.** Exactly the one cited location and the two use sites the rename forces. Nothing else in the file was touched.
- **Deliberately left un-elevated.**
  - `docs/changes/drift-t001-issue-ref-false-positive-1824/investigation.md` mentions `HEX_PATTERN` in three places. That file is a historical investigation record describing the code as it stood during issue #1824; rewriting the identifier there would falsify the record. It is also outside the cited finding's location. Left as-is.
  - The sibling constants `FONT_FAMILY_PATTERN` and `PX_VALUE_PATTERN` were **not** renamed — they already name their design property, which is precisely what the finding holds up as the standard.
  - No other naming, structural, or stylistic observation in this file was acted on. No cited finding, no rewrite.
- **Generated artifact.** The commit also carries a one-line `sourceHash` refresh in `.harness/comprehension/packages/cli/src/drift/rules/_module.md`, written automatically by the pre-commit comprehension hook as a mechanical consequence of editing the source file. Not a hand edit.

Claude-Session: https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy

https://claude.ai/code/session_01M9UCgzuYQVDdkLbf3n1KZy
