### PR TITLE
fix(roadmap): stop blaming dry-run skips on a flag nobody passed

### DIFF
--- a/.changeset/skipped-create-reason.md
+++ b/.changeset/skipped-create-reason.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/cli': patch
+---
+
+`roadmap sync` no longer blames withheld creates on `--no-create` in a dry run
+
+`--apply` is opt-in, so the default `harness roadmap sync` is a dry run and
+withholds every create. It reported all of them as
+`Skipped N create(s) (--no-create)` — naming a flag the caller never passed and
+sending them looking for it.
+
+The plan already recorded the real reason: `SkippedCreate.reason` is
+`'create-disabled' | 'dry-run'`. The report type re-declared that shape inline
+with `reason: string`, which discarded the distinction and left the renderer
+nothing to switch on. The report now uses `SkippedCreate` directly and explains
+each cause separately:
+
+```
+Skipped 1 create(s) (dry run; re-run with --apply to create them): Not yet linked
+Skipped 1 create(s) (--no-create): Some other row
+```

--- a/.harness/comprehension/packages/cli/src/commands/roadmap/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands/roadmap'
-sourceHash: 'a5144c2e53c87f0c56f1324643c9de46936b3c97335775de95cf8003746c9459'
+sourceHash: 'c0d868e9a247db5ac216bfdb11c8d2a420acb5327b9c50f9d07a6b3630702e37'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -71,7 +71,7 @@ import { DenominatedMetric, Err, ExternalSyncOptions, ExternalTicketState, GitHu
 import { GraphNode, GraphStore } from '@harness-engineering/graph'
 import { AnalysisProvider, AnthropicAnalysisProvider, ForkGenerator, OpenAICompatibleAnalysisProvider, PrecedentLookup, RatchetOutcome, RatchetStage, StagedGoNoGoCandidate, V1_MAX_STAGE, dispatchableShapeKey, resolveGoNoGoStaged, resolveStage, shapeKey } from '@harness-engineering/intelligence'
 import { BrainstormWiringDeps, PoolState, PoolStateStore, RankProfile, RankableCandidate, TriageMarkItem, TriageVerdict, WiredBrainstormResult, artifactPresenceFromIssue, detectScopeTier, markApprovedForDispatch, poolStateToCandidates, precedentLookupFromStored, rankTriageCandidates, runBrainstormForIssue, triageIssue } from '@harness-engineering/orchestrator'
-import { Issue, Roadmap, RoadmapFeature, ScopeTier } from '@harness-engineering/types'
+import { Issue, Roadmap, RoadmapFeature, ScopeTier, SkippedCreate } from '@harness-engineering/types'
 import chalk from 'chalk'
 import { Command } from 'commander'
 import from 'dotenv'

--- a/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands/roadmap'
-sourceHash: '8c2961a57fdc86a1f4927126b98c6dd4424f1d7c7a478ae28e061283eb70a859'
+sourceHash: 'e6afcf36665dd07a745fe79b2df9b4175faa2d189a20874634ffaf0b6aff0d73'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/src/commands/roadmap/sync-report.ts
+++ b/packages/cli/src/commands/roadmap/sync-report.ts
@@ -1,4 +1,5 @@
 import type { SyncResult, ExternalSyncOptions, SuppressedInbound } from '@harness-engineering/core';
+import type { SkippedCreate } from '@harness-engineering/types';
 import { logger } from '../../output/logger';
 
 /**
@@ -36,7 +37,13 @@ export interface RoadmapSyncReport {
   };
   /** Changes a guard deliberately withheld — never silently dropped. */
   skipped: {
-    creates: Array<{ feature: string; milestone: string; reason: string }>;
+    /**
+     * `SkippedCreate` rather than a re-declared shape with `reason: string`.
+     * The widened copy is what let the renderer ignore the reason and blame
+     * every withheld create on `--no-create`, including in a plain dry run
+     * where no such flag was passed.
+     */
+    creates: SkippedCreate[];
     stateChanges: Array<{ externalId: string; from: string; to: string }>;
     /**
      * Inbound (tracker → roadmap) writes withheld because the tracker had no
@@ -134,14 +141,40 @@ function logChanges(report: RoadmapSyncReport): void {
   }
 }
 
+/** How each withheld-create reason is explained to the reader. */
+const SKIP_REASON_HINT: Record<SkippedCreate['reason'], string> = {
+  'create-disabled': '(--no-create)',
+  'dry-run': '(dry run; re-run with --apply to create them)',
+};
+
+/** Group withheld creates by why they were withheld, preserving order. */
+function groupByReason(
+  creates: readonly SkippedCreate[]
+): ReadonlyMap<SkippedCreate['reason'], SkippedCreate[]> {
+  const groups = new Map<SkippedCreate['reason'], SkippedCreate[]>();
+  for (const create of creates) {
+    const group = groups.get(create.reason);
+    if (group) group.push(create);
+    else groups.set(create.reason, [create]);
+  }
+  return groups;
+}
+
 /** Changes a guard withheld. Warn-level so they are never lost in the noise. */
 function logSuppressions(report: RoadmapSyncReport): void {
   const { creates, stateChanges, inbound } = report.skipped;
   if (creates.length > 0) {
-    logger.warn(
-      `Skipped ${creates.length} create(s) (--no-create): ` +
-        creates.map((c) => c.feature).join(', ')
-    );
+    // Report the reason the plan actually recorded, not a flag the caller may
+    // never have passed. `--apply` is opt-in, so the DEFAULT run withholds
+    // creates because it is a dry run — blaming `--no-create` there sends the
+    // reader looking for a flag they did not set, which is the same
+    // "the message lied about why" failure as #1863.
+    for (const [reason, group] of groupByReason(creates)) {
+      logger.warn(
+        `Skipped ${group.length} create(s) ${SKIP_REASON_HINT[reason]}: ` +
+          group.map((c) => c.feature).join(', ')
+      );
+    }
   }
   if (stateChanges.length > 0) {
     logger.warn(

--- a/packages/cli/tests/commands/roadmap/sync-report.test.ts
+++ b/packages/cli/tests/commands/roadmap/sync-report.test.ts
@@ -85,3 +85,65 @@ describe('logSyncReport() — suppressed inbound writes', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * A withheld create must say WHY it was withheld.
+ *
+ * `--apply` is opt-in, so the DEFAULT run is a dry run and withholds every
+ * create. The report used to blame all of them on `--no-create`, sending the
+ * reader hunting for a flag they never passed — the same "the message lied
+ * about why" failure as #1863, one layer up.
+ */
+describe('logSyncReport() — why a create was withheld', () => {
+  const skipped = (feature: string, reason: 'dry-run' | 'create-disabled') => ({
+    feature,
+    milestone: 'Intake',
+    reason,
+  });
+
+  it('attributes a dry-run skip to the dry run, not to --no-create', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    logSyncReport(
+      buildReport(syncResult({ dryRun: true, skippedCreates: [skipped('Alpha', 'dry-run')] }), {})
+    );
+
+    const line = warn.mock.calls.map((c) => String(c[0])).find((m) => m.includes('create(s)'));
+    expect(line).toBeDefined();
+    expect(line).not.toContain('--no-create');
+    expect(line).toContain('--apply');
+    expect(line).toContain('Alpha');
+  });
+
+  it('still names --no-create when that is genuinely the reason', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    logSyncReport(
+      buildReport(syncResult({ skippedCreates: [skipped('Beta', 'create-disabled')] }), {})
+    );
+
+    const line = warn.mock.calls.map((c) => String(c[0])).find((m) => m.includes('create(s)'));
+    expect(line).toContain('--no-create');
+    expect(line).toContain('Beta');
+  });
+
+  it('reports each reason separately when both occur', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    logSyncReport(
+      buildReport(
+        syncResult({
+          dryRun: true,
+          skippedCreates: [skipped('Alpha', 'dry-run'), skipped('Beta', 'create-disabled')],
+        }),
+        {}
+      )
+    );
+
+    const lines = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('create(s)'));
+    // Two causes must not be merged under one heading, or one of them is a lie.
+    expect(lines).toHaveLength(2);
+    expect(lines.find((l) => l.includes('Alpha'))).toContain('--apply');
+    expect(lines.find((l) => l.includes('Beta'))).toContain('--no-create');
+  });
+});


### PR DESCRIPTION
fix(roadmap): stop blaming dry-run skips on a flag nobody passed

`--apply` is opt-in, so the default `harness roadmap sync` is a dry run and
withholds every create. It reported all of them as

    ! Skipped 1 create(s) (--no-create): Not yet linked

on a run where `--no-create` was never passed and the header one line above says
`create=on`. The reader is sent hunting for a flag they did not set.

The plan already recorded the truth: `SkippedCreate.reason` is
`'create-disabled' | 'dry-run'`. The root cause is one layer up —
`RoadmapSyncReport` re-declared that shape inline as
`{ feature, milestone, reason: string }`, widening the union back to a string and
leaving the renderer nothing to switch on. Fixed by using `SkippedCreate` in the
report type rather than casting at the render site, so the distinction survives
end to end and reaches `--json` too.

Now:

    ! Skipped 1 create(s) (dry run; re-run with --apply to create them): Not yet linked
    ! Skipped 1 create(s) (--no-create): Some other row

Two causes are reported as two lines; merging them under one heading would make
one of them false.

Found by running the real binary against the live Waypoint staging service while
checking what a `kind: "pnyon"` sync actually does today. The rest of that path
behaves correctly and needs no change: the 404 surfaces as
`Waypoint HTTP 404: {"error":"not found"}` followed by "Ticket fetch failed, so
nothing could be compared against the tracker", and the command exits 2.

Verified with the built CLI against that same scenario, plus three tests that
pin each reason and the both-at-once case. cli 7501 passed.
