### PR TITLE
craft(test): name the contract these command tests check

### DIFF
--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,16 +1,162 @@
 ---
 schemaVersion: 1
-module: "packages/cli/tests/commands"
-sourceHash: "fa510e8ad1573b6a8a5272857b7fffb5959e2534cb40f0cb23c14fd884fa699d"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
+module: 'packages/cli/tests/commands'
+sourceHash: '84e0b5a46411af055b2112b616ab1cc1b7be02a514c6a8874af74f2ed2acabe5'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
-members: ["add-extra.test.ts", "add.test.ts", "adoption-retrospective.test.ts", "adoption.test.ts", "agent-review.test.ts", "agent-run-persona.test.ts", "agent-run.test.ts", "agent.test.ts", "align-design-system-command.test.ts", "audit-protected.test.ts", "backfill-skill-provenance.test.ts", "check-arch.test.ts", "check-deployment.test.ts", "check-deps.test.ts", "check-design.test.ts", "check-docs.test.ts", "check-harness-strength.test.ts", "check-perf.test.ts", "check-phase-gate.test.ts", "check-security.test.ts", "check-vocabulary.test.ts", "cleanup-sessions.test.ts", "cleanup.test.ts", "cli-command-harness.ts", "compound-scan-candidates.test.ts", "copy-craft-command.test.ts", "craft-command-harness.ts", "create-skill.test.ts", "cross-check.test.ts", "dashboard.test.ts", "deprecated-graph-aliases.test.ts", "design-command-harness.ts", "design-pipeline-command.test.ts", "distortion.test.ts", "doctor-hardening.test.ts", "doctor.test.ts", "fix-drift.test.ts", "generate-agent-definitions.test.ts", "generate-slash-commands.test.ts", "generate.test.ts", "golden-build-command.test.ts", "golden-build.test.ts", "graph-ingest-decisions.integration.test.ts", "graph-ingest.test.ts", "graph-integrity.test.ts", "graph.test.ts", "hooks.test.ts", "impact-preview.test.ts", "ingest-options.test.ts", "init-extra.test.ts", "init-minimal.test.ts", "init.test.ts", "insights.test.ts", "install-constraints.test.ts", "install.test.ts", "integrations-sync.test.ts", "integrations.test.ts", "learnings-prune.test.ts", "linter-generate.test.ts", "maintenance-command-shape.test.ts", "maintenance-run-check-runner.test.ts", "maintenance-run-integration.test.ts", "maintenance-run-selection.test.ts", "mcp-context-report.test.ts", "mcp-guard.test.ts", "mcp-list-capabilities.test.ts", "mcp-refinement-demand.test.ts", "migrate-backends.test.ts", "migrate.test.ts", "models-probe.test.ts", "models.test.ts", "naming-craft-command.test.ts", "outcome-eval-ci.test.ts", "perf.test.ts", "persona-list.test.ts", "persona.test.ts", "pre-merge-brief-guardian.test.ts", "pre-merge-brief.test.ts", "predict.test.ts", "proposals-status.test.ts", "proposals.test.ts", "publish-analyses.test.ts", "pulse-run.test.ts", "recommend.test.ts", "resolve-skill-sources.test.ts", "review-ci-local-adapter.test.ts", "review-ci.test.ts", "rollback.test.ts", "scan-config.test.ts", "search.test.ts", "security-craft-command.test.ts", "setup-mcp.picker-message.test.ts", "setup-mcp.test.ts", "setup.test.ts", "share.test.ts", "skill-create.test.ts", "skill-info.test.ts", "skill-list.test.ts", "skill-local-resolution.test.ts", "skill-publish.test.ts", "skill-run.test.ts", "skill-search.test.ts", "skill-update.test.ts", "skill-validate.test.ts", "skill.test.ts", "snapshot.test.ts", "spec-craft-command.test.ts", "stale-constraints.test.ts", "state-show.test.ts", "state-streams.test.ts", "state.test.ts", "sync-analyses-action.test.ts", "sync-analyses.test.ts", "sync-main.test.ts", "taint.test.ts", "telemetry-synthesize.test.ts", "telemetry-wizard-run.test.ts", "telemetry-wizard.test.ts", "telemetry.test.ts", "test-craft-command.test.ts", "traceability.test.ts", "uninstall-constraints.test.ts", "uninstall.test.ts", "update-integrations-sync.test.ts", "update-skill-providers.test.ts", "update.test.ts", "usage-pipeline.test.ts", "usage.test.ts", "validate-cross-check.test.ts", "validate-scope.test.ts", "validate.changed.test.ts", "validate.merge-driver.test.ts", "validate.roadmap-abstention.test.ts", "validate.roadmap-health.test.ts", "validate.roadmap-mode.test.ts", "validate.test.ts", "waypoint.test.ts"]
+members:
+  [
+    'add-extra.test.ts',
+    'add.test.ts',
+    'adoption-retrospective.test.ts',
+    'adoption.test.ts',
+    'agent-review.test.ts',
+    'agent-run-persona.test.ts',
+    'agent-run.test.ts',
+    'agent.test.ts',
+    'align-design-system-command.test.ts',
+    'api-craft-command.test.ts',
+    'audit-protected.test.ts',
+    'backfill-skill-provenance.test.ts',
+    'check-arch.test.ts',
+    'check-deployment.test.ts',
+    'check-deps.test.ts',
+    'check-design.test.ts',
+    'check-docs.test.ts',
+    'check-harness-strength.test.ts',
+    'check-perf.test.ts',
+    'check-phase-gate.test.ts',
+    'check-security.test.ts',
+    'check-vocabulary.test.ts',
+    'cleanup-sessions.test.ts',
+    'cleanup.test.ts',
+    'cli-command-harness.ts',
+    'cli-ergonomics-craft-command.test.ts',
+    'code-craft-command.test.ts',
+    'compound-scan-candidates.test.ts',
+    'copy-craft-command.test.ts',
+    'craft-command-harness-cohort-b.ts',
+    'craft-command-harness.ts',
+    'create-skill.test.ts',
+    'cross-check.test.ts',
+    'dashboard.test.ts',
+    'deprecated-graph-aliases.test.ts',
+    'design-command-harness.ts',
+    'design-pipeline-command.test.ts',
+    'distortion.test.ts',
+    'docs-craft-command.test.ts',
+    'doctor-hardening.test.ts',
+    'doctor.test.ts',
+    'fix-drift.test.ts',
+    'generate-agent-definitions.test.ts',
+    'generate-slash-commands.test.ts',
+    'generate.test.ts',
+    'golden-build-command.test.ts',
+    'golden-build.test.ts',
+    'graph-ingest-decisions.integration.test.ts',
+    'graph-ingest.test.ts',
+    'graph-integrity.test.ts',
+    'graph.test.ts',
+    'hooks.test.ts',
+    'impact-preview.test.ts',
+    'ingest-options.test.ts',
+    'init-extra.test.ts',
+    'init-minimal.test.ts',
+    'init.test.ts',
+    'insights.test.ts',
+    'install-constraints.test.ts',
+    'install.test.ts',
+    'integrations-sync.test.ts',
+    'integrations.test.ts',
+    'knowledge-craft-command.test.ts',
+    'learnings-prune.test.ts',
+    'linter-generate.test.ts',
+    'maintenance-command-shape.test.ts',
+    'maintenance-run-check-runner.test.ts',
+    'maintenance-run-integration.test.ts',
+    'maintenance-run-selection.test.ts',
+    'mcp-context-report.test.ts',
+    'mcp-guard.test.ts',
+    'mcp-list-capabilities.test.ts',
+    'mcp-refinement-demand.test.ts',
+    'migrate-backends.test.ts',
+    'migrate.test.ts',
+    'models-probe.test.ts',
+    'models.test.ts',
+    'naming-craft-command.test.ts',
+    'outcome-eval-ci.test.ts',
+    'perf.test.ts',
+    'persona-list.test.ts',
+    'persona.test.ts',
+    'pre-merge-brief-guardian.test.ts',
+    'pre-merge-brief.test.ts',
+    'predict.test.ts',
+    'proposals-status.test.ts',
+    'proposals.test.ts',
+    'publish-analyses.test.ts',
+    'pulse-run.test.ts',
+    'recommend.test.ts',
+    'resolve-skill-sources.test.ts',
+    'review-ci-local-adapter.test.ts',
+    'review-ci.test.ts',
+    'rollback.test.ts',
+    'scan-config.test.ts',
+    'search.test.ts',
+    'security-craft-command.test.ts',
+    'setup-mcp.picker-message.test.ts',
+    'setup-mcp.test.ts',
+    'setup.test.ts',
+    'share.test.ts',
+    'skill-create.test.ts',
+    'skill-info.test.ts',
+    'skill-list.test.ts',
+    'skill-local-resolution.test.ts',
+    'skill-publish.test.ts',
+    'skill-run.test.ts',
+    'skill-search.test.ts',
+    'skill-update.test.ts',
+    'skill-validate.test.ts',
+    'skill.test.ts',
+    'snapshot.test.ts',
+    'spec-craft-command.test.ts',
+    'stale-constraints.test.ts',
+    'state-show.test.ts',
+    'state-streams.test.ts',
+    'state.test.ts',
+    'sync-analyses-action.test.ts',
+    'sync-analyses.test.ts',
+    'sync-main.test.ts',
+    'taint.test.ts',
+    'telemetry-synthesize.test.ts',
+    'telemetry-wizard-run.test.ts',
+    'telemetry-wizard.test.ts',
+    'telemetry.test.ts',
+    'test-craft-command.test.ts',
+    'traceability.test.ts',
+    'uninstall-constraints.test.ts',
+    'uninstall.test.ts',
+    'update-integrations-sync.test.ts',
+    'update-skill-providers.test.ts',
+    'update.test.ts',
+    'usage-pipeline.test.ts',
+    'usage.test.ts',
+    'validate-cross-check.test.ts',
+    'validate-scope.test.ts',
+    'validate.changed.test.ts',
+    'validate.merge-driver.test.ts',
+    'validate.roadmap-abstention.test.ts',
+    'validate.roadmap-health.test.ts',
+    'validate.roadmap-mode.test.ts',
+    'validate.test.ts',
+    'waypoint.test.ts',
+  ]
 ---
 
 ## Interface Contract
 
 ```ts
+export DEFAULT_CWD
 export ProcessExitCalled
 export ProcessExitSignal
 export captureConsole
@@ -27,12 +173,19 @@ export stubProcessExit
 
 ```
 import { AlignDesignSystemOutput, runAlignDesignSystem } from '../../src/align/index.js'
+import { ApiCraftOutput, ApiFinding } from '../../src/api-craft/findings/schema.js'
+import { ApiCraftInput, runApiCraft } from '../../src/api-craft/index.js'
+import { CliErgonomicsCraftOutput, CliErgonomicsFinding } from '../../src/cli-ergonomics-craft/findings/schema.js'
+import { CliErgonomicsCraftInput, runCliErgonomicsCraft } from '../../src/cli-ergonomics-craft/index.js'
+import { CodeCraftOutput, CodeFinding } from '../../src/code-craft/findings/schema.js'
+import { CodeCraftInput, runCodeCraft } from '../../src/code-craft/index.js'
 import { createAddCommand, runAdd } from '../../src/commands/add'
 import { createAdoptionCommand } from '../../src/commands/adoption'
 import { createAgentCommand } from '../../src/commands/agent'
 import { createReviewCommand, runAgentReview } from '../../src/commands/agent/review'
 import { createRunCommand, runAgentTask } from '../../src/commands/agent/run'
 import { createAlignDesignSystemCommand } from '../../src/commands/align-design-system'
+import { createApiCraftCommand } from '../../src/commands/api-craft'
 import { createAuditProtectedCommand, runAuditProtected } from '../../src/commands/audit-protected'
 import { runBackfillSkillProvenance } from '../../src/commands/backfill-skill-provenance'
 import { createCheckArchCommand, runCheckArch } from '../../src/commands/check-arch'
@@ -47,6 +200,8 @@ import { runCheckSecurity } from '../../src/commands/check-security'
 import { createCheckVocabularyCommand, runCheckVocabulary } from '../../src/commands/check-vocabulary'
 import { createCleanupCommand, runCleanup } from '../../src/commands/cleanup'
 import { runCleanupAll, runCleanupSessions } from '../../src/commands/cleanup-sessions'
+import { createCliErgonomicsCraftCommand } from '../../src/commands/cli-ergonomics-craft'
+import { createCodeCraftCommand } from '../../src/commands/code-craft'
 import { runCompoundScanCandidatesCommand } from '../../src/commands/compound/scan-candidates'
 import from '../../src/commands/copy-craft.js'
 import { createCreateSkillCommand, generateSkillFiles } from '../../src/commands/create-skill'
@@ -54,6 +209,7 @@ import { createCrossCheckCommand } from '../../src/commands/cross-check'
 import { createDashboardCommand } from '../../src/commands/dashboard'
 import { createDesignPipelineCommand } from '../../src/commands/design-pipeline'
 import { createDistortionCommand } from '../../src/commands/distortion'
+import { createDocsCraftCommand } from '../../src/commands/docs-craft'
 import { checkBaselineFreshness, checkCatalogFreshness, checkHookValidity, checkLivePings, checkSessionCorruption, isCatalogStale, runDoctor } from '../../src/commands/doctor'
 import { createFixDriftCommand, runFixDrift } from '../../src/commands/fix-drift'
 import { createGenerateCommand } from '../../src/commands/generate'
@@ -86,6 +242,7 @@ import from '../../src/commands/integrations/dismiss'
 import from '../../src/commands/integrations/list'
 import from '../../src/commands/integrations/remove'
 import { SyncIO, runSyncIntegrations } from '../../src/commands/integrations/sync'
+import { createKnowledgeCraftCommand } from '../../src/commands/knowledge-craft'
 import { createGenerateCommand } from '../../src/commands/linter/generate'
 import { createMaintenanceCommand } from '../../src/commands/maintenance'
 import { MaintenanceRunDeps, aggregateReport, buildTaskRunner, createCheckRunner, createFixDispatcher, deriveExitCode, loadRunHistory, makeResolveBackend, parseConcurrency, renderTable, resolveHarnessSpawn, resolveSelection, runMaintenanceRun } from '../../src/commands/maintenance-run'
@@ -150,10 +307,14 @@ import { resolveConfig } from '../../src/config/loader'
 import { HarnessConfig } from '../../src/config/schema'
 import { CopyCraftInput, CopyCraftOutput } from '../../src/copy-craft/index.js'
 import { DesignPipelineContext, runDesignPipeline } from '../../src/design-pipeline/index.js'
+import { DocsCraftOutput, DocsFinding } from '../../src/docs-craft/findings/schema.js'
+import { DocsCraftInput, runDocsCraft } from '../../src/docs-craft/index.js'
 import { DriftFinding } from '../../src/drift/findings/finding.js'
 import { createProgram } from '../../src/index'
 import { readMcpConfig, writeMcpEntry, writeOpencodeMcpEntry } from '../../src/integrations/config'
 import { CATALOG_LAST_REVIEWED, INTEGRATION_REGISTRY } from '../../src/integrations/registry'
+import { KnowledgeCraftOutput, KnowledgeFinding } from '../../src/knowledge-craft/findings/schema.js'
+import { KnowledgeCraftInput, runKnowledgeCraft } from '../../src/knowledge-craft/index.js'
 import { getToolDefinitions } from '../../src/mcp/index'
 import { getToolDefinitions } from '../../src/mcp/server'
 import { NETWORK_TOOL_NAMES, deriveScope, deriveToolCapabilities, deriveToolCapability } from '../../src/mcp/tool-capabilities'
@@ -190,6 +351,7 @@ import { markSetupComplete } from '../../src/utils/first-run'
 import { CLI_VERSION } from '../../src/version'
 import { VocabularyRule, formatViolations, scanFiles, scanText } from '../../src/vocabulary/scanner'
 import { ConsoleCapture, captureConsole, runToExit, stubProcessExit } from './cli-command-harness'
+import { CraftCommandRun, DEFAULT_CWD, runCraftCommand } from './craft-command-harness-cohort-b'
 import { llmCalls, runCraftCommand } from './craft-command-harness.js'
 import { parseJsonStdout, runCommand } from './design-command-harness'
 import * as clack from '@clack/prompts'

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '84e0b5a46411af055b2112b616ab1cc1b7be02a514c6a8874af74f2ed2acabe5'
+sourceHash: '03f2dc5c714984d17b62572c5322ef5e8b5ec55639708d57f897bc4f5a46f013'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '03f2dc5c714984d17b62572c5322ef5e8b5ec55639708d57f897bc4f5a46f013'
+sourceHash: '7d0782baea155cb6f363e3581a318fa962d315074279ed39dbc7381bf42ac7b4'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/tests/commands/doctor.test.ts
+++ b/packages/cli/tests/commands/doctor.test.ts
@@ -84,7 +84,7 @@ describe('runDoctor', () => {
     Object.defineProperty(process, 'version', { value: originalVersion, writable: true });
   });
 
-  it('returns allPassed true when all checks pass', () => {
+  it('passes a fully configured project with no failing check', () => {
     mockAllHealthy('/tmp/project');
 
     const result = runDoctor('/tmp/project');

--- a/packages/cli/tests/commands/setup-mcp.test.ts
+++ b/packages/cli/tests/commands/setup-mcp.test.ts
@@ -18,16 +18,6 @@ vi.mock('@clack/prompts', () => ({
 }));
 
 describe('setup-mcp command', () => {
-  let tempDir: string;
-
-  beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-setup-mcp-'));
-  });
-
-  afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  });
-
   describe('createSetupMcpCommand', () => {
     it('registers the subcommand as "setup-mcp"', () => {
       const cmd = createSetupMcpCommand();
@@ -43,6 +33,16 @@ describe('setup-mcp command', () => {
   });
 
   describe('setupMcp', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-setup-mcp-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
     it('configures Claude Code MCP server', () => {
       const result = setupMcp(tempDir, 'claude');
       expect(result.configured).toContain('Claude Code');

--- a/packages/cli/tests/commands/setup-mcp.test.ts
+++ b/packages/cli/tests/commands/setup-mcp.test.ts
@@ -29,7 +29,7 @@ describe('setup-mcp command', () => {
   });
 
   describe('createSetupMcpCommand', () => {
-    it('creates command with correct name', () => {
+    it('registers the subcommand as "setup-mcp"', () => {
       const cmd = createSetupMcpCommand();
       expect(cmd.name()).toBe('setup-mcp');
     });


### PR DESCRIPTION
## What this is

A `craft-fleet` **test-craft elevation** over `packages/cli/tests/commands`, applied by the real `harness-refactoring` pipeline: one small change per commit, suite re-run green after each. Three cited findings, nothing else.

**No cited finding, no rewrite.** Every changed location below is one of the three cites.

## The three cited findings (verbatim)

All from runId `88d732fc-d220-4704-a081-e059aea1d889`.

### 1. `TEST-R001` — `packages/cli/tests/commands/setup-mcp.test.ts:32` — polish/small/high

> 'creates command with correct name' narrates the test's steps and leans on 'correct', one of the tells the rubric calls out — correct according to what? The contract is that the CLI routes this subcommand under a specific literal, so name it that way: `it('registers the subcommand as "setup-mcp"')`. The assertion already says it; the title should not be vaguer than the code beneath it.

Applied verbatim: `it('creates command with correct name')` → `it('registers the subcommand as "setup-mcp"')`.

### 2. `TEST-R004` — `packages/cli/tests/commands/setup-mcp.test.ts:32` — polish/small/high

> A fixture/arrange-scope finding on the same file: a temp-dir fixture is scoped more broadly than the tests that need it. Move it down into the describe block that actually uses it.

The `tempDir` mkdtemp/rm fixture sat on the outer `describe('setup-mcp command')`, so it ran for the `createSetupMcpCommand` and `--pick flag stub` blocks, neither of which reads `tempDir`. Moved into `describe('setupMcp')` — the only block that uses it.

### 3. `TEST-R001` — `packages/cli/tests/commands/doctor.test.ts:87` — polish/small/high

> Same class as finding 1: a test title that narrates steps / leans on a vague qualifier instead of naming the contract the assertion checks.

`it('returns allPassed true when all checks pass')` names the return field and restates its own condition — "all checks pass" is the thing being asserted, not the contract being checked. The assertions are that a fully-configured project reports `allPassed` **and** that no check is in `fail` status. Renamed to `it('passes a fully configured project with no failing check')`.

## Non-circularity: why elevating tests is safe here

Refactoring proves behavior preservation *with* the suite, so touching the suite is circular unless the change provably cannot alter what it checks. All three conditions verified explicitly:

### 1. Every assertion expression is byte-identical

**Confirmed.** The complete set of changed lines across both files (`git diff 056e1a79d`) is two `it(...)` titles plus the relocated fixture block. **Zero changed lines contain `expect(`** — verified mechanically:

```
$ git diff 056e1a79d -- packages/cli/tests/commands/{setup-mcp,doctor}.test.ts \
    | grep -E '^[+-]' | grep -v '^\(+++\|---\)' | grep -c 'expect('
0
```

No assertion was sharpened, weakened, added, or removed.

### 2. Passing-test count unchanged

| | Tests | Passed | Failed |
|---|---|---|---|
| **Before** (`056e1a79d`) | 60 | **60** | 0 |
| **After** | 60 | **60** | 0 |

Both files green before the first change and after every one of the three commits.

### 3. Passing test-ID set differs only by the two renames

Full sorted-ID diff of the vitest JSON report, before vs after — nothing else moved:

```
> runDoctor passes a fully configured project with no failing check
< runDoctor returns allPassed true when all checks pass
< setup-mcp command createSetupMcpCommand creates command with correct name
> setup-mcp command createSetupMcpCommand registers the subcommand as "setup-mcp"
```

A rename changes a test's ID by construction — that is the point of the change. Finding 2 (fixture scope) changes no ID at all.

**No test was split and no assertion was sharpened.** Both would be genuine improvements and both are `file`, not elevation.

## COUNT-FLAT gate

Measured at base `056e1a79d` and again on the branch tip:

| Gate | Before | After | |
|---|---|---|---|
| `harness validate` | 430 issues | **430 issues** | FLAT |
| `harness check-deps` | 1 issue | **1 issue** | FLAT |

Neither rose. The single pre-existing `check-deps` issue is an unrelated two-node cycle — `packages/core/src/solutions/scan-candidates/read-commits.ts` imports `normalizeSince` from `./git-scan`, and `git-scan.ts` imports `readRawCommits` back from `./read-commits`. Untouched here.

## Pipeline trail

Three commits, one per finding, each with its own green re-run:

- `3c98b1fe2` — finding 1, setup-mcp title
- `b5225e2e3` — finding 2, fixture scope
- `ff56d88a6` — finding 3, doctor title

## Assumptions made

- **Finding 1's replacement title was taken verbatim** from the finding, which spelled it out exactly. No independent wording choice was made there.
- **Finding 3's title is my wording** — the finding named the defect class and told me to name the contract, but did not dictate a string. I derived `'passes a fully configured project with no failing check'` from the two assertions actually in the test body (`result.allPassed` is true, and `result.checks.every(c => c.status !== 'fail')`), so the title covers both rather than only the first.
- **Finding 2's target block was inferred by use, not stated.** I read the file: `tempDir` is read only inside `describe('setupMcp')`, so that is where it moved. The two sibling blocks under the same outer describe (`createSetupMcpCommand`, `--pick flag stub`) never touch it. The later top-level `describe('--yes flag')` and `describe('--pick flag integration')` blocks already carry their **own** separate `tempDir` fixtures with different mkdtemp prefixes — those are untouched and were never in scope.
- **`_module.md` churn is not mine.** Each commit carries a regenerated `packages/cli/tests/commands/_module.md`; that is the repo's own fail-closed pre-commit comprehension driver rewriting a generated artifact for the touched directory, auto-staged by the hook. Not a hand edit.
- **Left alone deliberately:** every other test title in both files, including several in the same vague-qualifier family. They carry no cite in this run, and elevating them would be my taste rather than the critique's finding.


---

## Rebased onto new `main` — gate re-measured (supersedes the numbers above)

While this PR was open the human merged 44 commits into `main`, including craft-fleet's own
E1 (#1934) and E2 (#1935). This branch went `CONFLICTING`.

**Conflict cause:** confined to the generated comprehension shard
`.harness/comprehension/packages/cli/tests/commands/_module.md`. The only merged commit touching
that directory was #1909 (`24f9de659`), which *added* `bugfleet-publish-analyses-prefix-crosstalk.test.ts`
and modified neither of this PR's two test files. So this was regeneration residue, not a semantic
collision.

**Heal:** registered the repo's local-only `merge.comprehension.driver` (per `.gitattributes:40`)
and took a **merge**, not a rebase — merge commit `25ec0243c`. The driver auto-resolved the shard;
nothing was hand-edited and `--no-verify` was never used.

**Count-flat gate, re-measured against the NEW base `481a3a51e`** (the earlier 430/1 pair was taken
against the retired base `056e1a79d` and is stale):

| Gate | New base `481a3a51e` | This branch `25ec0243c` | Delta |
| --- | --- | --- | --- |
| `harness validate` | 430 issues | 430 issues | **0** |
| `harness check-deps` | 1 issue | 1 issue | **0** |

Both measured with the same built CLI so the only variable is repo content.

**Assertion byte-identity re-verified against the new base:**
`git diff origin/main..HEAD -- <both test files> | grep '^[+-]' | grep -c 'expect('` → **0**.
No assertion was added, removed, sharpened, or weakened by the elevation or by the merge.

The pre-existing `check-deps` issue is unchanged and untouched: a two-node cycle where
`packages/core/src/solutions/scan-candidates/read-commits.ts` imports `normalizeSince` from
`./git-scan`, and `git-scan.ts` imports `readRawCommits` from `./read-commits`.
