### PR TITLE
craft(copy): say what the mcp imports and roadmap branches are for

### DIFF
--- a/.changeset/craft-e2-mcp-comment-clarity.md
+++ b/.changeset/craft-e2-mcp-comment-clarity.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+craft(copy): replace unresolvable work-plan coordinates and code-restating comments in the MCP server import banners and the roadmap show handler with prose a stranger can act on. Comments only — no behavior change.

--- a/.harness/comprehension/packages/cli/src/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp'
-sourceHash: '58e1c69dfb46090e70150530ef675c7ea46d5ce399c48845b75019339eacc24e'
+sourceHash: 'fe98c16152d2aa239cadbaa58db8afda992b6380aa09f60f02e4afc823b0f8c6'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/mcp/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp'
-sourceHash: 'fe98c16152d2aa239cadbaa58db8afda992b6380aa09f60f02e4afc823b0f8c6'
+sourceHash: '262f715418be9928de495de062ada7ca869f581055a4f7db3d7a811a982689fc'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: 'aa04efef8108aea3b73bd1d2e295dcf4212cf47898c7204c952d032ee61f866f'
+sourceHash: '5b0b1e203aada41de16ee2d2581fb148ae0d439878efc3d59b2e92922c3a5c93'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
+++ b/.harness/comprehension/packages/cli/src/mcp/tools/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/mcp/tools'
-sourceHash: '5b0b1e203aada41de16ee2d2581fb148ae0d439878efc3d59b2e92922c3a5c93'
+sourceHash: '295e80c89be5f2b42118ff1d68bfb4b0952361046d8f8af7309d96984cc0098b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -185,7 +185,7 @@ import {
   listGatewayTokensDefinition,
   handleListGatewayTokens,
 } from './tools/gateway-tools.js';
-// Phase 3 Task 9: MCP wrapper for the webhook subscription endpoint.
+// MCP wrapper for the webhook subscription endpoint.
 import { subscribeWebhookDefinition, handleSubscribeWebhook } from './tools/webhook-tools.js';
 // Phase 4: emit a skill proposal into `.harness/proposals/`.
 import { emitSkillProposalDefinition, handleEmitSkillProposal } from './tools/skill-proposal.js';

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -178,7 +178,7 @@ import {
 } from './tools/constraint-emergence.js';
 import { runCIChecksDefinition, handleRunCIChecks } from './tools/ci.js';
 import { generateBlueprintDefinition, handleGenerateBlueprint } from './tools/blueprint.js';
-// Phase 2 Task 11: MCP wrappers around the Gateway API bridge primitives.
+// MCP wrappers around the Gateway API bridge primitives.
 import {
   triggerMaintenanceJobDefinition,
   handleTriggerMaintenanceJob,

--- a/packages/cli/src/mcp/tools/roadmap.ts
+++ b/packages/cli/src/mcp/tools/roadmap.ts
@@ -231,7 +231,8 @@ async function handleShow(
     };
   }
 
-  // Apply status filter
+  // Keep only features in the requested status, then drop milestones left with none, so the
+  // caller never has to skim past milestones that matched nothing.
   if (input.status) {
     const statusFilter = input.status;
     roadmap = {

--- a/packages/cli/src/mcp/tools/roadmap.ts
+++ b/packages/cli/src/mcp/tools/roadmap.ts
@@ -219,7 +219,8 @@ async function handleShow(
 
   let roadmap = result.value;
 
-  // Apply milestone filter
+  // Milestone names match case-insensitively so callers need not know the stored casing;
+  // an unknown name yields an empty milestone list rather than an error.
   if (input.milestone) {
     const milestoneFilter = input.milestone;
     roadmap = {


### PR DESCRIPTION
## What

`copy-craft` elevation of the **code-comment** surface in `packages/cli/src/mcp`, scoped to exactly four cited findings. Comments only — not one token of executable code changes.

## The four cited findings

All from craft run `d069bec2-c4cb-486a-ad06-da9d2a791503`.

### 1. `COPY-R007` — `packages/cli/src/mcp/server.ts:181` (polish / small / high)

> `Phase 2 Task 11` is a work-plan coordinate a stranger cannot resolve - no link, and the phase numbering appears nowhere in this file or in the import it annotates. The durable half of the comment is the second sentence. Drop the coordinate: `// MCP wrappers around the Gateway API bridge primitives.`

```diff
-// Phase 2 Task 11: MCP wrappers around the Gateway API bridge primitives.
+// MCP wrappers around the Gateway API bridge primitives.
```

### 2. `COPY-R007` — `packages/cli/src/mcp/server.ts:188` (polish / small / high)

> Same class of defect: an unresolvable internal work-plan coordinate in a comment that should describe what the import is for. Read the line and apply the same treatment — keep the durable description, drop the coordinate.

```diff
-// Phase 3 Task 9: MCP wrapper for the webhook subscription endpoint.
+// MCP wrapper for the webhook subscription endpoint.
```

### 3. `COPY-R008` — `packages/cli/src/mcp/tools/roadmap.ts:222` (polish / small / high)

> Comments that lean on private shorthand / restate the code rather than explaining why. Read them and make each say the thing a stranger actually needs.

`// Apply milestone filter` restated the `if (input.milestone)` directly beneath it. The two things a reader cannot see at a glance are that the name match is case-insensitive, and that an unknown name returns an empty milestone list rather than an error.

```diff
-  // Apply milestone filter
+  // Milestone names match case-insensitively so callers need not know the stored casing;
+  // an unknown name yields an empty milestone list rather than an error.
```

### 4. `COPY-R008` — `packages/cli/src/mcp/tools/roadmap.ts:233` (polish / small / high)

> Comments that lean on private shorthand / restate the code rather than explaining why. Read them and make each say the thing a stranger actually needs.

`// Apply status filter` restated the `if (input.status)` beneath it and hid the second half of the operation — the trailing `.filter((m) => m.features.length > 0)` prunes milestones left with no matching features.

```diff
-  // Apply status filter
+  // Keep only features in the requested status, then drop milestones left with none, so the
+  // caller never has to skim past milestones that matched nothing.
```

## Count-flat gate

The baseline at the pinned base SHA `056e1a79db68c980d50a70c4537812d87eb06f39` is not clean; elevation was approved on the condition that it does not get worse. Both counts are **flat**:

| Check | Before (`056e1a79d`) | After | Delta |
| --- | --- | --- | --- |
| `harness validate` | 430 issues | 430 issues | **0** |
| `harness check-deps` | 1 issue | 1 issue | **0** |

Reproduce in a worktree at the base SHA:

```
node packages/cli/dist/bin/harness.js validate      # "Validation failed (430 issues)"
node packages/cli/dist/bin/harness.js check-deps    # "Validation failed (1 issues)"
```

The single pre-existing `check-deps` issue is an unrelated two-node cycle in `packages/core/src/solutions/scan-candidates/` (`read-commits.ts` imports `normalizeSince` from `./git-scan`, and `git-scan.ts` imports `readRawCommits` back from `./read-commits`). Untouched here.

## Pipeline trail

One small change per commit, tests re-run green after each (`vitest run tests/mcp`: 106 files / 1081 tests passed, before the first change and after every one):

- `a2f43be34` — server.ts:181 gateway import banner
- `b26206e33` — server.ts:188 webhook import banner
- `dc8ad2562` — roadmap.ts:222 milestone filter
- `468f298ef` — roadmap.ts:233 status filter
- `1f3ddb8ce` — changeset

The two `.harness/comprehension/**/_module.md` `sourceHash` bumps in the diff are generated artifacts written by the fail-closed pre-commit hook, not hand edits.

## Assumptions made

**Ranking basis.** All four findings are the same tier (polish / small effort / high confidence), so they were taken in file order rather than re-ranked. No finding was judged more valuable than another.

**Routing call.** Elevated rather than filed because code comments cannot alter behavior at all — that is the entire reason this target was elevation-eligible. Every change here is inside a `//` comment; `git diff` shows zero executable-token changes in either source file.

**Elevation scope taken.** Exactly the four cited locations. No cited finding, no rewrite. No adjacent tidying, no logic touched, nothing renamed.

**Deliberately left un-elevated:**

- **User-facing strings in `packages/cli/src/mcp/tools/roadmap.ts`.** `copy-craft` covers error messages, but these are observable contracts, not internal prose, so they are out of scope for a comments-only elevation and belong in a filed item instead:
  - `'Error: roadmap not found. Create a roadmap first.'` (`roadmapNotFoundError`)
  - `` `Error: ${label} is required for add action` `` (`makeAddFieldError`)
- **Uncited sibling comments carrying the same `COPY-R007` defect** in the `server.ts` import banner block — `// Phase 4: …`, `// design-pipeline #2: …`, `// design-pipeline #6: …`, `// design-pipeline #1 (detect half): …`, `// design-pipeline #1 (align half): …`. Same class as findings 1 and 2, but no finding cited them, so they stay. Worth a follow-up sweep of that whole banner block.

Net-improvement proof belongs to VERIFY; no self re-critique was run.
