### PR TITLE
test(dashboard): characterize the chat block presentational components

### DIFF
--- a/.harness/comprehension/packages/dashboard/tests/client/components/chat/blocks/_module.md
+++ b/.harness/comprehension/packages/dashboard/tests/client/components/chat/blocks/_module.md
@@ -1,0 +1,44 @@
+---
+schemaVersion: 1
+module: 'packages/dashboard/tests/client/components/chat/blocks'
+sourceHash: '6db4b512d6b3a9a685bf2011e9cf6312ae16bd9cee39fa34417c0b183cc7065c'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'ActivityGroup.test.tsx',
+    'AgentBlockView.test.tsx',
+    'StreamingIndicator.rotation.test.tsx',
+    'StreamingIndicator.test.tsx',
+    'TextBlockView.test.tsx',
+    'TodoBlockView.test.tsx',
+    'ToolUseBlockView.test.tsx',
+    'format-tool-args.test.ts',
+    'render-assertions.ts',
+  ]
+---
+
+## Interface Contract
+
+```ts
+export expectNotRendered
+export expectRenderedOnce
+```
+
+## Dependency Slice
+
+```
+import { ActivityGroup } from '../../../../../src/client/components/chat/blocks/ActivityGroup'
+import { AgentBlockView } from '../../../../../src/client/components/chat/blocks/AgentBlockView'
+import { StreamingIndicator } from '../../../../../src/client/components/chat/blocks/StreamingIndicator'
+import { TextBlockView } from '../../../../../src/client/components/chat/blocks/TextBlockView'
+import { TodoBlockView } from '../../../../../src/client/components/chat/blocks/TodoBlockView'
+import { ToolUseBlockView } from '../../../../../src/client/components/chat/blocks/ToolUseBlockView'
+import { formatToolArgs } from '../../../../../src/client/components/chat/blocks/format-tool-args'
+import { ContentBlock, ToolUseBlock } from '../../../../../src/client/types/chat'
+import { expectNotRendered, expectRenderedOnce } from './render-assertions'
+import { Matcher, act, fireEvent, render, screen, within } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+```

--- a/packages/dashboard/tests/client/components/chat/blocks/ActivityGroup.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/ActivityGroup.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+import { ActivityGroup } from '../../../../../src/client/components/chat/blocks/ActivityGroup';
+import type { ContentBlock, ToolUseBlock } from '../../../../../src/client/types/chat';
+
+/**
+ * Characterization tests for ActivityGroup — the layout pass that decides when
+ * a run of tool calls collapses into a single "Used N tools" cluster and when
+ * each call gets its own row.
+ */
+
+function tool(name: string, overrides: Partial<ToolUseBlock> = {}): ToolUseBlock {
+  return { kind: 'tool_use', tool: name, ...overrides };
+}
+
+function renderGroup(
+  blocks: ContentBlock[],
+  opts: Partial<{ isStreaming: boolean; isLastGroup: boolean; startIndex: number }> = {}
+) {
+  return render(
+    <ActivityGroup
+      blocks={blocks}
+      startIndex={opts.startIndex ?? 0}
+      isStreaming={opts.isStreaming ?? false}
+      isLastGroup={opts.isLastGroup ?? false}
+    />
+  );
+}
+
+describe('ActivityGroup', () => {
+  describe('empty group', () => {
+    it('renders nothing for an empty block list', () => {
+      const { container } = renderGroup([]);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('single-block shortcuts', () => {
+    it('renders a lone thinking block unwrapped', () => {
+      renderGroup([{ kind: 'thinking', text: 'weighing the options' }]);
+      expectRenderedOnce('Thinking...');
+      expectRenderedOnce('weighing the options');
+    });
+
+    it('renders a lone status block unwrapped', () => {
+      renderGroup([{ kind: 'status', text: 'Scanning the graph' }]);
+      expectRenderedOnce('Scanning the graph');
+    });
+
+    it('renders a lone text block as prose', () => {
+      renderGroup([{ kind: 'text', text: 'Here is the plan.' }]);
+      expectRenderedOnce('Here is the plan.');
+    });
+
+    it('renders a lone tool call as a single row rather than a cluster', () => {
+      renderGroup([tool('Read')]);
+      expectRenderedOnce('Read');
+      expectNotRendered(/Used \d+ tools/);
+    });
+  });
+
+  describe('tool clustering', () => {
+    it('leaves two consecutive tool calls as separate rows', () => {
+      renderGroup([tool('Read'), tool('Grep')]);
+      expectRenderedOnce('Read');
+      expectRenderedOnce('Grep');
+      expectNotRendered(/Used \d+ tools/);
+    });
+
+    it('collapses three consecutive tool calls into a cluster', () => {
+      renderGroup([tool('Read'), tool('Grep'), tool('Edit')]);
+      expectRenderedOnce('Used 3 tools');
+    });
+
+    it('counts every tool call in the cluster summary', () => {
+      renderGroup([tool('Read'), tool('Grep'), tool('Edit'), tool('Write'), tool('Bash')]);
+      expectRenderedOnce('Used 5 tools');
+    });
+
+    it('names the LAST tool of the cluster in the summary', () => {
+      renderGroup([tool('Read'), tool('Grep'), tool('run_ci_checks')]);
+      const summary = screen.getByText('Used 3 tools').closest('summary');
+      expect(summary?.textContent).toContain('run ci checks');
+    });
+
+    it('previews the last tool’s args in the summary', () => {
+      const last = tool('Read', { args: JSON.stringify({ path: '/a/b/c.ts' }) });
+      renderGroup([tool('Grep'), tool('Edit'), last]);
+      const summary = screen.getByText('Used 3 tools').closest('summary');
+      expect(summary?.textContent).toContain('b/c.ts');
+    });
+
+    it('renders the cluster in a collapsible details element', () => {
+      const { container } = renderGroup([tool('Read'), tool('Grep'), tool('Edit')]);
+      expect(container.querySelector('details')).not.toBeNull();
+    });
+
+    it('still renders every clustered tool row inside the cluster body', () => {
+      const { container } = renderGroup([tool('Read'), tool('Grep'), tool('Edit')]);
+      const body = container.querySelector('details > div');
+      expect(body).not.toBeNull();
+      const rows = within(body as HTMLElement);
+      expect(rows.getByText('Read')).toBeDefined();
+      expect(rows.getByText('Grep')).toBeDefined();
+      expect(rows.getByText('Edit')).toBeDefined();
+    });
+
+    it('QUIRK: the last tool’s name appears twice — in the summary and its own row', () => {
+      renderGroup([tool('Read'), tool('Grep'), tool('Edit')]);
+      expect(screen.getAllByText('Edit')).toHaveLength(2);
+    });
+  });
+
+  describe('cluster boundaries', () => {
+    it('a non-tool block breaks the run, leaving a sub-threshold cluster uncollapsed', () => {
+      renderGroup([
+        tool('Read'),
+        tool('Grep'),
+        { kind: 'text', text: 'Now I will edit.' },
+        tool('Edit'),
+      ]);
+      expectNotRendered(/Used \d+ tools/);
+      expectRenderedOnce('Now I will edit.');
+    });
+
+    it('clusters only the run that reaches the threshold', () => {
+      renderGroup([
+        tool('Read'),
+        tool('Grep'),
+        tool('Edit'),
+        { kind: 'text', text: 'Now I will verify.' },
+        tool('Bash'),
+      ]);
+      expectRenderedOnce('Used 3 tools');
+      expectRenderedOnce('Bash');
+    });
+
+    it('forms a separate cluster for each qualifying run', () => {
+      renderGroup([
+        tool('Read'),
+        tool('Grep'),
+        tool('Edit'),
+        { kind: 'status', text: 'Halfway there' },
+        tool('Write'),
+        tool('Bash'),
+        tool('Glob'),
+      ]);
+      expect(screen.getAllByText(/Used 3 tools/)).toHaveLength(2);
+      expectRenderedOnce('Halfway there');
+    });
+
+    it('renders thinking blocks interleaved among tool rows', () => {
+      renderGroup([tool('Read'), { kind: 'thinking', text: 'reconsidering' }, tool('Grep')]);
+      expectRenderedOnce('Thinking...');
+      expectRenderedOnce('reconsidering');
+    });
+
+    it('closes a trailing cluster at the end of the group', () => {
+      renderGroup([
+        { kind: 'text', text: 'Starting now.' },
+        tool('Read'),
+        tool('Grep'),
+        tool('Edit'),
+      ]);
+      expectRenderedOnce('Used 3 tools');
+    });
+  });
+
+  describe('pending state of the final tool call', () => {
+    it('marks the last tool call pending while streaming the last group', () => {
+      const { container } = renderGroup([tool('Read'), tool('Grep')], {
+        isStreaming: true,
+        isLastGroup: true,
+      });
+      expect(container.querySelectorAll('.bg-gradient-to-b')).toHaveLength(1);
+    });
+
+    it('marks nothing pending when the group is not the last one', () => {
+      const { container } = renderGroup([tool('Read'), tool('Grep')], {
+        isStreaming: true,
+        isLastGroup: false,
+      });
+      expect(container.querySelectorAll('.bg-gradient-to-b')).toHaveLength(0);
+    });
+
+    it('marks nothing pending when not streaming', () => {
+      const { container } = renderGroup([tool('Read'), tool('Grep')], {
+        isStreaming: false,
+        isLastGroup: true,
+      });
+      expect(container.querySelectorAll('.bg-gradient-to-b')).toHaveLength(0);
+    });
+
+    it('marks the final tool of a cluster pending too', () => {
+      const { container } = renderGroup([tool('Read'), tool('Grep'), tool('Edit')], {
+        isStreaming: true,
+        isLastGroup: true,
+      });
+      expect(container.querySelectorAll('.bg-gradient-to-b')).toHaveLength(1);
+    });
+
+    it('QUIRK: nothing is marked pending when the group ends in a non-tool block', () => {
+      const { container } = renderGroup([tool('Read'), { kind: 'text', text: 'Wrapping up.' }], {
+        isStreaming: true,
+        isLastGroup: true,
+      });
+      expect(container.querySelectorAll('.bg-gradient-to-b')).toHaveLength(0);
+    });
+  });
+
+  describe('startIndex', () => {
+    it('renders the same visible output regardless of startIndex', () => {
+      const blocks = [tool('Read'), tool('Grep'), tool('Edit')];
+      const a = renderGroup(blocks, { startIndex: 0 }).container.textContent;
+      const b = renderGroup(blocks, { startIndex: 99 }).container.textContent;
+      expect(b).toBe(a);
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/AgentBlockView.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/AgentBlockView.test.tsx
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+import { AgentBlockView } from '../../../../../src/client/components/chat/blocks/AgentBlockView';
+import type { ToolUseBlock } from '../../../../../src/client/types/chat';
+
+/**
+ * Characterization tests for AgentBlockView — the framed card for a subagent
+ * dispatch or a skill invocation, including how it routes a structured result
+ * to a specialized viewer instead of the markdown fallback.
+ */
+
+function agentBlock(overrides: Partial<ToolUseBlock> = {}): ToolUseBlock {
+  return { kind: 'tool_use', tool: 'Agent', ...overrides };
+}
+
+const findingsResult = JSON.stringify({
+  findings: [
+    { ruleId: 'SEC-INJ-001', ruleName: 'SQL injection via string concat', severity: 'error' },
+  ],
+  summary: { errors: 1, warnings: 0, info: 0 },
+});
+
+const adviseResult = JSON.stringify({
+  featureName: 'checkout flow',
+  apply: [{ skill: 'harness-tdd', score: 0.9, when: 'on new feature', reasons: ['adds behavior'] }],
+});
+
+const impactResult = JSON.stringify({
+  targetNodeId: 'src/app.ts',
+  impact: { direct: [], transitive: [] },
+});
+
+describe('AgentBlockView', () => {
+  describe('subagent titling', () => {
+    it('names the subagent from subagent_type', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore' });
+      render(<AgentBlockView block={agentBlock({ args })} />);
+      expectRenderedOnce('Subagent: Explore');
+    });
+
+    it('falls back to the "type" field when subagent_type is absent', () => {
+      const args = JSON.stringify({ type: 'general-purpose' });
+      render(<AgentBlockView block={agentBlock({ args })} />);
+      expectRenderedOnce('Subagent: general-purpose');
+    });
+
+    it('falls back to "Execution" when no type is given at all', () => {
+      render(<AgentBlockView block={agentBlock()} />);
+      expectRenderedOnce('Subagent: Execution');
+    });
+
+    it('falls back to "Execution" when the args are unparseable', () => {
+      render(<AgentBlockView block={agentBlock({ args: 'not json' })} />);
+      expectRenderedOnce('Subagent: Execution');
+    });
+  });
+
+  describe('skill titling', () => {
+    it('names the skill from the skill argument', () => {
+      const args = JSON.stringify({ skill: 'harness:tdd' });
+      render(<AgentBlockView block={agentBlock({ tool: 'skill', args })} />);
+      expectRenderedOnce('Skill: harness:tdd');
+    });
+
+    it('treats a harness-prefixed tool name as a skill and uses its suffix', () => {
+      render(<AgentBlockView block={agentBlock({ tool: 'harness:test-craft' })} />);
+      expectRenderedOnce('Skill: test-craft');
+    });
+
+    it('prefers an explicit skill argument over the harness-prefixed tool suffix', () => {
+      const args = JSON.stringify({ skill: 'explicit-name' });
+      render(<AgentBlockView block={agentBlock({ tool: 'harness:test-craft', args })} />);
+      expectRenderedOnce('Skill: explicit-name');
+    });
+
+    it('falls back to "Execution" for a bare skill tool with no skill argument', () => {
+      render(<AgentBlockView block={agentBlock({ tool: 'skill' })} />);
+      expectRenderedOnce('Skill: Execution');
+    });
+
+    it('QUIRK: the harness prefix is matched case-insensitively but the suffix keeps its original case', () => {
+      render(<AgentBlockView block={agentBlock({ tool: 'HARNESS:Test-Craft' })} />);
+      expectRenderedOnce('Skill: Test-Craft');
+    });
+  });
+
+  describe('running / error state', () => {
+    it('shows a running indicator while there is no result', () => {
+      render(<AgentBlockView block={agentBlock()} />);
+      expectRenderedOnce('Running...');
+    });
+
+    it('drops the running indicator once a result arrives', () => {
+      render(<AgentBlockView block={agentBlock({ result: 'all done' })} />);
+      expectNotRendered('Running...');
+    });
+
+    it('shows an error flag when the call errored', () => {
+      render(<AgentBlockView block={agentBlock({ isError: true })} />);
+      expectRenderedOnce('Error');
+    });
+
+    it('QUIRK: an errored call with no result shows Error but not Running', () => {
+      render(<AgentBlockView block={agentBlock({ isError: true })} />);
+      expectNotRendered('Running...');
+    });
+  });
+
+  describe('description and prompt', () => {
+    it('shows the description for a subagent dispatch', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore', description: 'Find the router' });
+      render(<AgentBlockView block={agentBlock({ args })} />);
+      expectRenderedOnce('Find the router');
+    });
+
+    it('QUIRK: a skill invocation never shows its description', () => {
+      const args = JSON.stringify({ skill: 'harness:tdd', description: 'Find the router' });
+      render(<AgentBlockView block={agentBlock({ tool: 'skill', args })} />);
+      expectNotRendered('Find the router');
+    });
+
+    it('shows a subagent prompt from the prompt argument', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore', prompt: 'Search every package' });
+      render(<AgentBlockView block={agentBlock({ args })} />);
+      expectRenderedOnce('Search every package');
+    });
+
+    it('shows a skill prompt from the args argument instead', () => {
+      const args = JSON.stringify({ skill: 'harness:tdd', args: 'author the failing test' });
+      render(<AgentBlockView block={agentBlock({ tool: 'skill', args })} />);
+      expectRenderedOnce('author the failing test');
+    });
+
+    it('QUIRK: a skill ignores the prompt field a subagent would use', () => {
+      const args = JSON.stringify({ skill: 'harness:tdd', prompt: 'Search every package' });
+      render(<AgentBlockView block={agentBlock({ tool: 'skill', args })} />);
+      expectNotRendered('Search every package');
+    });
+
+    it('QUIRK: a subagent ignores the args field a skill would use', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore', args: 'author the failing test' });
+      render(<AgentBlockView block={agentBlock({ args })} />);
+      expectNotRendered('author the failing test');
+    });
+  });
+
+  describe('result rendering', () => {
+    it('renders an unstructured result as markdown', () => {
+      const { container } = render(
+        <AgentBlockView block={agentBlock({ result: '# Report\n\nEverything passed.' })} />
+      );
+      expect(container.querySelector('h1')?.textContent).toBe('Report');
+      expectRenderedOnce('Everything passed.');
+    });
+
+    it('renders no result region while the call is still running', () => {
+      const { container } = render(<AgentBlockView block={agentBlock()} />);
+      expect(container.querySelector('.prose')).toBeNull();
+    });
+
+    it('routes a findings payload to the findings viewer instead of dumping JSON', () => {
+      render(<AgentBlockView block={agentBlock({ result: findingsResult })} />);
+      expectRenderedOnce('SQL injection via string concat');
+      expectNotRendered(/SEC-INJ-001"/);
+    });
+
+    it('routes an advise-skills payload to the advise viewer', () => {
+      render(<AgentBlockView block={agentBlock({ result: adviseResult })} />);
+      expectRenderedOnce('checkout flow');
+    });
+
+    it('routes a graph-impact payload to the impact viewer', () => {
+      render(<AgentBlockView block={agentBlock({ result: impactResult })} />);
+      expectRenderedOnce('src/app.ts');
+    });
+
+    it('QUIRK: advise-skills wins when a payload satisfies both advise and findings shapes', () => {
+      const both = JSON.stringify({
+        featureName: 'checkout flow',
+        apply: [
+          { skill: 'harness-tdd', score: 0.9, when: 'on new feature', reasons: ['adds behavior'] },
+        ],
+        findings: [{ ruleName: 'SQL injection via string concat', severity: 'error' }],
+      });
+      render(<AgentBlockView block={agentBlock({ result: both })} />);
+      expectRenderedOnce('checkout flow');
+      expectNotRendered('SQL injection via string concat');
+    });
+  });
+
+  describe('KNOWN DEFECT (characterized, not fixed)', () => {
+    /**
+     * `parseAdviseSkillsResult` accepts a match validated only as
+     * `{ skill: string, score: number }` (see `looksLikeMatches`), but
+     * `SkillCard` then dereferences `match.reasons` unguarded. An
+     * advise_skills result whose matches omit `reasons` therefore throws
+     * during render and takes the whole chat message down with it.
+     *
+     * This test pins the CURRENT (broken) behavior so the crash cannot change
+     * silently. It is NOT an endorsement — see the PR's parked-defects note.
+     */
+    it('throws while rendering an advise-skills payload whose matches omit "reasons"', () => {
+      // React logs the boundary-less render failure; silence it so the expected
+      // throw does not look like a broken test run.
+      const quiet = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const missingReasons = JSON.stringify({
+        featureName: 'checkout flow',
+        apply: [{ skill: 'harness-tdd', score: 0.9 }],
+      });
+      expect(() =>
+        render(<AgentBlockView block={agentBlock({ result: missingReasons })} />)
+      ).toThrow(/reading 'map'/);
+    });
+  });
+
+  describe('activity trace', () => {
+    it('renders nested children under an activity-trace heading', () => {
+      render(
+        <AgentBlockView block={agentBlock()}>
+          <div>nested tool row</div>
+        </AgentBlockView>
+      );
+      expectRenderedOnce('Activity Trace');
+      expectRenderedOnce('nested tool row');
+    });
+
+    it('renders no activity trace when there are no children', () => {
+      render(<AgentBlockView block={agentBlock()} />);
+      expectNotRendered('Activity Trace');
+    });
+
+    it('renders no activity trace for an empty children array', () => {
+      render(<AgentBlockView block={agentBlock()}>{[]}</AgentBlockView>);
+      expectNotRendered('Activity Trace');
+    });
+
+    it('renders the activity trace for a non-empty children array', () => {
+      render(
+        <AgentBlockView block={agentBlock()}>{[<div key="a">nested tool row</div>]}</AgentBlockView>
+      );
+      expectRenderedOnce('Activity Trace');
+    });
+  });
+
+  describe('skill vs subagent styling', () => {
+    it('tints a skill card emerald', () => {
+      const { container } = render(<AgentBlockView block={agentBlock({ tool: 'skill' })} />);
+      expect(container.querySelector('.border-emerald-400\\/20')).not.toBeNull();
+    });
+
+    it('tints a subagent card with the secondary accent', () => {
+      const { container } = render(<AgentBlockView block={agentBlock()} />);
+      expect(container.querySelector('.border-secondary-400\\/20')).not.toBeNull();
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/StreamingIndicator.rotation.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/StreamingIndicator.rotation.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+
+/**
+ * Phrase-rotation characterization for StreamingIndicator.
+ *
+ * WHY framer-motion IS STUBBED HERE (and nowhere else in this directory):
+ * the phrase is wrapped in `AnimatePresence mode="wait"`, which keeps the
+ * OUTGOING phrase mounted until its exit animation completes. framer-motion's
+ * frameloop does not advance under jsdom + fake timers, so with the real
+ * library the exit never finishes and the phrase never visibly swaps — the
+ * rotation logic (the interval and its no-repeat `do/while`) would be
+ * untestable. The stub renders the same DOM shape, minus animation.
+ *
+ * Every other suite in this directory renders framer-motion for real.
+ */
+vi.mock('framer-motion', async () => {
+  const react = await import('react');
+  const passthrough = (tag: string) =>
+    react.forwardRef(function MotionStub(
+      props: Record<string, unknown>,
+      ref: React.Ref<HTMLElement>
+    ) {
+      // Keep layout-relevant props; drop the animation-only ones.
+      const { children, className, style, title } = props as {
+        children?: React.ReactNode;
+        className?: string;
+        style?: React.CSSProperties;
+        title?: string;
+      };
+      return react.createElement(tag, { ref, className, style, title }, children);
+    });
+  return {
+    motion: new Proxy({}, { get: (_target, tag: string) => passthrough(tag) }),
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+      react.createElement(react.Fragment, null, children),
+  };
+});
+
+const { StreamingIndicator } =
+  await import('../../../../../src/client/components/chat/blocks/StreamingIndicator');
+
+/** The phrase catalog, mirrored from the component so edits to it fail loudly. */
+const PROCESSING_PHRASES = [
+  'Thinking deeply…',
+  'Analyzing the codebase…',
+  'Connecting the dots…',
+  'Weaving through the code…',
+  'Exploring possibilities…',
+  'Building a mental model…',
+  'Following the thread…',
+  'Mapping dependencies…',
+  'Tracing the logic…',
+  'Piecing it together…',
+  'Diving into the details…',
+  'Reasoning through options…',
+  'Scanning for patterns…',
+  'Synthesizing insights…',
+  'Crafting a response…',
+  'Running the numbers…',
+  'Almost there…',
+  'Working through it…',
+  'Processing your request…',
+  'Engineering a solution…',
+];
+
+/** The longest possible rotation delay: 4500 + random * 2000. */
+const MAX_PHRASE_DELAY_MS = 6500;
+/** The shortest possible rotation delay. */
+const MIN_PHRASE_DELAY_MS = 4500;
+
+/**
+ * Read the rendered phrase from the DOM without consulting the catalog, so
+ * catalog-membership assertions stay falsifiable (test-craft TEST-R002).
+ */
+function phraseNodes(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('span')).filter(
+    (el) => el.children.length === 0 && (el.textContent ?? '').trim().endsWith('…')
+  );
+}
+
+function currentPhrase(container: HTMLElement): string {
+  const nodes = phraseNodes(container);
+  expect(nodes, 'expected exactly one processing phrase to be rendered').toHaveLength(1);
+  return (nodes[0]!.textContent ?? '').trim();
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('StreamingIndicator phrase rotation', () => {
+  it('swaps to a different phrase once the rotation interval elapses', () => {
+    const { container } = render(<StreamingIndicator />);
+    const first = currentPhrase(container);
+    advance(MAX_PHRASE_DELAY_MS);
+    expect(currentPhrase(container)).not.toBe(first);
+  });
+
+  it('holds the phrase steady before the shortest possible interval', () => {
+    const { container } = render(<StreamingIndicator />);
+    const first = currentPhrase(container);
+    advance(MIN_PHRASE_DELAY_MS - 1);
+    expect(currentPhrase(container)).toBe(first);
+  });
+
+  it('never repeats the same phrase on consecutive rotations', () => {
+    const { container } = render(<StreamingIndicator />);
+    let previous = currentPhrase(container);
+    for (let i = 0; i < 8; i++) {
+      advance(MAX_PHRASE_DELAY_MS);
+      const next = currentPhrase(container);
+      expect(next).not.toBe(previous);
+      previous = next;
+    }
+  });
+
+  it('always draws the replacement from the phrase catalog', () => {
+    const { container } = render(<StreamingIndicator />);
+    advance(MAX_PHRASE_DELAY_MS);
+    expect(PROCESSING_PHRASES).toContain(currentPhrase(container));
+  });
+
+  it('still shows exactly one phrase after rotating', () => {
+    const { container } = render(<StreamingIndicator />);
+    advance(MAX_PHRASE_DELAY_MS);
+    expect(phraseNodes(container)).toHaveLength(1);
+  });
+
+  it('stops rotating after unmount', () => {
+    const { container, unmount } = render(<StreamingIndicator />);
+    expect(phraseNodes(container)).toHaveLength(1);
+    unmount();
+    advance(MAX_PHRASE_DELAY_MS * 3);
+    expect(phraseNodes(container)).toHaveLength(0);
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/StreamingIndicator.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/StreamingIndicator.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+import { StreamingIndicator } from '../../../../../src/client/components/chat/blocks/StreamingIndicator';
+
+/**
+ * Characterization tests for StreamingIndicator — the "still working" affordance
+ * shown while the assistant streams.
+ *
+ * Timers are faked so the elapsed counter is deterministic. framer-motion and
+ * NeuralOrganism render for real here.
+ *
+ * Math.random is left REAL on purpose: the phrase-rotation loop is a `do/while`
+ * that retries until it draws a *different* index, so a constant-valued
+ * Math.random stub would spin forever. Assertions therefore pin the properties
+ * the component guarantees (membership in the phrase catalog) rather than one
+ * particular draw.
+ *
+ * Phrase ROTATION is covered in StreamingIndicator.rotation.test.tsx instead:
+ * `AnimatePresence mode="wait"` keeps the outgoing phrase mounted until its exit
+ * animation completes, and framer-motion's frameloop does not advance under
+ * jsdom + fake timers, so the swap is unobservable here. That file stubs
+ * framer-motion for exactly that reason.
+ */
+
+/** The phrase catalog, mirrored from the component so edits to it fail loudly. */
+const PROCESSING_PHRASES = [
+  'Thinking deeply…',
+  'Analyzing the codebase…',
+  'Connecting the dots…',
+  'Weaving through the code…',
+  'Exploring possibilities…',
+  'Building a mental model…',
+  'Following the thread…',
+  'Mapping dependencies…',
+  'Tracing the logic…',
+  'Piecing it together…',
+  'Diving into the details…',
+  'Reasoning through options…',
+  'Scanning for patterns…',
+  'Synthesizing insights…',
+  'Crafting a response…',
+  'Running the numbers…',
+  'Almost there…',
+  'Working through it…',
+  'Processing your request…',
+  'Engineering a solution…',
+];
+
+/** The longest possible phrase-rotation delay: 4500 + random * 2000. */
+const MAX_PHRASE_DELAY_MS = 6500;
+
+/**
+ * Read the rendered phrase straight out of the DOM, WITHOUT consulting the
+ * catalog. Looking it up by catalog membership would make any
+ * "the phrase is in the catalog" assertion a tautology (test-craft TEST-R002).
+ * The phrase is the only leaf element whose text ends in an ellipsis.
+ */
+function phraseNodes(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('span')).filter(
+    (el) => el.children.length === 0 && (el.textContent ?? '').trim().endsWith('…')
+  );
+}
+
+function currentPhrase(container: HTMLElement): string {
+  const nodes = phraseNodes(container);
+  expect(nodes, 'expected exactly one processing phrase to be rendered').toHaveLength(1);
+  return (nodes[0]!.textContent ?? '').trim();
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('StreamingIndicator', () => {
+  describe('processing phrase', () => {
+    it('renders a phrase drawn from the catalog', () => {
+      const { container } = render(<StreamingIndicator />);
+      expect(PROCESSING_PHRASES).toContain(currentPhrase(container));
+    });
+
+    it('renders exactly one phrase at a time', () => {
+      const { container } = render(<StreamingIndicator />);
+      expect(phraseNodes(container)).toHaveLength(1);
+    });
+
+    it('keeps the outgoing phrase mounted while its exit animation is pending', () => {
+      const { container } = render(<StreamingIndicator />);
+      const first = currentPhrase(container);
+      advance(MAX_PHRASE_DELAY_MS);
+      // AnimatePresence mode="wait" holds the outgoing child until exit
+      // completes; see the rotation suite for the swap itself.
+      expect(currentPhrase(container)).toBe(first);
+    });
+  });
+
+  describe('elapsed counter', () => {
+    it('is hidden on first render', () => {
+      render(<StreamingIndicator />);
+      expectNotRendered(/^T\+/);
+    });
+
+    it('is still hidden at two seconds', () => {
+      render(<StreamingIndicator />);
+      advance(2000);
+      expectNotRendered(/^T\+/);
+    });
+
+    it('appears once more than two seconds have passed', () => {
+      render(<StreamingIndicator />);
+      advance(3000);
+      expectRenderedOnce('T+3s');
+    });
+
+    it('counts up in whole seconds below a minute', () => {
+      render(<StreamingIndicator />);
+      advance(45_000);
+      expectRenderedOnce('T+45s');
+    });
+
+    it('switches to minutes-and-seconds at exactly one minute', () => {
+      render(<StreamingIndicator />);
+      advance(60_000);
+      expectRenderedOnce('T+1m 0s');
+    });
+
+    it('shows the remainder seconds past a minute', () => {
+      render(<StreamingIndicator />);
+      advance(95_000);
+      expectRenderedOnce('T+1m 35s');
+    });
+
+    it('shows the last second before the minute boundary in seconds only', () => {
+      render(<StreamingIndicator />);
+      advance(59_000);
+      expectRenderedOnce('T+59s');
+    });
+  });
+
+  describe('composition', () => {
+    it('renders the neural organism avatar', () => {
+      const { container } = render(<StreamingIndicator />);
+      expect(container.querySelector('svg')).not.toBeNull();
+    });
+
+    it('renders the full set of ambient activity bars', () => {
+      const { container } = render(<StreamingIndicator />);
+      expect(container.querySelectorAll('.origin-bottom')).toHaveLength(20);
+    });
+  });
+
+  describe('teardown', () => {
+    it('stops its timers on unmount', () => {
+      const { unmount } = render(<StreamingIndicator />);
+      unmount();
+      expect(() => advance(120_000)).not.toThrow();
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/TextBlockView.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/TextBlockView.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+import { TextBlockView } from '../../../../../src/client/components/chat/blocks/TextBlockView';
+
+/**
+ * Characterization tests for TextBlockView — assistant prose, which either
+ * routes to the terminal-output frame or renders as markdown with fenced-code
+ * syntax highlighting, after graph-packing envelopes are lifted out as chips.
+ */
+
+function renderText(text: string) {
+  return render(<TextBlockView block={{ kind: 'text', text }} />);
+}
+
+describe('TextBlockView', () => {
+  describe('terminal-output routing', () => {
+    it('renders ordinary prose as markdown, not terminal output', () => {
+      renderText('Everything passed on the first run.');
+      expectNotRendered('Terminal Output');
+      expectRenderedOnce('Everything passed on the first run.');
+    });
+
+    it('routes shell-prompt output to the terminal frame', () => {
+      renderText('$ pnpm test\nall good');
+      expectRenderedOnce('Terminal Output');
+    });
+
+    it('routes package-manager style output to the terminal frame', () => {
+      renderText('> harness@1.0.0 build\n> tsc -p .');
+      expectRenderedOnce('Terminal Output');
+    });
+
+    it('routes check-mark log lines to the terminal frame', () => {
+      renderText('✔ 12 tests passed');
+      expectRenderedOnce('Terminal Output');
+    });
+
+    it('QUIRK: a single log-looking line routes the WHOLE block to terminal output', () => {
+      const mostlyProse = [
+        'Here is a long explanation of what happened.',
+        'It goes on for several sentences of ordinary prose.',
+        'And a little more prose to be sure.',
+        '$ pnpm test',
+      ].join('\n');
+      renderText(mostlyProse);
+      expectRenderedOnce('Terminal Output');
+    });
+
+    it('QUIRK: prose beginning with a slashed path is misread as terminal output', () => {
+      renderText('src/index.ts is the entry point of the package.');
+      expectRenderedOnce('Terminal Output');
+    });
+
+    it('QUIRK: markdown whose fenced code contains an import is misread as terminal output', () => {
+      renderText("Here is the setup:\n\n```ts\nimport { x } from './x';\n```");
+      expectRenderedOnce('Terminal Output');
+    });
+
+    it('does not lift packed chips out of terminal output', () => {
+      renderText('<!-- packed: structural -->\n$ pnpm test');
+      expectRenderedOnce('Terminal Output');
+      expectNotRendered(/Packed: structural/);
+    });
+  });
+
+  describe('graph-packing chips', () => {
+    it('lifts a packed envelope into a chip', () => {
+      renderText('<!-- packed: structural | 200 to 100 tokens -->\nThe summary follows.');
+      expectRenderedOnce('Packed: structural | 200 to 100 tokens');
+    });
+
+    it('removes the packed envelope from the rendered prose', () => {
+      renderText('<!-- packed: structural -->\nThe summary follows.');
+      expectRenderedOnce('The summary follows.');
+      expectNotRendered(/<!--/);
+    });
+
+    it('renders one chip per packed envelope', () => {
+      renderText('<!-- packed: first -->\n<!-- packed: second -->\nThe summary follows.');
+      expectRenderedOnce('Packed: first');
+      expectRenderedOnce('Packed: second');
+    });
+
+    it('labels the chip with an explanatory tooltip', () => {
+      renderText('<!-- packed: structural -->\nThe summary follows.');
+      const chip = screen.getByText('Packed: structural').closest('span[title]');
+      expect(chip?.getAttribute('title')).toBe('Graph context packing applied');
+    });
+
+    it('QUIRK: the angle brackets are optional, so a bare "!-- packed: x --" also matches', () => {
+      renderText('!-- packed: structural --\nThe summary follows.');
+      expectRenderedOnce('Packed: structural');
+    });
+
+    it('renders no prose region when the block is nothing but a packed envelope', () => {
+      const { container } = renderText('<!-- packed: structural -->');
+      expectRenderedOnce('Packed: structural');
+      expect(container.querySelector('.prose')).toBeNull();
+    });
+
+    it('renders no chips for prose with no packed envelope', () => {
+      renderText('Just ordinary prose here.');
+      expectNotRendered(/^Packed:/);
+    });
+  });
+
+  describe('markdown rendering', () => {
+    it('renders headings', () => {
+      const { container } = renderText('# The Heading\n\nAnd a paragraph.');
+      expect(container.querySelector('h1')?.textContent).toBe('The Heading');
+    });
+
+    it('renders bullet lists', () => {
+      const { container } = renderText('Some intro text.\n\n* alpha\n* beta');
+      expect(container.querySelectorAll('li')).toHaveLength(2);
+    });
+
+    it('renders GitHub-flavoured tables', () => {
+      const md = 'Intro text.\n\n| Name | Value |\n| ---- | ----- |\n| a | 1 |';
+      const { container } = renderText(md);
+      expect(container.querySelector('table')).not.toBeNull();
+    });
+
+    it('renders inline code without a language chrome', () => {
+      const { container } = renderText('Call the `formatToolArgs` helper.');
+      const code = container.querySelector('code');
+      expect(code?.textContent).toBe('formatToolArgs');
+      expect(container.querySelector('.font-mono.leading-relaxed')).toBeNull();
+    });
+  });
+
+  describe('fenced code blocks', () => {
+    it('labels a fenced block with its language', () => {
+      renderText("Example:\n\n```ts\nconst greeting = 'hi';\n```");
+      expectRenderedOnce('ts');
+    });
+
+    it('renders the fenced code contents', () => {
+      const { container } = renderText("Example:\n\n```ts\nconst greeting = 'hi';\n```");
+      expect(container.textContent).toContain('const greeting');
+    });
+
+    it('QUIRK: a fenced block with no language is rendered as inline-style code', () => {
+      const { container } = renderText('Example:\n\n```\nplain block\n```');
+      expect(container.querySelector('code')?.textContent).toContain('plain block');
+      expectNotRendered('ts');
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/TodoBlockView.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/TodoBlockView.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+import { TodoBlockView } from '../../../../../src/client/components/chat/blocks/TodoBlockView';
+import type { ToolUseBlock } from '../../../../../src/client/types/chat';
+
+/** Characterization tests for TodoBlockView — the todo-plan checklist card. */
+
+type Todo = { content: string; status: string; activeForm?: string };
+
+function todoBlock(todos: Todo[], overrides: Partial<ToolUseBlock> = {}): ToolUseBlock {
+  return {
+    kind: 'tool_use',
+    tool: 'TodoWrite',
+    args: JSON.stringify({ todos }),
+    ...overrides,
+  };
+}
+
+/** The task row wrapping a given task label. */
+function row(content: string): HTMLElement {
+  const el = screen.getByText(content).closest('div.flex.items-start');
+  if (!el) throw new Error(`no task row for "${content}"`);
+  return el as HTMLElement;
+}
+
+describe('TodoBlockView', () => {
+  describe('fallback when there is no task list', () => {
+    it('falls back to the raw tool row when args are absent', () => {
+      render(<TodoBlockView block={{ kind: 'tool_use', tool: 'TodoWrite' }} />);
+      expectNotRendered('Todo Plan');
+      expectRenderedOnce('TodoWrite');
+    });
+
+    it('falls back to the raw tool row when args are unparseable', () => {
+      render(<TodoBlockView block={{ kind: 'tool_use', tool: 'TodoWrite', args: 'not json' }} />);
+      expectNotRendered('Todo Plan');
+      expectRenderedOnce('TodoWrite');
+    });
+
+    it('falls back to the raw tool row when todos is not an array', () => {
+      const block = {
+        kind: 'tool_use',
+        tool: 'TodoWrite',
+        args: '{"todos":"nope"}',
+      } as ToolUseBlock;
+      render(<TodoBlockView block={block} />);
+      expectNotRendered('Todo Plan');
+    });
+
+    it('QUIRK: an empty todos array still renders the card, with no rows', () => {
+      const { container } = render(<TodoBlockView block={todoBlock([])} />);
+      expectRenderedOnce('Todo Plan');
+      expect(container.querySelectorAll('div.flex.items-start')).toHaveLength(0);
+    });
+  });
+
+  describe('task list', () => {
+    it('renders the card header', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Write tests', status: 'pending' }])} />);
+      expectRenderedOnce('Todo Plan');
+    });
+
+    it('renders one row per task, in order', () => {
+      render(
+        <TodoBlockView
+          block={todoBlock([
+            { content: 'First task', status: 'completed' },
+            { content: 'Second task', status: 'in_progress' },
+            { content: 'Third task', status: 'pending' },
+          ])}
+        />
+      );
+      expectRenderedOnce('First task');
+      expectRenderedOnce('Second task');
+      expectRenderedOnce('Third task');
+    });
+
+    it('strikes through a completed task', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Done thing', status: 'completed' }])} />);
+      expect(expectRenderedOnce('Done thing').className).toContain('line-through');
+    });
+
+    it('also treats the "done" status as completed', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Done thing', status: 'done' }])} />);
+      expect(expectRenderedOnce('Done thing').className).toContain('line-through');
+    });
+
+    it('does not strike through a pending task', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Todo thing', status: 'pending' }])} />);
+      expect(expectRenderedOnce('Todo thing').className).not.toContain('line-through');
+    });
+
+    it('does not strike through an in-progress task', () => {
+      render(
+        <TodoBlockView block={todoBlock([{ content: 'Busy thing', status: 'in_progress' }])} />
+      );
+      expect(expectRenderedOnce('Busy thing').className).not.toContain('line-through');
+    });
+
+    it('marks a completed task with a checkmark icon', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Done thing', status: 'completed' }])} />);
+      expect(row('Done thing').querySelector('svg')).not.toBeNull();
+    });
+
+    it('marks an in-progress task with a pulsing dot rather than a checkmark', () => {
+      render(
+        <TodoBlockView block={todoBlock([{ content: 'Busy thing', status: 'in_progress' }])} />
+      );
+      const r = row('Busy thing');
+      expect(r.querySelector('svg')).toBeNull();
+      expect(r.querySelector('.animate-pulse')).not.toBeNull();
+    });
+
+    it('marks a pending task with an empty box', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Todo thing', status: 'pending' }])} />);
+      const r = row('Todo thing');
+      expect(r.querySelector('svg')).toBeNull();
+      expect(r.querySelector('.animate-pulse')).toBeNull();
+    });
+
+    it('QUIRK: an unrecognized status is rendered exactly like pending', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Odd thing', status: 'banana' }])} />);
+      const r = row('Odd thing');
+      expect(r.querySelector('svg')).toBeNull();
+      expect(r.querySelector('.animate-pulse')).toBeNull();
+      expect(expectRenderedOnce('Odd thing').className).not.toContain('line-through');
+    });
+  });
+
+  describe('active form', () => {
+    it('shows the active form of the in-progress task', () => {
+      const todos = [
+        { content: 'Write tests', status: 'in_progress', activeForm: 'Writing tests' },
+      ];
+      render(<TodoBlockView block={todoBlock(todos)} />);
+      expectRenderedOnce(/Writing tests/);
+    });
+
+    it('hides the active form of a task that is not in progress', () => {
+      const todos = [{ content: 'Write tests', status: 'pending', activeForm: 'Writing tests' }];
+      render(<TodoBlockView block={todoBlock(todos)} />);
+      expectNotRendered(/Writing tests/);
+    });
+
+    it('hides the active form of a completed task', () => {
+      const todos = [{ content: 'Write tests', status: 'completed', activeForm: 'Writing tests' }];
+      render(<TodoBlockView block={todoBlock(todos)} />);
+      expectNotRendered(/Writing tests/);
+    });
+
+    it('omits the active form line when the task carries none', () => {
+      render(
+        <TodoBlockView block={todoBlock([{ content: 'Write tests', status: 'in_progress' }])} />
+      );
+      expect(row('Write tests').textContent).toBe('Write tests');
+    });
+  });
+
+  describe('error and result', () => {
+    it('flags a parse error on the card header', () => {
+      const todos = [{ content: 'Write tests', status: 'pending' }];
+      render(<TodoBlockView block={todoBlock(todos, { isError: true })} />);
+      expectRenderedOnce('Error Parsing');
+    });
+
+    it('shows no error flag on a healthy card', () => {
+      render(<TodoBlockView block={todoBlock([{ content: 'Write tests', status: 'pending' }])} />);
+      expectNotRendered('Error Parsing');
+    });
+
+    it('renders the tool result as markdown beneath the tasks', () => {
+      const todos = [{ content: 'Write tests', status: 'pending' }];
+      const { container } = render(
+        <TodoBlockView block={todoBlock(todos, { result: '# Updated\n\nAll set.' })} />
+      );
+      expect(container.querySelector('h1')?.textContent).toBe('Updated');
+      expectRenderedOnce('All set.');
+    });
+
+    it('renders no result region when there is no result', () => {
+      const { container } = render(
+        <TodoBlockView block={todoBlock([{ content: 'Write tests', status: 'pending' }])} />
+      );
+      expect(container.querySelector('.prose')).toBeNull();
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/ToolUseBlockView.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/blocks/ToolUseBlockView.test.tsx
@@ -1,0 +1,404 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { expectRenderedOnce, expectNotRendered } from './render-assertions';
+import React from 'react';
+import { ToolUseBlockView } from '../../../../../src/client/components/chat/blocks/ToolUseBlockView';
+import type { ToolUseBlock } from '../../../../../src/client/types/chat';
+
+/**
+ * Characterization tests for ToolUseBlockView — the collapsible tool-call row.
+ *
+ * Pins CURRENT behavior as-is, quirks included. framer-motion is rendered for
+ * real; under jsdom it emits ordinary DOM nodes.
+ */
+
+function toolBlock(overrides: Partial<ToolUseBlock> = {}): ToolUseBlock {
+  return { kind: 'tool_use', tool: 'Read', ...overrides };
+}
+
+/** The clickable header is the parent of the tool-title span. */
+function header(titleText: string | RegExp): HTMLElement {
+  const el = screen.getByText(titleText).parentElement;
+  if (!el) throw new Error('tool header not found');
+  return el;
+}
+
+function captureSendEvents(): string[] {
+  const seen: string[] = [];
+  const listener = (e: Event) => seen.push((e as CustomEvent<string>).detail);
+  window.addEventListener('chat-action-send', listener);
+  cleanups.push(() => window.removeEventListener('chat-action-send', listener));
+  return seen;
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+describe('ToolUseBlockView', () => {
+  describe('header', () => {
+    it('renders the tool name with underscores replaced by spaces', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'run_ci_checks' })} />);
+      expectRenderedOnce('run ci checks');
+    });
+
+    it('renders an args preview beside the tool name, inside the header row', () => {
+      const block = toolBlock({ tool: 'Read', args: JSON.stringify({ path: '/a/b/c.ts' }) });
+      render(<ToolUseBlockView block={block} />);
+      // Scoped to the header so the assertion fails if the preview moves into
+      // the expanded body (test-craft TEST-R002: the name promised placement).
+      expectRenderedOnce('b/c.ts', header('Read'));
+    });
+
+    it('exposes the raw args as the preview tooltip', () => {
+      const args = JSON.stringify({ path: '/a/b/c.ts' });
+      render(<ToolUseBlockView block={toolBlock({ args })} />);
+      expect(expectRenderedOnce('b/c.ts').getAttribute('title')).toBe(args);
+    });
+
+    it('omits the args preview entirely when there are no args', () => {
+      const { container } = render(<ToolUseBlockView block={toolBlock({ tool: 'Read' })} />);
+      expect(container.querySelector('[title]')).toBeNull();
+    });
+
+    it('uses a bash call’s description as the title instead of the tool name', () => {
+      const args = JSON.stringify({ command: 'pnpm test', description: 'Run the test suite' });
+      render(<ToolUseBlockView block={toolBlock({ tool: 'bash', args })} />);
+      expectRenderedOnce('Run the test suite');
+      expectNotRendered('bash');
+    });
+
+    it('falls back to the tool name when bash args are unparseable', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'bash', args: 'not json' })} />);
+      expectRenderedOnce('bash');
+    });
+
+    it('falls back to the tool name when a bash call carries no description', () => {
+      const args = JSON.stringify({ command: 'pnpm test' });
+      render(<ToolUseBlockView block={toolBlock({ tool: 'bash', args })} />);
+      expectRenderedOnce('bash');
+    });
+  });
+
+  describe('attribution badge', () => {
+    it('renders the attribution when one is supplied', () => {
+      render(<ToolUseBlockView block={toolBlock()} attribution="architect" />);
+      expectRenderedOnce('architect');
+    });
+
+    it('renders no attribution badge by default', () => {
+      render(<ToolUseBlockView block={toolBlock()} />);
+      expectNotRendered('architect');
+    });
+  });
+
+  describe('result status badge', () => {
+    it('shows OK once a successful result has arrived', () => {
+      render(<ToolUseBlockView block={toolBlock({ result: 'done' })} />);
+      expectRenderedOnce('OK');
+    });
+
+    it('shows ERR when the tool call errored', () => {
+      render(<ToolUseBlockView block={toolBlock({ result: 'boom', isError: true })} />);
+      expectRenderedOnce('ERR');
+    });
+
+    it('shows no status badge while the result is still absent', () => {
+      render(<ToolUseBlockView block={toolBlock()} />);
+      expectNotRendered('OK');
+      expectNotRendered('ERR');
+    });
+
+    it('treats a forceResult as a result for badge purposes', () => {
+      render(<ToolUseBlockView block={toolBlock()} forceResult="from the stream" />);
+      expectRenderedOnce('OK');
+    });
+  });
+
+  describe('expand / collapse', () => {
+    it('starts collapsed for an ordinary tool, hiding the result body', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'Read', result: 'the result body' })} />);
+      expectNotRendered('the result body');
+    });
+
+    it('reveals the result body when the header is clicked', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'Read', result: 'the result body' })} />);
+      fireEvent.click(header('Read'));
+      expectRenderedOnce('the result body');
+    });
+
+    it('hides the result body again on a second click', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'Read', result: 'the result body' })} />);
+      fireEvent.click(header('Read'));
+      fireEvent.click(header('Read'));
+      expectNotRendered('the result body');
+    });
+
+    it('renders the result body as markdown', () => {
+      const block = toolBlock({ tool: 'Read', result: '# Heading\n\n- one\n- two' });
+      const { container } = render(<ToolUseBlockView block={block} />);
+      fireEvent.click(header('Read'));
+      expect(container.querySelector('h1')?.textContent).toBe('Heading');
+      expect(container.querySelectorAll('li')).toHaveLength(2);
+    });
+
+    it('renders a forceResult body when the block itself has no result', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'Read' })} forceResult="streamed body" />);
+      fireEvent.click(header('Read'));
+      expectRenderedOnce('streamed body');
+    });
+
+    it('prefers the block result over forceResult when both are present', () => {
+      const block = toolBlock({ tool: 'Read', result: 'own result' });
+      render(<ToolUseBlockView block={block} forceResult="forced result" />);
+      fireEvent.click(header('Read'));
+      expectRenderedOnce('own result');
+      expectNotRendered('forced result');
+    });
+
+    it.each(['emit_interaction', 'ask_question', 'ask_human', 'human_review'])(
+      'starts expanded for the human-facing tool %s',
+      (tool) => {
+        render(<ToolUseBlockView block={toolBlock({ tool, result: 'needs your input' })} />);
+        expectRenderedOnce('needs your input');
+      }
+    );
+
+    it('matches the auto-expand tool names case-insensitively', () => {
+      render(<ToolUseBlockView block={toolBlock({ tool: 'ASK_HUMAN', result: 'input please' })} />);
+      expectRenderedOnce('input please');
+    });
+
+    it('QUIRK: expanding a tool that has no result yet renders no body at all', () => {
+      const { container } = render(<ToolUseBlockView block={toolBlock({ tool: 'Read' })} />);
+      fireEvent.click(header('Read'));
+      // The expanded region is gated on hasResult, so nothing is revealed.
+      expect(container.querySelector('.prose')).toBeNull();
+    });
+
+    it('QUIRK: a todo tool’s parsed tasks are never rendered by this view', () => {
+      const args = JSON.stringify({ todos: [{ content: 'Write the tests', status: 'pending' }] });
+      const block = toolBlock({ tool: 'TodoWrite', args, result: 'ok' });
+      render(<ToolUseBlockView block={block} />);
+      fireEvent.click(header('TodoWrite'));
+      // TodoBlockView owns task rendering; the parse here feeds only dead code.
+      expectNotRendered('Write the tests');
+    });
+  });
+
+  describe('pending scan overlay', () => {
+    it('renders the scan overlay while pending with no result', () => {
+      const { container } = render(<ToolUseBlockView block={toolBlock()} isPending />);
+      expect(container.querySelector('.bg-gradient-to-b')).not.toBeNull();
+    });
+
+    it('drops the scan overlay once a result has arrived', () => {
+      const { container } = render(
+        <ToolUseBlockView block={toolBlock({ result: 'done' })} isPending />
+      );
+      expect(container.querySelector('.bg-gradient-to-b')).toBeNull();
+    });
+
+    it('renders no scan overlay when not pending', () => {
+      const { container } = render(<ToolUseBlockView block={toolBlock()} />);
+      expect(container.querySelector('.bg-gradient-to-b')).toBeNull();
+    });
+  });
+
+  describe('emit_interaction action buttons', () => {
+    const question = {
+      type: 'question',
+      question: {
+        options: [{ label: 'Ship it' }, { label: 'Hold' }, { label: 'Rework' }],
+        recommendation: { optionIndex: 1 },
+      },
+    };
+
+    function renderQuestion(payload: unknown = question) {
+      return render(
+        <ToolUseBlockView
+          block={toolBlock({
+            tool: 'emit_interaction',
+            args: JSON.stringify(payload),
+            result: 'Awaiting your decision',
+          })}
+        />
+      );
+    }
+
+    it('offers an approve-recommendation button naming the recommended letter', () => {
+      renderQuestion();
+      expectRenderedOnce(/Approve Recommendation \(B\)/);
+    });
+
+    it('dispatches the recommended option label when approving the recommendation', () => {
+      const sent = captureSendEvents();
+      renderQuestion();
+      fireEvent.click(screen.getByText(/Approve Recommendation \(B\)/));
+      expect(sent).toEqual(['Approve recommendation: Hold']);
+    });
+
+    it('offers a button for every non-recommended option', () => {
+      renderQuestion();
+      expectRenderedOnce('Option A');
+      expectRenderedOnce('Option C');
+    });
+
+    it('omits a plain option button for the recommended index', () => {
+      renderQuestion();
+      expectNotRendered('Option B');
+    });
+
+    it('QUIRK: option buttons show only a letter, never the option label', () => {
+      renderQuestion();
+      expectNotRendered('Ship it');
+      expectNotRendered('Rework');
+    });
+
+    it('dispatches the letter and label when a plain option is chosen', () => {
+      const sent = captureSendEvents();
+      renderQuestion();
+      fireEvent.click(screen.getByText('Option C'));
+      expect(sent).toEqual(['Approve option C: Rework']);
+    });
+
+    it('accepts plain-string options', () => {
+      const sent = captureSendEvents();
+      renderQuestion({ type: 'question', question: { options: ['Yes', 'No'] } });
+      fireEvent.click(screen.getByText('Option A'));
+      expect(sent).toEqual(['Approve option A: Yes']);
+    });
+
+    it('always offers a Continue button for a question', () => {
+      const sent = captureSendEvents();
+      renderQuestion();
+      fireEvent.click(screen.getByText('Continue'));
+      expect(sent).toEqual(['Continue']);
+    });
+
+    it('offers only Continue when a question carries no options', () => {
+      renderQuestion({ type: 'question', question: {} });
+      expectRenderedOnce('Continue');
+      expectNotRendered('Option A');
+    });
+
+    it('offers only Continue when the options array is empty', () => {
+      renderQuestion({ type: 'question', question: { options: [] } });
+      expectRenderedOnce('Continue');
+      expectNotRendered('Option A');
+    });
+
+    it('renders confirm and cancel buttons for a confirmation', () => {
+      renderQuestion({ type: 'confirmation' });
+      expectRenderedOnce('Confirm & Proceed');
+      expectRenderedOnce('Cancel');
+    });
+
+    it('dispatches an affirmative on confirm', () => {
+      const sent = captureSendEvents();
+      renderQuestion({ type: 'confirmation' });
+      fireEvent.click(screen.getByText('Confirm & Proceed'));
+      expect(sent).toEqual(['Yes, proceed']);
+    });
+
+    it('dispatches a refusal on cancel', () => {
+      const sent = captureSendEvents();
+      renderQuestion({ type: 'confirmation' });
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(sent).toEqual(['No, stop']);
+    });
+
+    it('names both phases for a transition needing confirmation', () => {
+      renderQuestion({
+        type: 'transition',
+        transition: {
+          requiresConfirmation: true,
+          suggestedNext: 'execution',
+          completedPhase: 'planning',
+        },
+      });
+      expectRenderedOnce('Proceed to execution');
+      expectRenderedOnce('Stay in planning');
+    });
+
+    it('dispatches the target phase when proceeding through a transition', () => {
+      const sent = captureSendEvents();
+      renderQuestion({
+        type: 'transition',
+        transition: {
+          requiresConfirmation: true,
+          suggestedNext: 'execution',
+          completedPhase: 'planning',
+        },
+      });
+      fireEvent.click(screen.getByText('Proceed to execution'));
+      expect(sent).toEqual(['Yes, proceed to execution']);
+    });
+
+    it('renders no buttons for a transition that does not require confirmation', () => {
+      const { container } = renderQuestion({
+        type: 'transition',
+        transition: { requiresConfirmation: false, suggestedNext: 'execution' },
+      });
+      expect(container.querySelectorAll('button')).toHaveLength(0);
+    });
+
+    it('renders approve-all and reject buttons for a batch', () => {
+      renderQuestion({ type: 'batch' });
+      expectRenderedOnce('Approve All');
+      expectRenderedOnce('Reject');
+    });
+
+    it('dispatches a batch approval', () => {
+      const sent = captureSendEvents();
+      renderQuestion({ type: 'batch' });
+      fireEvent.click(screen.getByText('Approve All'));
+      expect(sent).toEqual(['Approve all decisions']);
+    });
+
+    it('renders no buttons for an unrecognized interaction type', () => {
+      const { container } = renderQuestion({ type: 'something-else' });
+      expect(container.querySelectorAll('button')).toHaveLength(0);
+    });
+
+    it('leaves the UI untouched when the interaction args are unparseable', () => {
+      const block = toolBlock({
+        tool: 'emit_interaction',
+        args: 'not json',
+        result: 'Awaiting your decision',
+      });
+      const { container } = render(<ToolUseBlockView block={block} />);
+      expectRenderedOnce('Awaiting your decision');
+      expect(container.querySelectorAll('button')).toHaveLength(0);
+    });
+
+    it('withholds the action buttons while the interaction is still pending', () => {
+      const block = toolBlock({
+        tool: 'emit_interaction',
+        args: JSON.stringify({ type: 'confirmation' }),
+        result: 'Awaiting your decision',
+      });
+      const { container } = render(<ToolUseBlockView block={block} isPending />);
+      expect(container.querySelectorAll('button')).toHaveLength(0);
+    });
+
+    it('renders no action buttons for a non-interaction tool with the same payload', () => {
+      const block = toolBlock({
+        tool: 'Read',
+        args: JSON.stringify({ type: 'confirmation' }),
+        result: 'Awaiting your decision',
+      });
+      const { container } = render(<ToolUseBlockView block={block} />);
+      fireEvent.click(header('Read'));
+      expect(container.querySelectorAll('button')).toHaveLength(0);
+    });
+
+    it('scopes the action buttons to the expanded result region', () => {
+      renderQuestion({ type: 'confirmation' });
+      const region = screen.getByText('Confirm & Proceed').closest('div.not-prose');
+      expect(region).not.toBeNull();
+      expect(within(region as HTMLElement).getAllByRole('button')).toHaveLength(2);
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/format-tool-args.test.ts
+++ b/packages/dashboard/tests/client/components/chat/blocks/format-tool-args.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { formatToolArgs } from '../../../../../src/client/components/chat/blocks/format-tool-args';
+
+/**
+ * Characterization tests for `formatToolArgs` — the one-line args preview shown
+ * next to a tool name in the chat transcript.
+ *
+ * These pin CURRENT behavior as-is (including quirks); they are not a
+ * specification of desired behavior. Quirks are called out explicitly so a
+ * future intentional change fails loudly rather than silently.
+ */
+describe('formatToolArgs', () => {
+  describe('when there is nothing to preview', () => {
+    // Both inputs hit the single `if (!args) return ''` guard, so they are one
+    // contract with two callers rather than two behaviors (test-craft TEST-R006).
+    it.each([
+      ['absent', undefined],
+      ['an empty string', ''],
+    ])('returns an empty preview when args are %s', (_label, args) => {
+      expect(formatToolArgs('Read', args)).toBe('');
+    });
+  });
+
+  describe('non-JSON args', () => {
+    it('passes unparseable args through verbatim', () => {
+      expect(formatToolArgs('Read', 'not json at all')).toBe('not json at all');
+    });
+
+    it('truncates unparseable args to 100 characters', () => {
+      const long = 'x'.repeat(250);
+      expect(formatToolArgs('Read', long)).toBe('x'.repeat(100));
+    });
+  });
+
+  describe('todo tools', () => {
+    it('summarizes a todo list by task count', () => {
+      const args = JSON.stringify({
+        todos: [{ content: 'a' }, { content: 'b' }, { content: 'c' }],
+      });
+      expect(formatToolArgs('TodoWrite', args)).toBe('Updating 3 tasks');
+    });
+
+    it('matches the todo branch on any tool whose name contains "todo"', () => {
+      const args = JSON.stringify({ todos: [{ content: 'a' }] });
+      expect(formatToolArgs('mcp__x__update_todos', args)).toBe('Updating 1 tasks');
+    });
+
+    it('QUIRK: pluralizes unconditionally, so a single task reads "1 tasks"', () => {
+      const args = JSON.stringify({ todos: [{ content: 'only one' }] });
+      expect(formatToolArgs('TodoWrite', args)).toBe('Updating 1 tasks');
+    });
+
+    it('falls through to the JSON fallback when todos is not an array', () => {
+      const args = JSON.stringify({ todos: 'nope' });
+      expect(formatToolArgs('TodoWrite', args)).toBe('{"todos":"nope"}');
+    });
+  });
+
+  describe('bash tools', () => {
+    it('previews the command', () => {
+      expect(formatToolArgs('Bash', JSON.stringify({ command: 'pnpm test' }))).toBe('pnpm test');
+    });
+
+    it('falls back to the args field when command is absent', () => {
+      expect(formatToolArgs('bash', JSON.stringify({ args: 'ls -la' }))).toBe('ls -la');
+    });
+
+    it('strips a leading unquoted "cd ... &&" prefix', () => {
+      const args = JSON.stringify({ command: 'cd /repo/packages && pnpm build' });
+      expect(formatToolArgs('Bash', args)).toBe('pnpm build');
+    });
+
+    it('strips a leading double-quoted "cd ... &&" prefix', () => {
+      const args = JSON.stringify({ command: 'cd "/repo/my dir" && pnpm build' });
+      expect(formatToolArgs('Bash', args)).toBe('pnpm build');
+    });
+
+    it('strips a leading single-quoted "cd ... &&" prefix', () => {
+      const args = JSON.stringify({ command: "cd '/repo/my dir' && pnpm build" });
+      expect(formatToolArgs('Bash', args)).toBe('pnpm build');
+    });
+
+    it('QUIRK: strips EVERY "cd ... &&" occurrence, not just the leading one', () => {
+      const args = JSON.stringify({ command: 'cd /a && ls && cd /b && pwd' });
+      expect(formatToolArgs('Bash', args)).toBe('ls && pwd');
+    });
+
+    it('truncates a long command to 100 characters', () => {
+      const args = JSON.stringify({ command: `echo ${'y'.repeat(250)}` });
+      expect(formatToolArgs('Bash', args)).toHaveLength(100);
+    });
+
+    it('QUIRK: only the exact tool name "bash" takes the bash branch', () => {
+      const args = JSON.stringify({ command: 'pnpm test' });
+      expect(formatToolArgs('BashOutput', args)).toBe('{"command":"pnpm test"}');
+    });
+  });
+
+  describe('agent / subagent tools', () => {
+    it('joins subagent type and description', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore', description: 'find the router' });
+      expect(formatToolArgs('Agent', args)).toBe('Explore: find the router');
+    });
+
+    it('uses the description alone when no type is present', () => {
+      const args = JSON.stringify({ description: 'find the router' });
+      expect(formatToolArgs('agent', args)).toBe('find the router');
+    });
+
+    it('reads the type from the "type" field when subagent_type is absent', () => {
+      const args = JSON.stringify({ type: 'general', description: 'sweep' });
+      expect(formatToolArgs('subagent', args)).toBe('general: sweep');
+    });
+
+    it('QUIRK: a subagent_type field routes ANY tool into the agent branch', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore', description: 'find the router' });
+      expect(formatToolArgs('SomeUnrelatedTool', args)).toBe('Explore: find the router');
+    });
+
+    it('falls through to the path branch when an agent call has no description', () => {
+      const args = JSON.stringify({ subagent_type: 'Explore', file_path: '/repo/src/app.ts' });
+      expect(formatToolArgs('Agent', args)).toBe('src/app.ts');
+    });
+  });
+
+  describe('path-bearing tools', () => {
+    it('shows the last two segments of "path"', () => {
+      expect(formatToolArgs('Read', JSON.stringify({ path: '/a/b/c/d.ts' }))).toBe('c/d.ts');
+    });
+
+    it('shows the last two segments of "file_path"', () => {
+      expect(formatToolArgs('Read', JSON.stringify({ file_path: '/a/b/c/d.ts' }))).toBe('c/d.ts');
+    });
+
+    it('shows the last two segments of "filePath"', () => {
+      expect(formatToolArgs('Read', JSON.stringify({ filePath: '/a/b/c/d.ts' }))).toBe('c/d.ts');
+    });
+
+    it('prefers "path" over "file_path" when both are present', () => {
+      const args = JSON.stringify({ path: '/from/path.ts', file_path: '/from/file_path.ts' });
+      expect(formatToolArgs('Read', args)).toBe('from/path.ts');
+    });
+
+    it('returns a bare filename unchanged when there is no directory', () => {
+      expect(formatToolArgs('Read', JSON.stringify({ path: 'README.md' }))).toBe('README.md');
+    });
+
+    it('QUIRK: a Windows-style backslash path is not split, so it is shown whole', () => {
+      const args = JSON.stringify({ path: 'C:\\repo\\src\\app.ts' });
+      expect(formatToolArgs('Read', args)).toBe('C:\\repo\\src\\app.ts');
+    });
+  });
+
+  describe('JSON fallback', () => {
+    it('re-serializes args that match no specialized branch', () => {
+      expect(formatToolArgs('Grep', JSON.stringify({ pattern: 'TODO' }))).toBe(
+        '{"pattern":"TODO"}'
+      );
+    });
+
+    it('truncates the re-serialized fallback to 100 characters', () => {
+      const args = JSON.stringify({ pattern: 'z'.repeat(250) });
+      expect(formatToolArgs('Grep', args)).toHaveLength(100);
+    });
+
+    it('QUIRK: re-serialization normalizes whitespace and key order is preserved as parsed', () => {
+      expect(formatToolArgs('Grep', '{ "pattern" :  "TODO" }')).toBe('{"pattern":"TODO"}');
+    });
+  });
+
+  describe('branch precedence', () => {
+    it('todo wins over bash when a tool name contains both', () => {
+      const args = JSON.stringify({ todos: [{ content: 'a' }], command: 'ls' });
+      expect(formatToolArgs('bash_todo', args)).toBe('Updating 1 tasks');
+    });
+
+    it('bash wins over path when a bash call also carries a file_path', () => {
+      const args = JSON.stringify({ command: 'cat x', file_path: '/a/b/c.ts' });
+      expect(formatToolArgs('bash', args)).toBe('cat x');
+    });
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/blocks/render-assertions.ts
+++ b/packages/dashboard/tests/client/components/chat/blocks/render-assertions.ts
@@ -1,0 +1,31 @@
+import { expect } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import type { Matcher } from '@testing-library/react';
+
+/**
+ * Shared assertions for the chat-block render suites.
+ *
+ * These exist because `expect(screen.getByText(x)).toBeDefined()` cannot fail:
+ * `getByText` throws when nothing matches and otherwise returns an element,
+ * which is always defined — the query does all the work and the matcher adds
+ * nothing (test-craft TEST-R002). Asserting cardinality instead gives a matcher
+ * that can genuinely fail, catches accidental duplicate rendering, and carries
+ * a failure message that names the expected text (TEST-R008).
+ */
+
+function queries(scope?: HTMLElement) {
+  return scope ? within(scope) : screen;
+}
+
+/** Asserts exactly one node matching `text` is rendered, and returns it. */
+export function expectRenderedOnce(text: Matcher, scope?: HTMLElement): HTMLElement {
+  const matches = queries(scope).queryAllByText(text);
+  expect(matches, `expected exactly one rendered node matching ${String(text)}`).toHaveLength(1);
+  return matches[0] as HTMLElement;
+}
+
+/** Asserts nothing matching `text` is rendered. */
+export function expectNotRendered(text: Matcher, scope?: HTMLElement): void {
+  const matches = queries(scope).queryAllByText(text);
+  expect(matches, `expected no rendered node matching ${String(text)}`).toHaveLength(0);
+}


### PR DESCRIPTION
Characterization tests for the six untested presentational components in
`packages/dashboard/src/client/components/chat/blocks/`, plus the pure
`format-tool-args` helper and the three small siblings they render through.

These components render the entire assistant transcript, so regressions in them
are user-visible and silent. There was effectively no coverage here.

Refs #2016

## What this is (and is not)

These tests **characterize current behavior as-is**. They are not a statement of
desired behavior. Where the current behavior is odd, the test pins it and says so
in the test name (`QUIRK: ...`), so an intentional future change fails loudly
instead of drifting silently. **No source file is modified.**

Every test asserts visible text, ARIA/DOM structure, or a dispatched event —
no snapshots, and no import-only or assertion-free tests (verified: 200 `it`
blocks scanned, 0 without an assertion).

## Coverage: before → after

Measured with the same command on both sides, at base `b72ede296`:

```
npx vitest run --project client --coverage --coverage.provider=v8 --coverage.all \
  --coverage.include='src/client/components/chat/blocks/**' --coverage.exclude='**/*.test.*'
```

(The explicit include/exclude is required — `vitest.config.mts` excludes `src/client/**` from coverage by default.)

| File | Stmts | Branch | Funcs | Lines |
| --- | --- | --- | --- | --- |
| **Directory aggregate** | **0.48% → 98.53%** | **0% → 97.89%** | **0% → 96%** | **0.52% → 98.95%** |
| ActivityGroup.tsx | 0% → 100% | 0% → 96.77% | 0% → 100% | 0% → 100% |
| AgentBlockView.tsx | 0% → 100% | 0% → 100% | 0% → 100% | 0% → 100% |
| StreamingIndicator.tsx | 3.33% → 100% | 0% → 100% | 0% → 100% | 3.33% → 100% |
| TextBlockView.tsx | 0% → 100% | 0% → 88.88% | 0% → 100% | 0% → 100% |
| TodoBlockView.tsx | 0% → 100% | 0% → 100% | 0% → 100% | 0% → 100% |
| ToolUseBlockView.tsx | 0% → 96.29% | 0% → 98.59% | 0% → 87.5% | 0% → 96.15% |
| format-tool-args.ts | 0% → 96.55% | 0% → 97.29% | 0% → 100% | 0% → 100% |
| LogOutputView.tsx | 0% → 100% | 0% → 100% | 0% → 100% | 0% → 100% |
| StatusBlockView.tsx | 0% → 100% | 0% → 100% | 0% → 100% | 0% → 100% |
| ThinkingBlockView.tsx | 0% → 100% | 0% → 100% | 0% → 100% | 0% → 100% |

Local runs: 203 tests in the new directory; **996/996 passing** across the whole
`client` project (105 files), so nothing existing broke.

## Assumptions made

- **Characterized current behavior as-is.** Where behavior looked wrong, the test
  pins what the code does today and is labelled a quirk or a known defect. Nothing
  under `src/` was changed.
- **`framer-motion` renders for real** under jsdom in every suite except one.
  `StreamingIndicator.rotation.test.tsx` stubs it, because the phrase sits inside
  `AnimatePresence mode="wait"`, which keeps the *outgoing* node mounted until an
  exit animation completes — and framer-motion's frameloop does not advance under
  jsdom + fake timers. With the real library the phrase never visibly swaps, so the
  rotation logic would be untestable. The reason is documented in the file, and the
  sibling suite pins the real-library behavior instead.
- **`Math.random` is left real.** The rotation loop is a `do/while` that retries
  until it draws a *different* index, so a constant-valued stub would spin forever.
  Assertions pin the guaranteed properties (catalog membership, "never repeats
  consecutively") rather than one particular draw.
- **The phrase catalog is mirrored into the test** so edits to it fail loudly.
- **Sibling structured-result viewers** (`FindingsView` / `AdviseSkillsView` /
  `GraphImpactView`) are exercised only as far as `AgentBlockView`'s routing
  decision; their internals are covered by their own suites.
- Coverage below 100% is the intentionally unreached remainder (e.g. the dead
  todo-parsing branch noted below), not an oversight.

## Skills run

- **`harness:tdd`** — authored all 8 files. Since the code already exists and must
  not change, the RED contract was applied in its characterization form: predict the
  behavior, run, and watch the wrong predictions fail. Four genuine REDs came back
  (an ambiguous matcher, a duplicate-name collision, the `AnimatePresence` freeze,
  and the crash below). Because most predictions passed first try, the suite was
  additionally proven to bite via a **mutation-sensitivity probe**: three seeded
  mutations in a scratch copy of `format-tool-args.ts` failed 10 tests.
- **`harness:test-craft`** — critiqued the suites against its 8 rubrics (128 prompts,
  16 tests sampled; `testsTruncated: 184`, so findings are a floor). It returned
  4 findings, all applied:
  - `TEST-R002` *(foundational/large)* — `expect(PROCESSING_PHRASES).toContain(currentPhrase())`
    could never fail, because the helper looked the phrase up **by catalog membership**.
    Genuine coverage theater. The phrase is now read out of the DOM independently of
    the catalog, so a phrase that drifts out of it actually fails.
  - `TEST-R002` *(foundational/medium)* — `expect(screen.getByText(x)).toBeDefined()` is a
    tautology on a throwing query. Applied repo-wide across these files via a shared
    `expectRenderedOnce` / `expectNotRendered` helper that asserts **cardinality** and
    carries a descriptive failure message — which also catches duplicate rendering.
  - `TEST-R002` *(polish)* — "renders an args preview **beside the tool name**" asserted
    no adjacency; now scoped to the header row.
  - `TEST-R006` *(polish)* — two tests covered the same `if (!args) return ''` guard;
    merged into one `it.each`.

  Applying the same rubric to my own work also removed a tautological
  "test-suite hygiene" test I had written.

## Parked — defects found, deliberately not fixed

Found while characterizing; pinned as current behavior, not repaired.

1. **`AdviseSkillsView` crashes the transcript** when an `advise_skills` result's
   matches omit `reasons` — the guard validates only `skill`/`score` but `SkillCard`
   dereferences `match.reasons`. Filed as **#2017** with a full repro. Pinned by the
   `KNOWN DEFECT (characterized, not fixed)` test in `AgentBlockView.test.tsx`, which
   asserts the throw — whoever fixes it must flip that test.
2. **Dead code in `ToolUseBlockView`** — it parses `block.args.todos` into a `todos`
   local that feeds only `_hasExpandedContent`, which is never read. A `TodoWrite`
   tool renders no task list here (`TodoBlockView` owns that). Pinned by
   *"QUIRK: a todo tool's parsed tasks are never rendered by this view"*.
3. **`isLogOutput` is far too eager** — it returns true on `matches > 0`, so a *single*
   log-looking line routes an entire prose block into the terminal frame. Ordinary
   prose beginning with a slashed path, or markdown whose fenced code contains an
   `import`, is misread as terminal output and loses markdown rendering. Pinned by
   three `QUIRK:` tests in `TextBlockView.test.tsx`.

Minor, not filed: `formatToolArgs` renders "Updating 1 tasks"; its `cd ... &&`
stripper is global rather than leading-only, so `cd /a && ls && cd /b && pwd`
previews as `ls && pwd`.
