### PR TITLE
fix(ci): land the architecture snapshot via PR fallback instead of a rejected push to main

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,11 +4,23 @@ on:
     - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
   workflow_dispatch: {} # Manual trigger
 
+# The weekly cron and a manual dispatch can overlap. Two runs both appending to the
+# same `.harness/arch/timeline.json` would race on the fallback branch below, so
+# serialize them instead of cancelling (a cancelled capture loses that week's point).
+concurrency:
+  group: architecture-snapshot
+  cancel-in-progress: false
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
     permissions:
+      # `contents: write` for the direct-push path; `pull-requests: write` for the
+      # `gh pr create` fallback taken when branch protection blocks a direct push to
+      # main (which is the current ruleset — see the Commit snapshot step). Without
+      # `pull-requests: write`, gh fails with "Resource not accessible by integration".
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -18,10 +30,62 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: node packages/cli/dist/bin/harness.js snapshot capture
+      # Commit the captured timeline point via the bot. Scoped strictly to
+      # `.harness/arch/timeline.json` so the bot can only ever touch the artifact it
+      # just generated. Direct push first; PR fallback (for human review — no PAT,
+      # no auto-approve) when branch protection blocks the direct push. Mirrors the
+      # "Commit refreshed semantic shards" job in ci.yml.
       - name: Commit snapshot
+        env:
+          # Disable husky so `git commit`/`git push` hooks cannot run the pre-commit
+          # gauntlet (coverage ratchet, `generate-docs --check`, tool-catalog
+          # `--check`) inside this step and fail it or leave the tree dirty. Same
+          # posture as roadmap-auto-done.yml.
+          HUSKY: '0'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .harness/arch/timeline.json
-          git diff --cached --quiet || git commit -m "chore: architecture snapshot $(date +%Y-%m-%d)"
-          git push
+          TIMELINE=".harness/arch/timeline.json"
+          git add "$TIMELINE"
+          if git diff --cached --quiet; then
+            echo "No snapshot change to commit."
+            exit 0
+          fi
+          # `[skip ci]` keeps the direct-push path from starting a fresh CI run on main
+          # (the same guard every other commit-back job in this repo carries).
+          git commit -m "chore: architecture snapshot $(date +%Y-%m-%d) [skip ci]"
+          OURS=$(git rev-parse HEAD)
+          if git push 2>&1; then
+            exit 0
+          fi
+          echo "Direct push blocked by branch protection. Opening a PR instead."
+          git fetch origin main
+          # Never stack a second snapshot PR on an unmerged one: both branches append
+          # to the same timeline file and would conflict on the same JSON array, which
+          # is how automated-artifact PRs end up DIRTY and abandoned. Exit clean and
+          # let the operator merge the one that is already waiting.
+          EXISTING=$(gh pr list --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("chore/arch-snapshot-"))] | .[0].number' || true)
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            echo "Snapshot PR #$EXISTING is already open and unmerged; not opening a duplicate."
+            exit 0
+          fi
+          BRANCH="chore/arch-snapshot-$(date +%s)"
+          git checkout -B "$BRANCH" origin/main
+          # Re-apply the freshly captured timeline on top of the latest main. Capture
+          # appends to whatever main carried at checkout, so "ours" is a superset of
+          # main's series and this re-apply cannot conflict.
+          git checkout "$OURS" -- "$TIMELINE"
+          git add "$TIMELINE"
+          if git diff --cached --quiet; then
+            echo "Latest main already carries this snapshot; nothing to PR."
+            exit 0
+          fi
+          git commit -m "chore: architecture snapshot $(date +%Y-%m-%d) [skip ci]"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: architecture snapshot $(date +%Y-%m-%d)" \
+            --body "Automated weekly architecture-timeline capture. Opened because a direct push to main is blocked by branch protection (GH013 \`Changes must be made through a pull request\`). Merging advances \`.harness/arch/timeline.json\`, the series read by \`get_decay_trends\`, \`harness snapshot trend\`, and \`predict_failures\` (which needs >= 3 points)." \
+            --base main \
+            --head "$BRANCH"

--- a/docs/changes/arch-snapshot-commit-back/audit-session.md
+++ b/docs/changes/arch-snapshot-commit-back/audit-session.md
@@ -1,0 +1,120 @@
+# Audit Session: Architecture Snapshot commit-back rejected by branch protection
+
+Status: resolved
+Started: 2026-09-07
+Skill: `harness-workflow-audit` (INVENTORY -> MECHANICAL -> JUDGMENT -> REPORT)
+Fleet: cicd-fleet, item `Architecture Snapshot` (cause: infra-config)
+Workflow: `.github/workflows/snapshot.yml`
+Error: `remote: error: GH013: Repository rule violations found for refs/heads/main. - Changes must be made through a pull request.`
+CI: run 34120963994 (`schedule`, 2026-09-07T12:16:11Z), step `Commit snapshot`
+
+## Phase 1 — INVENTORY
+
+- 23 workflow files under `.github/workflows/*.yml`.
+- Commit-back sub-inventory (the scoped defect class) — grep for
+  `git push|git commit|gh pr create|peter-evans` returns 5 jobs across 5 files, plus the sibling
+  lane's `holiday-confidence-track.yml`.
+- `peter-evans/create-pull-request`: **0 occurrences repo-wide.** The push-then-fall-back-to-PR
+  idiom is hand-rolled and is the convention.
+- Two distinct working shapes found:
+  - **PAT self-approve + auto-merge** — `ci.yml:329-380` (baselines), `release.yml:130-175`
+    (golden manifest), `roadmap-auto-done.yml:170-205`. All use `secrets.BASELINE_AUTOAPPROVE_PAT`
+    and a `scripts/assert-diff-scope.mjs` scope guard.
+  - **Plain PR for human review** — `ci.yml:463-500` (comprehension shards). `GITHUB_TOKEN` only.
+- `git ls-files` snapshot taken at `e7340f5c9` for path-filter resolution.
+
+## Phase 2 — MECHANICAL
+
+### Step — resolve every path glob (M1)
+
+`snapshot.yml` has no `paths:` filters. Resolved the rest anyway per the skill's gate:
+
+- `src/**` -> **0 tracked files.** Used by 4 `persona-*.yml` workflows. ERROR, out of scope.
+- `docs/**` -> 2045; `packages/**` -> 4223;
+  `packages/orchestrator/src/gateway/openapi/**` -> 4; `packages/types/src/auth.ts` -> 1;
+  `docs/api/openapi.yaml` -> 1; `.github/workflows/openapi-drift-check.yml` -> 1. All live.
+
+### Step — read the failing step, do not trust the summary (M4)
+
+`gh run view 34120963994 --log-failed` shows, in order, inside the **`Commit snapshot`** step:
+
+1. `turbo run test:coverage` -> `Running test:coverage in 0 packages` / `No tasks were executed`
+2. `Coverage ratchet: all packages meet or exceed baselines. (7 package(s) skipped)`
+3. `node scripts/generate-docs.mjs "--check"` -> `✓ All reference docs are fresh.`
+4. `node scripts/generate-tool-catalog.mjs --check` -> `✓ Tool & skill catalog is up to date.`
+5. `remote: error: GH013 ... - Changes must be made through a pull request.`
+6. `! [remote rejected] main -> main` / `##[error]Process completed with exit code 1`
+
+Two facts, both load-bearing:
+
+- Steps 1-4 are the **husky pre-commit gauntlet running inside the workflow step**. They passed on
+  this run; they are a latent second failure mode on a run where a generated artifact has drifted on
+  main. This is why fork D1 (`HUSKY=0`) is a real fix and not decoration.
+- Step 5 is the actual cause. `permissions: contents: write` is token scope; the ruleset is enforced
+  server-side and no token scope satisfies it. The only fix is to stop pushing to `main` directly.
+
+### Step — establish it is systematic, not a one-off
+
+`gh run list --workflow=snapshot.yml --limit 15` -> **15 runs, 15 `failure`, all `event=schedule`**,
+`2026-06-01T11:51:31Z` through `2026-09-07T12:16:11Z`. No success anywhere in visible history.
+
+### Step — other mechanical checks on snapshot.yml
+
+- M2 permissions: `contents: write` only -> insufficient once a PR fallback exists. ERROR.
+- M3 pinning: `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v5`. All 12
+  distinct `uses:` refs repo-wide are mutable tags; **nothing** is SHA-pinned. Consistent with
+  convention. INFO, repo-wide, not fixed here.
+- M4.2 `[skip ci]`: absent from the snapshot commit subject; present in all four working
+  precedents. ERROR.
+- M4.5 concurrency: no `concurrency:` group; cron + `workflow_dispatch` can overlap. WARNING.
+- M5 secrets: clean, none referenced.
+- M6 dead refs: `snapshot capture` resolves — `_registry.ts:102` registers `createSnapshotCommand`,
+  `snapshot.ts:238` declares `capture`. Clean.
+
+## Phase 3 — JUDGMENT (not skipped; Phase 2 was not clean, and this is where the impact is)
+
+### J2 — the gate has been dead for five months
+
+- `git log -1 -- .harness/arch/timeline.json` -> `f8d593648` `2026-04-06`
+  _"chore: architecture snapshot 2026-04-06"_.
+- File is 826 bytes and holds **exactly one** entry:
+  `capturedAt: 2026-04-06T14:20:52.339Z`, `commitHash: 0669068`, `stabilityScore: 57`.
+- Consumers traced:
+  - `packages/core/src/architecture/prediction-engine.ts:81` —
+    `if (snapshots.length < 3) throw "PredictionEngine requires at least 3 snapshots, got N"`.
+    With 1 point, `predict_failures` has thrown for five months.
+  - `packages/core/src/architecture/timeline-manager.ts:116` — `snapshots.length === 1` degenerate
+    branch, so `get_decay_trends` / `harness snapshot trend` return "no trend", which reads
+    identically to "stable".
+  - `packages/cli/src/mcp/tools/decay-trends.ts:77`, `packages/core/src/insights/aggregator.ts:78`.
+- **No staleness signal exists.** No consumer compares `capturedAt` to now. The Iron Law case
+  exactly: the gate manufactured confidence while enforcing nothing.
+
+### J1 / J3 / J4
+
+- J1 injection: clean. Only `$(date +%Y-%m-%d)`; no `github.event.*`, no `head_ref`, no
+  `pull_request_target`. The new `GH_TOKEN` is routed through `env:`.
+- J3 ratchet calibration: N/A — `snapshot capture` is observational and gates nothing.
+- J4 fork-PR degradation: N/A — `schedule` + `workflow_dispatch` only; no fork path.
+
+## Phase 4 — REPORT / FIX
+
+Applied to `.github/workflows/snapshot.yml`, mirroring `ci.yml:463-500`: explicit empty-diff
+short-circuit, `[skip ci]`, `HUSKY=0`, `GH_TOKEN`, `pull-requests: write`, `concurrency:` group,
+direct push -> `chore/arch-snapshot-<epoch>` branch off `origin/main` -> `gh pr create` for human
+review, plus a duplicate-snapshot-PR guard (append-only weekly artifact; see the plan for why this
+one line deviates from the precedent).
+
+Reported but deliberately NOT fixed: dead `src/**` filter in 4 `persona-*.yml`;
+`holiday-confidence-track.yml` bare push (sibling lane, fork E1); repo-wide mutable action tags;
+missing staleness signal in the timeline consumers.
+
+## Local verification
+
+- YAML parses; `permissions` -> `{"contents":"write","pull-requests":"write"}`; `concurrency` ->
+  `{"group":"architecture-snapshot","cancel-in-progress":false}`; commit-step `env` ->
+  `{"HUSKY":"0","GH_TOKEN":"${{ secrets.GITHUB_TOKEN }}"}`.
+- `bash -n` on the extracted `Commit snapshot` script — clean.
+- Duplicate-PR guard executed live: returns empty, takes the `would-create` branch correctly.
+- The PR-fallback path itself is only exercisable by a real run against the protected branch; it is
+  the same shape already proven in `ci.yml`.

--- a/docs/changes/arch-snapshot-commit-back/plans/2026-09-07-arch-snapshot-commit-back-plan.md
+++ b/docs/changes/arch-snapshot-commit-back/plans/2026-09-07-arch-snapshot-commit-back-plan.md
@@ -1,0 +1,342 @@
+# Plan — Architecture Snapshot commit-back: replace the bare `git push` to protected `main` with the repo's push-then-PR idiom
+
+Trace of the `harness-workflow-audit` (INVENTORY -> MECHANICAL -> JUDGMENT -> REPORT) run executed
+autonomously in a cicd-fleet remediation lane, scoped to the **commit-back defect class**.
+
+- **Workflow:** `.github/workflows/snapshot.yml` (`Architecture Snapshot`)
+- **Failure history:** 15/15 visible scheduled runs failed, unbroken from `2026-06-01` through `2026-09-07`
+- **Classification:** infra-config defect (workflow), not a product defect
+- **Branch:** `cicd/snapshot-commit-back-via-pr`, based on `origin/main` = `e7340f5c9`
+- **Refs:** #1965
+
+---
+
+## Phase 1 — INVENTORY
+
+### Workflows enumerated
+
+23 files under `.github/workflows/*.yml`. Parsed for triggers, `paths:` filters, `permissions:`
+blocks, `concurrency:` groups, `uses:` refs, and every `run:` script.
+
+### The commit-back sub-inventory (this audit's scope)
+
+Grepping every workflow for `git push` / `git commit` / `gh pr create` / `peter-evans` yields exactly
+**five** commit-back jobs, in two shapes:
+
+| Workflow                             | Line      | Shape                                                       | `[skip ci]` | `HUSKY=0`  | Status                |
+| ------------------------------------ | --------- | ----------------------------------------------------------- | ----------- | ---------- | --------------------- |
+| `ci.yml` (refresh-baselines)         | 329–380   | push -> PR fallback, scope-guarded self-approve + automerge | yes         | yes        | working               |
+| `ci.yml` (comprehension refresh)     | 473–500   | push -> PR fallback, **plain PR for human review**          | yes         | yes        | working               |
+| `release.yml` (golden promote)       | 130–175   | rebase-retry x3 -> PR fallback, self-approve                | yes         | yes        | working               |
+| `roadmap-auto-done.yml`              | 170–205   | rebase-retry x3 -> PR fallback, self-approve                | yes         | yes        | working               |
+| **`snapshot.yml` (Commit snapshot)** | **21–27** | **bare `git push`, no fallback**                            | **no**      | **no**     | **BROKEN**            |
+| `holiday-confidence-track.yml`       | 110–111   | bare `git push`, no fallback                                | yes         | (see note) | BROKEN — sibling lane |
+
+No `peter-evans/create-pull-request` anywhere in the repo; the push-then-fall-back-to-PR idiom is
+entirely hand-rolled and is the established convention.
+
+### Documented gates that consume this workflow's output
+
+`.harness/arch/timeline.json` is a **tracked** file with three live readers:
+
+- `packages/core/src/architecture/prediction-engine.ts:81` — `if (snapshots.length < 3) throw`
+- `packages/cli/src/mcp/tools/decay-trends.ts:77` — `get_decay_trends`
+- `packages/core/src/architecture/timeline-manager.ts:116` — `snapshots.length === 1` degenerate path
+- `packages/core/src/insights/aggregator.ts:78` — insights rollup
+- `packages/cli/src/commands/snapshot.ts:196` — `harness snapshot trend`
+
+### File-tree snapshot
+
+`git ls-files` at `e7340f5c9`, used for every path-filter resolution in Phase 2.
+
+---
+
+## Phase 2 — MECHANICAL
+
+### M1 — Path-filter correctness
+
+`snapshot.yml` carries **no** `paths:` / `paths-ignore:` filters (`schedule` + `workflow_dispatch`
+only), so M1 is vacuous for the item. Every glob in the repo was still resolved, per the skill's
+gate ("a filter you did not resolve is a filter you did not audit"):
+
+| Glob                                           | Workflow(s)                                                                                             | `git ls-files` matches |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `src/**`                                       | `persona-architecture-enforcer`, `-documentation-maintainer`, `-performance-guardian`, `-task-executor` | **0**                  |
+| `docs/**`                                      | `persona-documentation-maintainer`                                                                      | 2045                   |
+| `packages/**`                                  | `persona-performance-guardian`, `persona-task-executor`                                                 | 4223                   |
+| `packages/orchestrator/src/gateway/openapi/**` | `openapi-drift-check`                                                                                   | 4                      |
+| `packages/types/src/auth.ts`                   | `openapi-drift-check`                                                                                   | 1                      |
+| `docs/api/openapi.yaml`                        | `openapi-drift-check`                                                                                   | 1                      |
+| `.github/workflows/openapi-drift-check.yml`    | `openapi-drift-check`                                                                                   | 1                      |
+
+**[ERROR] path-filter-dead** — `src/**` matches **zero** tracked files (this is a pnpm workspace;
+sources live under `packages/*/src`). Four persona workflows are gated on it. **Reported, not
+fixed** — out of this item's diff scope (see REPORT).
+
+### M2 — Permission scoping
+
+**[ERROR] permissions-insufficient** `.github/workflows/snapshot.yml:10-11`
+
+`permissions: contents: write` is the whole grant. `contents: write` is _scope_, not a ruleset
+bypass — it cannot satisfy a "Changes must be made through a pull request" rule, which is enforced
+server-side regardless of token scope. And once a PR fallback exists, `pull-requests: write` is
+required or `gh pr create` fails with `Resource not accessible by integration` (the exact hazard
+already documented at `ci.yml:238-243`).
+
+### M3 — Action pinning
+
+`snapshot.yml` uses `actions/checkout@v6`, `actions/setup-node@v6` (first-party, mutable major tag)
+and `pnpm/action-setup@v5` (third-party, mutable major tag).
+
+**[INFO] pinning** — the repo pins **nothing** to a SHA: all 12 distinct `uses:` refs across all 23
+workflows are on mutable major tags (`changesets/action@v1`, `codecov/codecov-action@v5`,
+`docker/*`, `pnpm/action-setup@v5`, …). `snapshot.yml` is _consistent with_ repo convention, not a
+regression against it. Per M3.2 the finding is repo-wide and belongs to a dedicated supply-chain
+pass — changing it here would be an unreviewable one-off. Reported, not fixed.
+
+### M4 — Self-trigger and concurrency safety
+
+**[ERROR] pushback-unguarded** `.github/workflows/snapshot.yml:26-27` — this is the root cause.
+
+```
+git diff --cached --quiet || git commit -m "chore: architecture snapshot $(date +%Y-%m-%d)"
+git push
+```
+
+A bare `git push` to the protected default branch. Verified against run `34120963994`
+(`gh run view 34120963994 --log-failed`):
+
+```
+remote: error: GH013: Repository rule violations found for refs/heads/main.
+remote: - Changes must be made through a pull request.
+ ! [remote rejected] main -> main (push declined due to repository rule violations)
+error: failed to push some refs
+##[error]Process completed with exit code 1
+```
+
+**[ERROR] selftrigger-no-skip-ci** `.github/workflows/snapshot.yml:26` — the commit message carries
+no `[skip ci]`. Every other commit-back job in the repo does. Latent: if the push ever _did_ land on
+main it would start a fresh CI run on main (including `refresh-baselines`, itself a commit-back job).
+
+**[WARNING] concurrency-missing** `.github/workflows/snapshot.yml` — no `concurrency:` group. A
+weekly cron plus an ad-hoc `workflow_dispatch` can overlap; both would append to the same
+`timeline.json` and race on the fallback branch.
+
+### M5 — Secret handling
+
+Clean. `snapshot.yml` referenced no secrets before this change and echoes none after it.
+
+### M6 — Dead and stale references
+
+Clean. `node packages/cli/dist/bin/harness.js snapshot capture` resolves:
+`createSnapshotCommand` is registered at `packages/cli/src/commands/_registry.ts:102` and the
+`capture` subcommand is declared at `packages/cli/src/commands/snapshot.ts:238`.
+
+---
+
+## Phase 3 — JUDGMENT
+
+Run in full. The skill's gate is explicit: _"No skipping Phase 3 on a clean Phase 2."_ Phase 2 was
+not clean, and Phase 3 is where the actual blast radius surfaced.
+
+### J1 — Script injection
+
+Clean. The only interpolation in the `run:` block is `$(date +%Y-%m-%d)`, a shell substitution of a
+trusted command. No `github.event.*`, no `github.head_ref`, no `pull_request_target`. The
+`GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` added by this change is routed through `env:` (data, not
+code), matching the M5/J1 prescription.
+
+### J2 — Gate completeness — **this is the real finding**
+
+The workflow ran weekly and failed weekly, so the _gate_ (the architecture-trend series) has been
+silently dead while looking scheduled. Evidence, not assertion:
+
+- `.harness/arch/timeline.json` last changed in `f8d593648` — _"chore: architecture snapshot
+  2026-04-06"_. **Five months** of a weekly job producing nothing.
+- The file contains **exactly one** snapshot entry (`capturedAt: 2026-04-06T14:20:52.339Z`,
+  `commitHash: 0669068`, `stabilityScore: 57`).
+- `packages/core/src/architecture/prediction-engine.ts:81` throws
+  `PredictionEngine requires at least 3 snapshots, got ${snapshots.length}`. With one point, the
+  `predict_failures` MCP tool has been **hard-erroring for five months**.
+- `packages/core/src/architecture/timeline-manager.ts:116` takes the degenerate
+  `snapshots.length === 1` branch, so `get_decay_trends` and `harness snapshot trend` return a
+  no-trend answer that is indistinguishable from "the architecture is stable".
+- There is **no staleness signal** anywhere: no consumer compares `capturedAt` against now. A
+  five-month-old single data point is served as if it were current.
+
+This is the skill's Iron Law verbatim: _a gate that never fires is worse than no gate — it
+manufactures false confidence._ The MECHANICAL finding is the mechanism; this is why it mattered.
+
+Per the skill's Escalation rule for a long-dead gate, re-arming it is expected to surface a step
+change in the metrics (five months of drift folded into one delta against the 2026-04-06 point).
+That is a **reporting** artifact, not a regression: `snapshot capture` is observational and blocks
+nothing. No backfill is possible — the metrics are computed against a working tree, and historical
+points would require checking out and building 22 past commits. Recommended instead: merge the
+first new point, then read the second and third weeks' deltas as the first honest trend.
+
+### J3 — Ratchet and severity calibration
+
+Not applicable. `snapshot capture` writes an observational series; it is not a ratchet and gates
+nothing. No severity threshold to calibrate.
+
+### J4 — Fork-PR degradation
+
+Not applicable. `snapshot.yml` triggers only on `schedule` and `workflow_dispatch`, both of which
+run on the base repository with a writable `GITHUB_TOKEN`. There is no fork-PR path.
+
+---
+
+## Phase 4 — REPORT
+
+```
+WORKFLOW AUDIT: harness-engineering (scope: commit-back defect class)
+Workflows audited: 23   Findings: 4 error, 2 warning, 1 info
+Gates that never fire: snapshot.yml (commit-back rejected 15/15 runs since 2026-06-01);
+                       4x persona-*.yml (paths: src/** matches 0 tracked files)
+Documented-but-unwired gates: none new — but the architecture-trend series has been
+                       frozen at a single 2026-04-06 point for five months
+```
+
+Ranked:
+
+1. **[ERROR] pushback-unguarded** `snapshot.yml:26-27` — FIXED here
+2. **[ERROR] permissions-insufficient** `snapshot.yml:10-11` — FIXED here
+3. **[ERROR] selftrigger-no-skip-ci** `snapshot.yml:26` — FIXED here
+4. **[ERROR] path-filter-dead** `persona-*.yml` `src/**` -> 0 matches — REPORTED, out of scope
+5. **[WARNING] concurrency-missing** `snapshot.yml` — FIXED here
+6. **[WARNING] pushback-unguarded** `holiday-confidence-track.yml:110-111` — same defect class,
+   **owned by a concurrent sibling lane**; deliberately untouched
+7. **[INFO] pinning** — repo-wide mutable-tag convention, not a `snapshot.yml` regression
+
+---
+
+## The fix
+
+Fork A -> **A1**: reuse this repo's own proven push-then-fall-back-to-PR idiom. No
+`peter-evans/create-pull-request`, no PAT, no ruleset bypass.
+
+Two in-repo shapes exist. The PAT-bearing self-approve+automerge shape
+(`ci.yml` refresh-baselines, `release.yml`, `roadmap-auto-done.yml`) requires
+`secrets.BASELINE_AUTOAPPROVE_PAT`; the decision explicitly forbids adding a PAT. So the fix mirrors
+the **plain-PR-for-human-review** shape at `ci.yml:463-500` ("Commit refreshed semantic shards"),
+which uses only `secrets.GITHUB_TOKEN`.
+
+Fork D -> **D1**: `HUSKY: '0'` on the commit step, precedent `roadmap-auto-done.yml:152`. This is not
+speculative — the failing run's log shows the full pre-commit gauntlet executing _inside_ the
+`Commit snapshot` step before the push was rejected:
+
+```
+Running test:coverage in 0 packages ... Coverage ratchet: all packages meet or exceed baselines.
+> node scripts/generate-docs.mjs "--check"   ... ✓ All reference docs are fresh.
+> node scripts/generate-tool-catalog.mjs --check ... ✓ Tool & skill catalog is up to date.
+```
+
+Those gates happened to pass on this run. On a run where a generated doc has drifted on main (a
+documented recurring condition in this repo) they would fail the step for an unrelated reason — a
+latent second failure mode, removed.
+
+Fork E -> **E1**: this ships as its own PR. `holiday-confidence-track.yml` and `.harness/.gitignore`
+are untouched.
+
+### `.github/workflows/snapshot.yml` — what changed
+
+1. **`concurrency:`** group `architecture-snapshot`, `cancel-in-progress: false` (M4.5). Serializing
+   is correct rather than cancelling: a cancelled capture silently loses that week's data point.
+2. **`permissions:`** gains `pull-requests: write` alongside `contents: write` (M2), with the
+   `Resource not accessible by integration` rationale recorded inline as `ci.yml:238-243` does.
+3. **`env:`** on the commit step: `HUSKY: '0'` (D1) and `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` for
+   the `gh` calls.
+4. **Explicit empty-diff short-circuit.** The old `git diff --cached --quiet || git commit` left the
+   step to fall through to `git push` even with nothing staged. Now an empty diff `exit 0`s
+   immediately, matching all four working precedents.
+5. **`[skip ci]`** appended to the commit subject on both the direct-push and PR paths (M4.2),
+   matching every other commit-back job in the repo.
+6. **Push-then-PR fallback**, mirroring `ci.yml:475-500`: try `git push`; on failure
+   `git fetch origin main`, branch `chore/arch-snapshot-$(date +%s)` off `origin/main`,
+   `git checkout "$OURS" -- "$TIMELINE"` to re-apply the captured series on top of latest main,
+   re-check for an empty diff, push the branch, `gh pr create --base main`. No auto-approve, no
+   auto-merge — a human reviews and merges.
+7. **Duplicate-PR guard** (the one addition beyond the precedent, justified below): before creating
+   a PR, list open PRs whose head branch starts with `chore/arch-snapshot-` and exit clean if one
+   exists.
+
+### Why the duplicate-PR guard was added
+
+The precedents' commit-back jobs are event-driven (per-merge, per-release) and their artifacts are
+regenerated **wholesale**, so a stale open PR is self-correcting. `timeline.json` is different: it is
+**append-only** and this job is **weekly**. Without the guard, an unmerged week-1 PR and a fresh
+week-2 PR would both append to the same JSON array from divergent bases and conflict on merge —
+precisely the DIRTY-automated-PR failure mode `ci.yml:340-345` documents for `baselines.json`. Seven
+lines prevent it and cost nothing when no PR is open.
+
+The trade-off is recorded honestly: when a snapshot PR sits unmerged, subsequent weeks are **skipped
+rather than queued**, so those weeks produce no data point. Skipping is the better failure — a gap in
+the series is visible and recoverable; a pile of mutually-conflicting DIRTY PRs is neither. The step
+logs `Snapshot PR #N is already open and unmerged` and exits green.
+
+### Verification performed locally
+
+- **YAML parse:** loads clean; top-level keys `name, on, concurrency, jobs`; job permissions resolve
+  to `{"contents":"write","pull-requests":"write"}`; concurrency to
+  `{"group":"architecture-snapshot","cancel-in-progress":false}`; 7 steps; commit-step `env` to
+  `{"HUSKY":"0","GH_TOKEN":"${{ secrets.GITHUB_TOKEN }}"}`.
+- **Shell syntax:** the `Commit snapshot` `run:` block extracted and checked with `bash -n` — clean.
+- **Duplicate-PR guard, executed live** against this repo:
+  `gh pr list --state open --json number,headRefName --jq '[.[] | select(.headRefName | startswith("chore/arch-snapshot-"))] | .[0].number'`
+  returns empty and the guard correctly takes the `would-create` branch.
+- **Root cause re-derived from primary evidence**, not accepted from the brief:
+  `gh run list --workflow=snapshot.yml` -> 15/15 `failure`, all `schedule`, `2026-06-01` ->
+  `2026-09-07`; `gh run view 34120963994 --log-failed` -> the GH013 rejection quoted above.
+
+The end-to-end PR-fallback path can only be exercised by a real scheduled/dispatched run against the
+protected branch; it is not locally reproducible. What _is_ proven locally is that the shape is
+byte-for-byte the shape that already works in `ci.yml`, that the YAML and shell parse, and that the
+one novel line (the `gh pr list` guard) executes correctly against the live repo.
+
+---
+
+## Remediation actions / assumptions made
+
+**Actions taken**
+
+1. Replaced the bare `git push` in `.github/workflows/snapshot.yml` with the repo's push-then-PR
+   idiom, copied from `ci.yml` "Commit refreshed semantic shards".
+2. Added `pull-requests: write` to the job permissions.
+3. Added `HUSKY: '0'` and `GH_TOKEN` to the commit step.
+4. Added `[skip ci]` to the snapshot commit subject.
+5. Added a `concurrency:` group.
+6. Added a duplicate-snapshot-PR guard.
+7. Wrote this plan artifact plus `provenance.json` and `audit-session.md` under
+   `docs/changes/arch-snapshot-commit-back/`.
+
+**Assumptions**
+
+- **Chose the no-PAT PR shape.** Three of the four working precedents self-approve with
+  `secrets.BASELINE_AUTOAPPROVE_PAT` and auto-merge. The decision forbids adding a PAT, so the
+  fourth precedent (`ci.yml` comprehension refresh: plain PR, `GITHUB_TOKEN` only, human merges) was
+  used. **Consequence the reviewer must accept: the timeline no longer advances unattended.** Every
+  week a human merges a small `chore: architecture snapshot` PR. If unattended advancement is
+  wanted, the self-approve shape is a one-step upgrade — but it needs the PAT this lane was told not
+  to add.
+- **Assumed the branch-protection rule is permanent.** The fix does not attempt to bypass it; it
+  tries the direct push first and falls back, so if the ruleset is ever relaxed the workflow
+  silently takes the fast path with no further edit.
+- **Assumed "ours" is the correct conflict resolution** when re-applying `timeline.json` onto latest
+  main, matching the precedents' reasoning. This holds because `snapshot capture` appends to
+  whatever main carried at checkout, so the captured file is a superset of main's series. The
+  `concurrency:` group plus the duplicate-PR guard make a concurrent divergent append effectively
+  impossible; without both, an append-only file would be a weaker fit for this idiom than the
+  wholesale-regenerated artifacts the precedents handle.
+- **Did not backfill the five missing months.** Historical points would require checking out and
+  building 22 past commits; the series restarts from the next capture. The 2026-04-06 point is left
+  in place as the anchor.
+- **Did not add a staleness signal to the consumers.** `get_decay_trends` / `predict_failures` /
+  `harness snapshot trend` still cannot tell a caller that the series is months old — the exact
+  condition that let this failure hide for five months. That is a product change requiring design
+  judgment, out of scope for an infra-config lane, and is reported as a follow-up.
+- **Did not touch `holiday-confidence-track.yml` or `.harness/.gitignore`** (fork E1 — sibling lane).
+- **Did not fix the dead `src/**`path filter** in the four`persona-\*.yml` workflows. It is a real
+  ERROR-severity finding surfaced by this audit but a different defect class, and folding it in
+  would make this PR unreviewable. Reported for separate triage.
+- **Did not SHA-pin any action.** `snapshot.yml` matches the repo-wide mutable-tag convention; a
+  one-workflow deviation would be noise. Reported as repo-wide INFO.

--- a/docs/changes/arch-snapshot-commit-back/provenance.json
+++ b/docs/changes/arch-snapshot-commit-back/provenance.json
@@ -1,0 +1,84 @@
+{
+  "issues": ["1965"],
+  "fleet": "cicd-fleet",
+  "item": "Architecture Snapshot — .github/workflows/snapshot.yml commit-back rejected by branch protection (12+/12 consecutive scheduled failures)",
+  "classification": "infra-config",
+  "stages": ["inventory", "mechanical", "judgment", "report"],
+  "skill": "harness-workflow-audit",
+  "baseSha": "e7340f5c9",
+  "branch": "cicd/snapshot-commit-back-via-pr",
+  "planArtifact": "docs/changes/arch-snapshot-commit-back/plans/2026-09-07-arch-snapshot-commit-back-plan.md",
+  "sessionRecord": "docs/changes/arch-snapshot-commit-back/audit-session.md",
+  "ciEvidence": {
+    "runId": "34120963994",
+    "workflow": "snapshot.yml (Architecture Snapshot)",
+    "event": "schedule",
+    "createdAt": "2026-09-07T12:16:11Z",
+    "step": "Commit snapshot",
+    "failure": "remote: error: GH013: Repository rule violations found for refs/heads/main. - Changes must be made through a pull request. ! [remote rejected] main -> main",
+    "consecutiveFailures": 15,
+    "failureWindow": "2026-06-01T11:51:31Z .. 2026-09-07T12:16:11Z (15/15 scheduled runs, no success in visible history)",
+    "runIds": [
+      "34120963994",
+      "33397134570",
+      "32700465391",
+      "32004505784",
+      "31367861901",
+      "30803795990",
+      "30256581788",
+      "29731650071",
+      "29240080885",
+      "28786403739",
+      "28368172264",
+      "27952191512",
+      "27546644435",
+      "27133811466",
+      "26753160628"
+    ]
+  },
+  "auditFindings": [
+    "[ERROR] pushback-unguarded snapshot.yml:26-27 — bare `git push` to protected main; rejected GH013 on every run. FIXED.",
+    "[ERROR] permissions-insufficient snapshot.yml:10-11 — `contents: write` is token scope, not a ruleset bypass; `pull-requests: write` also required for the gh pr create fallback (hazard already documented at ci.yml:238-243). FIXED.",
+    "[ERROR] selftrigger-no-skip-ci snapshot.yml:26 — commit subject lacks `[skip ci]`, unlike all four working commit-back precedents. FIXED.",
+    "[ERROR] path-filter-dead persona-architecture-enforcer.yml / persona-documentation-maintainer.yml / persona-performance-guardian.yml / persona-task-executor.yml — `paths: src/**` matches 0 tracked files (pnpm workspace; sources live under packages/*/src). REPORTED, out of this item's diff scope.",
+    "[WARNING] concurrency-missing snapshot.yml — no concurrency group; weekly cron and workflow_dispatch can overlap on the same append-only timeline. FIXED.",
+    "[WARNING] pushback-unguarded holiday-confidence-track.yml:110-111 — same defect class; owned by a concurrent sibling lane (fork E1). DELIBERATELY UNTOUCHED.",
+    "[INFO] pinning — all 12 distinct `uses:` refs across all 23 workflows are on mutable major tags; nothing is SHA-pinned. snapshot.yml matches convention. REPORTED repo-wide, not fixed here."
+  ],
+  "impact": {
+    "artifact": ".harness/arch/timeline.json",
+    "lastAdvanced": "f8d593648 (2026-04-06) chore: architecture snapshot 2026-04-06",
+    "entriesInSeries": 1,
+    "consumers": [
+      "packages/core/src/architecture/prediction-engine.ts:81 — throws `requires at least 3 snapshots`; predict_failures has hard-errored for five months",
+      "packages/core/src/architecture/timeline-manager.ts:116 — snapshots.length === 1 degenerate branch; get_decay_trends and `harness snapshot trend` return no-trend, indistinguishable from 'stable'",
+      "packages/cli/src/mcp/tools/decay-trends.ts:77",
+      "packages/core/src/insights/aggregator.ts:78",
+      "packages/cli/src/commands/snapshot.ts:196"
+    ],
+    "stalenessSignal": "none — no consumer compares capturedAt against now"
+  },
+  "decisionForks": {
+    "A": "A1 — reuse the repo's own push-then-fall-back-to-PR idiom; no peter-evans/create-pull-request, no PAT, no ruleset bypass. Of the two in-repo shapes, chose the plain-PR-for-human-review shape at ci.yml:463-500 (GITHUB_TOKEN only) because the PAT-bearing self-approve shape used by ci.yml:329-380, release.yml:130-175 and roadmap-auto-done.yml:170-205 requires secrets.BASELINE_AUTOAPPROVE_PAT, which the decision forbids adding.",
+    "D": "D1 — HUSKY: '0' on the commit step, precedent roadmap-auto-done.yml:152. Justified by primary evidence: the failing run's log shows the coverage ratchet, generate-docs --check and tool-catalog --check all executing inside the `Commit snapshot` step.",
+    "E": "E1 — own PR; holiday-confidence-track.yml and .harness/.gitignore untouched."
+  },
+  "assumptions": [
+    "Chose the no-PAT PR shape per fork A1's prohibition on adding a PAT. CONSEQUENCE THE REVIEWER MUST ACCEPT: the timeline no longer advances unattended — a human merges a small `chore: architecture snapshot` PR each week. Upgrading to the self-approve + auto-merge shape is a one-step change if unattended advancement is wanted, but it needs the PAT this lane was told not to add.",
+    "Assumed the branch-protection ruleset is permanent. The fix does not bypass it: the direct push is still attempted first, so if the ruleset is ever relaxed the workflow silently takes the fast path with no further edit.",
+    "DEVIATION FROM THE PRECEDENT, taken deliberately and surfaced here: added a duplicate-snapshot-PR guard (gh pr list, skip if an open PR's head branch starts with chore/arch-snapshot-). The precedents' artifacts are regenerated WHOLESALE and their jobs are event-driven, so a stale open PR is self-correcting there. timeline.json is APPEND-ONLY and this job is WEEKLY: without the guard, an unmerged week-1 PR and a fresh week-2 PR both append to the same JSON array from divergent bases and conflict on merge — the DIRTY-automated-PR failure mode ci.yml:340-345 documents for baselines.json. Trade-off recorded honestly: while a snapshot PR sits unmerged, subsequent weeks are SKIPPED rather than queued, so those weeks produce no data point. A visible gap in the series is recoverable; a pile of mutually-conflicting DIRTY PRs is not.",
+    "Assumed 'ours' is the correct resolution when re-applying timeline.json onto latest main, matching the precedents' stated reasoning. This holds because `snapshot capture` appends to whatever main carried at checkout, so the captured file is a superset of main's series. The concurrency group plus the duplicate-PR guard together make a concurrent divergent append effectively impossible; without both, an append-only file would be a weaker fit for this idiom than the wholesale-regenerated artifacts the precedents handle.",
+    "Did NOT backfill the five missing months. Historical points would require checking out and building 22 past commits; `snapshot capture` computes metrics against a working tree. The series restarts from the next capture, with the 2026-04-06 point left as the anchor. Per the skill's long-dead-gate escalation rule, expect the first new point to show a step change folding five months of drift — a reporting artifact, not a regression, since the capture is observational and blocks nothing.",
+    "Did NOT add a staleness signal to the timeline consumers. That the series can be five months old and still be served as current is the condition that let this failure hide, but adding it is a product change requiring design judgment, out of scope for an infra-config lane. Reported as a follow-up.",
+    "Did NOT fix the dead `src/**` path filter in the four persona-*.yml workflows. A real ERROR-severity finding surfaced by this audit, but a different defect class; folding it in would make this PR unreviewable. Reported for separate triage.",
+    "Did NOT SHA-pin any action. snapshot.yml matches the repo-wide mutable-tag convention; a one-workflow deviation would be noise rather than a security improvement."
+  ],
+  "verification": {
+    "yamlParse": "clean — top-level keys name/on/concurrency/jobs; permissions {contents: write, pull-requests: write}; concurrency {group: architecture-snapshot, cancel-in-progress: false}; 7 steps; commit-step env {HUSKY: '0', GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}}",
+    "shellSyntax": "bash -n on the extracted `Commit snapshot` run: block — clean",
+    "duplicatePrGuard": "executed live against this repo; returns empty and correctly takes the would-create branch",
+    "rootCauseReDerived": "gh run list --workflow=snapshot.yml -> 15/15 failure, all event=schedule, 2026-06-01..2026-09-07; gh run view 34120963994 --log-failed -> GH013 rejection",
+    "notLocallyReproducible": "the PR-fallback path can only be exercised by a real scheduled/dispatched run against the protected branch. What is proven locally: the shape is the shape already working in ci.yml, the YAML and shell parse, and the one novel line executes correctly."
+  },
+  "closingKeyword": null
+}


### PR DESCRIPTION
## The defect

`.github/workflows/snapshot.yml` (`Architecture Snapshot`) ends its `Commit snapshot` step in a bare `git push` to the protected default branch. Repository rules reject it on **every** run:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
error: failed to push some refs
##[error]Process completed with exit code 1
```

`permissions: contents: write` is token **scope**, not a ruleset bypass — the rule is enforced server-side and no token scope satisfies it.

**15/15 visible scheduled runs failed**, unbroken from `2026-06-01T11:51:31Z` to `2026-09-07T12:16:11Z`, with no success anywhere in visible history. Evidence: `gh run view 34120963994 --log-failed`.

## Why it mattered

`.harness/arch/timeline.json` is **tracked** but frozen at `f8d593648` — *"chore: architecture snapshot 2026-04-06"* — for five months, while the job ran weekly and failed weekly. The file holds **exactly one** entry.

Every architecture-trend consumer reads that dead series, and none of them can tell:

| Consumer | Behaviour with a 1-entry, 5-month-old series |
| --- | --- |
| `packages/core/src/architecture/prediction-engine.ts:81` | throws — `requires at least 3 snapshots, got 1`. `predict_failures` has hard-errored for five months. |
| `packages/core/src/architecture/timeline-manager.ts:116` | degenerate `snapshots.length === 1` branch — `get_decay_trends` and `harness snapshot trend` return "no trend", which reads identically to "stable". |
| `packages/cli/src/mcp/tools/decay-trends.ts:77`, `packages/core/src/insights/aggregator.ts:78` | serve the stale point as current. |

No consumer compares `capturedAt` against now, so there is **no staleness signal** — which is exactly how this hid for five months.

## The fix

Reuses **this repo's own** push-then-fall-back-to-PR idiom. No `peter-evans/create-pull-request`, no PAT, no ruleset bypass.

Two working shapes exist in-tree. The self-approve + auto-merge shape (`ci.yml:329-380`, `release.yml:130-175`, `roadmap-auto-done.yml:170-205`) needs `secrets.BASELINE_AUTOAPPROVE_PAT`; adding a PAT was ruled out. So this mirrors the fourth precedent — the **plain-PR-for-human-review** shape at `ci.yml:463-500` ("Commit refreshed semantic shards"), which uses `GITHUB_TOKEN` only.

Changes to `.github/workflows/snapshot.yml`:

1. **Push -> PR fallback.** Try `git push`; on failure `git fetch origin main`, branch `chore/arch-snapshot-<epoch>` off `origin/main`, re-apply the captured timeline with `git checkout "$OURS" -- "$TIMELINE"`, re-check for an empty diff, push the branch, `gh pr create --base main`. Human reviews and merges.
2. **`pull-requests: write`** alongside `contents: write` — otherwise `gh pr create` fails with `Resource not accessible by integration` (the hazard already documented at `ci.yml:238-243`).
3. **`HUSKY: '0'`** on the commit step. Not speculative: the failing run's log shows the full pre-commit gauntlet — coverage ratchet, `generate-docs --check`, tool-catalog `--check` — executing *inside* the `Commit snapshot` step. They passed on that run; on a run where a generated doc has drifted on main they fail the step for an unrelated reason. Precedent `roadmap-auto-done.yml:152`.
4. **`[skip ci]`** on the commit subject, matching all four working commit-back jobs.
5. **`concurrency:` group**, `cancel-in-progress: false` — cron and `workflow_dispatch` can overlap on the same append-only file. Serializing rather than cancelling, because a cancelled capture silently loses that week's point.
6. **Explicit empty-diff short-circuit** — the old `git diff --cached --quiet || git commit` fell through to `git push` even with nothing staged.
7. **Duplicate-snapshot-PR guard** (see assumptions).

## Remediation actions / assumptions made

**Actions:** the seven workflow changes above, plus the audit artifacts under `docs/changes/arch-snapshot-commit-back/` (plan, `audit-session.md`, `provenance.json`).

**Assumptions — please read before approving:**

- **The timeline no longer advances unattended.** The no-PAT shape means a human merges a small `chore: architecture snapshot` PR each week. Upgrading to the self-approve + auto-merge shape is a one-step change if unattended advancement is wanted — but it needs the PAT this change was told not to add.
- **The branch-protection rule is assumed permanent, but not assumed away.** The direct push is still attempted first, so if the ruleset is ever relaxed the workflow silently takes the fast path with no further edit.
- **DEVIATION FROM THE PRECEDENT, surfaced deliberately:** the duplicate-PR guard is not in the precedents. Theirs regenerate artifacts *wholesale* and are event-driven, so a stale open PR is self-correcting. `timeline.json` is **append-only** and this job is **weekly**: without the guard, an unmerged week-1 PR and a fresh week-2 PR both append to the same JSON array from divergent bases and conflict on merge — the DIRTY-automated-PR failure mode `ci.yml:340-345` documents for `baselines.json`. **Trade-off, stated honestly:** while a snapshot PR sits unmerged, later weeks are *skipped rather than queued*, so those weeks produce no data point. A visible gap in the series is recoverable; a pile of mutually-conflicting DIRTY PRs is not.
- **"Ours" is assumed the correct resolution** when re-applying the timeline onto latest main, matching the precedents' reasoning. It holds because `snapshot capture` appends to whatever main carried at checkout, so the captured file is a superset of main's series.
- **No backfill of the five missing months.** Historical points would need 22 past commits checked out and built. The series restarts from the next capture; the 2026-04-06 point stays as the anchor. Expect the first new point to show a step change folding five months of drift — a reporting artifact, not a regression, since the capture is observational and gates nothing.
- **No staleness signal added** to the timeline consumers. That is a product change requiring design judgment, out of scope here. Filed as a follow-up below.

## Audit findings reported but deliberately NOT fixed here

The `harness-workflow-audit` run covered all 23 workflows. Findings outside this item's diff scope:

- **[ERROR] `paths: src/**` matches 0 tracked files** in `persona-architecture-enforcer.yml`, `persona-documentation-maintainer.yml`, `persona-performance-guardian.yml`, `persona-task-executor.yml`. This is a pnpm workspace — sources live under `packages/*/src`. Four gates never fire. Different defect class; folding it in would make this PR unreviewable.
- **[WARNING] `holiday-confidence-track.yml:110-111`** — same bare-push defect class. **Owned by a concurrent sibling lane**; deliberately untouched here, as is `.harness/.gitignore`.
- **[INFO] action pinning** — all 12 distinct `uses:` refs across all 23 workflows are on mutable major tags; nothing is SHA-pinned. `snapshot.yml` matches convention, so a one-workflow deviation would be noise. Belongs to a dedicated supply-chain pass.
- **Follow-up:** no timeline consumer carries a staleness signal.

## Verification

- **YAML parses:** permissions -> `{contents: write, pull-requests: write}`; concurrency -> `{group: architecture-snapshot, cancel-in-progress: false}`; commit-step env -> `{HUSKY: '0', GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}}`.
- **`bash -n`** on the extracted `Commit snapshot` script — clean.
- **Duplicate-PR guard executed live** against this repo: returns empty, correctly takes the create branch.
- **Root cause re-derived from primary evidence**, not taken on trust: `gh run list --workflow=snapshot.yml` and `gh run view 34120963994 --log-failed`.
- **Not locally reproducible:** the PR-fallback path can only be exercised by a real scheduled/dispatched run against the protected branch. What *is* proven is that the shape is the shape already working in `ci.yml`, and that the one novel line executes correctly.

Full audit trace: `docs/changes/arch-snapshot-commit-back/plans/2026-09-07-arch-snapshot-commit-back-plan.md`

Refs #1965

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
