### PR TITLE
fix(orchestrator): treat a blank secret-backend setting as unconfigured (#1883)

### DIFF
--- a/.changeset/secret-backend-blank-config-1883.md
+++ b/.changeset/secret-backend-blank-config-1883.md
@@ -1,0 +1,31 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Treat a blank secret-backend setting as unconfigured instead of forwarding it (#1883)
+
+`createSecretBackend` supplied its three optional defaults with `??`, which falls
+back only on `null` / `undefined`. An empty string is not nullish, so a blank
+`opVault` was treated as a real vault name and built the 1Password reference
+`op:///API_KEY/password` — no vault segment at all. A blank `vaultAddr` spawned
+the Vault CLI with `VAULT_ADDR=''`, and a blank `vaultPath` ran
+`vault kv get -format=json ''`.
+
+Blank is what an unset environment variable interpolated into JSON, a templated
+config whose substitution never fired, or a key created to be filled in later all
+leave behind — every one of which means "I did not configure this", which is what
+an absent key already means. A `nonEmptyString` guard now normalises blank and
+whitespace-only to `undefined` before the `??`, so those two spellings of
+unconfigured finally agree and take the same documented default.
+
+Blank is treated as absent rather than rejected because this repo draws its line
+at required-vs-optional, not blank-vs-absent: `registry.ts` rejects a blank
+required `url` and, two lines later, silently drops a blank optional `token`;
+`serverless.ts` validates the required `image` while leaving every
+optional-with-default field on a plain `??`. All three fields here are optional
+with a documented default. The refusal of a falsy `backend` — the required
+discriminant — is unchanged.
+
+Values are matched blank-or-not but returned untrimmed, so a legitimate vault name
+containing spaces still reaches the CLI unaltered. Absent-key and real-value
+behaviour is unchanged, which the pre-existing assertions continue to pin.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '70cffe851e9e2a48e31cbd21fc0c95e13f9faea043d94c22ce6732040ad0f5e4'
+sourceHash: '46efb95827a5a73488f7e0d54428ffdf928ffe9de0cf0a29b6d8e8ccebebf183'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/config/_module.md
+++ b/.harness/comprehension/packages/cli/src/config/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/config'
-sourceHash: '3f3bf5ea1ee1dca8ee517bea76fab573543d5f72c707265b8d8d02da9a51418c'
+sourceHash: '177da5bb5f67e3d6e8471bc599b1f1df9cd472bd910a8cd4d24353c7e7d3bc35'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/skill/_module.md
+++ b/.harness/comprehension/packages/cli/src/skill/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/skill'
-sourceHash: '72b04c0ed5a159c340c21df0c9382ca5a0e754b920c64518d0b17cee4927f44e'
+sourceHash: 'e63311278f5e51441b6ee1551b9cef30dc585d95fdf9e092c989456c602c227a'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '7d0782baea155cb6f363e3581a318fa962d315074279ed39dbc7381bf42ac7b4'
+sourceHash: 'a28b3d12849962dce087e7b99766de47bf3fddd88c74a0705a9cac2453337630'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -19,6 +19,7 @@ members:
     'api-craft-command.test.ts',
     'audit-protected.test.ts',
     'backfill-skill-provenance.test.ts',
+    'bugfleet-publish-analyses-prefix-crosstalk.test.ts',
     'check-arch.test.ts',
     'check-deployment.test.ts',
     'check-deps.test.ts',

--- a/.harness/comprehension/packages/cli/tests/config/_module.md
+++ b/.harness/comprehension/packages/cli/tests/config/_module.md
@@ -1,13 +1,14 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/config'
-sourceHash: '428d8caee8f80e8fb784c6420c68044629a2efed80f113b1cd8efd0280ee7c8f'
+sourceHash: 'e79e35721abe0bdd68337c6373795efa7bc940b914362566eeaa3147ac97141b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
     'analysis-schema.test.ts',
+    'bugfleet-stripped-keys-prototype-key.test.ts',
     'constraint-packs-schema.test.ts',
     'deployment-schema.test.ts',
     'design-schema.test.ts',
@@ -41,6 +42,7 @@ members:
 import { AnalysisConfigSchema, DepsConfigSchema, loadAnalysisExclude, loadDepsExclude } from '../../src/config/analysis-schema'
 import { findConfigFile, loadConfig } from '../../src/config/loader'
 import { DeploymentGateConfigSchema, DepsConfigSchema, DesignConfigSchema, HarnessConfigSchema, I18nConfigSchema, I18nCoverageConfigSchema, I18nMcpConfigSchema, IntegrationsConfigSchema, KnowledgeConfigSchema, LocalModelsConfigSchema, LocalModelsHarnessFitConfigSchema, ModelTierConfigSchema, ReviewConfigSchema, RollbackConfigSchema, SkillHookEntrySchema, SkillHooksConfigSchema, TelemetryConfigSchema, TelemetryExportOTLPSchema, TrackerConfigSchema, loadDepsExclude } from '../../src/config/schema'
+import * as fs from 'fs'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'

--- a/.harness/comprehension/packages/cli/tests/skill/_module.md
+++ b/.harness/comprehension/packages/cli/tests/skill/_module.md
@@ -1,12 +1,14 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/skill'
-sourceHash: '4c8442759eec3764b258fbb92784a4f6bc7fe7dd80504bdf37aaeabebbd74914'
+sourceHash: '25b08e83d3a9c91db313f77df77ee1acd5bbbba339f0d07507683352e34f8ea5'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
+    'bugfleet-index-tier-overrides-cache.test.ts',
+    'bugfleet-skills-md-empty-reason-row.test.ts',
     'capabilities.test.ts',
     'complexity-extra.test.ts',
     'complexity.test.ts',
@@ -45,7 +47,7 @@ members:
 import { buildPreamble } from '../../src/commands/skill/preamble'
 import { isHarnessAuthoredSkill } from '../../src/commands/skill/validate'
 import { detectComplexity, evaluateSignals } from '../../src/skill/complexity'
-import { ContentSignals } from '../../src/skill/content-matcher-types.js'
+import { ContentMatchResult, ContentSignals } from '../../src/skill/content-matcher-types.js'
 import { classifyTier, computeDomainMatch, computeKeywordOverlap, computeStackMatch, computeTermOverlap, inferWhen, matchContent, scoreSkillByContent } from '../../src/skill/content-matcher.js'
 import { SIGNAL_CATEGORIES, buildDiffInfoFromGit, computeEstimatedImpact, computeParallelSafe, dispatchSkills, dispatchSkillsFromGit, enrichSnapshotForDispatch, getChangedFiles, getLatestCommitMessage, getSignalCategory, parseNewFilesOutput, parseNumstatOutput } from '../../src/skill/dispatch-engine'
 import { dispatchSkillsFromGit } from '../../src/skill/dispatch-engine.js'

--- a/.harness/comprehension/packages/core/src/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/src/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/roadmap'
-sourceHash: '930e672c0143b2d801fea85e2cfdc81ea65c6c53434a24ffb68128770258fff8'
+sourceHash: 'e6db9438e4859f7e415ddddd674f3374054c0157287211b6e724778e0a494b98'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -152,7 +152,7 @@ export syncToExternal
 import * as eventSourcing from '../state/event-sourcing'
 import { emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange } from '../waypoint/events'
 import { assigneeInvariantHolds, isMachineAssignee, setStatus } from './assignee-lifecycle'
-import { parseAssignmentHistory, serializeAssignmentHistory } from './assignment-history'
+import { ASSIGNMENT_HISTORY_HEADING, parseAssignmentHistory, serializeAssignmentHistory } from './assignment-history'
 import { deriveRepoFromGitRemote } from './derive-repo'
 import { GROUP_PREFIX, matchFeatureHeadings, serializeFeatureHeading } from './heading'
 import { decodeListField, encodeListField } from './list-field'

--- a/.harness/comprehension/packages/core/tests/roadmap/_module.md
+++ b/.harness/comprehension/packages/core/tests/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/roadmap'
-sourceHash: '3a094409cce9039ee51bc1a440a6c4c84c9b2b6f462f2ccf8901e9ee8b2c2df7'
+sourceHash: 'b65ce2a8fb4a9379afafaf73a4af998ff3fb09f862dba3c4257dcc4a134c5584'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -10,6 +10,8 @@ members:
     'assignee-lifecycle-waypoint.test.ts',
     'assignee-lifecycle.test.ts',
     'assignment-history-round-trip.test.ts',
+    'bugfleet-plan-path-suffix-crosstalk.test.ts',
+    'bugfleet-preservation-history-keys-leak.test.ts',
     'derive-repo.test.ts',
     'external-id-path-traversal.test.ts',
     'fixtures.ts',
@@ -115,5 +117,5 @@ import * as os, { tmpdir } from 'node:os'
 import * as path, { join } from 'node:path'
 import * as os from 'os'
 import * as path from 'path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 ```

--- a/.harness/comprehension/packages/orchestrator/src/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src'
-sourceHash: 'e0179462e82abd96ed26f369825bfee8f2607346cd4b162837fcaf7a676ea9cb'
+sourceHash: '0d48eb7dbef847d1ed8d05d5a9e954d67b36acee9294402f87f355a063b31f42'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/orchestrator/src/agent/secrets/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/agent/secrets/_module.md
@@ -1,27 +1,12 @@
 ---
 schemaVersion: 1
-module: "packages/orchestrator/src/agent/secrets"
-sourceHash: "6320b036433eeaa86747a4b0d85b211530ae96ed5f617e07d0c0eadb488b51b4"
-compiledAt: "2026-08-28T01:22:12.128Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["env.ts", "index.ts", "onepassword.ts", "vault.ts"]
+module: 'packages/orchestrator/src/agent/secrets'
+sourceHash: '32a2a2b22f417b1220f072801144610cf337f34f6f5d9ab4f2965686683299a3'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members: ['env.ts', 'index.ts', 'onepassword.ts', 'vault.ts']
 ---
-
-## Summary
-
-The `secrets` module provides a pluggable abstraction for resolving secret values at runtime. It offers three backend implementations—environment variables, 1Password CLI, and HashiCorp Vault CLI—all conforming to a common `SecretBackend` interface. A factory function `createSecretBackend` instantiates the appropriate backend based on config. Each backend can fetch a batch of secrets and report health status via `Result<T, SecretError>` types.
-
-## Invariants
-
-- Atomic batch resolution: if any requested secret is missing or inaccessible, the entire call fails with Err. Partial success is not possible.
-- CLI availability assumptions: OnePasswordBackend and VaultBackend spawn CLI processes (op and vault). If the CLI is absent or not authenticated, healthCheck() will fail and secret resolution will too.
-- Error categories are specific (secret_not_found, access_denied, or provider_unavailable). Correct categorization is load-bearing for upstream retry logic.
-- Factory exhaustiveness: the switch statement uses never to enforce that all config backends are handled. Adding a new backend type forces compilation failure until the factory is updated.
-- EnvSecretBackend fails-fast on first missing key, while VaultBackend fetches the entire path first, then validates all keys exist within it. This asymmetry matters for error messages and performance.
-- Secret key format varies by backend: Env uses raw env-var names; 1Password uses op://{vault}/{key}/password URIs; Vault uses bare key names within the configured path.
-- Result types are never thrown: errors wrap in Err(); only the factory's exhaustiveness check throws. Upstream code must handle Result destructuring, not try/catch.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/orchestrator/src/core/_module.md
+++ b/.harness/comprehension/packages/orchestrator/src/core/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/src/core'
-sourceHash: 'ddcb706d0bbdd81b5ccf8a778379c0a4eec77ad2ca746c0984a6bbc255d1ab5a'
+sourceHash: '90cc627dee71073751947c286bc9cfad1d7ea9866f8b19665c86e97d61dd75be'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/orchestrator/tests/agent/secrets/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/agent/secrets/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/tests/agent/secrets'
-sourceHash: '5b1788b2db6a83cb4f20e5b14cb9f11984cd53c41a8856f780c08f3a639a174c'
+sourceHash: '1099735264600e64235f9be4e3a389bca1e85b7f2754d48510f5bf81e2caaf27'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/orchestrator/tests/core/_module.md
+++ b/.harness/comprehension/packages/orchestrator/tests/core/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/orchestrator/tests/core'
-sourceHash: '5eb4620f8a999bc6168d66797ff3021932a5b261a7db86fcc3775aa7410c09fc'
+sourceHash: 'e7633c2a3253f046b9ceabe2830f9125e3ee798b79a34821d44d45843c8d9c47'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -12,6 +12,9 @@ members:
     'auto-publish.test.ts',
     'budget-governor.behavior.test.ts',
     'budget-governor.wired.test.ts',
+    'bugfleet-analysis-archive-list-swallows.test.ts',
+    'bugfleet-interaction-queue-list-swallows.test.ts',
+    'bugfleet-stop-rearms-poll-timer.test.ts',
     'candidate-selection.test.ts',
     'circuit-breaker.test.ts',
     'claim-manager.test.ts',

--- a/docs/changes/1883-secret-backend-empty-string-defaults/provenance.json
+++ b/docs/changes/1883-secret-backend-empty-string-defaults/provenance.json
@@ -1,0 +1,53 @@
+{
+  "item": "createSecretBackend treats a blank opVault/vaultAddr/vaultPath as configured",
+  "issues": [1883],
+  "issue": 1883,
+  "slug": "1883-secret-backend-empty-string-defaults",
+  "title": "Treat a blank secret-backend setting as unconfigured instead of forwarding it",
+  "branch": "fix/1883-secret-backend-empty-string-defaults",
+  "route": "bug",
+  "closingKeyword": "Closes #1883",
+  "closing_keyword": "Closes #1883",
+  "stages": ["debugging"],
+  "stagesRun": ["investigate", "analyze", "hypothesize", "fix"],
+  "base": "e530ae6bc67c003f11e4e32a606b7c929618a5f0",
+  "reproducingTest": "packages/orchestrator/tests/agent/secrets/index.test.ts",
+  "rootCause": "packages/orchestrator/src/agent/secrets/index.ts:15,18-19 supplied the three optional secret-backend defaults with `??`, which falls back only on null/undefined. An empty or whitespace-only string is not nullish, so it was treated as a supplied value and forwarded verbatim to the backend constructor, which interpolates it straight into a spawned CLI invocation with no validation of its own (onepassword.ts:26,34; vault.ts:28-29,35-37).",
+  "fix": "A module-local `nonEmptyString` guard normalises blank-or-whitespace-only to `undefined` before the `??`, so a blank value takes the same documented default an absent key already takes. Applied identically to all three fields. Mirrors the established `nonEmptyString` guard in packages/orchestrator/src/agent/backends/codex.ts:25-28.",
+  "observedBeforeFix": {
+    "opVault=''": "op:///API_KEY/password",
+    "opVault='   '": "op://   /API_KEY/password",
+    "vaultAddr=''": "VAULT_ADDR=''",
+    "vaultPath=''": "vault kv get -format=json ''"
+  },
+  "observedAfterFix": {
+    "opVault=''": "op://Private/API_KEY/password",
+    "opVault='   '": "op://Private/API_KEY/password",
+    "vaultAddr=''": "VAULT_ADDR='http://127.0.0.1:8200'",
+    "vaultPath=''": "vault kv get -format=json secret/data/harness"
+  },
+  "regressionTestEvidence": {
+    "withFixReverted": "6 failed | 14 passed (20) — exactly the 6 new blank/whitespace assertions fail",
+    "withFixApplied": "20 passed (20)"
+  },
+  "verification": {
+    "reproducingTests": "packages/orchestrator/tests/agent/secrets/index.test.ts — 7 tests added to the existing suite from #1875 (extended in place, not duplicated): blank + whitespace-only for each of opVault / vaultAddr / vaultPath, plus an over-trimming guard asserting a legitimate 'Shared Team' vault name still reaches the CLI unaltered",
+    "preExistingCoverage": "The absent-key and real-value cases for all three fields were already asserted by #1875 and are unchanged, which is what pins that this fix did not alter the documented defaults"
+  },
+  "assumptions": [
+    "A1 — FIX SHAPE (the fork the issue asked to be settled explicitly): blank is treated as ABSENT and falls back to the documented default, rather than being rejected loudly. Chosen because this repo already draws the line at required-vs-optional, not at blank-vs-absent: packages/core/src/roadmap/tracker/registry.ts:76-84 rejects a blank REQUIRED `url` and then at :85 silently drops a blank OPTIONAL `token`; packages/orchestrator/src/agent/backends/serverless.ts:344-352 validates the REQUIRED `image` while resolveOciConfig uses plain `??` for every optional-with-default field. All three fields here are optional WITH a documented default, which puts them on the treat-as-absent side of that line.",
+    "A2 — The in-file refusal of a falsy `backend` (tests/agent/secrets/index.test.ts:234-242) is NOT a counter-precedent. `backend` is the required discriminant with no default; refusing it is the required-and-blank branch of the same rule. It is left exactly as it was.",
+    "A3 — Rejecting loudly was also weighed on feasibility and found materially larger than this defect warrants. `SecretConfig` has no schema-validation layer at all: it is a plain interface (packages/types/src/container.ts:140-151) with no Zod companion, and `agent.secrets` is not among the sub-blocks validateWorkflowConfig parses (packages/orchestrator/src/workflow/config.ts:230-364). A loud rejection would need the first Zod schema in container.ts plus a new branch in workflow/config.ts, and would still not cover the direct-call path at orchestrator-backend-factory.ts:289.",
+    "A4 — Counter-argument considered and rejected: defaulting a blank opVault to 'Private' could read from the wrong vault when a template substitution silently fails. It loses because that exact risk is already accepted and test-pinned for the absent case, and making blank stricter than absent would be an odd asymmetry — `{}` fine but `{opVault: ''}` fatal. This change makes the two spellings of 'not configured' agree rather than introducing a new class of risk.",
+    "A5 — Values are matched blank-or-not but returned UNTRIMMED, so a legitimate vault name containing spaces ('Shared Team') is unaffected. Trimming every value would be a behaviour change beyond this defect; the bug is 'blank treated as supplied', not 'values are not trimmed'. This matches both the issue's own suggested `orDefault` and the codex.ts:25-28 precedent, and is pinned by a dedicated test.",
+    "A6 — The guard is module-local rather than shared. No exported blank-normalising helper exists anywhere in the repo; the established idiom is a small private guard, duplicated three times already (agent/backends/codex.ts:25-28, dashboard/src/server/routes/signoff.ts:54-57, core/src/waypoint/validate.ts:30-32). Extracting a shared helper was deliberately not folded into a low-severity bug fix.",
+    "A7 — Deferred, not fixed here: adding a SecretConfigSchema so a typo'd or malformed secrets block is rejected at config load (the rationale workflow/config.ts:261-263 already states for its other sub-blocks) remains open. It is a separate, larger change and is noted in the PR body rather than filed, since it is not required to resolve this defect.",
+    "A8 — Pre-existing and unrelated, left untouched: `harness check-deps` reports one circular dependency in packages/core/src/solutions/scan-candidates/, and `harness cleanup` reports 1628 documentation-drift entropy issues under docs/api/. Both are present on the base commit and neither is near the failure site."
+  ],
+  "notTouched": [
+    "packages/orchestrator/src/agent/secrets/onepassword.ts — the backend still trusts its constructor argument; the boundary fix is in the factory, the last place the operator's intent is still legible",
+    "packages/orchestrator/src/agent/secrets/vault.ts — same",
+    "packages/types/src/container.ts — SecretConfig shape unchanged; the type system cannot express non-blank and this fix does not need it to"
+  ],
+  "debugSession": ".harness/debug/resolved/1883-secret-backend-empty-string-defaults.md (gitignored via .harness/.gitignore:4 — local state, not committed)"
+}

--- a/packages/orchestrator/src/agent/secrets/index.ts
+++ b/packages/orchestrator/src/agent/secrets/index.ts
@@ -7,16 +7,34 @@ export { EnvSecretBackend } from './env';
 export { OnePasswordSecretBackend } from './onepassword';
 export { VaultSecretBackend } from './vault';
 
+/**
+ * The value only when it is a non-empty, non-blank string, else `undefined`.
+ *
+ * A blank value is what an unset environment variable interpolated into JSON, a
+ * templated config whose substitution never fired, or a key created to be filled
+ * in later all leave behind. Every one of those means "I did not configure this"
+ * — the same thing an absent key means. `??` alone cannot hear it, because `''`
+ * is not nullish, so a blank would be forwarded as though it were a real vault
+ * name or address.
+ *
+ * Mirrors the `nonEmptyString` guard in `../backends/codex.ts`.
+ */
+function nonEmptyString(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim() !== '' ? value : undefined;
+}
+
 export function createSecretBackend(config: SecretConfig): SecretBackend {
   switch (config.backend) {
     case 'env':
       return new EnvSecretBackend();
     case 'onepassword':
-      return new OnePasswordSecretBackend({ vault: config.opVault ?? 'Private' });
+      return new OnePasswordSecretBackend({
+        vault: nonEmptyString(config.opVault) ?? 'Private',
+      });
     case 'vault':
       return new VaultSecretBackend({
-        addr: config.vaultAddr ?? 'http://127.0.0.1:8200',
-        path: config.vaultPath ?? 'secret/data/harness',
+        addr: nonEmptyString(config.vaultAddr) ?? 'http://127.0.0.1:8200',
+        path: nonEmptyString(config.vaultPath) ?? 'secret/data/harness',
       });
     default: {
       const exhaustive: never = config.backend;

--- a/packages/orchestrator/tests/agent/secrets/index.test.ts
+++ b/packages/orchestrator/tests/agent/secrets/index.test.ts
@@ -148,6 +148,49 @@ describe('createSecretBackend — onepassword', () => {
 
     expect(spawnedCommands()[0]?.args).toEqual(['read', 'op://Private/API_KEY/password']);
   });
+
+  it('treats a blank vault name as unconfigured rather than forwarding "op://"', async () => {
+    // #1883. An empty string is not nullish, so `??` forwarded it and built
+    // `op:///API_KEY/password` — a reference with no vault segment at all. The
+    // assertion is on the reference rather than on some validation error
+    // because the reference is what the operator's secret actually resolves
+    // against; a malformed one fails later, naming the lookup instead of the
+    // config key that caused it.
+    const backend = createSecretBackend({ backend: 'onepassword', keys: ['API_KEY'], opVault: '' });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual(['read', 'op://Private/API_KEY/password']);
+  });
+
+  it('treats a whitespace-only vault name as unconfigured', async () => {
+    // Whitespace is the shape a partially-substituted template leaves behind,
+    // and it is worse than empty: `op://   /API_KEY/password` looks structurally
+    // well-formed, so nothing downstream reads it as missing.
+    const backend = createSecretBackend({
+      backend: 'onepassword',
+      keys: ['API_KEY'],
+      opVault: '   ',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual(['read', 'op://Private/API_KEY/password']);
+  });
+
+  it('still forwards a configured vault name that merely contains spaces', async () => {
+    // The blank check must not become a trim of every value: "Shared Team" is a
+    // legitimate 1Password vault name and must reach the CLI unaltered.
+    const backend = createSecretBackend({
+      backend: 'onepassword',
+      keys: ['API_KEY'],
+      opVault: 'Shared Team',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual(['read', 'op://Shared Team/API_KEY/password']);
+  });
 });
 
 describe('createSecretBackend — vault', () => {
@@ -205,6 +248,74 @@ describe('createSecretBackend — vault', () => {
       backend: 'vault',
       keys: ['API_KEY'],
       vaultAddr: 'https://vault.example.com',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual([
+      'kv',
+      'get',
+      '-format=json',
+      'secret/data/harness',
+    ]);
+  });
+
+  it('treats a blank address as unconfigured rather than spawning with VAULT_ADDR=""', async () => {
+    // #1883. `??` forwarded the empty string, so the Vault CLI was spawned with
+    // an empty VAULT_ADDR — which fails against whatever the CLI falls back to,
+    // reporting a connection problem rather than a configuration one.
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: '',
+      vaultPath: 'secret/data/myapp',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.env.VAULT_ADDR).toBe('http://127.0.0.1:8200');
+  });
+
+  it('treats a whitespace-only address as unconfigured', async () => {
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: '  ',
+      vaultPath: 'secret/data/myapp',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.env.VAULT_ADDR).toBe('http://127.0.0.1:8200');
+  });
+
+  it('treats a blank secret path as unconfigured rather than reading path ""', async () => {
+    // #1883. An empty path made the spawned argv `kv get -format=json ''`,
+    // which reads nothing and reports a missing secret rather than a missing
+    // configuration.
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: 'https://vault.example.com',
+      vaultPath: '',
+    });
+
+    await backend.resolveSecrets(['API_KEY']);
+
+    expect(spawnedCommands()[0]?.args).toEqual([
+      'kv',
+      'get',
+      '-format=json',
+      'secret/data/harness',
+    ]);
+  });
+
+  it('treats a whitespace-only secret path as unconfigured', async () => {
+    const backend = createSecretBackend({
+      backend: 'vault',
+      keys: ['API_KEY'],
+      vaultAddr: 'https://vault.example.com',
+      vaultPath: '   ',
     });
 
     await backend.resolveSecrets(['API_KEY']);


### PR DESCRIPTION
## What

`createSecretBackend` supplied its three optional defaults with `??`, which falls back only on `null` / `undefined`. An empty string is not nullish, so a blank value was treated as a supplied value and forwarded verbatim to the backend constructor — which interpolates it straight into a spawned CLI invocation with no validation of its own.

Observed at `origin/main` `e530ae6bc`, by inspecting the argv the selected backend actually spawns:

| Config | Spawned before | Spawned after |
| --- | --- | --- |
| `opVault: ''` | `op:///API_KEY/password` | `op://Private/API_KEY/password` |
| `opVault: '   '` | `op://   /API_KEY/password` | `op://Private/API_KEY/password` |
| `vaultAddr: ''` | `VAULT_ADDR=''` | `VAULT_ADDR='http://127.0.0.1:8200'` |
| `vaultPath: ''` | `vault kv get -format=json ''` | `... secret/data/harness` |

A `nonEmptyString` guard now normalises blank and whitespace-only to `undefined` before the `??`, so a blank value takes the same documented default an absent key already takes. Applied identically to all three fields. It mirrors the existing `nonEmptyString` guard in `packages/orchestrator/src/agent/backends/codex.ts:25-28` — the same idiom, one directory over.

## The fork the issue asked to be settled

The issue explicitly asked whether to **silently default a blank value** or **reject it as a config error**, and required the answer to be stated rather than defaulted to whichever is fewer lines.

**Chosen: treat blank as absent and fall back to the documented default.**

The deciding evidence is that this repo already draws its line at **required-vs-optional**, not blank-vs-absent:

- `packages/core/src/roadmap/tracker/registry.ts:76-84` rejects a blank **required** `url` loudly — and then at `:85` silently drops a blank **optional** `token`.
- `packages/orchestrator/src/agent/backends/serverless.ts:344-352` validates the **required** `image`, while `resolveOciConfig` leaves every **optional-with-default** field on a plain `??`.
- The consumption-boundary idiom for optional-with-default is `?.trim() || DEFAULT`: `packages/cli/src/commands/roadmap/install-hook.ts:152`, `packages/cli/src/mcp/utils/analysis-provider.ts:55,63`, `packages/orchestrator/src/orchestrator.ts:3399`.

All three fields here are optional **with a documented default**, which puts them on the treat-as-absent side of that line.

The in-file refusal of a falsy `backend` (`tests/agent/secrets/index.test.ts:234-242`) is **not** a counter-precedent — `backend` is the required discriminant with no default, so refusing it is the *required*-and-blank branch of the same rule. It is left exactly as it was.

Rejecting loudly was also weighed on feasibility and found materially larger than this defect warrants: `SecretConfig` has **no** validation layer at all. It is a plain interface (`packages/types/src/container.ts:140-151`) with no Zod companion, and `agent.secrets` is not among the sub-blocks `validateWorkflowConfig` parses (`packages/orchestrator/src/workflow/config.ts:230-364`). A loud rejection would need the first Zod schema in `container.ts` plus a new branch in `workflow/config.ts` — and would still not cover the direct-call path at `orchestrator-backend-factory.ts:289`.

## Assumptions made

- **A1 — Fix shape:** blank is treated as absent, not rejected. Rationale and citations above.
- **A2 —** The existing refusal of a falsy `backend` is the required-discriminant case and is unchanged.
- **A3 —** "Reject at config-schema validation time" was rejected on feasibility: no such layer exists for `SecretConfig` today.
- **A4 — Counter-argument considered and rejected:** defaulting a blank `opVault` to `Private` could read from the wrong vault if a template substitution silently fails. It loses because that exact risk is *already* accepted and test-pinned for the absent case, and making blank **stricter** than absent would be an odd asymmetry — `{}` fine but `{opVault: ''}` fatal. This change makes the two spellings of "not configured" agree rather than introducing a new class of risk.
- **A5 —** Values are matched blank-or-not but returned **untrimmed**, so a legitimate vault name containing spaces (`Shared Team`) still reaches the CLI unaltered. Trimming every value would be a behaviour change beyond this defect. Matches both the issue's own suggested `orDefault` and the `codex.ts` precedent; pinned by a dedicated test.
- **A6 —** The guard is module-local rather than shared. No exported blank-normalising helper exists anywhere in the repo; the established move is a small private guard, already duplicated in three places (`agent/backends/codex.ts:25-28`, `dashboard/src/server/routes/signoff.ts:54-57`, `core/src/waypoint/validate.ts:30-32`). Extracting a shared helper was deliberately not folded into a low-severity bug fix.
- **A7 — Deferred, not fixed here:** adding a `SecretConfigSchema` so a typo'd or malformed secrets block is rejected at config load — the rationale `workflow/config.ts:261-263` already states for its other sub-blocks — remains open. Separate and larger; noted rather than filed, since it is not required to resolve this defect.
- **A8 — Pre-existing and untouched:** `harness check-deps` reports one circular dependency in `packages/core/src/solutions/scan-candidates/`, and `harness cleanup` reports 1628 doc-drift entropy issues under `docs/api/`. Both present on the base commit; neither near the failure site.
- **A9 —** The `.harness/comprehension/**/_module.md` shard updates in this commit were produced by the repo's pre-commit comprehension driver, not hand-edited.

## Testing

Extends the existing suite from #1875 **in place** rather than duplicating it — that PR added coverage of this switch but did not fix the defect. The absent-key and real-value cases it already asserts are unchanged, which is what pins that this fix did not alter the documented defaults.

7 tests added: blank and whitespace-only for each of `opVault` / `vaultAddr` / `vaultPath`, plus an over-trimming guard asserting `Shared Team` still reaches the CLI unaltered.

Revert-and-fail protocol (mandatory, actually run):

- fix stashed → `6 failed | 14 passed (20)` — exactly the 6 new blank/whitespace assertions fail
- fix restored → `20 passed (20)`
- full orchestrator suite → `2921 passed | 1 skipped`

`tsc --noEmit` clean; all pre-commit and pre-push gates passed without `--no-verify`.

## Provenance

`docs/changes/1883-secret-backend-empty-string-defaults/provenance.json` — route `bug`, stage `debugging`. There is no `plans/` directory for a debugging run, which is expected.

Closes #1883
