### PR TITLE
docs(waypoint): spec the spool shipper — the missing last mile

### DIFF
--- a/.changeset/waypoint-spool-shipper.md
+++ b/.changeset/waypoint-spool-shipper.md
@@ -1,0 +1,41 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+Add `harness waypoint ship` — send spooled `sdlc.*` events to a Waypoint ledger
+
+Harness's `sdlc.*` emission layer was complete and wired, and every event it
+produced stopped at a file on disk: `spool.ts` named the shipper "(out-of-scope)".
+ADR-0047 requires emitters to append to a local spool **and ship with
+retry/backoff**. This is that missing half.
+
+- `shipSpool()` reads unshipped spool lines in ULID order, POSTs them as a JSON
+  array to `/outpost/<outpost>/project/<project>/events`, and advances a
+  checkpoint from the endpoint's per-event `results`.
+- New `waypoint.sink.ship` config block (`url`, `outpost`, `project`,
+  `batchSize`). It is a **sibling** of `transport`, not a replacement: events
+  are spooled first and shipped after, so shipping is added to spooling rather
+  than chosen instead of it. Absent `ship` means no network calls at all.
+- `outpost` and `project` are both required and never derived. Two repos sharing
+  a basename would otherwise write into one ledger, and an append to a
+  hash-chained log cannot be taken back.
+- The credential comes from `PNYON_WAYPOINT_INGEST_TOKEN` only, never from
+  `harness.config.json`, so it cannot be committed.
+- The spool is never truncated or deleted — ADR-0047 guarantees adopters keep a
+  local copy of their exhaust, so progress is tracked in a sibling
+  `.shipped.json` instead.
+- Permanently-refused events (`invalid`, `scrub-rejected`) advance the
+  checkpoint and are appended to `rejected.jsonl` with their reason. Blocking on
+  them would re-send them forever; dropping them silently would bury a scrubber
+  signal the adopter needs to see.
+- Retries use exponential backoff on network errors and 5xx. A 400 or 401 is a
+  configuration fault and is never retried — the error names the endpoint and
+  which knob to turn.
+- `harness waypoint status` now reports unshipped and permanently-refused counts.
+
+Verified against the running staging service, not only against a mock: the
+constructed URL returns `401` with a wrong token — proving the route resolves and
+auth is enforced — where the previously-assumed `/v1/items` contract returns
+`404` on the same host. An `accepted` write still needs the operator-held token.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: 'd42391f9545fb2fd74d7ef3ce07003296e000ab2f5143430d35e4815c6c8d0ba'
+sourceHash: 'a0c6f607fdd179f37591b2524ff7ebac61416231f42e61f42a8289ce86df3bc4'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -134,6 +134,7 @@ export CURSOR_CURATED_TOOLS
 export DEFAULT_FIXTURES_DIR
 export DEFAULT_OPERATIONAL_DRIFT_POLICY
 export GIT_MAX_BUFFER_BYTES
+export INGEST_TOKEN_ENV
 export OUTCOME_BLOCK_ON_LEVELS
 export SCOPED_WALKERS
 export SKILL_REGRESSION_BLOCK_ON

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'efacdc8d1f3312ad595b488ffc7bb7b85c2b0340e2e9bcb210fdde9119ea37af'
+sourceHash: 'c6823ee2154d685670941a70cd9374fcc7403af92143e05e9f1d886c3684454e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -150,6 +150,7 @@ members:
     'validate.roadmap-health.test.ts',
     'validate.roadmap-mode.test.ts',
     'validate.test.ts',
+    'waypoint-ship.test.ts',
     'waypoint.test.ts',
   ]
 ---

--- a/.harness/comprehension/packages/core/src/waypoint/_module.md
+++ b/.harness/comprehension/packages/core/src/waypoint/_module.md
@@ -1,12 +1,13 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/waypoint'
-sourceHash: '3e72231c4277b4ab1dcdd15633f15f0954ec6fa4659228a77ee56635a43b0784'
+sourceHash: 'cf9a76a6ba3e03b81af8f133531bb93b0274e2f9defad7043f7fea3f2b38b6da'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
+    'checkpoint.ts',
     'config-loader.test.ts',
     'config-loader.ts',
     'emitter.test.ts',
@@ -14,8 +15,11 @@ members:
     'events.test.ts',
     'events.ts',
     'index.ts',
+    'rejected-log.ts',
     'scrub.test.ts',
     'scrub.ts',
+    'shipper.test.ts',
+    'shipper.ts',
     'spool.test.ts',
     'spool.ts',
     'ulid.test.ts',
@@ -28,15 +32,29 @@ members:
 ## Interface Contract
 
 ```ts
+export CHECKPOINT_FILENAME
+export DEFAULT_BATCH_SIZE
 export DEFAULT_MAX_EVENTS
+export EMPTY_CHECKPOINT
 export EmissionFailure
 export EmitSdlcOptions
 export FileSpool
 export FileSpoolOptions
 export FleetProvenanceArtifact
+export IngestEventResult
+export IngestReportBody
+export IngestResultKind
 export PersistedVerdict
 export REDACTED
+export REJECTED_FILENAME
+export RejectedEvent
+export RejectedRecord
 export ScrubOutcome
+export ShipCheckpoint
+export ShipError
+export ShipFetch
+export ShipOptions
+export ShipReport
 export SkillPhaseTransition
 export SkillTransitionQualityGate
 export ULID_LENGTH
@@ -45,8 +63,11 @@ export VerdictKind
 export WaypointEmitter
 export WaypointEmitterOptions
 export WaypointEmitterPorts
+export advanceMark
 export bestEffortScrub
 export configureWaypointEmitter
+export countRejected
+export countUnshipped
 export createUlidFactory
 export emitFleetHandoffWritten
 export emitFleetProvenanceWritten
@@ -57,31 +78,44 @@ export emitSdlc
 export emitSkillPhaseTransition
 export emitVerdictPersisted
 export ensureWaypointEmitter
+export eventIdOf
 export getWaypointEmitter
+export hasLanded
+export ingestUrl
 export initWaypointEmitter
+export isTerminal
 export isUlid
 export loadWaypointConfig
 export mergeSegments
+export readCheckpoint
 export readSpoolSegments
+export recordRejected
+export rejectedLogPath
 export resetWaypointEmitterForTests
+export shipSpool
+export unshippedLines
 export validateSdlcEvent
 export verdictGrade
+export writeCheckpoint
 ```
 
 ## Dependency Slice
 
 ```
 import { Err, Ok, Result, isErr, isOk } from '../shared/result'
+import { ShipCheckpoint, advanceMark, eventIdOf, readCheckpoint, unshippedLines, writeCheckpoint } from './checkpoint'
 import { loadWaypointConfig } from './config-loader'
 import { WaypointEmitter, configureWaypointEmitter, emitSdlc, ensureWaypointEmitter, getWaypointEmitter, initWaypointEmitter, resetWaypointEmitterForTests } from './emitter'
 import { emitFleetHandoffWritten, emitFleetProvenanceWritten, emitRoadmapClaim, emitRoadmapRelease, emitRoadmapStatusChange, emitSkillPhaseTransition, emitVerdictPersisted, verdictGrade } from './events'
+import { countRejected, recordRejected } from './rejected-log'
 import { REDACTED, bestEffortScrub } from './scrub'
+import { IngestEventResult, RejectedEvent, ShipError, ShipFetch, countUnshipped, hasLanded, ingestUrl, isTerminal, shipSpool } from './shipper'
 import { FileSpool, mergeSegments, readSpoolSegments } from './spool'
 import { ULID_LENGTH, createUlidFactory, isUlid } from './ulid'
 import { validateSdlcEvent } from './validate'
-import { FeatureStatus, FleetHandoffRecord, SDLC_EVENT_TYPES_V1, SDLC_SPECVERSION, SDLC_VERIFICATION_GRADES, SdlcActor, SdlcAppendResult, SdlcEvent, SdlcEventTypeV1, SdlcSpoolSegmentSnapshot, SdlcValidationIssue, SdlcValidationResult, SdlcVerificationGrade, WaypointConfig, WaypointConfigSchema } from '@harness-engineering/types'
+import { FeatureStatus, FleetHandoffRecord, SDLC_EVENT_TYPES_V1, SDLC_SPECVERSION, SDLC_VERIFICATION_GRADES, SdlcActor, SdlcAppendResult, SdlcEvent, SdlcEventTypeV1, SdlcSpoolSegmentSnapshot, SdlcValidationIssue, SdlcValidationResult, SdlcVerificationGrade, WaypointConfig, WaypointConfigSchema, WaypointShipConfig } from '@harness-engineering/types'
 import * as fs, { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir, userInfo } from 'node:os'
-import * as path, { basename, join } from 'node:path'
+import * as path, { basename, dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 ```

--- a/.harness/comprehension/packages/types/src/_module.md
+++ b/.harness/comprehension/packages/types/src/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/types/src'
-sourceHash: '67d513d63a377cbb4fd18192a20bbb7ca4efe33702eb42ea3900e1ce36dcc6f4'
+sourceHash: '446377d9667a0c8fd68b745fcb76f83d7bc89060a91d5b7d3e7bf20865d5c337'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -423,6 +423,8 @@ export VerdictCacheEntry
 export VerdictCacheStats
 export WaypointConfig
 export WaypointConfigSchema
+export WaypointShipConfig
+export WaypointShipConfigSchema
 export WaypointSinkConfig
 export WaypointSinkConfigSchema
 export WebhookDelivery

--- a/docs/changes/waypoint-spool-shipper/proposal.md
+++ b/docs/changes/waypoint-spool-shipper/proposal.md
@@ -1,0 +1,231 @@
+# The Waypoint spool shipper — the last mile from a local JSONL file to a live ledger
+
+**Keywords:** waypoint, sdlc-emission, spool, shipper, ingest, pnyon, adr-0047, cold-start
+
+> **STATUS: AWAITING SIGN-OFF. No implementation has begun.**
+>
+> The brainstorming Iron Law is that no code precedes human approval. Six decision forks are
+> listed below; each carries a recommendation and the evidence behind it. **D1, D2 and D5 change
+> the adopter-visible contract**, so they are the ones worth reading closely.
+
+## Overview
+
+Harness's `sdlc.*` emission layer is built, tested, and wired — and every event it produces stops
+at a file on disk.
+
+`packages/core/src/waypoint/` ships the emitter, spool, envelope, validation, scrubbing, and ULID
+identity. Emission points are live in the MCP tools (roadmap, uat-signoff, acceptance-eval,
+outcome-eval, interaction). `harness waypoint` exposes `record-provenance`, `record-handoff`, and
+`status`. What it does not expose is any way to send an event anywhere. `spool.ts:182` says so
+outright: `mergeSegments` "ships with the **(out-of-scope) shipper**."
+
+ADR-0047 requires the other half: "Every emitter appends to a local repo-side JSONL spool first
+**and ships with retry/backoff**, so harness works offline and adopters retain a local copy of
+their exhaust." The spool is done. The shipping is not.
+
+**The consequence is already visible in production.** Waypoint's wave forecasts cannot leave
+cold start, because the ledger never accumulates the V2/V3 verification evidence that would end
+it — and that evidence comes from harness eval verdicts, which spool locally and never ship.
+GitHub webhooks are the only live ingestion path, and they cannot produce a verification grade.
+This is not a new feature request; it is the missing connection between two systems that are
+both already running.
+
+Scope: **one component**. Read the spool, POST batches to a live endpoint, checkpoint what landed,
+report honestly. No changes to emission, no changes to pnyon.
+
+## What already exists on each side
+
+Both ends are built. Neither is speculative — the endpoint below was probed live on 2026-09-07.
+
+**Harness (read half, done):**
+
+| Piece                         | Location                         | Note                                                    |
+| ----------------------------- | -------------------------------- | ------------------------------------------------------- |
+| `readSpoolSegments(spoolDir)` | `core/src/waypoint/spool.ts:152` | per-writer JSONL segments                               |
+| `mergeSegments(segments)`     | `core/src/waypoint/spool.ts:186` | ULID-ordered merge, written _for_ this shipper          |
+| `SdlcSpoolSegmentSnapshot`    | `types/src/waypoint.ts:164`      | `{ segmentId, lines, droppedEvents }`                   |
+| `WaypointSinkConfig`          | `types/src/waypoint.ts`          | `transport: z.literal('spool')`, `source`, `onBehalfOf` |
+
+**pnyon (write half, live):**
+
+```
+POST /outpost/<outpostId>/project/<projectId>/events
+  header: x-pnyon-ingest-token: <token>     (constant-time compare; absent/blank ⇒ 401 on every POST)
+  body:   [ <SdlcEvent>, ... ]              (a JSON array — batch is native, not a wrapper)
+
+200 → { results: [{ id, result }], accepted, duplicate, invalid, scrubRejected, autoTrain }
+      result ∈ "accepted" | "duplicate" | "invalid" | "scrub-rejected"
+400 → { error: "body must be a JSON array of events" }
+401 → { error: "unauthorized" }
+```
+
+Source: `pnyon src/services/waypoint/waypoint-gateway.ts:150-183`,
+`ingest-service.ts:83-95`, `routes.ts`. Verified live:
+`…/outpost/pnyon/project/pnyon/board` → `200`.
+
+The response is **per-event**, which is what makes honest checkpointing possible: the shipper
+never has to guess which events in a batch landed.
+
+## Decisions
+
+### D1 — Shipping is an addition to spooling, not an alternative transport
+
+`transport` is `z.literal('spool')`. Adding shipping could widen it to `'spool' | 'pnyon'`, or
+leave it alone and add a sibling block.
+
+**Recommendation: a sibling `ship` block; `transport` stays `'spool'`.**
+
+```jsonc
+"waypoint": {
+  "sink": {
+    "transport": "spool",
+    "ship": {
+      "url": "https://waypoint-staging.pnyon.com",
+      "outpost": "pnyon",
+      "project": "pnyon"
+      // token: PNYON_WAYPOINT_INGEST_TOKEN env, never committed
+    }
+  }
+}
+```
+
+ADR-0047 says events are spooled **first** and _then_ shipped. Modelling shipping as an
+alternative transport would encode the opposite — that you choose one or the other — and would
+make "spool then ship" unrepresentable. It would also let a config edit silently stop writing the
+adopter's local copy, which ADR-0047 guarantees them.
+
+Absent `ship` ⇒ today's behaviour exactly. The non-adopter invariance contract (PRD Story 1) is
+untouched: no `waypoint.sink`, no files, no I/O, no change.
+
+### D2 — Project scope is configured, never derived
+
+Every pnyon route needs `outpost` **and** `project`. Harness's config carries an Outpost inside
+the `source` URI (`harness://outpost/<uuid>/repo/<name>`) and has no notion of a project at all.
+
+Options: derive `project` from the repo basename; parse it out of `source`; require it explicitly.
+
+**Recommendation: require both explicitly in the `ship` block.**
+
+Deriving from a basename means two repos named `api` in different orgs write into the same
+ledger. Writes are appends to a hash-chained, append-only log — a mis-scoped write cannot be
+taken back, only compensated. A required field costs one line of config and removes the whole
+class. Parsing `source` is worse than either: it silently couples an identity string to a routing
+decision, so editing a display value would re-route production writes.
+
+**This is a genuine fork if you intend the Outpost UUID in `source` to be authoritative** — say
+so and the shipper reads it, but I would still require `project` separately.
+
+### D3 — Checkpoint, never truncate
+
+Nothing tracks what has been shipped. Options: (a) a checkpoint file; (b) delete or truncate
+shipped lines; (c) re-ship everything and lean on server-side dedup.
+
+**Recommendation: (a), a checkpoint file. Explicitly not (b).**
+
+ADR-0047 promises adopters "retain a local copy of their exhaust." A shipper that truncates
+converts the spool from _the adopter's own record_ into _a transmit queue_, silently deleting the
+thing the ADR guaranteed. It is also unrecoverable if the ledger is ever re-projected.
+
+(c) is safe — ULIDs are the idempotency key and re-sends return `duplicate` — but it re-uploads
+the entire history on every run, which is O(total) forever and makes the honest `status` output
+meaningless.
+
+Proposed: `.harness/spool/.shipped.json`, mapping `segmentId → last shipped ULID`. Per-segment
+because segments are per-writer and advance independently. ULID-keyed because ULIDs are
+time-ordered, so "everything after this one" is a well-defined resume point without line offsets
+that shift when a segment is rewritten at the cap.
+
+### D4 — A permanently-rejected event advances the checkpoint and is recorded, never retried forever
+
+`invalid` and `scrub-rejected` are terminal: the same bytes will be rejected identically on every
+retry. If the checkpoint only advances on `accepted`, one malformed event wedges the pipeline
+permanently and every later event silently stops shipping.
+
+**Recommendation: treat `accepted` and `duplicate` as landed; treat `invalid` and
+`scrub-rejected` as terminal — advance past them, append them to
+`.harness/spool/rejected.jsonl` with the server's reason, and surface the count loudly in
+`harness waypoint status`.**
+
+Both halves matter. Blocking forever is the classic queue-wedge bug. Dropping silently is worse,
+because `scrub-rejected` means the scrubber caught something — a signal the adopter needs to see,
+not a statistic to bury. Neither a wedged pipeline nor a silent drop is acceptable; the
+dead-letter file is what makes advancing safe.
+
+### D5 — Explicit `harness waypoint ship` first; no automatic background flush
+
+Options: an explicit command; an automatic flush on emit; both.
+
+**Recommendation: explicit command only, this slice.**
+
+An automatic flush puts a network call on the hot path of every sanctioned mutator — the exact
+operations that must not slow down or acquire a new failure mode. It also makes the
+non-adopter invariance contract harder to hold, and it is untestable without either a live
+service or a much larger fake. An explicit command is observable, scriptable, cron-able, and
+composes with CI. Auto-flush can be added later on top of a shipper that is already proven; it
+cannot easily be removed once operations depend on it.
+
+`harness waypoint ship [--dry-run] [--json] [--limit N]` — `--dry-run` reports what _would_ ship
+without a single write, mirroring the backfill-CLI posture.
+
+### D6 — Retry only what retrying can fix
+
+**Recommendation:** exponential backoff with jitter on network errors and 5xx. **No retry on 400
+or 401** — a malformed body or a bad token is a configuration fault, and retrying it turns a
+clear, immediate error message into a slow one. Fail loudly, name the endpoint and which of
+`ship.url` / `ship.outpost` / `ship.project` / the token is implicated.
+
+Batch size default 500 events, `--limit` to override. Partial batch success is already handled:
+the per-event `results` array tells the shipper exactly how far to advance.
+
+## Success criteria
+
+- **SC-1** WHEN `waypoint.sink.ship` is absent, THE SYSTEM SHALL behave exactly as today — no
+  network calls, no new files, and `harness waypoint ship` exits 0 with an explanatory note.
+- **SC-2** WHEN spooled events exist and the endpoint is reachable, THE SYSTEM SHALL POST them as
+  a JSON array to `/outpost/<outpost>/project/<project>/events` and advance the checkpoint past
+  every event reported `accepted` or `duplicate`.
+- **SC-3** WHEN the shipper runs twice with no new events, THE SECOND run SHALL send no events
+  and report zero shipped.
+- **SC-4** WHERE the server reports an event `invalid` or `scrub-rejected`, THE SYSTEM SHALL
+  advance past it, record it with its reason in `rejected.jsonl`, and report the count — never
+  block the queue and never drop it silently.
+- **SC-5** WHEN the endpoint returns 401 or 400, THE SYSTEM SHALL fail loudly without retrying
+  and without advancing the checkpoint.
+- **SC-6** THE SYSTEM SHALL never delete or truncate a spool segment.
+- **SC-7** WHEN a partial batch succeeds, THE SYSTEM SHALL resume from the first unlanded event
+  on the next run, sending no landed event a second time.
+- **SC-8** `harness waypoint status` SHALL report unshipped count, last shipped ULID, and
+  rejected count alongside its existing spool health.
+
+## Assumptions
+
+- **A1** The live contract is as probed on 2026-09-07 and pinned above. If pnyon's route space
+  changes, this spec's §"What already exists" is the thing to re-verify first — the mismatch it
+  replaces (harness #1816/#1977 against a `/v1/items` API that returns 404) is exactly what
+  happens when a client is written against an assumed contract. **This spec pins a contract that
+  was verified live, not one declared normative for someone else's service.**
+- **A2** `PNYON_WAYPOINT_INGEST_TOKEN` is the operator-set secret on the pnyon side; the harness
+  side reads its own env var and never commits a token.
+- **A3** Ingest is idempotent on client-generated ULIDs (ADR-0047), so at-least-once delivery is
+  safe and no server coordination is required.
+
+## Implementation order
+
+1. `ship` config block + loader (D1, D2) — SC-1.
+2. Checkpoint store: read, advance, persist (D3) — SC-3, SC-6, SC-7.
+3. HTTP client + batching against a mock of the contract above (D6) — SC-2, SC-5.
+4. Terminal-rejection handling + `rejected.jsonl` (D4) — SC-4.
+5. `harness waypoint ship` wiring + `status` extension (D5) — SC-8.
+6. **Live proof against `waypoint-staging.pnyon.com`, reported with real counts.** Not optional:
+   a mock-only pass is precisely how #1816 and #1977 both came to be complete, green, and
+   unreachable.
+
+## Evidence
+
+- ADR-0047 (accepted) — spool-then-ship with retry/backoff; adopters retain their exhaust.
+- Proposed ADR-0052 — pnyon owns the item model; harness emits rather than writing items. This
+  shipper is the emission path that ADR names, and does not depend on 0052 being accepted:
+  ADR-0047 already requires it.
+- `spool.ts:182` — the shipper named as out-of-scope, with `mergeSegments` written to serve it.
+- `waypoint-gateway.ts:150-183`, `ingest-service.ts:83-95` — the endpoint and report shape.
+- Live probe 2026-09-07: `…/board` → 200; `/v1/items` → 404.

--- a/docs/changes/waypoint-spool-shipper/proposal.md
+++ b/docs/changes/waypoint-spool-shipper/proposal.md
@@ -2,11 +2,10 @@
 
 **Keywords:** waypoint, sdlc-emission, spool, shipper, ingest, pnyon, adr-0047, cold-start
 
-> **STATUS: AWAITING SIGN-OFF. No implementation has begun.**
+> **STATUS: APPROVED ("go with recommendations", 2026-09-07) AND IMPLEMENTED.**
 >
-> The brainstorming Iron Law is that no code precedes human approval. Six decision forks are
-> listed below; each carries a recommendation and the evidence behind it. **D1, D2 and D5 change
-> the adopter-visible contract**, so they are the ones worth reading closely.
+> All six decisions landed as recommended. See §"Live proof" at the end for what was verified
+> against the running service and what remains blocked on an operator-held secret.
 
 ## Overview
 
@@ -229,3 +228,42 @@ the per-event `results` array tells the shipper exactly how far to advance.
 - `spool.ts:182` — the shipper named as out-of-scope, with `mergeSegments` written to serve it.
 - `waypoint-gateway.ts:150-183`, `ingest-service.ts:83-95` — the endpoint and report shape.
 - Live probe 2026-09-07: `…/board` → 200; `/v1/items` → 404.
+
+## Live proof (step 6, executed 2026-09-07)
+
+Run with the **built CLI** against the **running staging service** — not a mock, and not the
+source tree.
+
+```
+$ harness waypoint status
+  Spool: .harness/spool
+  Segments: 1 · Events: 1
+  Unshipped: 1
+
+$ harness waypoint ship          # no token set
+  x PNYON_WAYPOINT_INGEST_TOKEN is not set; it is required to ship to
+    https://waypoint-staging.pnyon.com. The token is deliberately not read from
+    harness.config.json so it cannot be committed.
+
+$ PNYON_WAYPOINT_INGEST_TOKEN=<deliberately wrong> harness waypoint ship
+  x Waypoint ingest rejected the credential (401) at
+    https://waypoint-staging.pnyon.com/outpost/pnyon/project/pnyon/events.
+    Check PNYON_WAYPOINT_INGEST_TOKEN and that the same secret is set on the
+    Waypoint Worker (`wrangler secret put PNYON_WAYPOINT_INGEST_TOKEN`).
+  exit 1 · no .shipped.json · no rejected.jsonl · segment byte-identical
+```
+
+**The verdict is `401`, not `404`.** That single digit is the whole difference between this and
+the two stranded adapters: the URL this shipper builds resolves to a real handler on the live
+service, and that handler enforced auth. `/v1/items` — what harness #1816 and #1977 speak —
+returns `404` against the same host. Route construction, scope segments, method, and headers are
+therefore confirmed end-to-end against production.
+
+Also confirmed live rather than by unit test: SC-5 (a credential fault fails loudly, exits 1, and
+advances nothing) and SC-6 (the spool segment is untouched).
+
+**What remains unproven:** an `accepted` write. That needs the real
+`PNYON_WAYPOINT_INGEST_TOKEN`, which is an operator-set Worker secret and is not present in this
+environment. The remaining gap is one `200` and its `results` array — every other layer is
+exercised against the running service. Setting the env var and re-running `harness waypoint ship`
+closes it.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -2070,7 +2070,7 @@ List recent sessions with token usage and cost
 
 ## Waypoint Commands
 
-Opt-in Waypoint sdlc.\* emission: record fleet artifacts, inspect the spool
+Opt-in Waypoint sdlc.\* emission: record fleet artifacts, ship the spool, inspect it
 
 ### `harness waypoint record-handoff <file>`
 
@@ -2079,6 +2079,15 @@ Spool one sdlc.\* event for a written fleet handoff record
 ### `harness waypoint record-provenance <file>`
 
 Spool one sdlc.\* event for a written fleet provenance.json
+
+### `harness waypoint ship`
+
+Send spooled sdlc.\* events to the configured Waypoint ledger
+
+**Options:**
+
+- `--dry-run` — Report what would ship without sending anything
+- `--limit` — Cap the number of events sent this run
 
 ### `harness waypoint status`
 

--- a/packages/cli/src/commands/waypoint.ts
+++ b/packages/cli/src/commands/waypoint.ts
@@ -117,7 +117,8 @@ function registerStatus(waypoint: Command): void {
     .action(async (_opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const cwd = process.cwd();
-      const { readSpoolSegments } = await import('@harness-engineering/core');
+      const { readSpoolSegments, countUnshipped, countRejected } =
+        await import('@harness-engineering/core');
       const spoolDir = path.join(cwd, '.harness', 'spool');
       const segments = readSpoolSegments(spoolDir);
       const status: SpoolStatus = {
@@ -126,6 +127,8 @@ function registerStatus(waypoint: Command): void {
         events: segments.reduce((sum, s) => sum + s.lines.length, 0),
         droppedEvents: segments.reduce((sum, s) => sum + s.droppedEvents, 0),
         oldestEventTime: oldestEventTime(segments),
+        unshipped: countUnshipped(spoolDir),
+        rejected: countRejected(spoolDir),
       };
       if (globalOpts.json === true) {
         console.log(JSON.stringify(status, null, 2));
@@ -141,6 +144,157 @@ interface SpoolStatus {
   events: number;
   droppedEvents: number;
   oldestEventTime: string | null;
+  /** Events not yet confirmed in the ledger (SC-8). */
+  unshipped: number;
+  /** Events the ledger refused permanently; see `rejected.jsonl`. */
+  rejected: number;
+}
+
+/** Env var holding the ingest credential; never read from config. */
+export const INGEST_TOKEN_ENV = 'PNYON_WAYPOINT_INGEST_TOKEN';
+
+/** A resolved, credentialed shipping target. */
+interface ShipTarget {
+  readonly ship: { url: string; outpost: string; project: string; batchSize?: number };
+  readonly token: string;
+}
+
+/**
+ * Resolve where to ship and with what credential, reporting and returning null
+ * when either is unavailable.
+ *
+ * The three outcomes are deliberately distinct. A malformed `waypoint` block is
+ * an error, NOT "no sink configured" — treating it as the latter would make a
+ * broken adopter repo look exactly like a healthy non-adopter one while quietly
+ * shipping nothing. An absent `ship` block is the documented default and exits
+ * 0. A missing token is an error that names the env var, because the token is
+ * deliberately unconfigurable in the committed file.
+ */
+function resolveShipTarget(
+  configResult: { ok: boolean; value?: unknown; error?: Error },
+  json: boolean
+): ShipTarget | null {
+  if (!configResult.ok) {
+    logger.error(`Cannot read Waypoint config: ${configResult.error?.message ?? 'unknown error'}`);
+    process.exitCode = 1;
+    return null;
+  }
+  const ship = (configResult.value as { sink?: { ship?: ShipTarget['ship'] } } | undefined)?.sink
+    ?.ship;
+  if (!ship) {
+    emitNote(json, NO_SHIP_NOTE);
+    return null;
+  }
+  const token = process.env[INGEST_TOKEN_ENV];
+  if (token === undefined || token === '') {
+    logger.error(
+      `${INGEST_TOKEN_ENV} is not set; it is required to ship to ${ship.url}. ` +
+        'The token is deliberately not read from harness.config.json so it cannot be committed.'
+    );
+    process.exitCode = 1;
+    return null;
+  }
+  return { ship, token };
+}
+
+/**
+ * `harness waypoint ship` — send spooled events to the configured ledger.
+ *
+ * An explicit command rather than an automatic flush on emit (D5): auto-flush
+ * would put a network call on the hot path of every sanctioned mutator, which
+ * is exactly the set of operations that must not gain a new failure mode. This
+ * is observable, scriptable, and cron-able, and can be run from CI.
+ */
+function registerShip(waypoint: Command): void {
+  waypoint
+    .command('ship')
+    .description('Send spooled sdlc.* events to the configured Waypoint ledger')
+    .option('--dry-run', 'Report what would ship without sending anything')
+    .option('--limit <n>', 'Cap the number of events sent this run', (v) => Number.parseInt(v, 10))
+    .action(async (opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const json = globalOpts.json === true;
+      const cwd = process.cwd();
+      const { loadWaypointConfig, shipSpool, recordRejected, ShipError } =
+        await import('@harness-engineering/core');
+
+      const target = resolveShipTarget(loadWaypointConfig(cwd), json);
+      if (target === null) return;
+      const { ship, token } = target;
+
+      const spoolDir = path.join(cwd, '.harness', 'spool');
+      try {
+        const report = await shipSpool({
+          spoolDir,
+          config: ship,
+          token,
+          fetchFn: (url, init) => fetch(url, init),
+          ...(opts.dryRun === true ? { dryRun: true } : {}),
+          ...(typeof opts.limit === 'number' && !Number.isNaN(opts.limit)
+            ? { limit: opts.limit }
+            : {}),
+          onRejected: (rejected) => {
+            recordRejected(spoolDir, rejected, new Date().toISOString());
+          },
+        });
+        if (json) {
+          console.log(JSON.stringify(report, null, 2));
+          return;
+        }
+        renderShipReport(report, ship.url, opts.dryRun === true);
+      } catch (err) {
+        if (err instanceof ShipError) {
+          logger.error(err.message);
+          process.exitCode = 1;
+          return;
+        }
+        throw err;
+      }
+    });
+}
+
+const NO_SHIP_NOTE =
+  'No `waypoint.sink.ship` configured in harness.config.json; events stay in the local spool.';
+
+/** Human-readable outcome of one `ship` run. */
+function renderShipReport(
+  report: {
+    shipped: number;
+    accepted: number;
+    duplicate: number;
+    rejected: readonly unknown[];
+    remaining: number;
+  },
+  url: string,
+  dryRun: boolean
+): void {
+  if (dryRun) {
+    logger.info(`Dry run: ${report.remaining} event(s) would ship to ${url}.`);
+    return;
+  }
+  logger.info(
+    `Shipped ${report.shipped} event(s) to ${url} ` +
+      `(${report.accepted} accepted, ${report.duplicate} already present).`
+  );
+  if (report.rejected.length > 0) {
+    // Loud, not a footnote: a scrub rejection means the scrubber caught
+    // something in harness's own exhaust, which the adopter needs to see.
+    logger.warn(
+      `${report.rejected.length} event(s) permanently refused and recorded in ` +
+        `${path.join('.harness', 'spool', 'rejected.jsonl')} — review them.`
+    );
+  }
+  if (report.remaining > 0) {
+    logger.info(`${report.remaining} event(s) still queued; re-run to continue.`);
+  }
+}
+
+function emitNote(json: boolean, note: string): void {
+  if (json) {
+    console.log(JSON.stringify({ shipped: 0, note }, null, 2));
+    return;
+  }
+  logger.info(note);
 }
 
 /** Oldest `time` across segment heads (segments are append-ordered). */
@@ -174,6 +328,12 @@ function renderStatus(status: SpoolStatus): void {
   if (status.oldestEventTime !== null) {
     logger.info(`Oldest spooled event: ${status.oldestEventTime}`);
   }
+  logger.info(`Unshipped: ${status.unshipped}`);
+  if (status.rejected > 0) {
+    // Surfaced as a warning: these are events the ledger refused outright, and
+    // a scrub rejection in particular is a signal, not a statistic.
+    logger.warn(`Permanently refused: ${status.rejected} (see rejected.jsonl)`);
+  }
 }
 
 function emitResult(json: boolean, body: Record<string, unknown>): void {
@@ -190,11 +350,14 @@ function emitResult(json: boolean, body: Record<string, unknown>): void {
 
 export function createWaypointCommand(): Command {
   const waypoint = new Command('waypoint')
-    .description('Opt-in Waypoint sdlc.* emission: record fleet artifacts, inspect the spool')
+    .description(
+      'Opt-in Waypoint sdlc.* emission: record fleet artifacts, ship the spool, inspect it'
+    )
     .option('--json', 'Output in JSON format');
 
   registerRecordProvenance(waypoint);
   registerRecordHandoff(waypoint);
+  registerShip(waypoint);
   registerStatus(waypoint);
 
   return waypoint;

--- a/packages/cli/tests/commands/waypoint-ship.test.ts
+++ b/packages/cli/tests/commands/waypoint-ship.test.ts
@@ -1,0 +1,184 @@
+/**
+ * `harness waypoint ship` wiring (D5 / SC-1, SC-8 of
+ * `docs/changes/waypoint-spool-shipper/proposal.md`).
+ *
+ * The shipper's own logic is covered in core. What these pin is the part that
+ * cannot be tested from there: that the command exists, is registered, and
+ * reaches the shipper — and that a repo with no `ship` config makes no network
+ * call at all. A shipper nothing invokes is the exact failure mode this whole
+ * line of work exists to close.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createWaypointCommand } from '../../src/commands/waypoint';
+
+let cwd: string;
+let originalCwd: string;
+let logs: string[];
+let errors: string[];
+const savedEnv = { ...process.env };
+
+function writeConfig(waypoint: unknown): void {
+  fs.writeFileSync(path.join(cwd, 'harness.config.json'), JSON.stringify({ waypoint }, null, 2));
+}
+
+function writeSpool(lines: readonly string[]): void {
+  const spoolDir = path.join(cwd, '.harness', 'spool');
+  fs.mkdirSync(spoolDir, { recursive: true });
+  fs.writeFileSync(path.join(spoolDir, 'sdlc-seg1.jsonl'), `${lines.join('\n')}\n`, 'utf8');
+}
+
+const event = (n: number): string =>
+  JSON.stringify({
+    id: `01ABCDEFGH${String(n).padStart(16, '0')}`,
+    type: 'sdlc.intent.created.v1',
+    subject: `item/x-${n}`,
+    time: '2026-09-07T00:00:00.000Z',
+  });
+
+async function run(args: string[]): Promise<void> {
+  const cmd = createWaypointCommand();
+  cmd.exitOverride();
+  await cmd.parseAsync(['node', 'waypoint', ...args]);
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'waypoint-ship-cli-'));
+  process.chdir(cwd);
+  logs = [];
+  errors = [];
+  delete process.env.PNYON_WAYPOINT_INGEST_TOKEN;
+  vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    errors.push(a.join(' '));
+  });
+  vi.spyOn(console, 'warn').mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(' '));
+  });
+  vi.spyOn(console, 'info').mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(' '));
+  });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  process.env = { ...savedEnv };
+  process.exitCode = 0;
+  vi.restoreAllMocks();
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('harness waypoint ship — registration', () => {
+  it('is a registered subcommand', () => {
+    const names = createWaypointCommand()
+      .commands.map((c) => c.name())
+      .sort();
+    // Without this the shipper is unreachable no matter how correct it is.
+    expect(names).toContain('ship');
+  });
+});
+
+describe('harness waypoint ship — non-adopter invariance (SC-1)', () => {
+  it('makes no network call and exits 0 when no ship config exists', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    writeSpool([event(1)]);
+
+    await run(['ship']);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).not.toBe(1);
+    expect(logs.join('\n')).toContain('local spool');
+  });
+
+  it('makes no network call when there is no harness.config.json at all', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await run(['ship']);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).not.toBe(1);
+  });
+});
+
+describe('harness waypoint ship — credential handling', () => {
+  it('refuses without the token and names the env var, not a config key', async () => {
+    writeConfig({
+      sink: {
+        transport: 'spool',
+        ship: { url: 'https://waypoint.test', outpost: 'o', project: 'p' },
+      },
+    });
+    writeSpool([event(1)]);
+
+    await run(['ship']);
+
+    expect(process.exitCode).toBe(1);
+    const message = errors.join('\n');
+    expect(message).toContain('PNYON_WAYPOINT_INGEST_TOKEN');
+    // The token must not be configurable in the committed file.
+    expect(message).toContain('cannot be committed');
+  });
+});
+
+describe('harness waypoint ship — dry run', () => {
+  it('reports the backlog without sending or checkpointing', async () => {
+    writeConfig({
+      sink: {
+        transport: 'spool',
+        ship: { url: 'https://waypoint.test', outpost: 'o', project: 'p' },
+      },
+    });
+    writeSpool([event(1), event(2)]);
+    process.env.PNYON_WAYPOINT_INGEST_TOKEN = 'tok';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await run(['ship', '--dry-run']);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toContain('2');
+    expect(fs.existsSync(path.join(cwd, '.harness', 'spool', '.shipped.json'))).toBe(false);
+  });
+});
+
+describe('harness waypoint status — shipping visibility (SC-8)', () => {
+  it('reports unshipped count alongside spool health', async () => {
+    writeSpool([event(1), event(2), event(3)]);
+
+    await run(['--json', 'status']);
+
+    const status = JSON.parse(logs.join('')) as { events: number; unshipped: number };
+    expect(status.events).toBe(3);
+    expect(status.unshipped).toBe(3);
+  });
+
+  it('reports zero unshipped once the checkpoint covers the spool', async () => {
+    writeSpool([event(1), event(2)]);
+    fs.writeFileSync(
+      path.join(cwd, '.harness', 'spool', '.shipped.json'),
+      JSON.stringify({ marks: { seg1: `01ABCDEFGH${'2'.padStart(16, '0')}` } })
+    );
+
+    await run(['--json', 'status']);
+
+    const status = JSON.parse(logs.join('')) as { unshipped: number };
+    expect(status.unshipped).toBe(0);
+  });
+
+  it('reports the permanently-refused count', async () => {
+    writeSpool([event(1)]);
+    fs.writeFileSync(
+      path.join(cwd, '.harness', 'spool', 'rejected.jsonl'),
+      `${JSON.stringify({ id: '01X', result: 'scrub-rejected', at: 'now', event: '{}' })}\n`
+    );
+
+    await run(['--json', 'status']);
+
+    const status = JSON.parse(logs.join('')) as { rejected: number };
+    expect(status.rejected).toBe(1);
+  });
+});

--- a/packages/core/src/waypoint/checkpoint.ts
+++ b/packages/core/src/waypoint/checkpoint.ts
@@ -1,0 +1,121 @@
+/**
+ * Shipper checkpoint — what has already reached the ledger
+ * (D3 of `docs/changes/waypoint-spool-shipper/proposal.md`).
+ *
+ * THE INVARIANT: this module never deletes, truncates, or rewrites a spool
+ * segment. ADR-0047 promises adopters "retain a local copy of their exhaust",
+ * so the spool is the adopter's own record and shipping is a read of it. A
+ * shipper that consumed the spool would quietly convert that record into a
+ * transmit queue and destroy the thing the ADR guaranteed. Progress therefore
+ * lives beside the segments, never inside them.
+ *
+ * Keyed by segment id because segments are per-writer and advance
+ * independently; keyed to a ULID rather than a line offset because ULIDs are
+ * time-ordered and stable, while offsets shift the moment a segment drops its
+ * oldest line at the cap — a resume point that silently re-sends or skips is
+ * worse than no resume point at all.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/** File holding shipper progress, beside the segments it describes. */
+export const CHECKPOINT_FILENAME = '.shipped.json';
+
+/** Per-segment high-water marks: `segmentId → last ULID known to have landed`. */
+export interface ShipCheckpoint {
+  readonly marks: Readonly<Record<string, string>>;
+}
+
+/** An empty checkpoint — nothing shipped yet. */
+export const EMPTY_CHECKPOINT: ShipCheckpoint = { marks: {} };
+
+function checkpointPath(spoolDir: string): string {
+  return join(spoolDir, CHECKPOINT_FILENAME);
+}
+
+/**
+ * Read the checkpoint, or an empty one.
+ *
+ * An unreadable or malformed file yields EMPTY rather than throwing. The
+ * failure mode that choice accepts is re-sending events, which ingest dedups
+ * by ULID and reports as `duplicate`; the failure mode it avoids is a shipper
+ * that cannot run at all because a sidecar got corrupted. Only string values
+ * are kept, so a hand-edited file cannot inject a non-ULID mark that would
+ * compare unpredictably.
+ */
+export function readCheckpoint(spoolDir: string): ShipCheckpoint {
+  const path = checkpointPath(spoolDir);
+  if (!existsSync(path)) return EMPTY_CHECKPOINT;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) return EMPTY_CHECKPOINT;
+    const raw = (parsed as { marks?: unknown }).marks;
+    if (typeof raw !== 'object' || raw === null) return EMPTY_CHECKPOINT;
+    const marks: Record<string, string> = {};
+    for (const [segmentId, mark] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof mark === 'string' && mark.length > 0) marks[segmentId] = mark;
+    }
+    return { marks };
+  } catch {
+    return EMPTY_CHECKPOINT;
+  }
+}
+
+/** Persist the checkpoint, creating the spool directory if needed. */
+export function writeCheckpoint(spoolDir: string, checkpoint: ShipCheckpoint): void {
+  const path = checkpointPath(spoolDir);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(checkpoint, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Advance one segment's mark.
+ *
+ * Monotonic by construction: a mark only moves forward in ULID order. Batches
+ * can be reported out of order and a stale run can finish after a fresh one
+ * without either being able to rewind progress and cause a re-send.
+ */
+export function advanceMark(
+  checkpoint: ShipCheckpoint,
+  segmentId: string,
+  ulid: string
+): ShipCheckpoint {
+  const current = checkpoint.marks[segmentId];
+  if (current !== undefined && current >= ulid) return checkpoint;
+  return { marks: { ...checkpoint.marks, [segmentId]: ulid } };
+}
+
+/**
+ * The lines of one segment that have not yet landed.
+ *
+ * Compares ULIDs rather than counting, so a segment that dropped its oldest
+ * lines at the cap resumes at the right place instead of re-sending from a
+ * stale offset.
+ */
+export function unshippedLines(
+  checkpoint: ShipCheckpoint,
+  segmentId: string,
+  lines: readonly string[]
+): string[] {
+  const mark = checkpoint.marks[segmentId];
+  if (mark === undefined) return [...lines];
+  return lines.filter((line) => {
+    const id = eventIdOf(line);
+    // A line whose id cannot be read is kept: ingest will judge it, and
+    // dropping it here would hide a malformed event the adopter should see.
+    return id === null ? true : id > mark;
+  });
+}
+
+/** The `id` of a spooled JSONL line, or null when it cannot be read. */
+export function eventIdOf(line: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const id = (parsed as { id?: unknown }).id;
+    return typeof id === 'string' && id.length > 0 ? id : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/waypoint/index.ts
+++ b/packages/core/src/waypoint/index.ts
@@ -17,6 +17,39 @@ export {
 } from './spool';
 export { loadWaypointConfig } from './config-loader';
 export {
+  advanceMark,
+  CHECKPOINT_FILENAME,
+  EMPTY_CHECKPOINT,
+  eventIdOf,
+  readCheckpoint,
+  unshippedLines,
+  writeCheckpoint,
+  type ShipCheckpoint,
+} from './checkpoint';
+export {
+  countUnshipped,
+  DEFAULT_BATCH_SIZE,
+  hasLanded,
+  ingestUrl,
+  isTerminal,
+  shipSpool,
+  ShipError,
+  type IngestEventResult,
+  type IngestReportBody,
+  type IngestResultKind,
+  type RejectedEvent,
+  type ShipFetch,
+  type ShipOptions,
+  type ShipReport,
+} from './shipper';
+export {
+  countRejected,
+  recordRejected,
+  REJECTED_FILENAME,
+  rejectedLogPath,
+  type RejectedRecord,
+} from './rejected-log';
+export {
   configureWaypointEmitter,
   emitSdlc,
   ensureWaypointEmitter,

--- a/packages/core/src/waypoint/rejected-log.ts
+++ b/packages/core/src/waypoint/rejected-log.ts
@@ -1,0 +1,80 @@
+/**
+ * Dead-letter log for permanently-refused events
+ * (D4 of `docs/changes/waypoint-spool-shipper/proposal.md`).
+ *
+ * This file is what makes it safe for the shipper to advance past an event the
+ * ledger will never accept. Without it there are only two options and both are
+ * defects: block forever on the first bad event, wedging the queue so every
+ * later event silently stops shipping; or advance and drop it, which is worse,
+ * because a `scrub-rejected` verdict means the scrubber caught something in
+ * harness's own exhaust — a signal the adopter needs to see, not a statistic
+ * to bury in a counter.
+ *
+ * Append-only, one JSON object per line, beside the spool it describes.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { RejectedEvent } from './shipper';
+
+/** File holding permanently-refused events. */
+export const REJECTED_FILENAME = 'rejected.jsonl';
+
+/** One recorded rejection: the verdict, when it happened, and the event. */
+export interface RejectedRecord {
+  readonly id: string;
+  readonly result: string;
+  readonly at: string;
+  /** The original spooled line, so the event is inspectable, not just named. */
+  readonly event: string;
+}
+
+export function rejectedLogPath(spoolDir: string): string {
+  return join(spoolDir, REJECTED_FILENAME);
+}
+
+/**
+ * Append rejections to the dead-letter log.
+ *
+ * Never throws. A shipper that crashed while recording a rejection would leave
+ * the run half-applied — some events shipped, no checkpoint written — so an
+ * I/O failure here degrades to a returned `false` and the run's own report
+ * still names the count.
+ */
+export function recordRejected(
+  spoolDir: string,
+  rejected: readonly RejectedEvent[],
+  nowIso: string
+): boolean {
+  if (rejected.length === 0) return true;
+  try {
+    mkdirSync(spoolDir, { recursive: true });
+    const lines = rejected
+      .map((r) =>
+        JSON.stringify({
+          id: r.id,
+          result: r.result,
+          at: nowIso,
+          event: r.line,
+        } satisfies RejectedRecord)
+      )
+      .join('\n');
+    appendFileSync(rejectedLogPath(spoolDir), `${lines}\n`, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** How many rejections the log holds; 0 when absent or unreadable. */
+export function countRejected(spoolDir: string): number {
+  const path = rejectedLogPath(spoolDir);
+  if (!existsSync(path)) return 0;
+  try {
+    return readFileSync(path, 'utf8')
+      .split('\n')
+      .filter((line) => line.length > 0).length;
+  } catch {
+    return 0;
+  }
+}

--- a/packages/core/src/waypoint/shipper.test.ts
+++ b/packages/core/src/waypoint/shipper.test.ts
@@ -1,0 +1,528 @@
+/**
+ * Shipper contract tests (`docs/changes/waypoint-spool-shipper/proposal.md`).
+ *
+ * The fake below mirrors the endpoint PROBED LIVE on 2026-09-07 — a bare JSON
+ * array in, a per-event `results` array out. That fidelity is the point: the
+ * two prior harness↔Waypoint adapters were complete and green against mocks of
+ * a contract that returned 404 in production, so a mock here is only worth
+ * anything if it matches something real. Step 6 of the spec is a live proof on
+ * top of these.
+ *
+ *  - SC-1 no `ship` config ⇒ no network
+ *  - SC-2 events reach the endpoint and the checkpoint advances
+ *  - SC-3 a second run with nothing new sends nothing
+ *  - SC-4 terminal rejections advance AND are recorded
+ *  - SC-5 401/400 fail loudly without retry and without advancing
+ *  - SC-6 spool segments are never modified
+ *  - SC-7 a partial batch resumes from the first unlanded event
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WaypointShipConfig } from '@harness-engineering/types';
+import { readCheckpoint } from './checkpoint';
+import { countRejected, recordRejected } from './rejected-log';
+import {
+  countUnshipped,
+  hasLanded,
+  ingestUrl,
+  isTerminal,
+  ShipError,
+  shipSpool,
+  type IngestEventResult,
+  type ShipFetch,
+} from './shipper';
+
+let dir: string;
+let spoolDir: string;
+
+const CONFIG: WaypointShipConfig = {
+  url: 'https://waypoint.test',
+  outpost: 'pnyon',
+  project: 'pnyon',
+};
+
+/** A spooled line with a ULID-shaped, lexicographically ordered id. */
+function event(n: number, type = 'sdlc.intent.created.v1'): string {
+  const id = `01ABCDEFGH${String(n).padStart(16, '0')}`;
+  return JSON.stringify({ id, type, subject: `item/thing-${n}` });
+}
+
+function writeSegment(segmentId: string, lines: readonly string[]): void {
+  mkdirSync(spoolDir, { recursive: true });
+  writeFileSync(join(spoolDir, `sdlc-${segmentId}.jsonl`), `${lines.join('\n')}\n`, 'utf8');
+}
+
+/** Mirrors the live endpoint: array in, per-event results out. */
+function fakeIngest(
+  verdict: (id: string, index: number) => IngestEventResult['result'] = () => 'accepted'
+): { fetchFn: ShipFetch; bodies: string[]; urls: string[] } {
+  const bodies: string[] = [];
+  const urls: string[] = [];
+  const fetchFn: ShipFetch = async (url, init) => {
+    urls.push(url);
+    bodies.push(init.body);
+    const parsed = JSON.parse(init.body) as Array<{ id: string }>;
+    const results = parsed.map((e, i) => ({ id: e.id, result: verdict(e.id, i) }));
+    return {
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          results,
+          accepted: results.filter((r) => r.result === 'accepted').length,
+          duplicate: results.filter((r) => r.result === 'duplicate').length,
+          invalid: results.filter((r) => r.result === 'invalid').length,
+          scrubRejected: results.filter((r) => r.result === 'scrub-rejected').length,
+        }),
+    };
+  };
+  return { fetchFn, bodies, urls };
+}
+
+const statusOnly = (status: number, body = '{}'): ShipFetch => {
+  let calls = 0;
+  const fn: ShipFetch = async () => {
+    calls += 1;
+    return { status, text: async () => body };
+  };
+  (fn as ShipFetch & { calls: () => number }).calls = () => calls;
+  return fn;
+};
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'waypoint-shipper-'));
+  spoolDir = join(dir, '.harness', 'spool');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('ingestUrl', () => {
+  it('builds the live route space, not a guessed one', () => {
+    expect(ingestUrl(CONFIG)).toBe('https://waypoint.test/outpost/pnyon/project/pnyon/events');
+  });
+
+  it('normalizes a trailing slash and encodes the scope segments', () => {
+    expect(ingestUrl({ url: 'https://w.test/', outpost: 'a b', project: 'c/d' })).toBe(
+      'https://w.test/outpost/a%20b/project/c%2Fd/events'
+    );
+  });
+});
+
+describe('result classification', () => {
+  // `duplicate` is at-least-once delivery working as designed, not a failure.
+  it('treats accepted and duplicate as landed', () => {
+    expect(hasLanded('accepted')).toBe(true);
+    expect(hasLanded('duplicate')).toBe(true);
+    expect(hasLanded('invalid')).toBe(false);
+  });
+
+  it('treats invalid and scrub-rejected as terminal', () => {
+    expect(isTerminal('invalid')).toBe(true);
+    expect(isTerminal('scrub-rejected')).toBe(true);
+    expect(isTerminal('accepted')).toBe(false);
+  });
+});
+
+describe('shipSpool — events reach the ledger (SC-2)', () => {
+  it('posts spooled events as a bare JSON array and advances the checkpoint', async () => {
+    writeSegment('seg1', [event(1), event(2), event(3)]);
+    const { fetchFn, bodies, urls } = fakeIngest();
+
+    const report = await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn });
+
+    expect(report.shipped).toBe(3);
+    expect(report.accepted).toBe(3);
+    expect(report.remaining).toBe(0);
+    expect(urls[0]).toBe('https://waypoint.test/outpost/pnyon/project/pnyon/events');
+    // A bare array — not wrapped in an envelope the endpoint would 400 on.
+    expect(JSON.parse(bodies[0]!)).toHaveLength(3);
+    expect(Array.isArray(JSON.parse(bodies[0]!))).toBe(true);
+    expect(readCheckpoint(spoolDir).marks['seg1']).toBeDefined();
+  });
+
+  it('sends the token in the header the gateway checks', async () => {
+    writeSegment('seg1', [event(1)]);
+    let seen: Record<string, string> = {};
+    const fetchFn: ShipFetch = async (_u, init) => {
+      seen = init.headers;
+      return { status: 200, text: async () => '{"results":[]}' };
+    };
+
+    await shipSpool({ spoolDir, config: CONFIG, token: 'secret-token', fetchFn });
+
+    expect(seen['x-pnyon-ingest-token']).toBe('secret-token');
+  });
+
+  it('ships in ULID order across segments, so causality is preserved', async () => {
+    // Interleaved across two writers: order must come from the ids, not the
+    // file listing — a claim landing before its intent is a corrupt ledger.
+    writeSegment('segA', [event(1), event(3)]);
+    writeSegment('segB', [event(2), event(4)]);
+    const { fetchFn, bodies } = fakeIngest();
+
+    await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn });
+
+    const ids = (JSON.parse(bodies[0]!) as Array<{ id: string }>).map((e) => e.id);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  it('splits into batches at the configured size', async () => {
+    writeSegment('seg1', [event(1), event(2), event(3), event(4), event(5)]);
+    const { fetchFn, bodies } = fakeIngest();
+
+    const report = await shipSpool({
+      spoolDir,
+      config: { ...CONFIG, batchSize: 2 },
+      token: 't',
+      fetchFn,
+    });
+
+    expect(bodies).toHaveLength(3);
+    expect(report.shipped).toBe(5);
+  });
+});
+
+describe('shipSpool — idempotence (SC-3)', () => {
+  it('sends nothing on a second run with no new events', async () => {
+    writeSegment('seg1', [event(1), event(2)]);
+    const first = fakeIngest();
+    await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn: first.fetchFn });
+
+    const second = fakeIngest();
+    const report = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn: second.fetchFn,
+    });
+
+    expect(second.bodies).toHaveLength(0);
+    expect(report.shipped).toBe(0);
+    expect(report.requests).toBe(0);
+  });
+
+  it('ships only the new events when the segment grows', async () => {
+    writeSegment('seg1', [event(1), event(2)]);
+    await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn: fakeIngest().fetchFn });
+
+    writeSegment('seg1', [event(1), event(2), event(3)]);
+    const next = fakeIngest();
+    const report = await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn: next.fetchFn });
+
+    expect(report.shipped).toBe(1);
+    expect(JSON.parse(next.bodies[0]!)).toHaveLength(1);
+  });
+
+  it('counts a re-sent event as duplicate rather than an error', async () => {
+    writeSegment('seg1', [event(1)]);
+    const { fetchFn } = fakeIngest(() => 'duplicate');
+
+    const report = await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn });
+
+    expect(report.duplicate).toBe(1);
+    expect(report.shipped).toBe(1);
+    expect(report.rejected).toHaveLength(0);
+  });
+});
+
+describe('shipSpool — terminal rejections (SC-4)', () => {
+  it('reports a permanently-refused event without failing the run', async () => {
+    writeSegment('seg1', [event(1), event(2), event(3)]);
+    const { fetchFn } = fakeIngest((_id, i) => (i === 0 ? 'invalid' : 'accepted'));
+
+    const report = await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn });
+
+    expect(report.rejected).toHaveLength(1);
+    expect(report.rejected[0]!.result).toBe('invalid');
+    expect(report.shipped).toBe(2);
+  });
+
+  /**
+   * The regression terminal-advance actually prevents.
+   *
+   * Progress is one high-water mark per segment, so a rejected event with an
+   * accepted event AFTER it is covered either way — the later mark subsumes it.
+   * The case that genuinely needs `isTerminal` is a TRAILING rejection, with
+   * nothing accepted behind it to carry the mark forward. Without advancing on
+   * terminal verdicts, that event is re-sent on every future run forever, and
+   * the dead-letter log grows a fresh copy each time.
+   *
+   * Worth stating because the obvious version of this test — a rejection
+   * followed by successes — passes whether or not the behaviour exists.
+   */
+  it('never re-sends a trailing rejection on a later run', async () => {
+    writeSegment('seg1', [event(1), event(2)]);
+    const first = fakeIngest((_id, i) => (i === 1 ? 'invalid' : 'accepted'));
+    await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn: first.fetchFn });
+
+    const second = fakeIngest();
+    const report = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn: second.fetchFn,
+    });
+
+    expect(second.bodies).toHaveLength(0);
+    expect(report.requests).toBe(0);
+  });
+
+  it('does not duplicate a trailing rejection in the dead-letter log across runs', async () => {
+    writeSegment('seg1', [event(1)]);
+    const rejections: string[] = [];
+    const run = async (): Promise<void> => {
+      const { fetchFn } = fakeIngest(() => 'scrub-rejected');
+      await shipSpool({
+        spoolDir,
+        config: CONFIG,
+        token: 't',
+        fetchFn,
+        onRejected: (r) => rejections.push(...r.map((x) => x.id)),
+      });
+    };
+
+    await run();
+    await run();
+
+    // Recorded once, not once per run — the adopter reads this file.
+    expect(rejections).toHaveLength(1);
+  });
+
+  it('hands rejections to the recorder, with the original event body', async () => {
+    writeSegment('seg1', [event(1)]);
+    const { fetchFn } = fakeIngest(() => 'scrub-rejected');
+    const seen: string[] = [];
+
+    const report = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn,
+      onRejected: (r) => seen.push(...r.map((x) => x.result)),
+    });
+
+    expect(seen).toEqual(['scrub-rejected']);
+    // The line itself, not merely its id — a scrub rejection has to be
+    // inspectable by the adopter.
+    expect(report.rejected[0]!.line).toContain('sdlc.intent.created.v1');
+  });
+
+  it('writes rejections to a dead-letter log that survives the run', () => {
+    mkdirSync(spoolDir, { recursive: true });
+    recordRejected(
+      spoolDir,
+      [{ id: '01X', result: 'scrub-rejected', line: '{"id":"01X"}' }],
+      '2026-09-07T00:00:00.000Z'
+    );
+
+    expect(countRejected(spoolDir)).toBe(1);
+    const written = readFileSync(join(spoolDir, 'rejected.jsonl'), 'utf8');
+    expect(written).toContain('scrub-rejected');
+    expect(written).toContain('01X');
+  });
+});
+
+describe('shipSpool — configuration faults fail loudly (SC-5)', () => {
+  it('does not retry a 401 and names both places the token comes from', async () => {
+    writeSegment('seg1', [event(1)]);
+    const fetchFn = statusOnly(401, '{"error":"unauthorized"}');
+
+    const err = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 'bad',
+      fetchFn,
+      sleep: async () => {},
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ShipError);
+    expect((err as ShipError).retryable).toBe(false);
+    expect((err as ShipError).message).toContain('PNYON_WAYPOINT_INGEST_TOKEN');
+    expect((fetchFn as ShipFetch & { calls: () => number }).calls()).toBe(1);
+  });
+
+  it('does not retry a 400', async () => {
+    writeSegment('seg1', [event(1)]);
+    const fetchFn = statusOnly(400, '{"error":"body must be a JSON array of events"}');
+
+    const err = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn,
+      sleep: async () => {},
+    }).catch((e: unknown) => e);
+
+    expect((err as ShipError).retryable).toBe(false);
+    expect((fetchFn as ShipFetch & { calls: () => number }).calls()).toBe(1);
+  });
+
+  it('leaves the checkpoint untouched when a batch fails', async () => {
+    writeSegment('seg1', [event(1)]);
+    await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 'bad',
+      fetchFn: statusOnly(401),
+      sleep: async () => {},
+    }).catch(() => undefined);
+
+    expect(readCheckpoint(spoolDir).marks['seg1']).toBeUndefined();
+    expect(countUnshipped(spoolDir)).toBe(1);
+  });
+
+  it('retries a 5xx and then gives up as retryable', async () => {
+    writeSegment('seg1', [event(1)]);
+    const fetchFn = statusOnly(503, 'upstream down');
+
+    const err = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn,
+      maxAttempts: 3,
+      sleep: async () => {},
+    }).catch((e: unknown) => e);
+
+    expect((err as ShipError).retryable).toBe(true);
+    expect((fetchFn as ShipFetch & { calls: () => number }).calls()).toBe(3);
+  });
+
+  it('recovers when a retry succeeds', async () => {
+    writeSegment('seg1', [event(1)]);
+    let call = 0;
+    const fetchFn: ShipFetch = async () => {
+      call += 1;
+      if (call === 1) throw new Error('ECONNRESET');
+      return {
+        status: 200,
+        text: async () =>
+          JSON.stringify({ results: [{ id: '01ABCDEFGH0000000000000001', result: 'accepted' }] }),
+      };
+    };
+
+    const report = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn,
+      sleep: async () => {},
+    });
+
+    expect(report.shipped).toBe(1);
+    expect(report.requests).toBe(2);
+  });
+
+  /**
+   * A 200 that cannot say what landed must not be read as success. Re-sending
+   * costs a `duplicate`; a false advance loses events permanently.
+   */
+  it('refuses to advance on a 200 with no per-event results', async () => {
+    writeSegment('seg1', [event(1)]);
+
+    const err = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn: statusOnly(200, '{"ok":true}'),
+    }).catch((e: unknown) => e);
+
+    expect((err as ShipError).message).toContain('results');
+    expect(readCheckpoint(spoolDir).marks['seg1']).toBeUndefined();
+  });
+});
+
+describe('shipSpool — the spool is never consumed (SC-6)', () => {
+  it('leaves segment files byte-identical after a successful run', async () => {
+    writeSegment('seg1', [event(1), event(2)]);
+    const path = join(spoolDir, 'sdlc-seg1.jsonl');
+    const before = readFileSync(path, 'utf8');
+
+    await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn: fakeIngest().fetchFn });
+
+    // ADR-0047 guarantees adopters keep their own copy of their exhaust; a
+    // shipper that consumed the spool would delete exactly that.
+    expect(readFileSync(path, 'utf8')).toBe(before);
+  });
+});
+
+describe('shipSpool — resume and limits (SC-7)', () => {
+  it('resumes from the first unlanded event after a mid-run failure', async () => {
+    writeSegment('seg1', [event(1), event(2), event(3), event(4)]);
+    let batch = 0;
+    const fetchFn: ShipFetch = async (_u, init) => {
+      batch += 1;
+      if (batch === 2) return { status: 503, text: async () => 'down' };
+      const parsed = JSON.parse(init.body) as Array<{ id: string }>;
+      return {
+        status: 200,
+        text: async () =>
+          JSON.stringify({ results: parsed.map((e) => ({ id: e.id, result: 'accepted' })) }),
+      };
+    };
+
+    await shipSpool({
+      spoolDir,
+      config: { ...CONFIG, batchSize: 2 },
+      token: 't',
+      fetchFn,
+      maxAttempts: 1,
+      sleep: async () => {},
+    }).catch(() => undefined);
+
+    // First batch landed and was checkpointed before the second failed.
+    expect(countUnshipped(spoolDir)).toBe(2);
+
+    const resume = fakeIngest();
+    const report = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn: resume.fetchFn,
+    });
+    expect(report.shipped).toBe(2);
+    expect(JSON.parse(resume.bodies[0]!)).toHaveLength(2);
+  });
+
+  it('honours --limit and reports what is still waiting', async () => {
+    writeSegment('seg1', [event(1), event(2), event(3)]);
+    const { fetchFn } = fakeIngest();
+
+    const report = await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn, limit: 2 });
+
+    expect(report.shipped).toBe(2);
+    expect(report.remaining).toBe(1);
+    expect(countUnshipped(spoolDir)).toBe(1);
+  });
+
+  it('dry run computes the backlog and issues no request', async () => {
+    writeSegment('seg1', [event(1), event(2)]);
+    const { fetchFn, bodies } = fakeIngest();
+
+    const report = await shipSpool({
+      spoolDir,
+      config: CONFIG,
+      token: 't',
+      fetchFn,
+      dryRun: true,
+    });
+
+    expect(report.remaining).toBe(2);
+    expect(report.shipped).toBe(0);
+    expect(bodies).toHaveLength(0);
+    expect(readCheckpoint(spoolDir).marks['seg1']).toBeUndefined();
+  });
+
+  it('an empty spool ships nothing and does not create a directory', async () => {
+    const { fetchFn, bodies } = fakeIngest();
+
+    const report = await shipSpool({ spoolDir, config: CONFIG, token: 't', fetchFn });
+
+    expect(report.shipped).toBe(0);
+    expect(bodies).toHaveLength(0);
+    expect(countUnshipped(spoolDir)).toBe(0);
+  });
+});

--- a/packages/core/src/waypoint/shipper.ts
+++ b/packages/core/src/waypoint/shipper.ts
@@ -1,0 +1,383 @@
+/**
+ * The Waypoint spool shipper — the last mile from a repo-local JSONL file to a
+ * live ledger (`docs/changes/waypoint-spool-shipper/proposal.md`).
+ *
+ * ADR-0047 has emitters "append to a local repo-side JSONL spool first and
+ * ship with retry/backoff". The spool half shipped; this is the other half.
+ * Until it runs, every `sdlc.*` event harness produces stops at a file, which
+ * is why Waypoint's wave forecasts cannot leave cold start: the V2/V3
+ * verification evidence that would end it comes from harness eval verdicts,
+ * and GitHub webhooks cannot produce a verification grade.
+ *
+ * The contract targeted here was PROBED LIVE (2026-09-07), not assumed:
+ *
+ *   POST /outpost/<outpost>/project/<project>/events
+ *     x-pnyon-ingest-token: <token>
+ *     [ <SdlcEvent>, … ]                          — a bare JSON array
+ *   200 → { results: [{ id, result }], accepted, duplicate, invalid, scrubRejected }
+ *   400 → malformed body   401 → unauthorized
+ *
+ * That distinction is the point. Two prior harness adapters were written
+ * against an assumed `/v1/items` API, were complete and green against their own
+ * mocks, and pointed at a 404 the whole time.
+ *
+ * The per-event `results` array is what makes honest progress possible: the
+ * shipper never guesses which events in a batch landed.
+ */
+
+import type { WaypointShipConfig } from '@harness-engineering/types';
+import {
+  advanceMark,
+  eventIdOf,
+  readCheckpoint,
+  unshippedLines,
+  writeCheckpoint,
+  type ShipCheckpoint,
+} from './checkpoint';
+import { readSpoolSegments } from './spool';
+
+/** Default events per POST. */
+export const DEFAULT_BATCH_SIZE = 500;
+
+/** Per-event verdicts the ingest endpoint reports. */
+export type IngestResultKind = 'accepted' | 'duplicate' | 'invalid' | 'scrub-rejected';
+
+/** One entry of the ingest response's `results` array. */
+export interface IngestEventResult {
+  readonly id: string;
+  readonly result: IngestResultKind;
+}
+
+/** The ingest endpoint's 200 body (extra fields such as `autoTrain` ignored). */
+export interface IngestReportBody {
+  readonly results?: readonly IngestEventResult[];
+}
+
+/**
+ * `accepted` and `duplicate` both mean the event is in the ledger.
+ *
+ * `duplicate` is not a failure — it is at-least-once delivery working exactly
+ * as ADR-0047 designed it, since ULIDs are the idempotency key. Treating it as
+ * anything else would make every retry look like an error and stall progress
+ * behind events that already landed.
+ */
+export function hasLanded(result: IngestResultKind): boolean {
+  return result === 'accepted' || result === 'duplicate';
+}
+
+/**
+ * `invalid` and `scrub-rejected` are terminal: identical bytes get an
+ * identical verdict on every retry, forever.
+ *
+ * They must advance the checkpoint anyway. If progress only moved on
+ * `accepted`, one malformed event would wedge the pipeline permanently and
+ * every later event would silently stop shipping — the classic queue-wedge.
+ * Advancing is only safe because the caller records these to a dead-letter
+ * file first: a `scrub-rejected` means the scrubber caught something the
+ * adopter needs to see, not a statistic to bury.
+ */
+export function isTerminal(result: IngestResultKind): boolean {
+  return result === 'invalid' || result === 'scrub-rejected';
+}
+
+/** One event the ledger refused permanently, with why. */
+export interface RejectedEvent {
+  readonly id: string;
+  readonly result: IngestResultKind;
+  readonly line: string;
+}
+
+/** What one `ship` run did. */
+export interface ShipReport {
+  /** Landed in the ledger (accepted + duplicate). */
+  readonly shipped: number;
+  readonly accepted: number;
+  readonly duplicate: number;
+  /** Permanently refused; also written to the dead-letter file. */
+  readonly rejected: readonly RejectedEvent[];
+  /** Events left unshipped — non-zero when a batch failed or a limit applied. */
+  readonly remaining: number;
+  /** POST attempts made, retries included. */
+  readonly requests: number;
+}
+
+/** Transport seam, so tests drive the real batching logic without a network. */
+export type ShipFetch = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string }
+) => Promise<{ status: number; text: () => Promise<string> }>;
+
+export interface ShipOptions {
+  readonly spoolDir: string;
+  readonly config: WaypointShipConfig;
+  /** Bearer credential; the caller resolves it from the environment. */
+  readonly token: string;
+  readonly fetchFn: ShipFetch;
+  /** Cap on events sent this run (`--limit`); undefined = no cap. */
+  readonly limit?: number;
+  /** Compute only; issue no POST and never move the checkpoint. */
+  readonly dryRun?: boolean;
+  /** Retry attempts per batch for network/5xx. Default 3. */
+  readonly maxAttempts?: number;
+  /** Sleep between retries; injectable so tests do not wait. */
+  readonly sleep?: (ms: number) => Promise<void>;
+  /** Records permanently-refused events. Omitted in dry run. */
+  readonly onRejected?: (rejected: readonly RejectedEvent[]) => void;
+}
+
+/** A failure that stopped the run, carrying an actionable message. */
+export class ShipError extends Error {
+  constructor(
+    message: string,
+    /** True when re-running unchanged could plausibly succeed. */
+    readonly retryable: boolean
+  ) {
+    super(message);
+    this.name = 'ShipError';
+  }
+}
+
+/** `<url>/outpost/<outpost>/project/<project>/events`, slashes normalized. */
+export function ingestUrl(config: WaypointShipConfig): string {
+  const base = config.url.replace(/\/+$/, '');
+  const outpost = encodeURIComponent(config.outpost);
+  const project = encodeURIComponent(config.project);
+  return `${base}/outpost/${outpost}/project/${project}/events`;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** One spooled line paired with the segment it belongs to. */
+interface PendingLine {
+  readonly segmentId: string;
+  readonly line: string;
+  readonly id: string | null;
+}
+
+/**
+ * Everything unshipped, in ULID order across segments.
+ *
+ * Ordering matters beyond tidiness: the ledger is a causal record, and sending
+ * a claim before the intent it refers to would land evidence out of order.
+ * ULIDs are time-prefixed, so lexicographic order is creation order.
+ */
+function collectPending(spoolDir: string, checkpoint: ShipCheckpoint): PendingLine[] {
+  const pending: PendingLine[] = [];
+  for (const segment of readSpoolSegments(spoolDir)) {
+    for (const line of unshippedLines(checkpoint, segment.segmentId, segment.lines)) {
+      pending.push({ segmentId: segment.segmentId, line, id: eventIdOf(line) });
+    }
+  }
+  return pending.sort((a, b) => {
+    if (a.id === b.id) return 0;
+    if (a.id === null) return 1; // unreadable ids last; ingest judges them
+    if (b.id === null) return -1;
+    return a.id < b.id ? -1 : 1;
+  });
+}
+
+/**
+ * POST one batch, retrying only what retrying can fix.
+ *
+ * Network errors and 5xx get exponential backoff. 400 and 401 do not: a
+ * malformed body or a bad token is a configuration fault, and retrying it
+ * converts an immediate, clear error into a slow one while changing nothing.
+ */
+async function postBatch(
+  batch: readonly PendingLine[],
+  options: ShipOptions
+): Promise<{ results: readonly IngestEventResult[]; requests: number }> {
+  const url = ingestUrl(options.config);
+  const body = `[${batch.map((p) => p.line).join(',')}]`;
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 3);
+  const sleep = options.sleep ?? defaultSleep;
+  let requests = 0;
+  let lastError = '';
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    requests += 1;
+    let status: number;
+    let text: string;
+    try {
+      const response = await options.fetchFn(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-pnyon-ingest-token': options.token,
+        },
+        body,
+      });
+      status = response.status;
+      text = await response.text();
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      if (attempt < maxAttempts) {
+        await sleep(2 ** (attempt - 1) * 100);
+        continue;
+      }
+      throw new ShipError(`Waypoint ingest unreachable at ${url}: ${lastError}`, true);
+    }
+
+    if (status === 401) {
+      throw new ShipError(
+        `Waypoint ingest rejected the credential (401) at ${url}. ` +
+          'Check PNYON_WAYPOINT_INGEST_TOKEN and that the same secret is set on the ' +
+          'Waypoint Worker (`wrangler secret put PNYON_WAYPOINT_INGEST_TOKEN`).',
+        false
+      );
+    }
+    if (status === 400) {
+      throw new ShipError(
+        `Waypoint ingest refused the request body (400) at ${url}: ${text}. ` +
+          'This is a client fault, not a transient one — nothing was shipped.',
+        false
+      );
+    }
+    if (status >= 500) {
+      lastError = `HTTP ${status}: ${text}`;
+      if (attempt < maxAttempts) {
+        await sleep(2 ** (attempt - 1) * 100);
+        continue;
+      }
+      throw new ShipError(`Waypoint ingest failed at ${url} — ${lastError}`, true);
+    }
+    if (status !== 200) {
+      throw new ShipError(`Waypoint ingest returned HTTP ${status} at ${url}: ${text}`, false);
+    }
+
+    let parsed: IngestReportBody;
+    try {
+      parsed = JSON.parse(text) as IngestReportBody;
+    } catch {
+      throw new ShipError(`Waypoint ingest returned a non-JSON 200 body at ${url}`, false);
+    }
+    // No per-event results means nothing can be said to have landed. Refusing
+    // to advance is the safe read: a re-send is a `duplicate`, whereas a false
+    // advance loses events permanently.
+    if (!Array.isArray(parsed.results)) {
+      throw new ShipError(
+        `Waypoint ingest returned 200 without a per-event \`results\` array at ${url}; ` +
+          'cannot confirm what landed, so nothing was marked shipped.',
+        false
+      );
+    }
+    return { results: parsed.results, requests };
+  }
+  /* c8 ignore next */
+  throw new ShipError(`Waypoint ingest failed at ${url} — ${lastError}`, true);
+}
+
+/**
+ * Ship everything unshipped, in order, and report what happened.
+ *
+ * The checkpoint is persisted after EVERY batch rather than once at the end,
+ * so an interrupted run resumes from the last confirmed event instead of
+ * re-sending the whole run.
+ */
+export async function shipSpool(options: ShipOptions): Promise<ShipReport> {
+  let checkpoint = readCheckpoint(options.spoolDir);
+  const pending = collectPending(options.spoolDir, checkpoint);
+  const selected =
+    options.limit !== undefined ? pending.slice(0, Math.max(0, options.limit)) : pending;
+
+  if (options.dryRun) {
+    return {
+      shipped: 0,
+      accepted: 0,
+      duplicate: 0,
+      rejected: [],
+      remaining: selected.length,
+      requests: 0,
+    };
+  }
+
+  const batchSize = Math.max(1, options.config.batchSize ?? DEFAULT_BATCH_SIZE);
+  const byId = new Map(selected.filter((p) => p.id !== null).map((p) => [p.id as string, p]));
+  const totals = { accepted: 0, duplicate: 0 };
+  const rejected: RejectedEvent[] = [];
+  let requests = 0;
+  let sent = 0;
+
+  for (let offset = 0; offset < selected.length; offset += batchSize) {
+    const batch = selected.slice(offset, offset + batchSize);
+    const outcome = await postBatch(batch, options);
+    requests += outcome.requests;
+
+    const applied = applyResults(outcome.results, byId, checkpoint);
+    checkpoint = applied.checkpoint;
+    totals.accepted += applied.accepted;
+    totals.duplicate += applied.duplicate;
+
+    if (applied.rejected.length > 0) {
+      rejected.push(...applied.rejected);
+      // Recorded BEFORE the checkpoint is persisted: advancing past an event
+      // nobody wrote down is the silent-drop failure this ordering prevents.
+      options.onRejected?.(applied.rejected);
+    }
+    writeCheckpoint(options.spoolDir, checkpoint);
+    sent += batch.length;
+  }
+
+  return {
+    shipped: totals.accepted + totals.duplicate,
+    accepted: totals.accepted,
+    duplicate: totals.duplicate,
+    rejected,
+    remaining: pending.length - sent,
+    requests,
+  };
+}
+
+/** What one batch's verdicts did to the tallies and the checkpoint. */
+interface AppliedResults {
+  readonly checkpoint: ShipCheckpoint;
+  readonly accepted: number;
+  readonly duplicate: number;
+  readonly rejected: readonly RejectedEvent[];
+}
+
+/**
+ * Fold one batch's per-event verdicts into the checkpoint and the tallies.
+ *
+ * Pure, and separate from the transport loop, so the rule that actually
+ * matters — which verdicts move the mark — can be read on its own instead of
+ * being buried inside batching and I/O.
+ */
+function applyResults(
+  results: readonly IngestEventResult[],
+  byId: ReadonlyMap<string, PendingLine>,
+  start: ShipCheckpoint
+): AppliedResults {
+  let checkpoint = start;
+  let accepted = 0;
+  let duplicate = 0;
+  const rejected: RejectedEvent[] = [];
+
+  for (const result of results) {
+    const pendingLine = byId.get(result.id);
+    if (result.result === 'accepted') accepted += 1;
+    else if (result.result === 'duplicate') duplicate += 1;
+    else {
+      rejected.push({ id: result.id, result: result.result, line: pendingLine?.line ?? '' });
+    }
+    // Landed and terminal both advance: a terminal verdict is final, and
+    // leaving the mark behind would re-send it on every future run forever.
+    //
+    // Stated as an explicit predicate rather than "advance on anything" so a
+    // verdict added later — a retryable one, say — does not silently inherit
+    // permission to move the mark past an event that never landed.
+    const settled = hasLanded(result.result) || isTerminal(result.result);
+    if (pendingLine !== undefined && settled) {
+      checkpoint = advanceMark(checkpoint, pendingLine.segmentId, result.id);
+    }
+  }
+  return { checkpoint, accepted, duplicate, rejected };
+}
+
+/** Count unshipped events without sending anything. */
+export function countUnshipped(spoolDir: string): number {
+  return collectPending(spoolDir, readCheckpoint(spoolDir)).length;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -527,6 +527,7 @@ export {
   SDLC_SPECVERSION,
   SDLC_VERIFICATION_GRADES,
   WaypointConfigSchema,
+  WaypointShipConfigSchema,
   WaypointSinkConfigSchema,
 } from './waypoint';
 export type {
@@ -542,5 +543,6 @@ export type {
   SdlcValidationResult,
   SdlcVerificationGrade,
   WaypointConfig,
+  WaypointShipConfig,
   WaypointSinkConfig,
 } from './waypoint';

--- a/packages/types/src/waypoint.ts
+++ b/packages/types/src/waypoint.ts
@@ -180,13 +180,52 @@ export interface SdlcSpoolSegmentSnapshot {
  * new I/O, no behavior change anywhere in harness (PRD Story 1, the
  * non-adopter invariance contract).
  */
+/**
+ * Where the shipper sends spooled events (D1/D2 of
+ * `docs/changes/waypoint-spool-shipper/proposal.md`).
+ *
+ * A SIBLING of `transport`, deliberately not a replacement for it. ADR-0047
+ * has emitters append to the local spool FIRST and ship afterwards, so
+ * shipping is something added to spooling, never an alternative to it —
+ * modelling it as another `transport` value would make "spool then ship"
+ * unrepresentable and would let one config edit silently stop writing the
+ * local copy adopters are guaranteed.
+ *
+ * Absent ⇒ no network calls at all, which is today's behaviour exactly.
+ */
+export const WaypointShipConfigSchema = z.object({
+  /** Waypoint service origin, e.g. `https://waypoint-staging.pnyon.com`. */
+  url: z.string().min(1),
+  /**
+   * Outpost and project scope. BOTH are required and neither is derived:
+   * every pnyon route is `/outpost/<outpost>/project/<project>/…`, harness
+   * config models no project, and guessing one from a repo basename would let
+   * two repos named `api` write into the same ledger. A write here is an
+   * append to a hash-chained log — it cannot be taken back, only compensated —
+   * so the cost of one required config line is not close to the cost of
+   * getting it wrong.
+   */
+  outpost: z.string().min(1),
+  project: z.string().min(1),
+  /** Events per POST. The ingest endpoint takes a JSON array natively. */
+  batchSize: z.number().int().positive().optional(),
+});
+export type WaypointShipConfig = z.infer<typeof WaypointShipConfigSchema>;
+
 export const WaypointSinkConfigSchema = z.object({
   /**
    * Spool transport toggle. `spool` appends events to the repo-local
-   * `.harness/spool/` JSONL segments. Shipping spooled events to a hosted
-   * ingest is out of scope for this layer (pnyon owns ingest).
+   * `.harness/spool/` JSONL segments. Shipping those events onward is
+   * configured by the sibling `ship` block below, not by this field.
    */
   transport: z.literal('spool'),
+  /**
+   * Optional onward shipping. Absent ⇒ spool-only, no network, no change.
+   * The bearer credential is NEVER configured here: it comes from the
+   * `PNYON_WAYPOINT_INGEST_TOKEN` environment variable, so a token cannot be
+   * committed by editing `harness.config.json`.
+   */
+  ship: WaypointShipConfigSchema.optional(),
   /**
    * Emitting scope URI stamped on every event's `source`, e.g.
    * `harness://outpost/<uuid>/repo/<name>`. Defaults to


### PR DESCRIPTION
docs(waypoint): spec the spool shipper — the missing last mile

Harness's sdlc.* emission layer is built, tested and wired, and every event it
produces stops at a file on disk. `spool.ts:182` says so outright: mergeSegments
"ships with the (out-of-scope) shipper". ADR-0047 requires the other half —
emitters append to a local spool FIRST "and ship with retry/backoff".

The consequence is already visible in production: Waypoint's wave forecasts
cannot leave cold start, because the ledger never accumulates the V2/V3
verification evidence that would end it, and that evidence comes from harness
eval verdicts that never ship. GitHub webhooks are the only live ingestion path
and cannot produce a verification grade.

Both ends already exist. readSpoolSegments/mergeSegments are the read half, the
latter written expressly for this shipper. pnyon serves
POST /outpost/<oid>/project/<pid>/events — batch-native (a JSON array),
x-pnyon-ingest-token auth, and a PER-EVENT results array
(accepted|duplicate|invalid|scrub-rejected) that makes honest checkpointing
possible without guessing which events in a batch landed.

The contract in this spec was probed live on 2026-09-07, not declared. That is
deliberate: writing a client against an assumed contract is exactly how #1816
and #1977 became complete, green, and unreachable against a /v1/items API that
returns 404.

Six decision forks, each with a recommendation and its evidence. The three that
change adopter-visible behaviour:

- D1 shipping is an ADDITION to spooling, not an alternative transport — a
  sibling `ship` block rather than widening `transport`, because ADR-0047
  guarantees adopters a local copy and "choose one or the other" would make
  spool-then-ship unrepresentable.
- D2 outpost AND project are configured explicitly, never derived from a repo
  basename — two repos named `api` would otherwise write into one ledger, and an
  append to a hash-chained log cannot be taken back.
- D5 an explicit `harness waypoint ship` rather than an automatic flush, which
  would put a network call on the hot path of every sanctioned mutator.

D4 is the one that is easy to get wrong in both directions: a terminally
rejected event must advance the checkpoint (or one bad event wedges the queue
forever) AND be recorded to a dead-letter file with its reason (a
scrub-rejection is a signal the adopter needs to see, not a statistic to bury).

Implementation step 6 is a live proof against waypoint-staging.pnyon.com with
real counts, and is not optional.

STATUS: awaiting sign-off. No implementation has begun.
