### PR TITLE
docs(ideation): strategy-track ideation sweep (2026-09-06)

### DIFF
--- a/docs/ideation/extend-the-harness-reliably-to-2026-09-06.md
+++ b/docs/ideation/extend-the-harness-reliably-to-2026-09-06.md
@@ -1,0 +1,183 @@
+---
+topic: Extend the harness reliably to the two edges where non-engineers meet the pipeline — authoring intent upstream of the spec, and adjudicating outcomes after ship — through role-shaped front doors rather than the CLI.
+generated_at: '2026-09-06T16:45:36Z'
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Extend the harness reliably to the two edges where non-engineers meet the pipeline
+
+## Inputs
+
+- Topic: Extend the harness reliably to the two edges where non-engineers meet the pipeline — authoring intent upstream of the spec, and adjudicating outcomes after ship — through role-shaped front doors rather than the CLI.
+- Generated: 2026-09-06T16:45:36Z
+- Count requested: 10
+- Strategy grounding: enabled — `STRATEGY.md` present and valid (v2, `last_updated: 2026-07-01`); matching Tracks bullet **Full-lifecycle reach**.
+- Objection policy: **none** — every candidate's single strongest objection is recorded as a standing, accepted downside. No objection was rebutted. Rebuttals are the user's judgment to enter; none were supplied, and the agent never authors one.
+
+## Grounding notes — what already exists at the two edges
+
+The track's grounding sources are **stale**, and this materially changes what counts as additive. Verified against the worktree at `e530ae6bc`:
+
+| Claim in `STRATEGY.md` / `sdlc-coverage-and-agentic-trajectory.md` | Verified reality                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "gaps at the product-requirements middle"                          | **Shipped.** `agents/skills/claude-code/product-requirements/` exists; authors `docs/product-requirements/<item>/prd.md`.                                                                                                                        |
+| "UAT / sign-off ... `—` ... gap" (coverage table)                  | **Shipped.** `agents/skills/claude-code/uat-signoff/` exists; writes `docs/changes/<slug>/signoff.md` + one `execution_outcome` node via `uat_signoff` / `UatSignoffRecorder`.                                                                   |
+| Recommendation 3, "Role-shaped dashboard front doors (next)"       | **Substantially shipped.** `packages/dashboard/src/shared/roles.ts` defines `dev` / `pm-ba` / `client` lanes; `Signoff.tsx` + `routes/signoff.ts`, `Traceability.tsx` + `routes/traceability.ts`, and an `AuthorIntentForm` on the Roadmap page. |
+| product-advisor as "first wedge"                                   | Shipped; writes `docs/inception/<engagement>/brd.md`.                                                                                                                                                                                            |
+
+Three further facts that shaped generation, and that no document currently records:
+
+1. **Adoption at both edges is zero.** `docs/inception/` and `docs/product-requirements/` do not exist. `find docs/changes -name signoff.md` returns nothing across **404** change directories (357 of which carry a `proposal.md`). The edge skills are shipped and unused.
+2. **The shipped edge skills are undiscoverable from the dashboard.** `packages/dashboard/src/client/constants/skills.ts` registers 30 skills; `product-advisor`, `product-requirements`, and `uat-signoff` are **not among them** (`harness:strategy` is the only entry in that neighbourhood).
+3. **Traceability is spec-rooted, not intent-rooted.** `gather/traceability.ts` → `queryTraceability` runs requirement → code → tests, keyed on `specPath`. It has no BRD/PRD upstream edge and no sign-off downstream edge, so the `client` lane cannot answer "what happened to what I asked for."
+
+Consequently the prior artifact for this track (`full-lifecycle-reach-role-shap-2026-08-13.md`) has been overtaken: its candidates **1** (UAT checklist from acceptance criteria), **3** (product-requirements middle), **6** (client-intake lane) and **7** (UAT sign-off lane) are now shipped. None are re-proposed here. The generative frame for this run is therefore **not "build the edge skills" but "the edges are built, unwired, undiscoverable, and unused."**
+
+## Scoring method
+
+- `low | medium | high → 1 | 2 | 3`. `base_score = (impact × confidence) ÷ effort`, to 2 decimals. Range `[0.33, 9.00]`.
+- Candidates sorted by `base_score` descending; order is monotonically non-increasing in final score.
+- Strategy-alignment bonus (max **+0.75**): `+0.5` when the premise plausibly advances the **Full-lifecycle reach** Tracks bullet, `+0.25` when premise/persona references the **Target problem** or **Our approach** sections. The bonus is **applied** only within an adjacent-pair tie window of `|Δbase_score| ≤ 0.05`; outside it the bonus is recorded for transparency and does not reorder. Citations are verbatim where a bonus was earned.
+
+## Ranked candidates
+
+### 1. Register `product-advisor`, `product-requirements`, and `uat-signoff` in the dashboard skill registry and place them in the lanes that need them — score: 6.50
+
+- Premise: The three shipped edge skills are added to `SKILL_REGISTRY` in `packages/dashboard/src/client/constants/skills.ts` and surfaced in the `pm-ba` and `client` lanes, so the non-engineer front door names the skills that serve it.
+- Persona: A PM/BA sitting in the dashboard's `pm-ba` lane who has never been shown that a PRD interview exists.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score **6.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"reach those edges through role-shaped front doors (guided interviews, dashboard lanes) rather than the CLI"_. Bonus **applied** (tied with candidate 2 at base 6.00, |Δ| = 0.00 ≤ 0.05) — final score **6.50**
+- Key risk: A registry entry names a slash command but does not run it.
+- Strongest objection: This treats a discovery problem as the cause of zero adoption when the binding constraint may be capability. Every entry in `SKILL_REGISTRY` resolves to a `slashCommand`, which presupposes the viewer has an agent client attached; a genuinely non-technical PM/BA reading the `pm-ba` lane in a browser gains the knowledge that `/harness:product-requirements` exists and no way to invoke it. Most likely failure mode: the three entries ship, the lanes look more complete, and `docs/product-requirements/` is still empty three months later — with the added harm that the roadmap now records the edge as "wired" and the real blocker gets one more layer of paint over it. For this objection not to hold, the population actually sitting in the `pm-ba` lane would have to be operators who already have a CLI and simply did not know the skills existed — which would make the lane a presentation preference for engineers rather than the non-engineer front door the track describes.
+- Objection answered: no — standing, accepted downside.
+
+### 2. Instrument and report edge adoption, so "shipped" and "used" stop being the same word — score: 6.50
+
+- Premise: Counters for BRDs authored, PRDs authored, and sign-offs recorded (against changes eligible for each) are gathered and surfaced on the existing Adoption surface, making zero-usage at the two edges a visible number rather than something a human discovers by scanning the filesystem.
+- Persona: The tech lead or maintainer deciding where the next unit of leverage goes on the Full-lifecycle reach track.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score **6.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"completing the two human edges is what lets non-technical people drive real lifecycle work"_. Bonus **applied** (tied with candidate 1 at base 6.00, |Δ| = 0.00 ≤ 0.05) — final score **6.50**
+- Key risk: Measuring the gap does not close it.
+- Strongest objection: This is instrumentation, not capability — it buys a number, and the number is already known to be zero. The work competes for the same slot as things that would actually move that number, and the counter's most probable career is to sit at 0 / 0 / 0 on a panel nobody with the authority to act on it opens. Most likely failure mode: the metric ships, confirms what a five-minute `find` established, and the team's response is to distrust the metric ("that can't be right, we shipped those skills") rather than the adoption. For this objection not to hold, the value would have to lie in the ongoing signal rather than the current reading — that is, an edge-usage number that regresses silently later is a class of drift worth a permanent detector, which is a real argument but is not the argument for building it now.
+- Objection answered: no — standing, accepted downside.
+
+### 3. Derive a sign-off invitation queue that tells the right non-engineer a change is waiting on them — score: 5.25
+
+- Premise: A queue is derived from changes that shipped with a `proposal.md` and carry no `signoff.md`, and is surfaced in the `client` and `pm-ba` lanes as "awaiting your acceptance," turning the sign-off door from a page someone must think to visit into an inbox that arrives.
+- Persona: The product owner or engagement sponsor who holds acceptance authority and has never once been told a change was ready for it.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score **4.50**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"adjudicating outcomes (user acceptance, sign-off, production signals feeding back into the graph)"_; `+0.25` — **Our approach**: _"Humans own the thinking layer (specs, decisions, strategy); the harness mechanically polices everything below it."_ Bonus **applied** (tied with candidate 4 at base 4.50, |Δ| = 0.00 ≤ 0.05) — final score **5.25**
+- Key risk: The derivation instantly produces a backlog nobody will ever work.
+- Strongest objection: The eligibility rule that makes the queue cheap to build is the rule that makes it useless. "Has a proposal, lacks a sign-off" evaluates to true for something on the order of 357 historical changes in this repository alone, none of which any human will retroactively adjudicate — so the first render is a 350-row wall in which the two changes that genuinely need a decision this week are invisible. Most likely failure mode: the queue ships, is dismissed as noise on first open, and is never opened again, which is strictly worse than the current state because the sign-off door at least carries no false claim of a backlog. For this objection not to hold, there would need to be a durable notion of which changes are _in scope for acceptance at all_ — an engagement boundary, an opt-in marker, or a recency/milestone cutoff — and no such marker exists in `docs/changes/` today, so the real work is defining that boundary, not building the list.
+- Objection answered: no — standing, accepted downside.
+
+### 4. Route a non-accepted sign-off item back into work instead of terminating it in a file — score: 5.25
+
+- Premise: When `uat-signoff` records a `REJECT` or `CHANGES_REQUESTED` item, the disposition and its note are routed into the harness's existing intake (a roadmap row or tracked issue linked to the originating change) rather than coming to rest in `signoff.md` and one graph node.
+- Persona: The product owner whose rejection is currently a sentence in a Markdown file, and the tech lead who never receives it.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score **4.50**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"authoring intent ... and adjudicating outcomes"_; `+0.25` — **Our approach**: _"encoding architectural decisions, process discipline, and strategic intent as machine-checkable constraints."_ Bonus **applied** (tied with candidate 3 at base 4.50, |Δ| = 0.00 ≤ 0.05) — final score **5.25**
+- Key risk: Auto-created rework items from free-text notes are unactionable.
+- Strongest objection: A human's rejection note is a lead, not a requirement, and promoting it directly into a work item launders it into one. The skill's own worked example records `"CHANGES_REQUESTED — fires on transaction but misses refunds"` — a sentence that names a symptom, no acceptance criterion, no scope, no priority — and the harness's own `product-requirements` Iron Law holds that _"a criterion that cannot be judged is not a criterion."_ Most likely failure mode: the roadmap accumulates rows whose entire body is a one-line complaint, each of which a human must re-interview the signer to make executable, so the automation moves the interview rather than removing it, and the roadmap's signal-to-noise falls. For this objection not to hold, the routing would have to pass through a requirements-shaping step rather than around it — which makes this candidate a composition of sign-off with `product-requirements`, a materially larger piece of work than the premise as stated admits.
+- Objection answered: no — standing, accepted downside.
+
+### 5. A mechanical staleness check that fails when a lifecycle-coverage claim contradicts the installed skill set — score: 4.00
+
+- Premise: A check cross-references the `gap` / `partial` rows in `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md` and the "Current:" clause of each `STRATEGY.md` Tracks bullet against the skills actually present under `agents/skills/`, and fails on a contradiction — so an upstream grounding source cannot keep describing shipped work as a gap.
+- Persona: Every downstream skill that grounds in `STRATEGY.md` (`ideate`, `brainstorming`, `roadmap-pilot`) and inherits its errors, plus the tech lead reading the track.
+- Complexity: low
+- Impact / Confidence / Effort: M/M/L — base score **4.00**
+- Strategy alignment: `+0.5` — track **Upstream grounding**: _"make the strategic and knowledge substrate ... durable enough that downstream skills ground reliably instead of starting cold each invocation"_; `+0.25` — **Our approach**: _"encoding architectural decisions, process discipline, and strategic intent as machine-checkable constraints."_ Bonus **recorded but NOT applied** — nearest neighbours are 4.50 (|Δ| = 0.50) and 3.75 (|Δ| = 0.25), both outside the 0.05 tie window — final score **4.00**
+- Key risk: Name-matching a skill directory to a prose stage label is a shallow proxy for coverage.
+- Strongest objection: The check would trade a false negative for a false positive. Its only available evidence is that a directory named `uat-signoff` exists, so it would flip the UAT row from `gap` to covered — while this very run established that zero sign-offs have ever been recorded across 404 changes. The coverage table's own header states that status reflects **enforcement, not mere presence**, which is exactly the distinction a filesystem check cannot make; the check would therefore assert the one thing the document explicitly refuses to assert. Most likely failure mode: the table drifts to "solid" across the board, the track reads as complete, and the genuine gap — nothing routes a human to any of it — becomes harder to see than it was when the document was merely out of date. For this objection not to hold, the check would need a usage or enforcement oracle (artifacts written, gates wired, nodes recorded) rather than a directory listing, which is a substantially different and larger build.
+- Objection answered: no — standing, accepted downside.
+
+### 6. Turn the author-intent form from a roadmap-row append into a PRD-seeding intake — score: 3.75
+
+- Premise: `AuthorIntentForm` currently writes a title and description straight to a roadmap row via `POST /api/roadmap/append`; it instead captures the minimum PRD seed (user, need, rationale, one success statement), writes `docs/product-requirements/<item>/prd.md`, and links the row to it — so the browser intent door lands in the artifact `harness-brainstorming` consumes.
+- Persona: A PM/BA authoring intent in the `pm-ba` lane with no terminal, whose input currently evaporates into a two-field backlog row.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score **3.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"authoring intent (client requirements upstream of the spec)"_; `+0.25` — **Our approach**: _"Humans own the thinking layer."_ Bonus **applied** (tied with candidate 7 at base 3.00, |Δ| = 0.00 ≤ 0.05) — final score **3.75**
+- Key risk: A form-authored PRD skips the interview that makes a PRD worth having.
+- Strongest objection: The value of `product-requirements` is not the file it writes but the guided interview and the Iron Law it enforces — _"Every user story carries at least one measurable acceptance criterion, or it ships as an open, named gap — never a silent guess."_ A four-field web form cannot chase a vague success statement, cannot detect an unmeasurable criterion, and cannot surface a named gap; it can only accept what was typed. Most likely failure mode: a stub PRD lands at the canonical path, `harness-brainstorming` seeds the spec's Success Criteria from it, `acceptance-eval` judges those criteria, and an unmeasurable requirement propagates the full length of the chain wearing the file name of the artifact designed to prevent exactly that — a worse outcome than today's honest two-field roadmap row, which at least does not impersonate a PRD. For this objection not to hold, the form would have to be a front end onto the interview rather than a replacement for it, which is candidate 10's problem and carries candidate 10's cost.
+- Objection answered: no — standing, accepted downside.
+
+### 7. Make UAT sign-off a declarable, opt-in ship gate per change — score: 3.75
+
+- Premise: A change can declare that its ship path waits on a human `ACCEPTED` from `uat-signoff`, converting the deliberately advisory record into an enforcing gate for the changes that opt in, with the advisory default unchanged for everything else.
+- Persona: The solution architect on a client engagement where acceptance is contractual rather than informational.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score **3.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"post-ship enforcement"_; `+0.25` — **Our approach**: _"constraints-as-code outperforms prompts-and-conventions."_ Bonus **applied** (tied with candidate 6 at base 3.00, |Δ| = 0.00 ≤ 0.05) — final score **3.75**
+- Key risk: A human-blocking gate converts agent throughput into a queue in front of one person.
+- Strongest objection: This inverts the harness's central bet at the one place the bet is load-bearing. Every other blocking gate in the pipeline (`outcome-eval`, `acceptance-eval`, the architecture and entropy checks) blocks on a _machine-derived_ verdict precisely so that autonomy survives; a gate whose pass condition is one named human's attention makes the pipeline's throughput equal to that person's response latency, and agents produce changes far faster than a sponsor adjudicates them. Most likely failure mode: the Agent Autonomy and Holiday Confidence KPIs both fall while the gate behaves exactly as specified, and the team's remedy is to stop opting in — leaving the feature built, correct, and switched off. The `uat-signoff` skill states its non-gate status four separate times ("NOT a gate", "advisory", "blocks nothing", "it does not block a merge, a ship, or a pipeline step"), and the dashboard route repeats it; that is a decision already taken deliberately, so this candidate is a reversal and owes an ADR rather than an implementation. For this objection not to hold, the blocking population would have to be small, bounded, and contractually forced — which is plausible for client engagements and not plausible for internal work, meaning the gate's honest scope is much narrower than "per change."
+- Objection answered: no — standing, accepted downside.
+
+### 8. Extend traceability from spec-rooted to intent-rooted, so the client lane traces requested → shipped → accepted — score: 2.00
+
+- Premise: `queryTraceability` and the Traceability page gain a BRD/PRD upstream edge and a sign-off downstream edge, so the chain a stakeholder sees runs from the requirement they authored to the outcome they accepted rather than from a spec they never read to a test file.
+- Persona: The `client`-lane stakeholder or sponsor whose only question is "what happened to what I asked for."
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score **2.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"reach those edges through role-shaped front doors."_ Bonus **recorded but NOT applied** — nearest neighbours are 3.75 (|Δ| = 1.75) and 1.75 (|Δ| = 0.25), both outside the 0.05 tie window — final score **2.00**
+- Key risk: The new edges have nothing to connect.
+- Strongest objection: This builds a graph traversal across a graph whose endpoints do not exist. There are zero BRDs (`docs/inception/` absent), zero PRDs (`docs/product-requirements/` absent), and zero sign-offs (no `signoff.md` in 404 change directories) — so both the upstream and the downstream edge would be provably correct and universally empty, and the Traceability page would render every requirement as intent-orphaned and outcome-orphaned. Most likely failure mode: the feature is verified against synthetic fixtures, ships green, and on real data displays a column of dashes that reads to a client as "nothing was traced" rather than "nothing was authored" — actively damaging the credibility of the one surface built to establish it. For this objection not to hold, the artifacts at both ends would have to exist first, which makes every intent-authoring and sign-off-adoption candidate above a hard prerequisite rather than a parallel option; sequenced correctly this is valuable, and sequenced now it is a traversal over an empty set.
+- Objection answered: no — standing, accepted downside.
+
+### 9. Ingest post-ship production signals into the graph as outcome evidence — score: 1.75
+
+- Premise: Operational signals from a shipped change (error rate, incident linkage, rollback occurrence) are pulled back into the knowledge graph alongside the existing `execution_outcome` nodes, closing the one half of the outcome edge that neither `uat-signoff` nor the advisory `deployment` skill nor the propose-only `rollback` skill covers.
+- Persona: The tech lead from the **Who it's for** primary persona who owns what happens to a change after it merges, not just whether it merged.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score **1.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"production signals feeding back into the graph"_; `+0.25` — **Our approach**: _"durable grounding in a knowledge graph and STRATEGY.md."_ Bonus **applied** (tied with candidate 10 at base 1.00, |Δ| = 0.00 ≤ 0.05) — final score **1.75**
+- Key risk: Production signal sources are per-adopter and unstandardized.
+- Strongest objection: Every other input the harness consumes is in the repository — specs, code, tests, git history, the graph — which is exactly why the constraints-as-code thesis ports to any adopter unchanged. Production signals are the first input that lives outside it, in a different system per adopter (Datadog, Sentry, CloudWatch, Grafana, an internal bus), each with its own auth, schema, and rate limits. Most likely failure mode: the ingest ships with one connector, works for the repository that built it, and every subsequent adopter needs a connector the harness now has to own and version — converting a self-contained substrate into an integration surface and pulling directly against the **Multi-client portability** track's goal of keeping the harness usable "without forking the substrate." For this objection not to hold, the ingest would have to define a narrow, source-agnostic signal contract that adopters push into rather than a set of connectors the harness pulls from — a defensible design that the premise as stated does not commit to, and one whose adoption depends entirely on adopters bothering to wire it.
+- Objection answered: no — standing, accepted downside.
+
+### 10. A browser-native runner so the guided interviews execute in the dashboard rather than requiring an agent CLI — score: 1.50
+
+- Premise: The dashboard gains a runner that executes the guided-interview skills (`product-advisor`, `product-requirements`, `uat-signoff`) turn by turn in the browser against their real `SKILL.md` phases, removing the agent-client prerequisite from the two edges entirely.
+- Persona: The genuinely non-technical PM/BA or client sponsor who has a browser, no terminal, and no Claude Code installation.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score **1.00**
+- Strategy alignment: `+0.5` — track **Full-lifecycle reach**: _"reach those edges through role-shaped front doors (guided interviews, dashboard lanes) rather than the CLI."_ Bonus **applied** (tied with candidate 9 at base 1.00, |Δ| = 0.00 ≤ 0.05) — final score **1.50**
+- Key risk: It forks each skill into a second implementation that drifts from its `SKILL.md`.
+- Strongest objection: The dashboard has already done this once and the seam is visible. `routes/signoff.ts` re-implements `uat-signoff`'s RESOLVE and INTERVIEW phases as a Hono route with its own basis gatherer, its own soft-degrade, and its own Markdown renderer — a second copy of a contract whose canonical statement lives in `SKILL.md`, kept in sync by nothing but care. Generalizing that to three interview skills triples the surface with no mechanism holding the copies together, in a codebase whose own memory records dual-source-of-truth desync (hook profiles, the core barrel allowlist) as a recurring class of silent bug. Most likely failure mode: `SKILL.md` gains a phase or tightens an Iron Law, the browser path does not, and a non-engineer authors a PRD through a runner that quietly enforces last quarter's rules — with the divergence invisible because both paths write to the same canonical file path. For this objection not to hold, the skills' phase contracts would have to become a shared executable definition that both the agent path and the browser path consume, which is a substantially larger architectural commitment than "add a runner" and is the real prerequisite this candidate implies.
+- Objection answered: no — standing, accepted downside.
+
+## Ranking summary
+
+| Rank | #   | Candidate                                      | I/C/E | Base | Bonus | Applied   | Final    |
+| ---- | --- | ---------------------------------------------- | ----- | ---- | ----- | --------- | -------- |
+| 1    | 1   | Register edge skills in the dashboard registry | M/H/L | 6.00 | +0.50 | yes (tie) | **6.50** |
+| 2    | 2   | Instrument edge adoption                       | M/H/L | 6.00 | +0.50 | yes (tie) | **6.50** |
+| 3    | 3   | Sign-off invitation queue                      | H/H/M | 4.50 | +0.75 | yes (tie) | **5.25** |
+| 4    | 4   | Route non-accepted sign-off items into work    | H/H/M | 4.50 | +0.75 | yes (tie) | **5.25** |
+| 5    | 5   | Lifecycle-coverage staleness check             | M/M/L | 4.00 | +0.75 | no        | **4.00** |
+| 6    | 6   | Author-intent form → PRD-seeding intake        | H/M/M | 3.00 | +0.75 | yes (tie) | **3.75** |
+| 7    | 7   | Opt-in UAT ship gate                           | H/M/M | 3.00 | +0.75 | yes (tie) | **3.75** |
+| 8    | 8   | Intent-rooted traceability                     | H/M/H | 2.00 | +0.50 | no        | **2.00** |
+| 9    | 9   | Production-signal ingestion                    | H/L/H | 1.00 | +0.75 | yes (tie) | **1.75** |
+| 10   | 10  | Browser-native interview runner                | H/L/H | 1.00 | +0.50 | yes (tie) | **1.50** |
+
+Ties at ranks 1–2 and 3–4 were not broken by the alignment bonus (both members earned the same bonus); generation order is preserved, per the stable-sort rule. The bonus did break the 9–10 tie, where candidate 9 earned `+0.75` against candidate 10's `+0.50`.
+
+## Handoff
+
+```
+Ideation artifact written: docs/ideation/extend-the-harness-reliably-to-2026-09-06.md
+Top pick: Register product-advisor, product-requirements, and uat-signoff in the dashboard skill registry and place them in the lanes that need them — score 6.50
+Next: invoke /harness:brainstorming to take a candidate into a spec, OR /harness:roadmap to enqueue picks for later.
+```
+
+Two follow-ups fall outside this skill's contract and are recorded, not acted on: `STRATEGY.md`'s **Full-lifecycle reach** bullet and `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md` both describe shipped work as gaps (see Grounding notes). `harness-ideate` reads those sources and never writes them — repair is `/harness:strategy`'s job for the former and a docs change for the latter.

--- a/docs/ideation/invest-in-mechanisms-that-make-2026-09-06.md
+++ b/docs/ideation/invest-in-mechanisms-that-make-2026-09-06.md
@@ -1,0 +1,144 @@
+---
+topic: 'Invest in mechanisms that make agents and skills measurably improve over time rather than holding steady — the skill proposal loop, effectiveness baselines, trust scoring, and prompt injection from historical outcomes.'
+generated_at: 2026-09-06T16:39:16Z
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Invest in mechanisms that make agents and skills measurably improve over time rather than holding steady — the skill proposal loop, effectiveness baselines, trust scoring, and prompt injection from historical outcomes
+
+## Inputs
+
+- Topic: "Invest in mechanisms that make agents and skills measurably improve over time rather than holding steady — the skill proposal loop, effectiveness baselines, trust scoring, and prompt injection from historical outcomes."
+- Generated: 2026-09-06T16:39:16Z
+- Strategy grounding: enabled — `STRATEGY.md` present and valid (`read_strategy`); matching track **Compounding feedback loops** ("skill proposal loop, skill effectiveness baselines, trust scoring, prompt injection from historical outcomes")
+- Count: 10
+- Objection policy: **none** — every candidate's strongest objection stands as an accepted, unrebutted downside. No objection was answered.
+
+### Grounding note
+
+This track is densely covered: 156 roadmap rows are open, and a large share of the obvious measurement ideas are already tracked — bandit/explore-exploit allocation, item-response difficulty×ability modelling, Kalman signal fusion, a Goodhart sentinel, skill P&L, precedent, a rejection ledger, counterfactual shadow trials, federated gate-calibration baselines, known-answer drills, statistical audit sampling, number-needed-to-run, "let the harness run a controlled experiment on its own effect", spaced-repetition re-verification, auto-triggered retrospection with applyable proposals, and trajectory-to-eval harvesting from black-box records. Candidates below were checked against that open set and against `docs/ideation/compounding-feedback-loops-mec-2026-08-13.md`, and deliberately target gaps that sit _underneath_ those mechanisms rather than beside them.
+
+What the codebase actually shows:
+
+- **The scorers exist and are version-blind.** `packages/intelligence/src/effectiveness/skill-scorer.ts` and `scorer.ts` apply Laplace (α=1) smoothing over `SkillInvocationRecord`s and graph `execution_outcome` nodes. Counts are unweighted by time and carry no identity for the skill revision or model that produced them.
+- **The learning evidence is gitignored, per-checkout local state.** `.gitignore:60,62,66` excludes `**/.harness/proposals/`, `**/.harness/black-box/`, and `**/.harness/metrics/*` — with a single carve-out, `!**/.harness/metrics/holiday-confidence.jsonl`. The durable-ledger pattern therefore already works in this repo (`.harness/arch/timeline.json`, `.harness/signals/timeline.json`, `.harness/security/timeline.json`, `holiday-confidence.jsonl`), but it is applied to KPI _trends_ and not to the _learning corpus_.
+- **A committed learning store exists and has never been fed.** `.harness/specialization-profiles.json` is committed and contains `{"profiles": {}}`, stamped `2026-07-08` — two months stale.
+- **A push-injection channel exists and does not carry outcomes.** `packages/orchestrator/src/workflow/stage-prompt-template.ts:32` renders `## Pre-warmed comprehension`, resolved by `resolveLeafPrewarmSources` (`orchestrator.ts:141,1940`) and budgeted by `core/context-budget-governor.ts`. Historical learnings are reachable only _pull-only_, as MCP resource `harness://learnings` (`packages/cli/src/mcp/resources/learnings.ts`).
+- **Fleet verdicts are validated and then dropped.** `packages/types/src/fleet-handoff.ts` defines `FleetHandoffRecordSchema` / `validateFleetHandoffRecord`, and no source outside `packages/types` imports `FleetHandoffRecord`. There is no path from a fleet lane's verdict to an `execution_outcome` node (`packages/intelligence/src/outcome/connector.ts:47,61`).
+- **The post-mortem corpus is nearly empty.** `docs/solutions/` holds 4 markdown files.
+
+## Ranked candidates
+
+### 1. Stamp every outcome record with the content hash of the skill revision and model that produced it, and score per revision — score: 9.00
+
+- Premise: Add a `skillContentHash` + `modelId` field to `SkillInvocationRecord` and the `execution_outcome` node, and group `skill-scorer.ts` / `scorer.ts` counts by that hash so each skill revision is scored as its own population with an explicit changepoint at every hash boundary.
+- Persona: A tech lead who rewrote a skill's SKILL.md last month and cannot tell from any harness surface whether the rewrite helped, hurt, or did nothing.
+- Complexity: low
+- Key risk: Per-revision partitioning shrinks each population, so most revisions never reach a countable sample.
+- Impact / Confidence / Effort: H / H / L — base score 9.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach (makes "measurably improve" machine-checkable) = +0.75 — **not applied** (|Δbase| vs next candidate = 2.25 > 0.05; recorded for transparency only) — final score 9.00
+- Strongest objection: Partitioning the evidence by revision hash makes the sparsity problem strictly worse, and sparsity is already the binding constraint on every scorer in this track. Today a skill pools every record it has ever produced and still gets a Laplace-smoothed rate that swings on one or two runs; splitting that pool at every SKILL.md edit — including whitespace and platform-mirror syncs, which this repo does constantly, since `agents/skills/{cursor,codex,gemini-cli}/<skill>` are symlinks that change together — leaves most revisions with an n of one or two and no revision with enough evidence to compare against another. Most likely failure mode: the changepoint report becomes a wall of single-sample partitions, nobody can read an improvement out of it, and the team either ignores it or re-pools the partitions manually, which is where they started. For the objection not to hold, the hash would need to be computed over semantically load-bearing content only (so cosmetic and mirror-sync edits do not fork the population) _and_ the comparison would need a stated minimum-sample rule that refuses to render a verdict below it, which turns a low-effort field addition into a real statistical design problem.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 2. A learning-loop liveness check that fails loudly when an evidence store has stopped being fed — score: 6.75
+
+- Premise: Ship one check that reports, per compounding loop (proposals, adoption records, black-box, specialization profiles, outcome nodes), the timestamp of its most recent record, and treats a store with no writes in N days as a failing condition rather than as a zero.
+- Persona: A tech lead who reads a skill-effectiveness report of all zeros and cannot tell whether the skills are untouched or the telemetry has been dark for two months.
+- Complexity: low
+- Key risk: A liveness signal tells you a store is empty without telling you why, so it may just relocate the confusion.
+- Impact / Confidence / Effort: M / H / L — base score 6.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Target problem ("conventions without enforcement" — an unenforced loop reports zeros indistinguishably from a healthy one) = +0.75 — applied (|Δbase| vs adjacent candidate = 0.00 ≤ 0.05) — final score 6.75
+- Strongest objection: The evidence that the loops are dormant is already in hand and did not need a detector to find it — `.harness/specialization-profiles.json` has been an empty object since 2026-07-08, and the in-progress row "Activate the skill-proposal pipeline in dogfood" concluded that the proposal surfaces are dormant _by design_ (opt-in, gated on `HARNESS_SESSION_RETROSPECTION` and an analysis provider). A liveness check would therefore report, correctly and permanently, that intentionally-off loops are off. Most likely failure mode: the check goes red on day one for four of five loops, the team adds suppressions to get CI green, and the suppressions outlive the reason for them — the standard fate of an alarm that fires on a known, accepted condition. For the objection not to hold, the check would need to distinguish "configured on but not receiving records" (a real fault) from "deliberately off" (not a fault), which means every loop first needs a declared expected-state that does not exist today.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 3. Time-decay the evidence in every scorer with an explicit half-life and staleness expiry — score: 6.50
+
+- Premise: Replace the unweighted Laplace counts in `skill-scorer.ts` and `scorer.ts` with exponentially time-weighted counts plus a staleness horizon, so a score reflects the system as it is now rather than as it was across its whole history.
+- Persona: An individual developer running agents 10+ sessions/week whose skill scores are still dominated by runs made against a model and a skill text that no longer exist.
+- Complexity: low
+- Key risk: Decay discards the only evidence sparse skills have, trading staleness for noise.
+- Impact / Confidence / Effort: M / H / L — base score 6.00
+- Strategy alignment: +0.5 track:Compounding feedback loops — applied (|Δbase| vs adjacent candidate = 0.00 ≤ 0.05) — final score 6.50
+- Strongest objection: Decay and sparsity pull in opposite directions, and in this repo sparsity wins. A half-life short enough to drop pre-rewrite and pre-model-swap evidence is also short enough to leave a skill invoked twice a month with an effective sample size below one, at which point the smoothed score is the prior and nothing else — a decayed score that is really just α=1 dressed as a measurement is worse than an honestly stale one, because it looks current. Most likely failure mode: rarely-used skills oscillate between "no signal" and "one recent failure defines the skill", and the first time that mis-ranks a correct-but-infrequent skill the team stops trusting scores generally. For the objection not to hold, the half-life would need to be fitted to observed per-skill invocation rates rather than picked as a constant, and the surface would need to publish effective sample size next to every decayed score so a reader can see when the number is really the prior.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 4. Promote the learning corpus from gitignored local state to a committed append-only ledger — score: 3.75
+
+- Premise: Move the outcome/effectiveness evidence (adoption records, proposal records, outcome verdicts) out of the gitignored `**/.harness/{proposals,black-box,metrics}/` set and into a committed append-only ledger, following the pattern already proven by `.harness/metrics/holiday-confidence.jsonl` and the arch/security/signals timelines.
+- Persona: A tech lead whose team of six each accumulate a private, invisible evidence store, so nothing any of them learns is available to the other five or to CI.
+- Complexity: medium
+- Key risk: A committed, high-write ledger becomes a merge-conflict generator on every concurrent PR.
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Target problem ("each agent invocation starts cold") = +0.75 — applied (|Δbase| vs adjacent candidates = 0.00 ≤ 0.05) — final score 3.75
+- Strongest objection: This repo has already been burned by exactly this shape. `.harness/baselines.json` — a committed, machine-appended state file — produced a documented conflict treadmill severe enough to need its own tolerance work, and the comprehension `_module.md` shards produced a second one that needed a custom merge driver to end. An append-only evidence ledger written on every agent run, in a repo that routinely has a dozen fleet worktrees in flight, is a higher-write version of the same file shape and will re-open the same wound; and unlike a baseline, an outcome ledger has no natural "recompute from scratch" resolution, because the records _are_ the state. Most likely failure mode: the ledger goes DIRTY on every merge burst, someone registers a union merge driver, the driver is local-only config that new checkouts and CI never register, and the ledger silently diverges per machine — which is the durability problem it was introduced to solve. For the objection not to hold, the ledger would need per-writer sharding with no shared line (so concurrent writers never touch the same file) and an aggregate that is regenerated rather than committed.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 5. Prewarm the executor with prior failures on the paths it is about to touch, over the existing budget-governed channel — score: 3.75
+
+- Premise: Add an outcome-evidence source type to `resolveLeafPrewarmSources` so the `## Pre-warmed comprehension` block in `stage-prompt-template.ts` also carries the recorded _failures_ previously seen on the leaf's touched paths, subject to the same `context-budget-governor` accounting as comprehension units.
+- Persona: A tech lead watching agents re-make, on the same files, a mistake the harness already recorded and can only surface if the agent thinks to pull `harness://learnings`.
+- Complexity: medium
+- Key risk: Injected failure history is context spend with no proven behavioral effect.
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Target problem ("each agent invocation starts cold, re-litigates settled architectural decisions") = +0.75 — applied (|Δbase| = 0.00 ≤ 0.05) — final score 3.75
+- Strongest objection: The comprehension prewarm that this would ride has itself never been shown to change behavior — the existing evidence for it is a token-delta figure, and the behavioral A/B was explicitly deferred. Adding a second, noisier payload to an unvalidated channel compounds an unproven bet rather than testing it, and failure records are a worse payload than comprehension units: comprehension describes what the code _is_, which is stably useful, whereas a past failure on a path may have been caused by a bug that is now fixed, a model that is now replaced, or a spec that has since changed, so the injected text can actively mislead. Most likely failure mode: the prewarm block grows, the context budget governor starts tripping on leaves that previously fit, and the harness pays a measurable context cost for an unmeasured — possibly negative — behavioral effect. For the objection not to hold, the comprehension prewarm's own behavioral A/B would need to land first, and injected failures would need an expiry tied to whether the failure's cause is still live.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 6. Publish a track-level improvement-rate KPI that answers "is this actually compounding?" — score: 3.75
+
+- Premise: Add a seventh KPI to `STRATEGY.md` that measures the _rate of change_ of first-pass success per unit of human intervention over a rolling window, so the compounding track has a number that would go flat if the loops stopped working.
+- Persona: A senior engineer asked to justify continued investment in feedback-loop machinery who can point to six KPIs, none of which measures improvement over time.
+- Complexity: medium
+- Key risk: A self-reported improvement metric is the most Goodhart-exposed number the project would own.
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach ("constraints-as-code … compounds — each constraint added now removes a class of future drift") = +0.75 — applied (|Δbase| = 0.00 ≤ 0.05) — final score 3.75
+- Strongest objection: The five existing input KPIs plus Holiday Confidence already measure state, and the honest reason none of them measures improvement rate is that a derivative of a noisy, low-volume, self-collected series is mostly noise — a 30-day window over this repo's merged-PR volume produces a slope whose confidence interval comfortably spans zero, so the number will be reportable long before it is meaningful. Worse, it is a metric the project both owns and optimizes, published as evidence for the project's own central wager, which is the textbook setup the tracked "Goodhart sentinel" row exists to police; a KPI that needs a sentinel to be trustworthy is a liability shipped ahead of its guard. Most likely failure mode: the slope reads positive during a quarter of heavy investment, gets cited as proof the thesis works, and then goes flat or negative for reasons (model changes, task-mix changes) that have nothing to do with the harness — and the number gets quietly redefined rather than believed. For the objection not to hold, the metric would need a denominator that controls for task mix and model version, and it would need to be published with its confidence interval rather than as a point estimate.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 7. Turn fleet handoff verdicts into durable outcome evidence — score: 3.50
+
+- Premise: Persist each lane's validated `FleetHandoffRecord` as an `execution_outcome` node via `packages/intelligence/src/outcome/connector.ts`, so that fleet execution — now the dominant way work gets done in this repo — contributes to effectiveness and trust scoring instead of being validated and dropped.
+- Persona: A tech lead running multi-lane fleets daily whose highest-volume source of agent work feeds exactly zero records into the machinery meant to learn from agent work.
+- Complexity: medium
+- Key risk: A lane's self-reported status is the worker's own claim, and scoring it rewards optimistic self-reporting.
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:Compounding feedback loops — applied (|Δbase| vs adjacent candidate = 0.00 ≤ 0.05) — final score 3.50
+- Strongest objection: The `status` field in a handoff record is the lane's assessment of its own work, and the fleet orchestrators exist precisely because that assessment is not trusted — every fleet member in the family independently re-derives its verdict from the lane's emitted artifacts rather than from the lane's self-report. Ingesting `status` as outcome evidence imports exactly the signal the surrounding architecture was built to distrust, and it does so into the scorers that feed skill ranking and trust, so a lane that overstates success would raise the measured effectiveness of the skill that let it overstate. Most likely failure mode: `done` counts accumulate faster than real successes, effectiveness scores drift upward across the board, and the drift is invisible because the same inflated records are the only evidence available to detect it. For the objection not to hold, the persisted outcome would need to be the _orchestrator's_ independently re-derived verdict rather than the lane's `status`, which means the ingestion point is in the verify stage and not in the handoff record at all.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 8. Bootstrap the evidence loops on adopter installs so the thesis compounds off-repo — score: 2.75
+
+- Premise: Make an adopter's first `harness init` create and begin feeding the evidence stores the compounding loops read from, so the mechanisms produce a real score on someone else's codebase rather than only inside the dogfood repo.
+- Persona: A tech lead at a team 3–6 months into agent adoption who installs harness, runs it for a month, and gets effectiveness surfaces that report nothing because no store was ever created.
+- Complexity: high
+- Key risk: Turning on evidence collection by default in someone else's repo is a privacy and consent decision, not a wiring decision.
+- Impact / Confidence / Effort: M / M / M — base score 2.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Our approach ("the wager: constraints-as-code outperforms prompts-and-conventions **at every scale**") = +0.75 — applied (|Δbase| = 0.00 ≤ 0.05) — final score 2.75
+- Strongest objection: The records these loops need — which skills ran, on which files, with what outcome, and the prompts and diffs behind them — are a detailed behavioral log of an adopter's proprietary codebase and their engineers' working patterns, and creating that by default at install time is the kind of decision that gets a tool banned from an enterprise rather than adopted by one. The project already respects `DO_NOT_TRACK` for anonymous telemetry, which signals that the consent bar here is understood to be high; a local-but-on-by-default forensic store is a materially larger collection than the anonymous counts that bar was set for. Most likely failure mode: it ships on-by-default, one security review at one prospective adopter reads what is in `.harness/black-box/`, and the finding propagates — costing more adoption than the feature was meant to win. For the objection not to hold, the bootstrap would need to be opt-in with a plain-language disclosure of exactly what is recorded, which reintroduces the dormancy problem this candidate exists to solve.
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 9. Record the rendered leaf prompt alongside its outcome, as a replayable corpus — score: 2.75
+
+- Premise: Persist the exact rendered prompt each leaf received — the thing the black-box forensic record explicitly does not store today — keyed to its outcome, so effectiveness can be attributed to prompt content and prior runs can be re-scored offline against a changed skill or model.
+- Persona: A senior engineer trying to work out why a skill's success rate moved, who has the verdict and the diff but not the one artifact that actually varied between runs.
+- Complexity: high
+- Key risk: A prompt corpus is a large, secret-bearing store whose cost is paid on every run and whose value is paid out only later.
+- Impact / Confidence / Effort: H / M / H — base score 2.00
+- Strategy alignment: +0.5 track:Compounding feedback loops, +0.25 Target problem ("each agent invocation starts cold") = +0.75 — applied (|Δbase| = 0.00 ≤ 0.05) — final score 2.75
+- Strongest objection: Rendered leaf prompts contain whatever the context assembly pulled in — source, config, environment values, and any secret that happened to sit in a file the prewarm resolved — so the corpus is a secret-bearing artifact by construction, and it grows at the full context size of every run rather than at the size of a verdict. The project's own security tooling already flags patterns inside comments, which means a prompt store will trip scanners constantly and generate exactly the false-positive stream that erodes attention to real findings. Most likely failure mode: storage and scan noise make the corpus expensive from week one, retention gets capped to a short window to control both, and the short window destroys the longitudinal comparison that was the entire justification for collecting it. For the objection not to hold, prompts would need to be stored as content-addressed references to already-committed units plus a small delta — not as full text — which is a substantially harder design than "record the prompt".
+- Objection answered: no (accepted downside per objection policy: none)
+
+### 10. Give the skill-proposal loop a fitness signal on its own output — score: 2.50
+
+- Premise: Track, for every proposal that clears the gate and is promoted into a real skill, whether the promoted skill subsequently outperforms the baseline it was meant to improve on — so the proposal loop is measured on the value of what it promotes, not on how many proposals it emits.
+- Persona: A tech lead approving skill proposals with no way to know whether their last ten approvals produced anything that got used or worked.
+- Complexity: medium
+- Key risk: Promotions are too rare to ever accumulate a countable population.
+- Impact / Confidence / Effort: M / M / M — base score 2.00
+- Strategy alignment: +0.5 track:Compounding feedback loops — applied (|Δbase| = 0.00 ≤ 0.05) — final score 2.50
+- Strongest objection: The loop this would measure has not run yet — `.harness/proposals/` is empty in the dogfood repo and both emission surfaces are dormant by design — so a fitness signal on promotions would be built over a population of zero and stay at zero until the upstream activation work lands, at which point promotions will still arrive at a rate of a handful per quarter. A measurement whose sample accrues that slowly cannot detect a regression within any window in which someone could act on it, and the intervening variable is brutal: a promoted skill that goes unused scores identically to one that is used and fails. Most likely failure mode: the surface is built, reports "insufficient data" for two quarters, and is quietly dropped before it ever renders a verdict — having consumed the effort that could have gone to activating the loop it was measuring. For the objection not to hold, the proposal pipeline would need to be genuinely live and producing promotions at volume first, which makes this a follow-on to that activation rather than a candidate that stands on its own.
+- Objection answered: no (accepted downside per objection policy: none)

--- a/docs/ideation/keep-one-harness-substrate-fai-2026-09-06.md
+++ b/docs/ideation/keep-one-harness-substrate-fai-2026-09-06.md
@@ -1,0 +1,118 @@
+---
+topic: Keep one harness substrate faithfully usable across Claude Code, Cursor, Codex, Gemini CLI, and OpenCode without forking it — cross-client fidelity of skills, agents, hooks, and backend routing, plus the gateway for external bridges.
+generated_at: 2026-09-06T16:32:48Z
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Keep one harness substrate faithfully usable across Claude Code, Cursor, Codex, Gemini CLI, and OpenCode without forking it — cross-client fidelity of skills, agents, hooks, and backend routing, plus the gateway for external bridges.
+
+## Inputs
+
+- Topic: Keep one harness substrate faithfully usable across Claude Code, Cursor, Codex, Gemini CLI, and OpenCode without forking it — cross-client fidelity of skills, agents, hooks, and backend routing, plus the gateway for external bridges.
+- Generated: 2026-09-06T16:32:48Z
+- Strategy grounding: enabled — `STRATEGY.md` present and valid; track **Multi-client portability** ("keep the harness usable across Claude Code, Cursor, Codex, Gemini CLI, and OpenCode without forking the substrate")
+- Objection policy for this run: **none answered**. Every strongest objection below stands unrebutted and is recorded as an accepted downside.
+- Scope boundary: this artifact covers cross-client substrate fidelity only. Off-repo distribution, adopter first-run value, marketplace publishing, courseware, and adoption telemetry are out of scope here.
+
+## Ranked candidates
+
+### 1. A build gate fails when any client's generated surface (skill mirrors, command files, plugin manifests) is stale against the claude-code source of truth — score: 6.00
+
+- Persona: Harness contributor editing a single `SKILL.md` who cannot tell, from the diff, which of six client surfaces silently went stale.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 Our approach (drift caught mechanically rather than by convention) = +0.75 recorded, **not applied** (|Δ| to the next candidate is 1.50 > 0.05) — final score 6.00
+- Strongest objection: The gate enforces freshness, not fidelity. A regenerated Codex command file, a re-emitted Gemini `.toml`, and a refreshed Cursor rule can all be byte-current against the claude-code source and still be unusable in their client — wrong tool names, an unsupported frontmatter key, a command shape that client never dispatches. The most likely failure mode is a green gate that manufactures false confidence: the team stops manually spot-checking the other clients precisely because CI says the mirrors are fresh, and a real portability regression rides in behind a passing check. For this objection not to hold, "generated surface" would have to be defined narrowly enough that freshness genuinely implies usability — which is only true for surfaces that are pure copies, and stops being true the moment a client needs a real transform.
+- Objection answered: no — stands as an accepted downside.
+
+### 2. A machine-readable client capability manifest declares, per client, which harness surfaces (skills, agents, commands, hooks, MCP transport, subagent spawn, interaction channel) are actually executable — score: 4.50
+
+- Persona: Tech lead 3–6 months into agent adoption whose team runs two or more clients against one repo and cannot answer "does this skill actually work in Cursor?" without trying it.
+- Complexity: medium
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 Our approach (encodes a portability decision as a machine-checkable constraint rather than a conventions doc) = +0.75 recorded, **not applied** (|Δ| to adjacent candidates is 1.50 > 0.05) — final score 4.50
+- Strongest objection: A manifest that nothing enforces is documentation, and documentation about capability drifts faster than the capability does — clients ship new primitives on their own release cadence, so the manifest is wrong the week after any of five vendors ships. The most likely failure mode is a manifest that is authored once, consulted by one generator, and then quietly diverges from reality; downstream code trusts a stale row and degrades a skill that the client can now actually run, or runs one it cannot. For this objection not to hold, the manifest would have to be derived from something executable — a probe against each client, or a conformance run — rather than hand-maintained, which makes it a consequence of candidate #9 rather than a standalone artifact.
+- Objection answered: no — stands as an accepted downside.
+
+### 3. A declared per-client interaction channel for human gates, so a confirmation prompt renders in that client's real surface or fails loudly rather than vanishing — score: 3.75
+
+- Persona: Tech lead who relies on a skill's human gate to hold, and for whom a gate that silently no-ops is worse than no gate.
+- Complexity: medium
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 Our approach ("humans own the thinking layer" — a gate is where that ownership is exercised) = +0.75, **applied** (base tied at 3.00 with adjacent candidates, |Δ| = 0.00 ≤ 0.05) — final score 3.75
+- Strongest objection: Some clients have no interactive channel at all, and in headless or CI invocation none of them do. Making the channel explicit therefore does not produce portability — it produces an honest refusal to run, which is a different and much less valuable outcome than the framing suggests. The most likely failure mode is that the abstraction is built, the truthful answer for three of six clients is "no channel", and every gated skill becomes unavailable there; the pressure then goes straight back onto auto-answering the gate, which is the exact silent failure this was meant to remove, only now with a config key blessing it. For this objection not to hold, gated skills would need a genuine non-interactive mode that is safe by construction — a design question upstream of the channel abstraction and untouched by it.
+- Objection answered: no — stands as an accepted downside.
+
+### 4. Every client's session instruction file (AGENTS.md, GEMINI.md, `.cursor/rules`, Codex config) is generated from one source so grounding and pre-warmed comprehension do not diverge by client — score: 3.75
+
+- Persona: Tech lead watching agents re-litigate settled architectural decisions in one client while honoring them in another, with no visible reason why.
+- Complexity: medium
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 Target problem (agents starting cold and re-litigating settled decisions is the stated problem) = +0.75, **applied** (base tied at 3.00, |Δ| = 0.00 ≤ 0.05) — final score 3.75
+- Strongest objection: Clients differ in instruction-file size budget, precedence order, and how aggressively they attend to the file, so one source cannot be byte-identical everywhere and must fan out through per-client transforms — at which point the divergence has moved into the transforms rather than been eliminated. The most likely failure mode is that the largest client's file (already six figures of bytes here) is truncated or ignored by a smaller-budget client, producing exactly the silent per-client grounding gap the idea claims to close, now harder to see because a generator asserts they came from one source. For this objection not to hold, either the shared core would have to be small enough to fit every client's real budget — which discards most of the grounding — or each client's attention behavior would have to be measurable, which it currently is not.
+- Objection answered: no — stands as an accepted downside.
+
+### 5. OpenCode is promoted from npm-install-only to a generated first-class target with its own skill mirror and plugin manifest emitted by the same generator as the other clients — score: 3.50
+
+- Persona: OpenCode-native developer who today gets the CLI but none of the per-client skill, command, or hook surface the other four clients receive.
+- Complexity: medium
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:Multi-client portability (OpenCode is named in the track); no Target-problem/Our-approach persona match (`Who it's for` names Claude Code, Cursor, Gemini CLI, and Codex, but not OpenCode) = +0.5, **applied** (base tied at 3.00, |Δ| = 0.00 ≤ 0.05) — final score 3.50
+- Strongest objection: OpenCode is the smallest client in the set and the one whose users are least represented in the stated primary persona, so full parity work buys the fewest additional users per unit of maintenance added — and every generated target is a permanent tax on all future skill changes, not a one-time build. The most likely failure mode is that the target is generated, lightly exercised, and becomes the mirror that is quietly broken for months because nobody on the team runs OpenCode daily, which degrades the credibility of "works across five clients" more than the current honest npm-only story does. For this objection not to hold, OpenCode usage would have to be materially larger than its current standing in the persona definition implies, or the marginal cost of an additional generated target would have to be genuinely near zero.
+- Objection answered: no — stands as an accepted downside.
+
+### 6. A client-neutral hook spec compiled into each client's native hook mechanism, with a git-hook or file-watcher fallback where the client has none — score: 2.75
+
+- Persona: Tech lead whose team works in Codex or Gemini CLI and therefore receives none of the real-time constraint enforcement that is the harness's central claim.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 Our approach (hooks are the mechanism by which constraints fire in real time so agents self-correct mid-stream) = +0.75, **applied** (base tied at 2.00 with adjacent candidates, |Δ| = 0.00 ≤ 0.05) — final score 2.75
+- Strongest objection: A fallback hook fires at a categorically different moment than a native one — a native pre-tool hook can stop an agent mid-stream, while a git hook or watcher fires after the edit is already written and often after the agent has moved on. Shipping both under one name means "enforced" denotes five materially different guarantees, and the weakest of them is post-hoc cleanup, which is precisely the cleanup tax the strategy exists to remove. The most likely failure mode is a portability claim that is technically true and operationally hollow: users on fallback clients believe constraints are firing, discover the drift downstream anyway, and conclude the constraint system does not work. For this objection not to hold, the fallback would need to be able to interrupt the agent loop rather than observe it — which depends on client primitives that do not exist today.
+- Objection answered: no — stands as an accepted downside.
+
+### 7. Client identity becomes a first-class dimension in backend routing, so a session routes to a model the running client can actually reach — score: 2.50
+
+- Persona: Engineer running harness inside Gemini CLI or Codex against a non-Anthropic model, where routing decisions made for a Claude-shaped session do not apply.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.5 track:Multi-client portability (per-client backend routing is named in the track); no Target-problem/Our-approach match = +0.5, **applied** (base tied at 2.00, |Δ| = 0.00 ≤ 0.05) — final score 2.50
+- Strongest objection: Per-client model availability is external data owned by five vendors on five release cadences, and it goes stale faster than anything in this repo — a routing table that encodes it becomes a standing maintenance obligation with a hard freshness requirement and no internal source of truth. The most likely failure mode is that routing confidently sends a session to a model the client dropped, deprecated, or renamed, producing a failure that looks like a harness bug and is diagnosed slowly because the routing decision is several layers from the error. For this objection not to hold, availability would need to be discovered at runtime from the client itself rather than declared, which is a different and larger piece of work than adding a routing dimension.
+- Objection answered: no — stands as an accepted downside.
+
+### 8. The gateway is promoted from webhook and telemetry fan-out to the canonical client-neutral execution bridge — run a skill, stream stage events, return artifacts over HTTP — for clients with no plugin path — score: 2.50
+
+- Persona: Platform engineer bridging an unsupported client, IDE, or internal tool into the harness without waiting for a native plugin target.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:Multi-client portability ("gateway API for external bridges" is named in the track); no Target-problem/Our-approach match = +0.5, **applied** (base tied at 2.00, |Δ| = 0.00 ≤ 0.05) — final score 2.50
+- Strongest objection: Putting a network boundary in the middle of the substrate creates a second product with its own auth model, API versioning contract, latency budget, failure semantics, and backward-compatibility obligations — and unlike the in-process path, every one of those must be right for the bridge to be trustworthy. The most likely failure mode is that the bridge works for a demo client and then accretes a long tail of per-consumer compatibility shims, reproducing the fork the track exists to prevent, only now across an HTTP contract that external consumers depend on and that therefore cannot be changed freely. For this objection not to hold, the set of bridged clients would have to stay small and the API surface genuinely narrow — an assumption that the word "canonical" in the premise directly contradicts.
+- Objection answered: no — stands as an accepted downside.
+
+### 9. A cross-client conformance suite drives a representative skill through each client's real entrypoint in CI and asserts the same artifact and the same verdict — score: 1.75
+
+- Persona: Harness maintainer shipping a skill change who currently has no mechanical evidence it still behaves the same in the other four clients.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score 1.00
+- Strategy alignment: +0.5 track:Multi-client portability, +0.25 Our approach (turns "works everywhere" from a convention into a machine-checkable constraint) = +0.75, **applied** (base tied at 1.00 with the adjacent candidate, |Δ| = 0.00 ≤ 0.05) — final score 1.75
+- Strongest objection: Running five real client binaries in CI introduces a flake, credential, rate-limit, and licensing surface substantially larger than the bug class it catches, and the suite's own signal is nondeterministic because the things under test are LLM-driven clients whose outputs vary run to run. The most likely failure mode is the familiar one for expensive nondeterministic gates: it goes red for reasons unrelated to the change, gets marked continue-on-error or quarantined within a quarter, and thereafter provides the appearance of conformance coverage while asserting nothing. For this objection not to hold, the assertions would have to be narrow enough to be deterministic — file written, exit shape, artifact frontmatter — at which point the suite is verifying plumbing rather than fidelity, and much of the premise is gone.
+- Objection answered: no — stands as an accepted downside.
+
+### 10. Subagent fan-out routed through the orchestrator so fleet and multi-agent skills run on clients with no native Agent tool instead of failing — score: 1.50
+
+- Persona: Senior engineer who wants the fleet skills from Cursor or Codex and today gets nothing, because the fleets assume a Claude Code subagent primitive.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score 1.00
+- Strategy alignment: +0.5 track:Multi-client portability; no Target-problem/Our-approach match = +0.5, **applied** (base tied at 1.00, |Δ| = 0.00 ≤ 0.05) — final score 1.50
+- Strongest objection: No other client in the set exposes a real subagent primitive — isolated context, independent tool budget, parallel scheduling, resumable handoff — so this is not a portability shim but a from-scratch reimplementation of the single hardest capability the harness currently borrows from its host. The most likely failure mode is a sequential in-process emulation that shares one context window, which removes the isolation the fleets depend on for honest independent verification; the fleets would still "run" on those clients while producing verdicts that are no longer independently derived, which is worse than not running at all because the output is indistinguishable from the real thing. For this objection not to hold, the orchestrator would need to own agent execution end to end rather than delegate it to the host client — a substrate-level inversion far beyond a routing change.
+- Objection answered: no — stands as an accepted downside.
+
+## Ranking notes
+
+- Base scores use the `low|medium|high → 1|2|3` mapping: `(impact × confidence) ÷ effort`.
+- Three base-score tie groups occurred — {3.00: candidates 3, 4, 5}, {2.00: candidates 6, 7, 8}, {1.00: candidates 9, 10}. The strategy-alignment bonus was applied inside each group because `|Δbase| = 0.00 ≤ 0.05`, and ordered them.
+- The two clear winners (6.00 and 4.50) had their alignment bonus recorded but **not** applied, since each is separated from its neighbours by 1.50 — well outside the 0.05 tie window. The bonus never reorders a clear base-score winner.
+- Objections do not participate in ranking. All ten stand unrebutted by policy for this run; that is recorded risk information, not a score input.

--- a/docs/ideation/make-the-harness-valuable-enou-2026-09-06.md
+++ b/docs/ideation/make-the-harness-valuable-enou-2026-09-06.md
@@ -1,0 +1,169 @@
+---
+topic: 'Make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale — first-run adopter value, constraint sharing, courseware, and telemetry-driven adoption insight.'
+generated_at: '2026-09-06T16:50:16Z'
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale — first-run adopter value, constraint sharing, courseware, and telemetry-driven adoption insight.
+
+## Inputs
+
+- Topic: Make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale — first-run adopter value, constraint sharing, courseware, and telemetry-driven adoption insight.
+- Generated: 2026-09-06T16:50:16Z
+- Count requested: 10
+- Strategy grounding: enabled — `STRATEGY.md` present and valid; matched track **External adoption flywheel** ("make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale").
+- Objection policy: **none** — every candidate's strongest objection is recorded as standing and unrebutted. An accepted downside is a real signal, not a gap.
+
+## Scoring notes
+
+- `low | medium | high` map to `1 | 2 | 3`. `base_score = (impact × confidence) ÷ effort`, range `[≈0.33, 9.0]`.
+- Strategy-alignment bonus: `+0.5` when the premise plausibly advances a `Tracks` bullet, `+0.25` when premise or persona references `Target problem` / `Our approach` / `Who it's for`. Maximum `+0.75`.
+- The bonus is **bounded**: applied only where the adjacent base-score delta is `≤ 0.05`. It is recorded for every candidate for transparency, but it reorders nothing outside a tie window. Two tie windows occurred this run — the three-way tie at `3.00` and the two-way tie at `2.00`.
+
+## Grounding against existing work
+
+This track is the most heavily covered in the repo (~107 roadmap rows, ~65 still open), and several of the obvious moves have already shipped rather than merely being queued. Candidates below were generated against that reality:
+
+- **Constraint sharing already exists** — `packages/core/src/constraints/sharing/` ships `bundle.ts`, `manifest.ts`, `lockfile.ts`, `merge.ts`, `remove.ts`, `write-config.ts`, alongside `harness install-constraints` / `uninstall-constraints` and shipped opt-in packs (`packages/core/src/constraints/packs.ts`, row `opt-in-constraint-packs` = done). So "build export/import" is not additive. What is missing is everything _around_ a bundle: integrity, provenance, discovery, and any evidence that an imported pack did anything.
+- **Courseware already has a one-shot generator** — `packages/cli/src/commands/blueprint.ts` runs `ProjectScanner` → `BlueprintGenerator` → a static `docs/blueprint/index.html`. So "build blueprint" is not additive; turning a dump into a sequenced, checkable, freshness-aware path is.
+- **Adoption telemetry is already collected but points inward** — `packages/cli/src/commands/adoption.ts` reads local `adoption.jsonl` records and aggregates by skill for the repo's own owner. Tracked rows cover the on-ramp funnel (`adoption-funnel-telemetry`), failure-reason categorization (`extend-adoption-jsonl-with-failure-reason-categorization`), the synthesis surface (`ship-aggregate-telemetry-synthesis-surface`, done) and standards interop (`standard-telemetry-semantics-interop`). Candidates here deliberately avoid re-describing those and instead target outcome evidence the adopter can act on or show someone else.
+- **Scope boundary honored** — cross-client substrate fidelity (Claude Code / Cursor / Codex / Gemini CLI / OpenCode) belongs to the sibling `multi-client-portability` track and is excluded here.
+
+## Ranked candidates
+
+### 1. `harness init` selects a graduated first-run constraint set — exactly one gate the repo already passes and one it nearly passes, deferring the rest — score: 9.00
+
+- Persona: The primary-persona tech lead from `Who it's for` — 3–6 months into agent adoption, with a CLAUDE.md and a review checklist but no enforcement — running `harness init` on a real, already-drifted repo for the first time.
+- Premise: Init runs the candidate constraints before writing config, and enables only a constraint the repository currently passes plus the nearest near-miss, recording the remainder as deferred with their violation counts.
+- Complexity: low
+- Impact / Confidence / Effort: H / H / L — base score 9.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 persona (`Who it's for` primary persona) = +0.75 — recorded, **not applied** (no adjacent tie) — final score 9.00
+- Key risk: A graduated on-ramp can read as the tool hiding the problem it was hired to find.
+- Strongest objection: The whole value proposition is that constraints fire mechanically and immediately; deliberately withholding constraints the repo fails inverts that on day one and teaches the adopter that harness findings are negotiable. The most likely failure mode is the deferred set never getting enabled — the "one more gate" step has no forcing function, so the adopter settles permanently at two constraints, reports the tool as installed, and contributes a green Harness Coverage number that means nothing. A second failure mode is that on a sufficiently drifted repo there is no constraint that currently passes, so the graduated selection degenerates to enabling nothing at all and the first run is vacuous rather than encouraging. For this objection not to hold, the deferred set would have to carry real forward pressure — a visible ratchet, a scheduled re-evaluation, or a Harness Coverage denominator that counts deferred constraints as unmet — and there would have to be evidence that first-run violation volume, not disagreement with the rules, is what actually loses adopters.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 2. Locally-computed Harness Coverage / Drift Floor badge with a verifiable report link — score: 6.00
+
+- Persona: A tech lead who has adopted the harness and now needs to show peers and leadership that it is doing something, without exporting source or granting anyone access to the repo.
+- Premise: `harness` emits a shields-compatible endpoint JSON plus a self-contained report page for the two KPIs it already computes locally (Harness Coverage from `harness validate` baselines, Drift Floor from the architecture timeline), so a repo can publish its enforcement posture from its own README.
+- Complexity: low
+- Impact / Confidence / Effort: M / H / L — base score 6.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 (`Key metrics` — Harness Coverage, Drift Floor) = +0.75 — recorded, **not applied** (no adjacent tie) — final score 6.00
+- Key risk: A self-reported badge is a number the badge's owner controls, so it persuades nobody who is paying attention.
+- Strongest objection: Badges are trivially gameable — the same repo can raise Harness Coverage by deleting documented rules rather than enforcing them, and can flatten Drift Floor by merging less, so the number that gets published is the number the publisher wanted rather than the number the substrate earned. The most likely failure mode is quiet Goodharting: coverage rises, the badge goes green, and enforcement quality is unchanged or worse, which is corrosive precisely because this project's credibility rests on measured claims. A related failure is irrelevance — outside observers have no calibration for what a given Drift Floor means, so the badge decorates a README without moving a single adoption decision. For this objection not to hold, the report behind the badge would have to carry enough provenance to be checked by a skeptic (which rules, which baselines, which window, which commits) and the metric definitions would have to be resistant to the deletion shortcut.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 3. Signed, provenanced constraint bundles with a publisher-trust policy — score: 4.50
+
+- Persona: A tech lead about to run someone else's constraint pack — machine-checkable rules that will execute in their CI and block their team's merges.
+- Premise: The existing sharing bundle gains a signed manifest, a publisher identity, and a `trust` policy in `harness.config.json` that refuses to install unsigned or unknown-publisher bundles by default.
+- Complexity: medium
+- Impact / Confidence / Effort: H / H / M — base score 4.50
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 (`Our approach` — constraints executing as code in the adopter's pipeline) = +0.75 — recorded, **not applied** (no adjacent tie) — final score 4.50
+- Key risk: Signing infrastructure is a real cost paid up front against a threat that has not yet materialized at this adoption volume.
+- Strongest objection: There is no meaningful third-party bundle ecosystem yet, so this hardens a supply chain that currently has approximately one supplier — and key management, revocation, and the "unknown publisher" refusal path add friction to exactly the flow (trying someone else's pack) that the flywheel needs to be frictionless. The most likely failure mode is that default-refuse becomes the first thing every adopter turns off, at which point the trust policy is a config option nobody honors and the signing work bought nothing but a slower install. A subtler failure is scope confusion: a signature attests to who published a bundle, not that its rules are sensible for the importing repo, and adopters will read the green checkmark as the latter. For this objection not to hold, either bundle sharing would have to reach a volume where an untrusted publisher is realistic, or the trust surface would have to deliver something adopters want independently of the threat — reproducible provenance, diffable pack history, an auditable record of what changed in their gates and when.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 4. `harness would-have` — replay the adopter's own merged-PR history through the gates and report what would have been caught — score: 3.75
+
+- Persona: The primary-persona tech lead evaluating adoption — already paying the cleanup tax described in `Target problem`, and unwilling to install anything into CI on the strength of a marketing claim.
+- Premise: A read-only, write-nothing command walks the last N merged PRs in an untouched repository, runs the harness checks against each diff, and reports the violations, layer breaks, and entropy findings that would have fired at the time — evidence drawn from the adopter's own history rather than a generic scan.
+- Complexity: medium
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 (`Target problem` — the compounding cleanup tax) = +0.75 — **applied** (three-way tie at base 3.00, |Δ| = 0.00 ≤ 0.05) — final score 3.75
+- Key risk: A retrospective replay measures what the rules say, not what the team would have wanted, and a large findings count reads as noise rather than as value.
+- Strongest objection: Running current constraints against historical diffs is anachronistic — the code was written under different conventions, by people who never agreed to these rules, so a big number is ambiguous between "look how much drift you accumulated" and "look how badly calibrated these defaults are to your codebase." The most likely failure mode is a hostile first impression: the prospective adopter runs the evaluation, sees four thousand findings across a year of merges, concludes the tool does not understand their repo, and never installs it — the command would have actively destroyed the adoption it was built to create. There is also a substantial correctness hazard in replaying gates against historical trees whose dependencies, configs, and layer definitions no longer resolve, producing findings that are artifacts of the replay rather than of the code. For this objection not to hold, the output would have to lead with a small, high-confidence, obviously-real subset — the findings a human would agree were bugs — and be honest about which checks could not be faithfully replayed at each historical commit.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 5. Pack efficacy receipts — every installed constraint pack carries a measured before/after Drift Floor delta for the repo that installed it — score: 3.75
+
+- Persona: A tech lead choosing between several available constraint packs, and the pack author who wants a reason anyone should prefer theirs.
+- Premise: Installing a pack stamps a local baseline; after a configurable window the adopter can render a receipt showing that pack's own contribution to violations-introduced-per-merged-PR, and can optionally contribute the receipt back so packs accumulate outcome evidence rather than only rule counts.
+- Complexity: medium
+- Impact / Confidence / Effort: H / M / M — base score 3.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 (`Key metrics` — Drift Floor; `Our approach` — constraints that compound) = +0.75 — **applied** (three-way tie at base 3.00, |Δ| = 0.00 ≤ 0.05) — final score 3.75
+- Key risk: Attributing a drift change to one pack is a causal claim the available data cannot support.
+- Strongest objection: A repo's Drift Floor moves for many reasons at once — team changes, release pressure, a refactor, other packs installed the same week, seasonal merge volume — and a before/after delta around a single install is confounded by all of them, so the receipt will confidently report an effect that is mostly noise. The most likely failure mode is that receipts become a marketing surface with a statistical veneer: pack authors publish the favorable windows, adopters treat the numbers as comparable across wildly different codebases, and the project ends up shipping exactly the kind of unfalsifiable claim its own metric discipline exists to prevent. Low merge volume makes it worse — most adopter repos will not produce enough merged PRs in any reasonable window for the delta to clear the noise floor at all. For this objection not to hold, receipts would need honest uncertainty reporting and a declared denominator, an explicit refusal to report when n is too small, and ideally a design that identifies the pack's effect mechanically (which specific violations that pack's rules caught) rather than inferring it from an aggregate time series.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 6. `harness eject` — emit the enforced constraint set as plain ESLint config and CI workflow with zero harness dependency — score: 3.75
+
+- Persona: The tech lead who must get a new tool past a skeptical staff engineer or a platform team whose first question is what happens when this project is abandoned.
+- Premise: A single command materializes the currently-enforced constraints as standalone linter configuration and workflow files that keep working after the harness is uninstalled, making the exit cost explicit and near-zero.
+- Complexity: medium
+- Impact / Confidence / Effort: M / H / M — base score 3.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 persona (`Who it's for` — the lead defending a new dependency) = +0.75 — **applied** (three-way tie at base 3.00, |Δ| = 0.00 ≤ 0.05) — final score 3.75
+- Key risk: Building a first-class exit is engineering effort spent making it easier to leave.
+- Strongest objection: Much of what the harness enforces is not expressible as static linter configuration — graph-derived layer rules, skill workflow rigidity, gate sequencing, comprehension freshness, the outcome-eval verdicts — so an honest eject produces a thin subset and advertises, in the adopter's own repo, how much of the value was locked in the parts that could not be ejected. The most likely failure mode is that the ejected config silently diverges: teams eject "for safety," the standalone files rot against the harness's evolving rules, and a later re-import or comparison is a mess of conflicts nobody owns. There is also a real strategic cost — a frictionless exit invites eject-and-abandon by teams who wanted the rules but not the substrate, which is precisely the population whose telemetry would have tested the thesis at scale. For this objection not to hold, the ejected artifact would have to be genuinely useful on its own while being unmistakably honest about the boundary, and the lock-in objection would have to be a real, observed blocker in adoption conversations rather than a hypothesized one.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 7. Author a shareable constraint pack from a team's own recurring PR review comments — score: 2.75
+
+- Persona: A staff engineer who writes the same review comment for the fifth time this quarter and has no path from that comment to a rule that enforces it.
+- Premise: A skill mines the repository's review-comment history for recurring, mechanically-checkable assertions, clusters them into candidate rules, and drafts them into a constraint pack the team can enforce internally and publish externally — supply for the flywheel, not just distribution.
+- Complexity: high
+- Impact / Confidence / Effort: H / M / H — base score 2.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 (`Our approach` — conventions-without-enforcement converted into machine-checkable constraints) = +0.75 — **applied** (two-way tie at base 2.00, |Δ| = 0.00 ≤ 0.05) — final score 2.75
+- Key risk: Most review comments are not mechanizable, and the ones that are have usually already been mechanized.
+- Strongest objection: Review comments are overwhelmingly contextual judgment — "this belongs in the service layer," "this name is misleading," "are we sure about this ordering?" — and the fraction that reduces cleanly to a deterministic rule is small and consists largely of things a linter already catches, so the mined output will be dominated by unmechanizable prose with a thin tail of redundant rules. The most likely failure mode is a plausible-looking pack full of rules that are subtly wrong: a comment that applied to one module is generalized into a repo-wide constraint, the team enables it, and it starts blocking correct code — which poisons trust in the entire constraint mechanism, not just the generated pack. Mining also depends on review-comment volume and quality that many adopter repos simply do not have. For this objection not to hold, the extraction would need to be aggressively conservative (proposing few rules, each with the specific comments and code sites that justify it) and the review corpus would have to be a demonstrably richer source of latent rules than the codebase itself.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 8. A searchable pack index generated from published bundle manifests, with no hosted service to operate — score: 2.50
+
+- Persona: An adopter who has decided to use shared constraints and now has no way to find out what exists beyond asking someone.
+- Premise: Opting in to publish emits a bundle's manifest to a static, version-controlled index that renders as a searchable catalog, so discovery is a build artifact rather than a service someone has to run and keep alive.
+- Complexity: medium
+- Impact / Confidence / Effort: M / M / M — base score 2.00
+- Strategy alignment: +0.5 track:External adoption flywheel = +0.50 — **applied** (two-way tie at base 2.00, |Δ| = 0.00 ≤ 0.05) — final score 2.50
+- Key risk: A discovery surface built before there is anything to discover is an empty room with good signage.
+- Strongest objection: Indexes are demand-side infrastructure and the binding constraint here is supply — with a handful of packs in existence the catalog's most honest state is near-empty, and an empty catalog is worse than no catalog because it advertises that nobody is sharing. The most likely failure mode is the cold-start trap made permanent: the index ships, stays sparse, prospective adopters read sparseness as a dead ecosystem, and the perception outlives the fix. Even granting supply, a static generated index carries no quality signal at all — no downloads, no maintenance status, no indication whether a pack is a serious rule set or someone's afternoon — so discovery succeeds mechanically while failing at the thing adopters actually need, which is knowing which pack to trust. For this objection not to hold, pack supply would have to be growing on its own, and the index would need to carry at least one credible quality or freshness signal per entry.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 9. Turn the blueprint dump into sequenced courseware — an ordered path with comprehension checks and a freshness contract — score: 1.33
+
+- Persona: A new hire, contractor, or agent operator arriving cold at an adopter's codebase, who needs to know what to read in what order rather than being handed a complete map.
+- Premise: The existing blueprint generator gains an ordering derived from the knowledge graph's critical paths, per-stop checks for understanding, a recorded completion trail, and a staleness signal that marks stops whose underlying code has moved.
+- Complexity: high
+- Impact / Confidence / Effort: M / M / H — base score 1.33
+- Strategy alignment: +0.5 track:External adoption flywheel = +0.50 — recorded, **not applied** (no adjacent tie) — final score 1.33
+- Key risk: Generated courseware is a documentation artifact, and documentation artifacts rot faster than anyone maintains them.
+- Strongest objection: Ordering a codebase into a curriculum is an editorial act requiring judgment about what a newcomer needs, and graph centrality is a poor proxy for pedagogical order — the most-depended-upon module is frequently the worst place to start. The most likely failure mode is a confidently-sequenced path that teaches the codebase in the wrong order, which is more damaging than an unordered reference because the reader trusts the sequence and blames themselves when it does not cohere. Auto-generated comprehension checks compound this: questions derived from structure tend to test whether you can read a call graph rather than whether you understand the design, and a learner who passes them has learned nothing durable. The freshness contract adds ongoing maintenance cost to an artifact whose consumption is bursty and rare — most repos onboard someone a few times a year. For this objection not to hold, the generated order would have to beat a hand-written onboarding doc in a real comparison, and the checks would have to test comprehension rather than navigation.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+### 10. Cohort benchmarking — show an adopter their Drift Floor as a percentile against comparable repositories — score: 1.00
+
+- Persona: The primary-persona tech lead who can see their own numbers but has no idea whether they are good, and needs a comparison to justify continued investment internally.
+- Premise: Opt-in telemetry aggregates KPI outcomes into anonymized cohorts by repository size and stack, so an adopter's own Drift Floor and Harness Coverage are reported as a position within a distribution rather than as a bare number.
+- Complexity: high
+- Impact / Confidence / Effort: H / L / H — base score 1.00
+- Strategy alignment: +0.5 track:External adoption flywheel, +0.25 (`Key metrics` — External Adoption, Drift Floor; primary persona) = +0.75 — recorded, **not applied** (no adjacent tie) — final score 1.00
+- Key risk: The cohorts do not exist yet, and building the comparison before the population exists produces confident statistics over a handful of repos.
+- Strongest objection: Percentile reporting requires a population large enough that a cohort is not three repositories, and External Adoption is precisely the metric this whole track exists to raise — so the feature's prerequisite is its own goal, and shipping it early means publishing percentiles computed over an n that would be embarrassing to disclose. The most likely failure mode is a privacy incident of the ordinary kind: "repositories of your size and stack" is a small enough bucket that a cohort statistic becomes attributable, and an adopter recognizes their own repo in someone else's benchmark — which for a tool asking teams to enable telemetry is close to unrecoverable. Cohort definition is also genuinely hard and contestable: size and stack are weak predictors of drift compared to team maturity, release cadence, and code age, so the comparison will feel wrong to the people it is meant to persuade. For this objection not to hold, the adopter population would need to be an order of magnitude larger than it is, the cohorting would need a defensible k-anonymity floor with suppression below it, and there would need to be evidence that a percentile actually changes an adoption decision that a raw number does not.
+- Objection answered: no — stands as an accepted, unrebutted downside.
+
+## Ranking table (final-score order)
+
+| Rank | Candidate                                                    | Complexity | I/C/E | Base | Alignment                | Applied | Final |
+| ---- | ------------------------------------------------------------ | ---------- | ----- | ---- | ------------------------ | ------- | ----- |
+| 1    | Graduated first-run constraint selection in `harness init`   | low        | H/H/L | 9.00 | +0.75 (track + persona)  | no      | 9.00  |
+| 2    | Harness Coverage / Drift Floor badge + verifiable report     | low        | M/H/L | 6.00 | +0.75 (track + metrics)  | no      | 6.00  |
+| 3    | Signed, provenanced bundles with publisher-trust policy      | medium     | H/H/M | 4.50 | +0.75 (track + approach) | no      | 4.50  |
+| 4    | `harness would-have` retrospective replay of merged PRs      | medium     | H/M/M | 3.00 | +0.75 (track + problem)  | yes     | 3.75  |
+| 5    | Pack efficacy receipts (per-pack Drift Floor delta)          | medium     | H/M/M | 3.00 | +0.75 (track + metrics)  | yes     | 3.75  |
+| 6    | `harness eject` — dependency-free constraint materialization | medium     | M/H/M | 3.00 | +0.75 (track + persona)  | yes     | 3.75  |
+| 7    | Constraint pack authored from recurring review comments      | high       | H/M/H | 2.00 | +0.75 (track + approach) | yes     | 2.75  |
+| 8    | Static, generated pack index (no hosted service)             | medium     | M/M/M | 2.00 | +0.50 (track)            | yes     | 2.50  |
+| 9    | Blueprint → sequenced courseware with comprehension checks   | high       | M/M/H | 1.33 | +0.50 (track)            | no      | 1.33  |
+| 10   | Cohort benchmarking of Drift Floor percentiles               | high       | H/L/H | 1.00 | +0.75 (track + metrics)  | no      | 1.00  |
+
+Tie windows: ranks 4–6 tied at base 3.00 (|Δ| = 0.00 ≤ 0.05) and ranks 7–8 tied at base 2.00 (|Δ| = 0.00 ≤ 0.05); the bonus was applied within those windows only, and reordered ranks 7 and 8 relative to base order. All other bonuses are recorded for transparency and changed no positions.
+
+## Handoff
+
+- Ideation artifact written: `docs/ideation/make-the-harness-valuable-enou-2026-09-06.md`
+- Top pick: Graduated first-run constraint selection in `harness init` — score 9.00
+- Next: invoke `/harness:brainstorming "<candidate>"` to take a candidate into a spec, OR `/harness:roadmap` to enqueue picks for later. This artifact is an input to brainstorming, never a substitute for it.

--- a/docs/ideation/make-the-strategic-and-knowled-2026-09-06.md
+++ b/docs/ideation/make-the-strategic-and-knowled-2026-09-06.md
@@ -1,0 +1,129 @@
+---
+topic: 'Make the strategic and knowledge substrate — STRATEGY.md, the knowledge graph, principles, and ADRs — durable enough that downstream skills ground reliably instead of starting cold each invocation.'
+generated_at: 2026-09-06T16:22:33Z
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Make the strategic and knowledge substrate — STRATEGY.md, the knowledge graph, principles, and ADRs — durable enough that downstream skills ground reliably instead of starting cold each invocation.
+
+## Inputs
+
+- Topic: Make the strategic and knowledge substrate — STRATEGY.md, the knowledge graph, principles, and ADRs — durable enough that downstream skills ground reliably instead of starting cold each invocation.
+- Generated: 2026-09-06T16:22:33Z
+- Strategy grounding: enabled — `STRATEGY.md` present and valid; `Tracks`, `Target problem`, `Our approach`, and `Who it's for` read for the alignment tiebreaker.
+- Objection policy for this run: **none answered**. Every strongest objection below stands as an accepted, unrebutted downside. No rebuttal was authored by the agent, and no objection changes any score or rank.
+
+### Observed substrate state at generation time
+
+Candidate effort and confidence estimates were calibrated against the repository as it stands at `e530ae6`, not against a blank slate:
+
+- `docs/knowledge/decisions/` holds 136 ADRs numbered through 0124. Status distribution: 116 `accepted`, 17 `proposed`, 2 records carrying a literal enum string rather than a value.
+- ADR 0123 carries `status: proposed` while its own body states the behavior it records already shipped — the status field is descriptive prose, not an enforced lifecycle.
+- 23 ADR files mention supersession in prose; no ADR carries `superseded` as a status value and there is no backlink invariant.
+- Compiled comprehension units, the serve-time hash gate, and dispatch-time pre-warm injection have already shipped, and cover **code shape**. Decisions, principles, and STRATEGY sections are not part of that compiled substrate.
+- `packages/linter-gen` exists, which raises the floor under any principle-to-constraint compilation idea relative to a from-scratch estimate.
+
+## Ranked candidates
+
+### 1. ADR status becomes a machine-enforced lifecycle — validated transitions plus reciprocal `superseded_by` / `supersedes` backlinks — so a reversed decision cannot keep presenting itself as live guidance — score: 6.75
+
+- Persona: The tech lead 3–6 months into agent adoption who keeps watching agents re-open decisions the team already settled, because the record the agent reads does not say which way the decision finally went.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:`Upstream grounding` ("make the strategic and knowledge substrate (STRATEGY.md, knowledge graph, principles, ADRs) durable enough that downstream skills ground reliably") +0.25 Target problem ("re-litigates settled architectural decisions") = +0.75 — final score 6.75 (bonus **applied**: base tied with candidate 2 at 6.00, |Δ| = 0.00 ≤ 0.05)
+- Strongest objection: This fixes the _integrity_ of the decision record without touching the _reachability_ of it, and reachability is the binding constraint. An agent that never opens the ADR directory is unaffected by whether the frontmatter in that directory is internally consistent; the enforcement lands entirely on the human authoring path, where the failure was never expensive. The most likely failure mode is a validator that goes green on day one — because 116 records already say `accepted` — while the 17 `proposed` records that actually shipped stay mislabeled until someone hand-audits them, so the gate holds a line that was never being crossed and the real corpus stays wrong. There is a second, meaner mode: forcing a status transition to be mechanically legal invites authors to satisfy the schema rather than the semantics, producing `superseded_by` links that are syntactically reciprocal and substantively arbitrary. For this objection not to hold, the ADRs would have to be genuinely load-bearing at agent runtime today — something a grounding-provenance record could establish but which nothing currently measures — and the initial backfill of the 17 mislabeled records would have to be part of the same change rather than deferred to a follow-up nobody schedules.
+- Objection answered: no
+
+### 2. Every skill invocation records its grounding provenance in the black-box run record — the exact STRATEGY sections, ADRs, principles, and graph nodes it actually consumed — so "started cold" becomes a measured fact rather than an assumption — score: 6.75
+
+- Persona: The maintainer of the harness itself, who cannot currently tell a genuinely grounded run from a cold one after the fact, and so cannot tell whether any grounding investment paid.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:`Upstream grounding` +0.25 Target problem ("each agent invocation starts cold") = +0.75 — final score 6.75 (bonus **applied**: base tied with candidate 1 at 6.00, |Δ| = 0.00 ≤ 0.05)
+- Strategy note: ranked below candidate 1 on the stable-tie rule (identical final score; generation order preserved), not on any judgment that it matters less.
+- Strongest objection: Provenance measures what was _injected_, not what was _used_, and the gap between those two is the entire question. The pre-warm resolver knows which nodes it put into the prompt; it has no visibility into whether the model attended to them, and a run record showing four ADRs and three STRATEGY sections resolved is fully compatible with a model that ignored all seven. The most likely failure mode is a metric that looks like rigor and functions as reassurance: grounding-coverage numbers climb, "cold start" appears solved on the dashboard, and downstream behavior is unchanged — the exact shape of the already-deferred behavioral A/B that this record does not substitute for. Compounding it, provenance is only as honest as the resolver's own bookkeeping, so any grounding that reaches the model through a path the resolver does not mediate is invisible and silently scores as absent. For this objection not to hold, the provenance record would have to be paired with an outcome signal that can distinguish injected-and-used from injected-and-ignored, which means this idea is a prerequisite for the measurement rather than the measurement itself.
+- Objection answered: no
+
+### 3. Extend the compiled-comprehension substrate from code to decisions: a committed, hash-gated unit per scope that resolves the handful of ADRs and principles actually binding on that scope, so a leaf agent receives its governing decisions pre-warmed instead of a directory of 136 files — score: 3.75
+
+- Persona: The leaf agent's operator — a tech lead dispatching autonomous work — who knows the binding decision exists somewhere in the corpus but has no way to get it in front of the agent that needs it.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:`Upstream grounding` +0.25 Target problem ("each agent invocation starts cold, re-litigates settled architectural decisions") = +0.75 — final score 3.75 (bonus **applied**: base tied with candidates 4 and 5 at 3.00, |Δ| = 0.00 ≤ 0.05)
+- Strongest objection: Decisions do not decompose along the file boundaries that made code comprehension compilable. A compiled comprehension unit works because a module's shape is a property of that module; an architectural decision is precisely the kind of knowledge that is _not_ local — its whole value is that it constrains code it never mentions, in packages that did not exist when it was written. The most likely failure mode is a relevance function that degrades into path matching: ADRs get attached to the scopes whose paths they happen to name, which systematically surfaces the decisions that are already obvious from reading the code and systematically misses the cross-cutting ones that an agent would actually re-litigate. There is a freshness trap underneath it too — the code substrate can re-derive units from source on every merge, but a decision-to-scope mapping has no mechanical ground truth to re-derive from, so it either needs human curation at 136-and-growing records or it silently rots into a stale index that is worse than no index because it looks authoritative. For this objection not to hold, decisions would need a durable machine-readable statement of what they bind that is authored once at decision time and does not require re-curation as the codebase moves underneath it.
+- Objection answered: no
+
+### 4. STRATEGY.md's tracks, metrics, and sections are ingested as first-class graph nodes with edges to the ADRs, roadmap items, and packages that serve them, so strategic intent is traversable rather than prose the graph cannot reason over — score: 3.75
+
+- Persona: The tech lead deciding what to build next, who wants to ask which packages currently serve a given track and gets no answer because the strategy lives outside the graph.
+- Complexity: medium
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:`Upstream grounding` +0.25 Our approach ("durable grounding in a knowledge graph and STRATEGY.md") = +0.75 — final score 3.75 (bonus **applied**: base tied with candidates 3 and 5 at 3.00, |Δ| = 0.00 ≤ 0.05)
+- Strongest objection: The edges are the product here, and the edges are the part that cannot be ingested — they have to be asserted. Ingesting six sections and six tracks as nodes is nearly free and nearly worthless; what makes the graph answer "which packages serve Upstream grounding" is a set of track-to-artifact relationships that exist in nobody's head in a form a parser can extract, and inferring them from keyword overlap will confidently connect every package to every track, since the tracks are written in exactly the vocabulary the codebase uses. The most likely failure mode is a graph that gains a strategy subgraph, gains the Context Density number that counts it, and answers strategic queries with plausible-looking noise that is harder to distrust than an honest absence. Worse, a strategy edge asserted once decays invisibly: a package stops serving a track when its purpose shifts, and nothing in the ingest path will ever retract that edge. For this objection not to hold, track membership would have to be declared at the artifact — a field on the roadmap item or ADR that names its track — which moves the cost onto every author and makes this an adoption problem rather than an ingestion one.
+- Objection answered: no
+
+### 5. Skills declare their required grounding set as an explicit precondition in `skill.yaml`; the runner resolves it before the first phase and records an honest DEGRADED verdict when the substrate is missing, stale, or invalid — score: 3.75
+
+- Persona: The adopter running harness skills in a repo whose substrate is partial, who today gets a confidently-executed run with no indication that the skill ran without the grounding it assumes.
+- Complexity: high
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:`Upstream grounding` +0.25 Our approach ("workflow rigidity in skills") = +0.75 — final score 3.75 (bonus **applied**: base tied with candidates 3 and 4 at 3.00, |Δ| = 0.00 ≤ 0.05)
+- Strongest objection: A precondition that degrades gracefully is a warning, and warnings on a per-invocation path get absorbed within a week. The harness ships to adopters whose repos will essentially never satisfy a full grounding set — no STRATEGY.md, no ADR corpus, an empty graph — so the DEGRADED verdict fires on the overwhelming majority of external runs and immediately becomes the ambient condition rather than a signal, which is the failure mode that makes the label worthless exactly where the substrate problem is worst. Making it blocking instead is not available: it would gate the marginal adopter out of the skill on their first invocation, which contradicts the portability commitment. The most likely failure mode is therefore a correctly-implemented contract that produces a field of yellow across every install and changes no behavior at either end — the adopter ignores it, and the maintainer cannot use it as a quality signal because it does not discriminate. For this objection not to hold, the declared grounding sets would have to be scoped tightly enough that a well-configured repo genuinely passes and a misconfigured one genuinely fails, which requires per-skill judgment across the whole skill catalog rather than one uniform contract.
+- Objection answered: no
+
+### 6. `harness ground <path>` — a read-only command that prints the exact grounding bundle an agent would receive for a given path, so cold-start is inspectable by a human before dispatch rather than diagnosed after a bad run — score: 3.50
+
+- Persona: The tech lead about to dispatch autonomous work on an unfamiliar package, who wants to see what the agent will actually know before spending a session finding out.
+- Complexity: low
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:`Upstream grounding` — final score 3.50 (bonus **applied**: base tied with candidates 3, 4, and 5 at 3.00, |Δ| = 0.00 ≤ 0.05; ranks below them on the smaller bonus)
+- Strongest objection: This is a window onto a resolver, and it inherits every weakness of the resolver it renders while adding a layer of false confidence on top. If the grounding assembly is thin, the command's honest output is a short list that a human reads as "fine" because they have no baseline for what a good bundle looks like — there is no expected set to diff against, so the tool can only report what is there, never what is missing. The most likely failure mode is a command that is run twice during onboarding and never again, because inspecting grounding before dispatch is a discipline nobody sustains when the dispatch path does not require it. It also risks the worse outcome of validating the substrate socially: a bundle that prints cleanly gets treated as evidence the grounding is adequate, when it is only evidence that the resolver ran. For this objection not to hold, the command would need to be wired into a path people already traverse — a pre-dispatch gate or a fleet CONFIRM round — rather than offered as a standalone verb.
+- Objection answered: no
+
+### 7. A staleness trip-wire evaluated at consumption time: when the upstream substrate is provably older than the code it describes, the grounding read reports the drift to the consuming skill instead of serving the stale content silently — score: 2.00
+
+- Persona: The individual developer running 10+ agent sessions a week whose ADRs and knowledge docs describe an architecture two refactors behind the code the agent is editing.
+- Complexity: medium
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.5 track:`Upstream grounding` +0.25 Target problem ("documentation rot") = +0.75 — recorded for transparency, **not applied** (nearest base score is 3.00, |Δ| = 1.00 > 0.05) — final score 2.00
+- Strongest objection: Timestamp comparison is a proxy for staleness that is wrong in both directions, and the errors are not symmetric in cost. A durable architectural decision is _supposed_ to outlive the code beneath it — an ADR from 2026-02 governing a package refactored last week is doing exactly its job, not rotting — so a mtime-based wire fires loudest on the records with the longest half-life, which are the most valuable ones. Meanwhile a doc updated yesterday with a stale claim in paragraph three passes cleanly. The most likely failure mode is a wire calibrated to avoid that false-positive flood, at which point its threshold is loose enough that it never fires on anything, and it becomes a check that is always green and therefore never read. Semantic staleness — does this document still describe reality — is the thing worth detecting, and it is not derivable from filesystem metadata or git dates at all. For this objection not to hold, staleness would have to be assessed against content rather than age, which is a materially different and more expensive piece of work than the trip-wire framing implies.
+- Objection answered: no
+
+### 8. A grounding-health lane surfaces per-package upstream coverage, substrate freshness, and grounding provenance in one view, and contributes a gate to Holiday Confidence — score: 1.50
+
+- Persona: The tech lead who owns the substrate's condition and currently has no single place that says whether it is healthy.
+- Complexity: medium
+- Impact / Confidence / Effort: L/H/M — base score 1.50
+- Strategy alignment: +0.5 track:`Upstream grounding` — recorded for transparency, **not applied** (nearest base score is 2.00, |Δ| = 0.50 > 0.05) — final score 1.50
+- Strongest objection: This is a presentation layer over data that does not exist yet, and building it early is how the underlying gap gets papered over. Every input it needs — per-package coverage, freshness, provenance — is the output of another candidate on this list, so shipping the lane first yields a view populated by whatever partial signals happen to be available, which is precisely the condition under which a dashboard misleads most. The likely failure mode is a lane that shows green because its inputs are thin rather than because the substrate is sound, and then gets promoted into a Holiday Confidence gate, where a soft measurement acquires hard authority over whether a window counts as safe to leave unwatched. Adding it to that KPI is the specific harm: Holiday Confidence derives its meaning from every input being an authority, and a coverage heuristic is not one. For this objection not to hold, the provenance and freshness signals would have to be real and validated first, which makes this strictly downstream work rather than a parallel track.
+- Objection answered: no
+
+### 9. A merge-time hook incrementally re-ingests changed source into the knowledge graph on every merge, so the substrate stays continuously fresh instead of being rebuilt on a manual or periodic cadence — score: 1.33
+
+- Persona: The team whose graph is authoritative-looking and hours-to-days behind main, so every agent grounding on it grounds on a past version of the repo.
+- Complexity: high
+- Impact / Confidence / Effort: M/M/H — base score 1.33
+- Strategy alignment: +0.5 track:`Upstream grounding` — recorded for transparency, **not applied** (nearest base score is 1.50, |Δ| = 0.17 > 0.05) — final score 1.33
+- Strongest objection: Merge-time is the single most contended point in this repository's workflow, and adding graph ingestion to it puts a slow, stateful, conflict-prone write on the path where the cost of being wrong is highest. This codebase has already paid repeatedly for artifacts that regenerate near merge — shard conflicts that required a dedicated merge driver and a single-writer ADR to stop, and a fail-closed pre-commit gate that blocks all commits when a baseline is red. An incremental ingest hook re-creates that class of problem with a heavier payload and a database behind it, and under concurrent merges the incremental path is exactly where correctness is hardest to guarantee: an ingest that races or partially applies leaves a graph that is fresh-looking and internally inconsistent, which is worse for grounding than one that is honestly a day old. For this objection not to hold, the ingest would have to be genuinely idempotent, order-independent, and cheap enough to never become the reason a merge is slow — and the repo's own history with merge-time regeneration argues that bar is rarely cleared on the first attempt.
+- Objection answered: no
+
+### 10. A compiler turns documented principles and ADR constraints into machine-checkable enforcement (ESLint rules, validators) semi-automatically, so an upstream decision fires in real time rather than waiting to be read — score: 1.00
+
+- Persona: The tech lead who has written the architectural rule down three times and still watches agents violate it, because prose in `docs/knowledge/` has no runtime.
+- Complexity: high
+- Impact / Confidence / Effort: H/L/H — base score 1.00
+- Strategy alignment: +0.5 track:`Upstream grounding` +0.25 Our approach ("encoding architectural decisions, process discipline, and strategic intent as machine-checkable constraints") = +0.75 — recorded for transparency, **not applied** (nearest base score is 1.33, |Δ| = 0.33 > 0.05) — final score 1.00
+- Strongest objection: The decisions worth enforcing are the ones least amenable to extraction, and this inverts the direction the existing tooling works in. `packages/linter-gen` generates rules from a specification someone wrote _as_ a specification; the input here is 136 ADRs of discursive English whose load-bearing content is context, trade-off, and the reasoning for a choice — the enforceable predicate, where one exists at all, is usually a single clause buried in prose that also contains three alternatives that were rejected. The most likely failure mode is a compiler with a very low yield that produces plausible rules from the syntactically simplest ADRs, which are also the ones whose constraints are already enforced or trivially obvious, while every genuinely valuable decision requires a human to formalize it anyway. And a mis-extracted constraint is not a neutral miss: a generated ESLint rule that enforces a rejected alternative teaches agents the opposite of the decision, in real time, with the authority of a mechanical check. For this objection not to hold, ADRs would need to carry an explicit machine-readable constraint clause authored at decision time, which makes the leverage sit in the ADR template rather than in a compiler over the existing corpus.
+- Objection answered: no
+
+## Ranking notes
+
+- Base scores use the `low|medium|high → 1|2|3` mapping on all three axes.
+- The alignment bonus was applied inside two tie windows: candidates 1 and 2 (base 6.00, |Δ| = 0.00) and candidates 3, 4, 5, and 6 (base 3.00, |Δ| = 0.00). In the second window the bonus did real work — candidate 6 carries a track-only +0.5 and so ranks below the three carrying +0.75.
+- Candidates 7 through 10 have their bonus recorded but not applied; each is separated from its nearest neighbour by more than 0.05, so the base score determines the order.
+- Ties after the bonus (candidates 1 and 2 at 6.75; candidates 3, 4, and 5 at 3.75) are broken stably by generation order.
+- No objection was answered on this run, by design. Objections do not enter the ranking under any circumstance; the order above is `(impact × confidence) ÷ effort` plus the bounded tiebreaker and nothing else.

--- a/docs/ideation/raise-the-quality-ceiling-with-2026-09-06.md
+++ b/docs/ideation/raise-the-quality-ceiling-with-2026-09-06.md
@@ -1,0 +1,152 @@
+---
+topic: Raise the quality ceiling with LLM-judgment critique that rule-based linters cannot reach, now that the craft family is complete and the track's committed work is exhausted.
+generated_at: 2026-09-06T16:27:46Z
+strategy_grounded: true
+strategy_path: STRATEGY.md
+count_requested: 10
+count_generated: 10
+ranking_formula: '(impact × confidence) ÷ effort; strategy-alignment tiebreaker (max +0.75) applied only when |Δbase_score| ≤ 0.05'
+---
+
+# Ideation: Raise the quality ceiling with LLM-judgment critique that rule-based linters cannot reach, now that the craft family is complete and the track's committed work is exhausted.
+
+## Inputs
+
+- Topic: Raise the quality ceiling with LLM-judgment critique that rule-based linters cannot reach, now that the craft family is complete and the track's committed work is exhausted.
+- Generated: 2026-09-06T16:27:46Z
+- Strategy grounding: enabled — `STRATEGY.md` (v2, `last_updated: 2026-07-01`) present and valid; `Tracks`, `Target problem`, `Our approach`, and `Who it's for` captured.
+- Objection policy for this run: **none** — no objection was rebutted. Every strongest objection below stands on the record as an accepted, unrebutted downside.
+
+### Grounding notes
+
+The strategy's **Ceiling-raising via LLM judgment** track reads: _"Current: complete the craft family — docs-craft, code-craft, api-craft, cli-ergonomics are the remaining four; six already shipped (naming, spec, test, copy, knowledge, security)."_ That line is **stale as of this run**. Verified against the repository at `e530ae6b`:
+
+- `docs/roadmap.d/craft-pipeline-sub-project-2-docs-craft.md`, `-4-code-craft.md`, `-7-api-craft.md`, and `-8-cli-ergonomics.md` are all **`Status: done`** — the four "remaining" sub-projects are finished.
+- Eleven craft skills exist under `packages/cli/src/`: `naming-`, `spec-`, `test-`, `copy-`, `knowledge-`, `security-`, `docs-`, `code-`, `api-`, `cli-ergonomics-`, and `design-craft`.
+- `craft-fleet` (`docs/roadmap.d/craft-fleet.md`) is **`Status: done`** — the sweep orchestrator ships.
+
+The track's committed work is therefore exhausted, and candidate generation targets what the completed family does _not_ yet do. Four structural asymmetries in the shipped family were read directly off the tree and seed several candidates below:
+
+1. **Ten of eleven craft skills carry only `phases/critique.ts`.** Only `design-craft` — the prototype — has `polish.ts`, `benchmark.ts`, and `award-bar.ts`. The family reports; with one exception it does not apply or score.
+2. **Six of eleven ship rubrics but no exemplars** (`copy-`, `knowledge-`, `naming-`, `security-`, `spec-`, `test-craft`). `catalog/exemplars/` exists only for `code-`, `docs-`, `api-`, `cli-ergonomics-`, and `design-craft`. Benchmarking against best-in-domain work is impossible for the other six.
+3. **Craft findings have no authority seam.** `packages/intelligence/src/outcome-eval/authority.ts` and its acceptance-eval twin derive `blocking | advisory` in TypeScript and never trust the LLM for it. `packages/cli/src/shared/craft/` has no counterpart: the 3-axis model (`findings/axes.ts`) and `derivePriority` (`findings/derived.ts`) produce a sort order, never a gate. Every craft finding is advisory, permanently.
+4. **The track's parent initiative is still marked blocked on work that is done.** `docs/roadmap.d/harness-craft-pipeline-orchestrator.md` is `Status: blocked` with `Blockers:` naming exactly the four sub-projects now `done`.
+
+## Ranked candidates
+
+### 1. Stamp every craft finding with the provider, model, and rubric version that produced it, so a judgment is reproducible and the effect of a model or rubric swap is visible rather than invisible — score: 6.00
+
+- Persona: Harness maintainers and tech leads who change the craft LLM backend (`shared/craft/llm/provider.ts` resolves `in-session` → `claude-cli` → `anthropic` → `mock`) and today cannot tell whether a shifted finding set reflects the code or the judge.
+- Complexity: low
+- Key risk: Provenance is only worth its plumbing if something downstream consumes it; it may become metadata nobody ever reads.
+- Impact / Confidence / Effort: M/H/L — base score 6.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment` — **recorded, not applied** (|Δ| to the next candidate is 1.50 > 0.05; base score determines rank) — final score 6.00
+- Strongest objection: This is bookkeeping dressed as a feature — it raises no ceiling by itself, and the craft family has survived eleven skills without it, which is evidence the pain is theoretical rather than felt. The most likely failure mode is that the fields ship, populate correctly, and are then read by no report, no gate, and no human, leaving eleven emit sites carrying dead weight that must be maintained through every future schema change. There is also a real chance the reproducibility it promises is illusory: stamping the model name does not make an LLM judgment reproducible, because the same model at the same version returns different findings across runs, so the stamp records an input without delivering the determinism a reader will assume it implies. For this objection not to hold, a concrete consumer would have to exist before the stamping lands — a calibration report, a model-swap diff, or a gate that refuses low-provenance findings — and the reproducibility claim would have to be narrowed honestly to "attributable" rather than "repeatable".
+- Objection answered: no
+
+### 2. Derive a `blocking | advisory` authority for each craft finding in TypeScript from the existing (tier, impact, confidence) axes, mirroring `deriveAuthority` in outcome-eval, so the highest-conviction ceiling findings can gate a merge while everything else stays advisory — score: 4.50
+
+- Persona: Tech leads whose CLAUDE.md and code-review checklists are, in the strategy's words, _"conventions without enforcement"_ — and who find that a craft finding nobody is obliged to act on gets skipped exactly like the convention it was meant to replace.
+- Complexity: medium
+- Key risk: A false-positive blocking gate on a taste judgment would poison trust in the entire craft family within one bad week.
+- Impact / Confidence / Effort: H/H/M — base score 4.50
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment`, +0.25 `Our approach` — **recorded, not applied** (|Δ| to the next candidate is 0.75 > 0.05; base score determines rank) — final score 4.50
+- Strongest objection: The two existing authority modules gate on a _verdict about a stated contract_ — outcome-eval asks whether an implementation met acceptance criteria it can read, acceptance-eval whether criteria are measurable — whereas craft findings are unbounded aesthetic judgments with no contract to check them against, so the analogy that makes this look cheap may not survive the transfer. The most likely failure mode is a `foundational`/`large`/`high` finding that is simply the model being confidently wrong about taste, blocking a correct merge, and teaching the team that the fastest path is an override flag which then becomes the default. Worse, the axes were designed under ADR 0019 for display ordering — `derivePriority` is documented as "for stable sort/display ONLY" — so promoting them into a merge gate loads them with an authority their calibration was never established for. For this objection not to hold, the confidence axis would need demonstrated precision at the `high` end (measured, not assumed), the blocking band would need to be narrow enough that it fires rarely, and an override would need to be auditable rather than routine.
+- Objection answered: no
+
+### 3. Build golden fixtures with human-labelled expected findings for each craft skill, measure precision, recall, and run-to-run self-consistency against them, and gate rubric and prompt PRs on the result — score: 3.75
+
+- Persona: Harness maintainers editing craft rubrics and prompts, who today ship a taste change across eleven skills with no measurement of whether the skill got better or worse.
+- Complexity: medium
+- Key risk: Hand-labelling golden craft fixtures is a large one-time taste investment that decays as the rubrics it measures evolve.
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment: add craft-pipeline skills that critique _quality_ (naming, prose, code shape, spec clarity, threat models) beyond what rule-based linters can catch`, +0.25 `Our approach: encoding architectural decisions, process discipline, and strategic intent as machine-checkable constraints` — **applied** (base score tied at 3.00 with candidates 4, 5, and 6; |Δ| = 0.00 ≤ 0.05, tie window) — final score 3.75
+- Strongest objection: A golden fixture encodes one labeller's taste at one moment as ground truth, which is precisely the thing the craft family exists to argue is not mechanizable — so the harness would be measuring agreement with a frozen opinion rather than quality, and a rubric change that genuinely improves the skill would register as a regression and be blocked by its own gate. The most likely failure mode is inverted: the gate makes rubrics harder to improve, maintainers learn to re-baseline the fixtures whenever they fail, and the CI check degrades into a rubber stamp that costs review latency and buys nothing. The existing `skill-regression-evaluator` (`Status: done`) already covers brainstorming, planning, and spec-craft, so part of the claimed gap may be narrower than it appears. For this objection not to hold, the fixtures would have to be labelled by more than one person with inter-rater agreement reported, the gate would have to fire on self-consistency (a property the skill should have regardless of taste) rather than on match-the-label, and re-baselining would need to be a reviewed event rather than a routine unblock.
+- Objection answered: no
+
+### 4. Run diff-scoped, risk-tiered craft critique inside the code-review pipeline at PR time instead of only in craft-fleet's periodic sweep, so ceiling findings arrive while the change is still open — score: 3.75
+
+- Persona: Tech leads on agent-heavy teams watching PR-review backlogs balloon, for whom a finding that lands a week after merge is a cleanup ticket rather than a review comment.
+- Complexity: medium
+- Key risk: Per-PR LLM judgment on every diff is a recurring token cost against a low hit rate — most diffs carry no ceiling finding worth the spend.
+- Impact / Confidence / Effort: H/M/M — base score 3.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment`, +0.25 `Target problem: ... that humans then absorb as code-review backlogs and manual checklists` — **applied** (base score tied at 3.00 with candidates 3, 5, and 6; |Δ| = 0.00 ≤ 0.05, tie window) — final score 3.75
+- Strongest objection: Craft findings are inherently whole-artifact judgments — whether an abstraction is earned, whether a doc teaches, whether a resource models the domain — and a diff is the wrong unit for all of them, so diff-scoping the critique will systematically produce the shallowest findings the family is capable of while charging the highest per-run cost. The most likely failure mode is comment fatigue: an aspirational-tier remark on every PR, reviewers muting the bot within a month, and the craft family acquiring the reputation of a nitpicker precisely when it needed authority for candidate 2. There is also a scope collision worth naming — `craft-fleet` already sweeps these skills and routes findings elevate/file/route, so this creates a second entry point whose boundary with the fleet is undefined. For this objection not to hold, the risk tiering would have to suppress the large majority of diffs rather than annotate them, the PR-time surface would have to be restricted to the finding classes that are genuinely diff-local, and the boundary against craft-fleet would need to be settled before either surface grows.
+- Objection answered: no
+
+### 5. Curate exemplar catalogs for copy-, knowledge-, naming-, security-, spec-, and test-craft — the six skills that ship rubrics but no exemplars — bringing the family to parity with the five that have them — score: 3.50
+
+- Persona: Senior engineers who want "how does this compare to the best work in this domain" rather than one more list of rubric violations.
+- Complexity: medium
+- Key risk: Exemplar curation is taste-labour that does not compound — the catalog goes stale and nobody notices it has.
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment` — **applied** (base score tied at 3.00 with candidates 3, 4, and 6; |Δ| = 0.00 ≤ 0.05, tie window) — final score 3.50
+- Strongest objection: The five domains that got exemplars got them because exemplars are _available and citable_ there — Stripe's API, `gh` and `rg` for CLIs, MDN and Linear for docs — whereas the six without them are the six where public best-in-class work either does not exist or cannot be quoted: there is no canonical corpus of exemplary threat models, exemplary knowledge captures, or exemplary internal specs, and the absence may be a correct earlier judgment rather than an oversight. The most likely failure mode is that the catalogs get filled with the harness's own artifacts, which makes the skill measure conformity to this repository's habits and calls it excellence — a self-referential ceiling that can only ever rise to where the repo already is. For this objection not to hold, each of the six domains would need at least a handful of genuinely external, defensible exemplars identified _before_ the build is committed, and any domain that cannot clear that bar would need to be dropped rather than padded.
+- Objection answered: no
+
+### 6. Build the `harness:craft-pipeline` orchestrator — the track's parent initiative, still marked `blocked` on four sub-projects that are now all `done` — composing the eleven craft skills as FRESHEN → JUDGE → SUGGEST → BENCHMARK → REPORT, the way docs-pipeline and design-pipeline compose their families — score: 3.50
+
+- Persona: Tech leads who want a single whole-repo ceiling-health command and report rather than invoking eleven skills by hand or waiting on a fleet sweep.
+- Complexity: medium
+- Key risk: `craft-fleet` already composes these eleven skills, so a second composition surface risks overlapping it with no clear boundary.
+- Impact / Confidence / Effort: M/H/M — base score 3.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment` — **applied** (base score tied at 3.00 with candidates 3, 4, and 5; |Δ| = 0.00 ≤ 0.05, tie window) — final score 3.50
+- Strongest objection: This initiative was specified before `craft-fleet` existed, and `craft-fleet` shipped and did the useful half of it — sweeping the eleven skills, ranking targets, routing findings — so building the orchestrator now is at serious risk of being archaeology rather than product, delivering a second front door to the same eleven skills and forcing every future craft change to be wired into two composition layers instead of one. The most likely failure mode is that the orchestrator ships, `craft-fleet` remains the surface people actually run because it produces PRs rather than a report, and the pipeline becomes a maintained-but-unused artifact whose FRESHEN and BENCHMARK phases quietly rot. The record also shows the two are not equivalent — the orchestrator's BENCHMARK phase has no implementation for six of eleven skills (see candidate 5) — which means shipping it now would ship a phase that half the family cannot execute. For this objection not to hold, the orchestrator/fleet boundary would need to be stated as a decision before any code, and the phases that cannot run family-wide would need to degrade explicitly rather than silently skip.
+- Objection answered: no
+
+### 7. Lift design-craft's POLISH phase into the shared craft layer so each of the ten critique-only skills can apply a bounded, cited fix for its own findings instead of only reporting them — score: 2.75
+
+- Persona: Engineers who receive a craft report and must hand-apply every finding, paying the reading cost of the critique twice — once to understand it, once to act on it.
+- Complexity: high
+- Key risk: An auto-applied ceiling rewrite is a machine acting on its own aesthetic judgment with no independent check between the opinion and the edit.
+- Impact / Confidence / Effort: H/M/H — base score 2.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment`, +0.25 `Our approach: Constraints fire in real time, so agents self-correct mid-stream instead of accumulating cleanup debt downstream` — **applied** (base score tied at 2.00 with candidate 8; |Δ| = 0.00 ≤ 0.05, tie window) — final score 2.75
+- Strongest objection: POLISH works in design-craft because design findings are largely token-level and mechanically checkable after the fact — a spacing value, a type scale, a contrast ratio — whereas code, spec, security, and knowledge findings are semantic, and a model that rewrites a function to satisfy its own "this abstraction is not earned" judgment can silently change behaviour with a diff that reads beautifully and passes review precisely because it reads beautifully. The most likely failure mode is a plausible, well-argued, subtly wrong rewrite landing through a pipeline whose reviewer is the same class of model that proposed it. The scale multiplies the risk: this is ten skills across every artifact type in the repo, and `code-craft` is documented as touching every PR. For this objection not to hold, POLISH would have to be gated behind a test-and-behaviour-preservation check per domain rather than a generic one, applied only to `foundational`-tier high-confidence findings, and shipped domain-by-domain with evidence from each before the next — not lifted family-wide in one move.
+- Objection answered: no
+
+### 8. Add a shared arbiter that collapses findings which multiple craft skills raise against the same construct — one poor function draws naming, code, docs, and test findings — into a single ranked elevation — score: 2.50
+
+- Persona: Engineers reading a craft-fleet batch where the finding count overstates the problem count several times over, and who cannot tell which of forty findings are the eight underlying issues.
+- Complexity: medium
+- Key risk: Cross-domain dedup requires a shared identity for "the same problem", which may not actually exist.
+- Impact / Confidence / Effort: M/M/M — base score 2.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment` — **applied** (base score tied at 2.00 with candidate 7; |Δ| = 0.00 ≤ 0.05, tie window) — final score 2.50
+- Strongest objection: Four skills flagging one function are usually saying four genuinely different things — the name misleads, the abstraction is unearned, the doc comment lies, the test asserts implementation — and collapsing them into one elevation destroys exactly the multi-perspective signal that motivated building eleven separate skills instead of one; the redundancy is the product, not a defect. The most likely failure mode is an arbiter that keeps the highest-priority finding and discards three, so the engineer fixes the name, closes the item, and never learns the test was also wrong. The skills already defer to each other by design where the overlap is real — code-craft is documented as deferring naming findings to naming-craft and doc-comment findings to docs-craft — which suggests the duplication is bounded by construction and the observed volume may be a presentation problem rather than a dedup problem. For this objection not to hold, the arbiter would have to group and nest rather than collapse, and the duplication rate would need measuring on real fleet output first to establish there is a problem worth an arbiter.
+- Objection answered: no
+
+### 9. Generalize design-craft's BENCHMARK phase into the shared craft layer so any craft skill scores its target against per-domain exemplars and reports a trend over time — score: 1.33
+
+- Persona: Tech leads who need to report quality movement upward and require a number that moves, rather than a finding list that resets on every run.
+- Complexity: high
+- Key risk: A single scalar craft score is the output most likely to be gamed, or dismissed as unfalsifiable.
+- Impact / Confidence / Effort: M/M/H — base score 1.33
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment` — **recorded, not applied** (|Δ| to the adjacent candidate is 1.17 > 0.05; base score determines rank) — final score 1.33
+- Strongest objection: The moment a craft score exists it becomes a target, and a target set by an LLM's own judgment is the easiest target in the repository to satisfy without improving anything — the score rises because the artifacts learn the rubric's vocabulary, which is Goodhart's law with an unusually short feedback loop. The most likely failure mode is a dashboard number that trends up while quality holds flat, which is worse than no number because it retires the question. There is also a hard dependency and a hard prior: six of eleven skills have no exemplars to benchmark against (candidate 5 must land first), and the repository has already ruled — in the `stability-gate-on-ranked-outputs` item, `Status: done` — that ranked outputs must prove two-window rank stability or degrade to tiers, a bar an LLM-derived craft score is unlikely to clear. For this objection not to hold, the score would have to demonstrate cross-window stability under that existing gate, and it would have to be reported as a tier rather than a point value if it cannot.
+- Objection answered: no
+
+### 10. Add review-craft, a twelfth craft skill that critiques the harness's own review output — whether review comments are specific, actionable, and correctly prioritized — turning the ceiling family on the reviewers themselves — score: 1.00
+
+- Persona: Tech leads who trust the review pipeline's coverage but not its signal-to-noise, and who today have no measure at all of review-comment quality.
+- Complexity: low
+- Key risk: Judging a judge with the same class of judge is circular — a model that writes weak reviews will rate weak reviews highly.
+- Impact / Confidence / Effort: M/L/M — base score 1.00
+- Strategy alignment: +0.5 track:`Ceiling-raising via LLM judgment` — **recorded, not applied** (|Δ| to the adjacent candidate is 0.33 > 0.05; base score determines rank) — final score 1.00
+- Strongest objection: The circularity is not a caveat here, it is the whole mechanism: the reviewer and the critic share a model, a prompt lineage, and a set of blind spots, so the skill is structurally incapable of finding the failures that matter most — the ones the reviewing model cannot see — and will instead reward reviews written in the style it would have written. The most likely failure mode is a consistently high review-quality score that is pure self-agreement, actively harmful because it manufactures confidence in a surface nobody has independently checked. The repository already holds a cheaper and less circular instrument for this question — `outcome-eval`'s post-merge `execution_outcome` verdicts, which the Holiday Confidence KPI already reads — so the ground truth about whether reviews caught what mattered is partly available without a new skill. For this objection not to hold, the critic would need a different model or a genuinely independent rubric from the reviewer, and it would need validation against real escaped-defect data before its verdicts were shown to anyone.
+- Objection answered: no
+
+## Ranking trace
+
+| Rank | Candidate                                | I/C/E | Base | Alignment bonus | Applied?           | Final |
+| ---- | ---------------------------------------- | ----- | ---- | --------------- | ------------------ | ----- |
+| 1    | Finding provenance stamping              | M/H/L | 6.00 | +0.5            | no (Δ 1.50 > 0.05) | 6.00  |
+| 2    | Craft finding authority module           | H/H/M | 4.50 | +0.75           | no (Δ 0.75 > 0.05) | 4.50  |
+| 3    | Judgment calibration harness             | H/M/M | 3.00 | +0.75           | yes (tie window)   | 3.75  |
+| 4    | Inline craft critique at PR time         | H/M/M | 3.00 | +0.75           | yes (tie window)   | 3.75  |
+| 5    | Exemplars for the six rubric-only skills | M/H/M | 3.00 | +0.5            | yes (tie window)   | 3.50  |
+| 6    | `harness:craft-pipeline` orchestrator    | M/H/M | 3.00 | +0.5            | yes (tie window)   | 3.50  |
+| 7    | Shared POLISH phase                      | H/M/H | 2.00 | +0.75           | yes (tie window)   | 2.75  |
+| 8    | Cross-craft finding arbitration          | M/M/M | 2.00 | +0.5            | yes (tie window)   | 2.50  |
+| 9    | Shared BENCHMARK phase                   | M/M/H | 1.33 | +0.5            | no (Δ 1.17 > 0.05) | 1.33  |
+| 10   | review-craft (twelfth skill)             | M/L/M | 1.00 | +0.5            | no (Δ 0.33 > 0.05) | 1.00  |
+
+Candidates 3 and 4 tie at 3.75, and candidates 5 and 6 tie at 3.50; ordering within each tie is stable on generation order. Rank is `(impact × confidence) ÷ effort` plus the bounded tiebreaker and nothing else — the unrebutted objections recorded above did not move any position.

--- a/docs/ideation/shortlists/strategy-track-sweep-2026-09-06.md
+++ b/docs/ideation/shortlists/strategy-track-sweep-2026-09-06.md
@@ -1,0 +1,140 @@
+---
+batch_label: strategy-track sweep (6 confirmed STRATEGY.md tracks)
+batch_slug: strategy-track-sweep
+pinned_date: 2026-09-06
+base_sha: e530ae6bc67c003f11e4e32a606b7c929618a5f0
+themes: 6
+themes_verified: 6
+themes_thin: 0
+themes_parked: 0
+themes_rejected: 0
+count_per_theme: 10
+per_theme_cut: 3
+global_cap: 10
+objection_policy: none
+novelty_lookback_days: 90
+concurrency: 1
+strategy_grounded: true
+strategy_path: STRATEGY.md
+all_os_ci: not-applicable (fleet produces no code or PR)
+filed: nothing
+committed: nothing
+---
+
+# Ideate-Fleet Curated Shortlist — strategy-track sweep (2026-09-06)
+
+Wave-1 `ideate-fleet` lane dispatched by `fleet-command`. Six `STRATEGY.md` tracks were each run through the **real** `harness-ideate` pipeline in its own git worktree, producing one ranked artifact per theme (10 candidates each, 60 total). Every shortlist row traces to a **verified** per-theme artifact collected byte-identical into `docs/ideation/`, and every score below was **independently re-derived** by the orchestrator from the artifact's own impact/confidence/effort values — never taken from a worker's self-report.
+
+**Nothing was filed. Nothing was committed, staged, or pushed.** This shortlist and the six collected artifacts are ordinary working-tree changes. The pick is the human's act.
+
+## The headline finding: this batch re-ideated a lot of August
+
+This is the **second** full sweep of these same six tracks; the first was `strategy-track-sweep-2026-08-13.md`, 24 days earlier, whose 60 candidates were never filed. At CONFIRM the human chose **Option A**, which added those six prior artifacts as a **fifth novelty source**. That decision is what makes this batch readable:
+
+| Theme                        | Repeat rate vs. 2026-08-13                       |
+| ---------------------------- | ------------------------------------------------ |
+| upstream-grounding           | **8 of 10** candidates are near-verbatim repeats |
+| multi-client-portability     | 3 of top 5 are repeats                           |
+| ceiling-raising-llm-judgment | ~3 of 10                                         |
+| full-lifecycle-reach         | 1 of top 3                                       |
+| external-adoption-flywheel   | 1 of top 3                                       |
+| compounding-feedback-loops   | **0 of top 3**                                   |
+
+**Without Option A every one of those repeats would have been reported `novel`** — none of them is tracked in an issue, a roadmap row, or a merged PR. The fleet's specified novelty machinery (issues + roadmap + merged PRs) is structurally blind to prior ideation output.
+
+Two second-order findings fall out of the same comparison:
+
+- **Roadmap coverage anti-predicted repeat rate.** SELECT ranked `upstream-grounding` first partly on thin-ish coverage (13 open rows) and `compounding-feedback-loops` fourth on heavy coverage (36 open rows). The thin track came back 8/10 repeats; the heavy track came back with three novel top candidates and needed no backfill. The coverage-thinness term in the SELECT score is, on this evidence, the wrong signal.
+- **Ranking is unstable across runs.** The ADR-lifecycle premise ranked **#7 at 2.75** in August and **#1 at 6.75** today — same idea, same artifact contract, same formula. Both artifacts re-derive correctly, so this is not a scoring defect; it is variance in the impact/confidence/effort judgment that feeds the formula. Read every score below as a rough tier, not a measurement.
+
+## Ranked shortlist (10 of 17 survivors; reserved-slot rule applied)
+
+| #   | Premise                                                                                                                                                                                                                                    | Theme                        | Re-derived score (base → final) | Standing objection (unrebutted)                                                                                                                                                                                           | Novelty                                                                                                                                                                                                                                                        | Artifact                                                       |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| 1   | Stamp every outcome record with the content hash of the skill revision and model that produced it, and score per revision                                                                                                                  | compounding-feedback-loops   | (3×3)/1 = 9.00 → 9.00           | Per-revision attribution fragments an already-sparse evidence pool: every skill edit resets that revision's sample to zero, so the scorer is best-informed about revisions nobody runs any more.                          | novel (adjacent: roadmap _Extend skill-effectiveness scorer to skill grain_; #579 Skill Regression Evaluator)                                                                                                                                                  | [compounding](../invest-in-mechanisms-that-make-2026-09-06.md) |
+| 2   | A learning-loop liveness check that fails loudly when an evidence store has stopped being fed                                                                                                                                              | compounding-feedback-loops   | (2×3)/1 = 6.00 → 6.75           | Liveness proves records arrive, not that they carry signal; a loop emitting well-formed useless records passes green, and the check becomes one more thing to maintain.                                                   | novel — generalizes a failure this repo keeps hitting (LMLM loop shipped wired-but-inert; skill-proposal pipeline still un-activated, #551)                                                                                                                    | [compounding](../invest-in-mechanisms-that-make-2026-09-06.md) |
+| 3   | Time-decay the evidence in every scorer with an explicit half-life and staleness expiry                                                                                                                                                    | compounding-feedback-loops   | (2×3)/1 = 6.00 → 6.50           | A half-life is a free parameter nobody can calibrate without the very outcome history the decay is discarding; set wrong it either erases signal or changes nothing.                                                      | novel (no covering row; distinct from _Federated gate-calibration baselines_)                                                                                                                                                                                  | [compounding](../invest-in-mechanisms-that-make-2026-09-06.md) |
+| 4   | Instrument and report edge adoption, so "shipped" and "used" stop being the same word                                                                                                                                                      | full-lifecycle-reach         | (2×3)/1 = 6.00 → 6.50           | Measuring usage of a front door nobody has been told about will report zero and be read as "the edge failed" rather than "the edge was never launched".                                                                   | novel (adjacent: roadmap _Adoption-funnel telemetry_, which measures the off-repo adopter funnel, not internal edge-skill usage)                                                                                                                               | [lifecycle](../extend-the-harness-reliably-to-2026-09-06.md)   |
+| 5   | Stamp every craft finding with the provider, model, and rubric version that produced it, so a judgment is reproducible and the effect of a model or rubric swap is visible                                                                 | ceiling-raising-llm-judgment | (2×3)/1 = 6.00 → 6.00           | Reproducible metadata is not a reproducible judgment: the same model and rubric still return different findings run to run, so the stamp records the inputs to a process that remains non-deterministic.                  | novel (adjacent: **ADR 0124** covers the _fleet handoff_ provenance record, not per-judgment reproducibility; #1856, #1777)                                                                                                                                    | [ceiling](../raise-the-quality-ceiling-with-2026-09-06.md)     |
+| 6   | Route a non-accepted sign-off item back into work instead of terminating it in a file                                                                                                                                                      | full-lifecycle-reach         | (3×3)/2 = 4.50 → 5.25           | Auto-routing a rejection assumes the rejection is well-formed; a vague "this isn't right" becomes a re-opened work item with no actionable delta, and the loop churns.                                                    | novel (adjacent: roadmap _UAT / user sign-off loop_ #710, **done** — the loop ships, the non-accept path is the gap)                                                                                                                                           | [lifecycle](../extend-the-harness-reliably-to-2026-09-06.md)   |
+| 7   | Derive a `blocking \| advisory` authority for each craft finding in TypeScript from the existing (tier, impact, confidence) axes, mirroring `deriveAuthority` in outcome-eval, so the highest-conviction ceiling findings can gate a merge | ceiling-raising-llm-judgment | (3×3)/2 = 4.50 → 4.50           | Craft findings are taste judgments; promoting any of them to a merge blocker converts an advisory signal into an authority, and the first false-positive block trains the team to bypass the gate.                        | novel, but **in direct tension with ADR 0121**, which holds that craft skills are _advisory by design_. Not the alternative 0121 rejected (that was orchestrator taste without a cite) — this is a mechanical non-LLM derivation. **Read 0121 before acting.** | [ceiling](../raise-the-quality-ceiling-with-2026-09-06.md)     |
+| 8   | Signed, provenanced constraint bundles with a publisher-trust policy                                                                                                                                                                       | external-adoption-flywheel   | (3×3)/2 = 4.50 → 4.50           | Signing secures distribution for an ecosystem that does not exist yet; with no third-party publishers the trust policy protects against a threat with no actors, and the crypto surface is real maintenance from day one. | novel (adjacent: roadmap _Opt-In Constraint Packs_, _Pin MCP server version + trust model_)                                                                                                                                                                    | [adoption](../make-the-harness-valuable-enou-2026-09-06.md)    |
+| 9   | Extend the compiled-comprehension substrate from code to decisions: a committed, hash-gated unit per scope resolving the ADRs and principles actually binding on that scope                                                                | upstream-grounding           | (3×2)/2 = 3.00 → 3.75           | Decisions do not decompose along the file boundaries that made code comprehension compilable; the relevance function degrades into path matching, surfacing obvious decisions and missing cross-cutting ones.             | novel-**adjacent** (2026-08-13 upstream #4 proposed a precompiled cached grounding bundle; mechanism differs — committed hash-gated per-scope units vs. a runtime topic cache. Adjacency cited rather than resolved in the fleet's favour.)                    | [upstream](../make-the-strategic-and-knowled-2026-09-06.md)    |
+| 10  | A declared per-client interaction channel for human gates, so a confirmation prompt renders in that client's real surface or fails loudly rather than vanishing                                                                            | multi-client-portability     | (3×2)/2 = 3.00 → 3.75           | A declared channel does not make a client capable of rendering a gate; where none exists the honest outcome is a loud failure, which converts a silent-drop bug into a hard block on that client.                         | novel (adjacent: PR #656 established plain-text asks; nothing declares a per-client channel)                                                                                                                                                                   | [portability](../keep-one-harness-substrate-fai-2026-09-06.md) |
+
+Score basis: `base = (impact × confidence) ÷ effort` with `low|medium|high → 1|2|3`; `final = base + strategy-alignment bonus`, bonus read from the artifact (never recomputed), applied only inside an exact base-score tie, `0 ≤ bonus ≤ 0.75`. Cross-batch ordering is final score descending, ties broken by theme SELECT order then artifact order.
+
+## Two candidates that are not ideas — route these, do not spec them
+
+Both surfaced as top-ranked candidates and were **dropped from the shortlist** as already-known, but they are real defects in shipped work and should go to `issue-fleet` / `bug-fleet` rather than being lost in a drop table:
+
+- **The lifecycle edge is shipped but unwired.** `product-advisor`, `product-requirements`, and `uat-signoff` all exist as skills, and _Role-shaped dashboard front doors_ (#711) and _UAT / user sign-off loop_ (#710) are both roadmap **`done`** — but nothing registers the three skills into the lanes. Classic WIRED-tier gap: components exist, integration does not. (Theme 5 candidate #1.)
+- **`harness:craft-pipeline` is blocked on nothing.** Issue #374 / its roadmap row sit `blocked` on four sub-projects — docs-craft, code-craft, api-craft, cli-ergonomics — that are **all now `done`**. The orchestrator is unblocked and nobody has noticed. (Theme 2 candidate #6.)
+
+## STRATEGY.md is stale in at least two of its six tracks
+
+Read-only to this fleet; routing to `harness-strategy` is the human's call.
+
+- **Ceiling-raising** says "complete the craft family — docs-craft, code-craft, api-craft, cli-ergonomics are the remaining four". All four roadmap sub-projects are `done` and all eleven craft skills exist.
+- **Full-lifecycle reach** describes "gaps at the product-requirements middle, UAT / sign-off edge". Both skills now exist (wiring notwithstanding, above).
+
+Theme 5's candidate #5 — _a mechanical staleness check that fails when a lifecycle-coverage claim contradicts the installed skill set_ — is the mechanized fix for exactly this class of drift. It survived cross-check as novel and sits just below the cap at final 4.00.
+
+## A convergence deliberately NOT collapsed as a duplicate
+
+Theme 2's #1 stamps **craft findings** with provider/model/rubric version; theme 4's #1 stamps **outcome records** with skill-revision/model hash. Different record types, different consumers — under `harness-ideate`'s near-duplicate rule these are two ideas, not one, so the dedup backstop left them separate and both are shortlisted (rows 5 and 1).
+
+But they were generated independently, in isolated worktrees, from different focus lines. Together with **ADR 0124** (canonical fleet provenance record), **#1856** (`provenance.json` has no schema), and **#1777** (provenance trailer CI gate), that is **five independent signals converging on attribution/provenance as a systemic gap**. Two ideation runs reaching for the same structural fix is a stronger signal than either candidate alone.
+
+## Assumptions made
+
+- **Derivation basis / merges.** The six themes are the six `STRATEGY.md` `Tracks` (present + valid, v2, 2026-07-01). Every pair of focus lines was compared; **no merges were applied**. The one genuinely overlapping pair — `multi-client-portability` × `external-adoption-flywheel`, which share the marketplace/plugin distribution surface — was held apart by an explicit boundary written into both workers' briefs (portability owns cross-client substrate fidelity; adoption owns off-repo value and distribution). The human declined the merge at CONFIRM. Evidence the split holds: the cross-theme dedup backstop found **0 collapses**, as it also did in August.
+- **SELECT order (= strategic weight).** 1 upstream-grounding (6.5), 2 ceiling-raising (6.5), 3 multi-client-portability (6.0), 4 compounding-feedback-loops (5.5), 5 full-lifecycle-reach (5.0), 6 external-adoption-flywheel (4.0). Composite of track membership × target-problem/approach touch × roadmap-coverage thinness. **See the headline finding — the coverage-thinness term anti-predicted this batch's results.**
+- **Pinned batch date.** 2026-09-06 (UTC), fixed at CONFIRM, used for every artifact filename and this shortlist. Base SHA pinned at `e530ae6bc`.
+- **Objection policy.** `none` — every candidate's single strongest objection stands as an accepted, unrebutted downside. None were answered by the fleet or by any worker.
+- **Bounds in force.** count/theme 10; per-theme cut 3; global cap 10; novelty lookback 90 days.
+- **Concurrency: 1, not the 2 tabled at CONFIRM.** The human explicitly re-allocated this lane to 1 slot so it could run alongside `roadmap-fleet` rather than stay parked. The gate text presented to the human said "2 — not raisable"; the executed value was 1. Recorded here because the tabled bound and the executed bound differ. No other bound changed.
+- **Reserved-slot rule.** 1 slot reserved for the highest-scoring survivor of each of the 6 non-thin themes; the remaining 4 filled by final score descending. Result: compounding ×3, lifecycle ×2, ceiling ×2, upstream ×1, portability ×1, adoption ×1. No cap raise needed (6 reserved ≤ 10). **Consequence worth seeing:** theme 5's #5 (final 4.00) was displaced by two lower-scoring reserved entries (rows 9 and 10, both 3.75) so that no theme was silently erased. That is the rule working as designed, not a scoring error.
+- **Novelty sources — five, all available, none missing.** 253 open issues (`gh`); 885 merged PRs covering the **full** 90-day window; 282 roadmap rows read directly from `docs/roadmap.d/`; **the six 2026-08-13 ideation artifacts** (added by the human's Option A); and ADR 0124 for provenance-adjacent premises. There are **no `novelty-unknown` annotations** in this batch. "novel (adjacent to X)" means nothing tracked **subsumes** the premise; adjacency is cited for the reader to judge.
+- **A truncation caught before it could mislead.** The first merged-PR page (600 results) reached back only to 2026-07-19 — 49 days, not 90. A single-page fetch would have silently checked half the window while reporting a 90-day lookback. The 2026-06-08 → 2026-07-19 slice was fetched separately (285 more PRs) to cover the confirmed window.
+- **A stale base, corrected.** This lane was parked at CONFIRM while the run moved on. It was resumed against `origin/main` = `e530ae6bc` (through #1950), not the `481a3a51e` named in the resume instruction — main had moved again in the interim. All novelty sources were gathered after re-basing.
+- **Worktree isolation was lost and rebuilt.** This lane's original isolation worktree was deleted while it was parked; on resume its working directory had silently become the shared checkout. Six fresh sibling worktrees were created outside the nested agent-config path, one per theme, each removed only after its artifact was collected. The shared checkout was never switched off the human's `chore/config-lingering-post-fleet-run` branch and no branch was created.
+
+## Per-theme outcome summary
+
+| Theme                        | Ran? | Generated | Verdict      | Survivors | Shortlisted | Already-ideated (prior artifact) | Already-known (issue/row) |
+| ---------------------------- | ---- | --------- | ------------ | --------- | ----------- | -------------------------------- | ------------------------- |
+| upstream-grounding           | yes  | 10/10     | **verified** | 2         | 1           | 8                                | 0                         |
+| ceiling-raising-llm-judgment | yes  | 10/10     | **verified** | 3         | 2           | 2                                | 1 (#374)                  |
+| multi-client-portability     | yes  | 10/10     | **verified** | 3         | 1           | 3                                | 0                         |
+| compounding-feedback-loops   | yes  | 10/10     | **verified** | 3         | 3           | 0                                | 0                         |
+| full-lifecycle-reach         | yes  | 10/10     | **verified** | 3         | 2           | 1                                | 1 (#711)                  |
+| external-adoption-flywheel   | yes  | 10/10     | **verified** | 3         | 1           | 1                                | 1 (#538/#539)             |
+
+All six themes: artifact resolved by frontmatter `topic`, frontmatter complete, `count_generated` = `count_requested` = 10 (**no thin themes**), all 60 base scores re-derived exactly, all six orders non-increasing in base score, all bonuses within `0 ≤ bonus ≤ 0.75` and non-zero only on exact base-score ties. **0 parked, 0 rejected, 0 retries.** Cross-theme dedup backstop: **0 collapses**. Backfills applied: 8. Below-cut candidates remaining in artifacts: 43.
+
+**All-OS CI: not applicable** for every theme — this member produces no code and no PR, so the family's CI half has no subject. Recorded, not silently dropped. The spine's base-freshness clause is likewise not-applicable: no verdict here derives from a CI conclusion.
+
+## Artifact integrity — a self-inflicted violation, disclosed
+
+**Five of the six collected artifacts are no longer byte-identical to what their worker wrote.** After collection and after verification, the orchestrator ran `prettier --write` over its own emissions to avoid tripping `format:check` on the human's next push, and the glob caught the collected artifacts as well as this shortlist. That is a violation of this member's "never edit a collected artifact" gate, committed by the orchestrator, not by any worker.
+
+| Artifact                       | SHA-1 at collection | SHA-1 now  | State         |
+| ------------------------------ | ------------------- | ---------- | ------------- |
+| make-the-strategic-and-knowled | `f29baa17`          | `f3356f95` | reformatted   |
+| raise-the-quality-ceiling-with | `fe92489f`          | `7304aba0` | reformatted   |
+| keep-one-harness-substrate-fai | `958b7435`          | `958b7435` | **unchanged** |
+| invest-in-mechanisms-that-make | `8cdd49ae`          | `0fa98f5d` | reformatted   |
+| extend-the-harness-reliably-to | `0d672742`          | `817a2ec3` | reformatted   |
+| make-the-harness-valuable-enou | `8da7e613`          | `e8f75a74` | reformatted   |
+
+What this does and does not cost:
+
+- **The verdicts stand on evidence that was valid when it was read.** Every provenance check and all 60 score re-derivations were performed _before_ the reformat, against copies whose byte-identity to the worker output was confirmed by SHA-1 at collection time (both hashes recorded in this run's log). No verdict rests on a post-mutation read.
+- **The change is formatting-only.** `prettier` normalizes markdown whitespace, wrapping, and table padding; it does not alter text. Re-checked after the fact, all six files still carry 10 candidates, 10 impact/confidence/effort lines, and `count_generated: 10`.
+- **Byte-identity is nonetheless gone and cannot be restored.** The six dispatch worktrees had already been released, so the originals no longer exist anywhere. A future reader cannot re-confirm byte-identity against the worker output; they can only rely on the collection-time hashes recorded here.
+- **The correct sequence was prettier-the-shortlist-only**, with the artifacts excluded from the glob. Collected evidence should never have been inside a `--write` path.
+
+## What was not done
+
+Nothing was filed — no issue, roadmap row, spec, plan, ADR, or PR. Nothing was committed, staged, or pushed. `STRATEGY.md` was read and never written. The six dispatch worktrees were removed after their artifacts were collected, and the shared checkout was never switched off the human's branch. This shortlist and the six artifacts under `docs/ideation/` are working-tree changes the human keeps or discards — see the integrity note above before treating the artifacts as untouched pipeline output.


### PR DESCRIPTION
## What

Commits the 2026-09-06 strategy-track ideation sweep, which was left as untracked files in the main worktree and would have been lost to any `git clean`.

Seven documents: six STRATEGY.md-grounded ideation runs (10 candidates each, critiqued against their strongest objection and ranked by (impact × confidence) ÷ effort), plus `shortlists/strategy-track-sweep-2026-09-06.md`, the batch shortlist that ranks across all six.

The tracks:

| Track | Theme |
|---|---|
| `make-the-strategic-and-knowled-` | STRATEGY.md / knowledge graph / ADR durability so downstream skills ground instead of starting cold |
| `raise-the-quality-ceiling-with-` | LLM-judgment critique above what rule-based linters reach, now the craft family is complete |
| `keep-one-harness-substrate-fai-` | Cross-client fidelity across Claude Code, Cursor, Codex, Gemini CLI, OpenCode |
| `invest-in-mechanisms-that-make-` | Agents/skills that measurably improve over time — proposal loop, effectiveness baselines, trust scoring |
| `extend-the-harness-reliably-to-` | Role-shaped front doors at the two non-engineer edges: intent upstream, adjudication after ship |
| `make-the-harness-valuable-enou-` | Off-repo adopter value to test the constraints-as-code thesis at scale |

All six record `strategy_grounded: true` against `STRATEGY.md`, and the shortlist pins `base_sha: e530ae6bc`.

## Scope

Docs only. No roadmap rows, specs, assignments, or code follow from this — it is ranked ideation, and picking anything off it is a separate decision.

https://claude.ai/code/session_019TcZHdqunxuZ1NAWMc6vah