### PR TITLE
craft(cli): extract reportSemanticRegression out of comprehend runCheckMode

### DIFF
--- a/.changeset/comprehend-runcheckmode-altitude-1743.md
+++ b/.changeset/comprehend-runcheckmode-altitude-1743.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/cli': patch
+---
+
+craft(code): lift the `--since` semantic-regression narrative out of `comprehend --check`
+
+`runCheckMode` opened as a tidy freshness reporter and then dropped an altitude into
+the `--since` regression story — base/head ref reads, unreadable-ref handling,
+`pr`-vs-`main` branching, three logger calls — all inlined in the same body.
+
+That narrative now lives in `reportSemanticRegression(since, context, deps, log)`,
+which returns `{ regressed, refUnreadable }`; `runCheckMode` feeds it and consumes the
+verdict, so the outer function tells one story. Behaviour-preserving: the moved logger
+strings are byte-identical, `runCheckMode`'s signature is unchanged, and no CLI flag or
+output changed.
+
+Because the git seam and the logger are both injected, the gate is now unit-testable —
+including the "refuse to report a pass on an unreadable ref" invariant, which had no
+test anywhere before.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: 'a0c6f607fdd179f37591b2524ff7ebac61416231f42e61f42a8289ce86df3bc4'
+sourceHash: '300d3214ecb0f51147e94555479dbc9a9cd2358b3608f03e6aafbdf04a38a504'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -316,6 +316,7 @@ export readReview
 export referencesTargetPr
 export refreshExitCode
 export renderTable
+export reportSemanticRegression
 export resolveBaseRef
 export resolveCandidates
 export resolveChangedScope
@@ -417,7 +418,7 @@ import { shouldRunComprehendHook } from '../comprehension/hook'
 import { enumerateModules, filesToModules } from '../comprehension/invalidation'
 import { committedSemanticAllowed } from '../comprehension/policy'
 import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../comprehension/refresh-gate'
-import { RegressionContext, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
+import { RefReadDeps, RegressionContext, SemanticState, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
 import { createStaticExtractor } from '../comprehension/static-extractor'
 import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js'
 import { findConfigFile, loadConfig, resolveConfig } from '../config/loader'
@@ -530,7 +531,7 @@ import { createCleanupSessionsCommand } from './cleanup-sessions'
 import { createCliErgonomicsCraftCommand } from './cli-ergonomics-craft'
 import { createCodeCraftCommand } from './code-craft'
 import { createCompoundCommand } from './compound'
-import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
+import { createComprehendCommand, formatCompiledUnits, reportSemanticRegression, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
 import { createComprehensionMergeDriverCommand } from './comprehension-merge-driver'
 import { createContextDictionaryCommand } from './context-dictionary'
 import { createCopyCraftCommand } from './copy-craft'

--- a/docs/changes/comprehend-runcheckmode-altitude/plans/2026-09-08-extract-report-semantic-regression-plan.md
+++ b/docs/changes/comprehend-runcheckmode-altitude/plans/2026-09-08-extract-report-semantic-regression-plan.md
@@ -1,0 +1,45 @@
+# Plan — extract `reportSemanticRegression` out of `runCheckMode`
+
+- **Spec:** `docs/changes/comprehend-runcheckmode-altitude/proposal.md`
+- **Issue:** #1743 (CODE-R003, craft-fleet `code-craft` finding, runId `0b56dbcd-7703-4b4e-aea9-4cdce91fe07c`)
+- **Base SHA:** `418f5e188`
+- **Route:** feature (harness-brainstorming → harness-autopilot)
+- **Character:** behaviour-preserving refactor. Every task below is verified against the
+  "no observable change" invariant, not against new behaviour.
+
+## Task graph
+
+| #   | Task                                                                                                                                                                                                                                                                                                                                         | Files                                          | Depends on | Checkpoint                                                                                                                                              |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | Add `SemanticRegressionReport` interface and `reportSemanticRegression(since, context, deps, log = logger)` immediately above `runCheckMode`. Move the `--since` body verbatim; rewrite `logger.x` → `log.x`; carry the ADR 0109 §4 / ADR 0116 §4 rationale comment onto the new function.                                                   | `packages/cli/src/commands/comprehend.ts`      | —          | Function compiles; `runCheckMode` still contains the old block (not yet removed) is NOT acceptable — T1 and T2 land together.                           |
+| T2  | Replace the `--since` block in `runCheckMode` with the destructured call; keep `const context = opts.context ?? 'main'` and the `ok` computation in place and in order.                                                                                                                                                                      | `packages/cli/src/commands/comprehend.ts`      | T1         | `runCheckMode` signature unchanged; `git diff` shows no edit to the `ciMode`, `runComprehendCheck`, stale-reporting, `refresh` or `process.exit` lines. |
+| T3  | Add `import type { RefReadDeps }` to the existing `../comprehension/regression` import group.                                                                                                                                                                                                                                                | `packages/cli/src/commands/comprehend.ts`      | T1         | Typecheck clean; no new import statement (extends the existing one).                                                                                    |
+| T4  | Add `describe('reportSemanticRegression — the --since gate contract')` to the co-located unit test, with a `makeDeps()` helper building an in-memory `RefReadDeps` and a `makeLog()` returning `vi.fn()` spies. Five cases: unreadable base; unreadable HEAD; `pr` with committed-semantic addition; `main` with a regression; `main` clean. | `packages/cli/src/commands/comprehend.test.ts` | T2         | Each case asserts BOTH the returned pair and the logger channel used. No git, no disk, no `process.exit`.                                               |
+| T5  | Build + verify.                                                                                                                                                                                                                                                                                                                              | —                                              | T4         | See Verification.                                                                                                                                       |
+
+## Verification (each must pass before commit)
+
+1. `pnpm turbo build` (Node 22) — required by the pre-commit architecture hook, and `packages/cli`
+   is the touched package.
+2. `pnpm --filter @harness-engineering/cli exec tsc --noEmit` (or the package's typecheck script).
+3. `pnpm --filter @harness-engineering/cli exec vitest run src/commands/comprehend.test.ts tests/comprehension`
+   — the pre-existing files must pass **unmodified** apart from T4's additive block.
+4. `pnpm --filter @harness-engineering/cli exec vitest run tests/e2e/comprehend-boundary.e2e.test.ts tests/comprehension/comprehend-e2e.test.ts tests/comprehension/comprehend-smoke.e2e.test.ts`
+   — the observable-CLI-behaviour backstop.
+5. `git diff --stat` shows exactly two files: `comprehend.ts` and `comprehend.test.ts` (plus the
+   `docs/changes/**` artifacts).
+6. `pnpm run format:check` clean; **no** `pnpm run generate-docs` delta (a delta means the CLI
+   surface changed ⇒ overreach ⇒ revert).
+
+## Rollback
+
+Single commit, two source files, no schema or barrel change. `git revert` restores `418f5e188`
+behaviour exactly.
+
+## Risks
+
+| Risk                                                                                                                                                                                                                               | Mitigation                                                                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Silent behaviour change in the unreadable-ref branch (the one path with no pre-existing test coverage anywhere in the repo — `grep -rn "since" --include="*.test.ts"` over `tests/comprehension` and `tests/e2e` returns nothing). | T4 pins it explicitly, including that the detector is never invoked once a ref is unreadable.           |
+| Scope creep into neighbouring `runCheckMode` concerns (`ciMode`, refresh main-pass).                                                                                                                                               | T2's checkpoint is a `git diff` assertion that those lines are untouched. One finding, one item.        |
+| Drift in `docs/reference/cli-commands.md` blocking pre-push.                                                                                                                                                                       | Verification step 6 — a delta is treated as evidence of overreach, not as something to regenerate past. |

--- a/docs/changes/comprehend-runcheckmode-altitude/proposal.md
+++ b/docs/changes/comprehend-runcheckmode-altitude/proposal.md
@@ -1,0 +1,119 @@
+# Extract `reportSemanticRegression` out of `runCheckMode`
+
+> Craft elevation for CODE-R003 (issue #1743). Behaviour-preserving altitude split of the
+> `harness comprehend --check` entrypoint.
+
+## Overview and goals
+
+`runCheckMode` in `packages/cli/src/commands/comprehend.ts` opens as a tidy freshness reporter —
+resolve the CI mode, run the compile check, warn on skips, report stale units — and then drops a
+full altitude into the `--since` semantic-regression narrative: base/head ref reads, unreadable-ref
+handling, `pr`-vs-`main` branching, and three separate logger calls, all inlined into the same
+function body [evidence: `packages/cli/src/commands/comprehend.ts:254-342`].
+
+The goal is to leave the outer function telling **one** story ("is the comprehension substrate
+fresh, and what is the exit verdict?") by lifting the regression narrative into a named
+`reportSemanticRegression(...)` that returns a `{ regressed, refUnreadable }` pair.
+
+**Non-goal:** any change to observable CLI behaviour, to `runCheckMode`'s signature, or to the
+`--since` gate's verdict semantics. This is a pure altitude split.
+
+**Strategy grounding:** advances the _Ceiling-raising via LLM judgment_ track — this item is a
+`code-craft` finding elevated through the craft pipeline, which is exactly the loop that track
+funds [evidence: `STRATEGY.md#tracks`].
+
+## Decisions made
+
+| #   | Decision                                                                                                                          | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | The extracted function stays **in `comprehend.ts`** (exported for tests) rather than moving to `src/comprehension/regression.ts`. | The finding scopes the surface as "within-unit, signature unchanged". `regression.ts` is deliberately a **pure, logger-free** detection module (`detectSemanticRegressions`, `readSemanticMapAtRef`) [evidence: `packages/cli/src/comprehension/regression.ts:1-160`]; pushing user-facing logger prose into it would smear the reporting/detection boundary that module currently holds cleanly. `comprehend.ts` already owns the CLI-narration layer. |
+| D2  | The function takes the git seam (`RefReadDeps`) as a **required parameter**, not as an internally-constructed default.            | `runCheckMode` already owns `opts.projectRoot` and is the only caller; passing `defaultRefReadDeps(opts.projectRoot)` in keeps the extracted function disk- and git-free, so its contract is unit-testable without a git fixture.                                                                                                                                                                                                                       |
+| D3  | The logger is an **injected seam with a `logger` default**, typed `Pick<typeof logger, 'error' \| 'warn' \| 'success'>`.          | Matches the file's established seam convention — `stageCompiledUnits(..., stage = defaultStagePaths, format = defaultFormatPaths)` and `resolveChangedScope(surface, { warn }, ...)` [evidence: `packages/cli/src/commands/comprehend.ts:119,237`] — so the new code reads like its neighbours and its three log lines are assertable.                                                                                                                  |
+| D4  | The `if (opts.since)` guard stays **at the call site**; the extracted function assumes a `since` ref.                             | Keeps the extracted function total (no "did nothing" third state) and keeps the `{ regressed: [], refUnreadable: false }` no-`--since` default visible in the outer function, where the verdict is computed.                                                                                                                                                                                                                                            |
+| D5  | The `context` default (`opts.context ?? 'main'`) stays resolved **at the call site** and is passed in explicitly.                 | The default is a CLI-flag concern, not a reporting concern; the extracted function should be honest that the context is always supplied.                                                                                                                                                                                                                                                                                                                |
+
+## Technical design
+
+### New exported surface (`packages/cli/src/commands/comprehend.ts`)
+
+```ts
+/** The `--since` gate's two outputs: which modules regressed, and whether a ref was unreadable. */
+export interface SemanticRegressionReport {
+  /** Modules that regressed `present → absent` (always `[]` under `context: 'pr'`). */
+  regressed: string[];
+  /** True when base or HEAD could not be read — refuse to report a pass. */
+  refUnreadable: boolean;
+}
+
+export function reportSemanticRegression(
+  since: string,
+  context: RegressionContext,
+  deps: RefReadDeps,
+  log: Pick<typeof logger, 'error' | 'warn' | 'success'> = logger
+): SemanticRegressionReport;
+```
+
+### Behaviour moved (verbatim, not rewritten)
+
+1. `readSemanticMapAtRef(since, deps)` and `readSemanticMapAtRef('HEAD', deps)`.
+2. Unreadable-ref path: either map `null` ⇒ `refUnreadable = true`, `log.error(...)` naming which
+   ref failed, and **no** regression detection runs.
+3. `context: 'pr'` path: `detectCommittedSemanticOnBranch` advisory `log.warn` when non-empty, then
+   the `log.success` "static-only PR path" line. `regressed` stays `[]` (the detector itself already
+   short-circuits `pr` to `[]`).
+4. `context: 'main'` path: `log.error` listing the regressed modules when non-empty, else the
+   `log.success` "no semantic regressions" line.
+
+### `runCheckMode` after the split
+
+```ts
+const context: RegressionContext = opts.context ?? 'main';
+const { regressed, refUnreadable } = opts.since
+  ? reportSemanticRegression(opts.since, context, defaultRefReadDeps(opts.projectRoot))
+  : { regressed: [] as string[], refUnreadable: false };
+```
+
+The `ok` computation (`result.ok && regressed.length === 0 && !refUnreadable`) and the `ciMode ===
+'refresh'` main-pass block are untouched, in their existing order.
+
+## Integration points
+
+- **Entry Points** — none created. `harness comprehend --check [--since <ref>] [--context pr|main]`
+  is unchanged; `reportSemanticRegression` is a module-internal export consumed only by
+  `runCheckMode` and by the co-located unit test.
+- **Registrations Required** — none. The symbol is not re-exported from any barrel and is not part
+  of `@harness-engineering/core`, so `scripts/generate-core-barrel.mjs` needs no allowlist edit.
+- **Documentation Updates** — none. No CLI flag, command, or output string changes, so
+  `docs/reference/cli-commands.md` does not drift.
+- **Architectural Decisions** — None. A within-unit extraction with an unchanged public surface does
+  not rise to an ADR.
+- **Knowledge Impact** — None new; the ADR 0109 §4 / ADR 0116 §4 rationale that motivates the gate
+  moves with the code as its doc comment.
+
+## Success criteria
+
+1. **When** `harness comprehend --check --since <ref>` runs and both refs read cleanly and no module
+   regressed, **the system shall** exit `SUCCESS` and emit exactly the same success line as before.
+2. **If** either the base ref or `HEAD` is unreadable, **then the system shall not** report a pass:
+   `reportSemanticRegression` returns `refUnreadable: true`, logs an error naming which ref failed,
+   and never calls the regression detector.
+3. **When** `context` is `'pr'` and the branch committed semantic, **the system shall** emit the
+   advisory warning and the static-only success line, and return `regressed: []`.
+4. **When** `context` is `'main'` and modules regressed, **the system shall** return those modules in
+   `regressed` and log the error listing them.
+5. `runCheckMode`'s signature is byte-identical to `418f5e188`, and every pre-existing test in
+   `packages/cli/src/commands/comprehend.test.ts`, `packages/cli/tests/comprehension/**`, and
+   `packages/cli/tests/e2e/comprehend-*.e2e.test.ts` passes **unmodified**.
+6. New unit tests pin the `{ regressed, refUnreadable }` contract on all four paths above, with the
+   git seam injected (no git, no disk).
+
+## Implementation order
+
+1. **Phase 1 — extract.** Add `SemanticRegressionReport` + `reportSemanticRegression` above
+   `runCheckMode`; move the `--since` block into it verbatim (logger calls become `log.*`); replace
+   the block in `runCheckMode` with the destructuring call.
+2. **Phase 2 — pin.** Add a `describe('reportSemanticRegression …')` block to
+   `packages/cli/src/commands/comprehend.test.ts` covering unreadable-base, unreadable-HEAD, the
+   `pr` advisory + success path, `main`-with-regressions, and `main`-clean.
+3. **Phase 3 — verify.** `pnpm turbo build`, typecheck, run the comprehension test surface plus the
+   `comprehend` e2e suites; confirm no `docs/reference/*` drift.

--- a/docs/changes/comprehend-runcheckmode-altitude/provenance.json
+++ b/docs/changes/comprehend-runcheckmode-altitude/provenance.json
@@ -1,0 +1,31 @@
+{
+  "issues": [1743],
+  "route": "feature",
+  "stages": ["brainstorming", "autopilot", "planning", "execution", "verification"],
+  "assumptions": [
+    "Autonomous fleet lane: the harness-brainstorming human sign-off gate and the section-by-section spec review were satisfied by the roadmap-fleet lane brief, which pre-confirmed the route (feature) and the prescribed shape (extract reportSemanticRegression returning {regressed, refUnreadable}). The spec was written in one pass rather than section-by-section because no human was available to review between sections.",
+    "D1 — the extracted function stays IN packages/cli/src/commands/comprehend.ts (exported for tests) rather than moving to src/comprehension/regression.ts. The finding scopes the surface as within-unit, and regression.ts is deliberately a pure, logger-free detection module; moving user-facing logger prose into it would smear that boundary.",
+    "D2 — RefReadDeps is a REQUIRED parameter supplied by the caller (defaultRefReadDeps(opts.projectRoot)) rather than constructed internally, so the extracted function is git- and disk-free and unit-testable without a fixture repo.",
+    "D3 — the logger is an injected seam defaulting to `logger`, typed Pick<typeof logger, 'error' | 'warn' | 'success'>, matching the file's existing seam convention (stageCompiledUnits, resolveChangedScope).",
+    "D4 — the `if (opts.since)` guard and the `opts.context ?? 'main'` default both stay at the call site, keeping the extracted function total and keeping the verdict computation visible in runCheckMode.",
+    "The four moved logger message strings are byte-identical to base; only the receiver changed (logger.x -> log.x). No observable CLI output changed.",
+    "No roadmap promotion was performed by this lane: the roadmap mutation for #1743 is the conductor's responsibility, and manage_roadmap is not worktree-aware (issue #1507)."
+  ],
+  "planArtifact": "docs/changes/comprehend-runcheckmode-altitude/plans/2026-09-08-extract-report-semantic-regression-plan.md",
+  "specArtifact": "docs/changes/comprehend-runcheckmode-altitude/proposal.md",
+  "baseSha": "418f5e188",
+  "finding": {
+    "id": "CODE-R003",
+    "runId": "0b56dbcd-7703-4b4e-aea9-4cdce91fe07c",
+    "cite": "packages/cli/src/commands/comprehend.ts:254-342",
+    "source": "craft-fleet code-craft"
+  },
+  "verification": [
+    "pnpm turbo build --filter=@harness-engineering/cli — green",
+    "tsc --noEmit (packages/cli) — clean",
+    "vitest run src/commands/comprehend.test.ts tests/comprehension — 13 files, 202 passed / 1 skipped",
+    "vitest run tests/e2e/comprehend-boundary.e2e.test.ts — passed",
+    "git diff --stat — exactly comprehend.ts + comprehend.test.ts (plus docs/changes artifacts)",
+    "pnpm run generate-docs — no docs/reference delta (CLI surface unchanged)"
+  ]
+}

--- a/packages/cli/src/commands/comprehend.test.ts
+++ b/packages/cli/src/commands/comprehend.test.ts
@@ -6,9 +6,11 @@ import {
   resolveStaticOnlyPosture,
   formatCompiledUnits,
   stageCompiledUnits,
+  reportSemanticRegression,
 } from './comprehend';
 import type { ComprehensionConfig } from '../config/schema';
 import type { ChangedSurface } from './validate-scope';
+import type { RefReadDeps, SemanticState } from '../comprehension/regression';
 
 /**
  * Behavior contract for the exported resolution + shard-output helpers of
@@ -154,5 +156,109 @@ describe('formatCompiledUnits / stageCompiledUnits — shard output seams', () =
     await stageCompiledUnits({ compiled: ['a'] }, store, stage, format);
     expect(order).toEqual(['format', 'stage']);
     expect(stage).toHaveBeenCalledWith(['.harness/comprehension/a/_module.md']);
+  });
+});
+
+/**
+ * #1743 / CODE-R003 — contract of the `--since` regression narrative extracted out of
+ * `runCheckMode`. This is the gate's only unit coverage: before the extraction the whole
+ * block was inlined behind a `process.exit` and untestable, so the unreadable-ref refusal
+ * (the "never report a false green" invariant) had no test anywhere in the repo. Both the
+ * git seam and the logger are injected — no git, no disk, no process exit.
+ */
+describe('reportSemanticRegression — the --since gate contract', () => {
+  const shardPath = (module: string) => `.harness/comprehension/${module}/_module.md`;
+  const shard = (module: string, semantic: SemanticState) =>
+    `module: ${module}\nsemantic: ${semantic}\n`;
+
+  /** In-memory RefReadDeps. A `null` ref models an unfetched / bad / git-errored ref. */
+  const makeDeps = (refs: Record<string, Record<string, SemanticState> | null>): RefReadDeps => ({
+    listShardsAtRef: (ref) => {
+      const modules = refs[ref];
+      return modules ? Object.keys(modules).map(shardPath) : null;
+    },
+    showAtRef: (ref, path) => {
+      const modules = refs[ref];
+      if (!modules) return null;
+      const hit = Object.entries(modules).find(([module]) => shardPath(module) === path);
+      return hit ? shard(hit[0], hit[1]) : null;
+    },
+  });
+
+  const makeLog = () => ({ error: vi.fn(), warn: vi.fn(), success: vi.fn() });
+
+  it('refuses to report a pass when the BASE ref is unreadable', () => {
+    const log = makeLog();
+    const deps = makeDeps({ 'origin/main': null, HEAD: { a: 'present' } });
+    expect(reportSemanticRegression('origin/main', 'main', deps, log)).toEqual({
+      regressed: [],
+      refUnreadable: true,
+    });
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("base ref 'origin/main'"));
+    // No comparison happened, so the gate must not narrate a verdict either way.
+    expect(log.success).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("names 'HEAD' when it is HEAD that is unreadable", () => {
+    const log = makeLog();
+    const deps = makeDeps({ 'origin/main': { a: 'present' }, HEAD: null });
+    expect(reportSemanticRegression('origin/main', 'main', deps, log)).toEqual({
+      regressed: [],
+      refUnreadable: true,
+    });
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("'HEAD'"));
+    expect(log.success).not.toHaveBeenCalled();
+  });
+
+  it("context 'pr': never flags present→absent, and advisory-warns on a committed-semantic addition", () => {
+    const log = makeLog();
+    const deps = makeDeps({ base: { a: 'absent' }, HEAD: { a: 'present' } });
+    expect(reportSemanticRegression('base', 'pr', deps, log)).toEqual({
+      regressed: [],
+      refUnreadable: false,
+    });
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('COMMITTED semantic'));
+    expect(log.success).toHaveBeenCalledWith(expect.stringContaining('Static-only PR path'));
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("context 'pr': the expected present→absent downgrade is silent (no warn, no regression)", () => {
+    const log = makeLog();
+    const deps = makeDeps({ base: { a: 'present' }, HEAD: { a: 'absent' } });
+    expect(reportSemanticRegression('base', 'pr', deps, log)).toEqual({
+      regressed: [],
+      refUnreadable: false,
+    });
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.success).toHaveBeenCalledWith(expect.stringContaining('Static-only PR path'));
+  });
+
+  it("context 'main': returns exactly the regressed modules and errors listing them", () => {
+    const log = makeLog();
+    const deps = makeDeps({
+      base: { a: 'present', b: 'present' },
+      HEAD: { a: 'absent', b: 'present' },
+    });
+    expect(reportSemanticRegression('base', 'main', deps, log)).toEqual({
+      regressed: ['a'],
+      refUnreadable: false,
+    });
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('1 module(s) regressed'));
+    expect(log.success).not.toHaveBeenCalled();
+  });
+
+  it("context 'main': reports a clean pass when nothing lost semantic", () => {
+    const log = makeLog();
+    const deps = makeDeps({ base: { a: 'present' }, HEAD: { a: 'present' } });
+    expect(reportSemanticRegression('base', 'main', deps, log)).toEqual({
+      regressed: [],
+      refUnreadable: false,
+    });
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('No semantic regressions on `main` vs base')
+    );
+    expect(log.error).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/comprehend.ts
+++ b/packages/cli/src/commands/comprehend.ts
@@ -28,6 +28,7 @@ import {
   detectCommittedSemanticOnBranch,
   readSemanticMapAtRef,
   defaultRefReadDeps,
+  type RefReadDeps,
   type RegressionContext,
 } from '../comprehension/regression';
 import type { ComprehensionConfig } from '../config/schema';
@@ -251,6 +252,89 @@ function loadHarnessConfig(configPath?: string): HarnessConfig | undefined {
   return resolved.ok ? resolved.value : undefined;
 }
 
+/** The two outputs of the `--since` semantic-regression gate, as the verdict consumes them. */
+export interface SemanticRegressionReport {
+  /**
+   * Modules that regressed `present → absent` versus the base ref. Always `[]`
+   * under `context: 'pr'` (where the downgrade is the designed outcome) and
+   * always `[]` when a ref was unreadable (nothing was compared).
+   */
+  regressed: string[];
+  /**
+   * True when the base ref or `HEAD` could not be read. Distinct from "no
+   * regressions": the caller must refuse to report a pass rather than treat an
+   * unreadable ref as a clean comparison.
+   */
+  refUnreadable: boolean;
+}
+
+/** Logger channels the regression narrative uses; injectable so the prose is assertable. */
+type RegressionLog = Pick<typeof logger, 'error' | 'warn' | 'success'>;
+
+/**
+ * ADR 0109 slice 4 / ADR 0116 §4 — token-free semantic-regression gate versus a
+ * base ref, and the whole user-facing narrative around it. Base and head are read
+ * the SAME way (committed shards via git + lenient frontmatter parse), so a shard
+ * cannot be counted as "present" on one side and dropped on the other. An
+ * unreadable ref fails LOUD — never a silent pass.
+ *
+ * The `context` reframes WHAT is a regression (ADR 0116 §4):
+ *  - `'main'` (default, post-merge): `present → absent` means `main` LOST
+ *    semantic — a real regression the single-writer main-pass must never produce.
+ *  - `'pr'` (the static-only PR path): `present → absent` is EXPECTED (semantic
+ *    deferred to `main`) and NEVER a regression — killing the per-PR false
+ *    positive. Instead we advisory-warn on any committed-semantic ADDITION, which
+ *    a static-only PR should not carry (single-writer, ADR 0116 §1).
+ *
+ * Extracted from `runCheckMode` (#1743 / CODE-R003) so the check entrypoint tells
+ * ONE story — "is the substrate fresh, and what is the verdict?" — while this
+ * function owns the regression story end to end. Behavior is unchanged: the git
+ * seam is injected by the caller (`defaultRefReadDeps(projectRoot)`), so this
+ * function itself is disk- and git-free.
+ */
+export function reportSemanticRegression(
+  since: string,
+  context: RegressionContext,
+  deps: RefReadDeps,
+  log: RegressionLog = logger
+): SemanticRegressionReport {
+  const base = readSemanticMapAtRef(since, deps);
+  const head = readSemanticMapAtRef('HEAD', deps);
+  if (base === null || head === null) {
+    const which = base === null ? `base ref '${since}'` : "'HEAD'";
+    log.error(
+      `Could not read ${which} for the semantic-regression check (unfetched / bad ref / ` +
+        `git error). Refusing to report a pass — fetch the ref and re-run.`
+    );
+    return { regressed: [], refUnreadable: true };
+  }
+
+  const regressed = detectSemanticRegressions(base, head, context);
+  if (context === 'pr') {
+    const committed = detectCommittedSemanticOnBranch(base, head);
+    if (committed.length > 0) {
+      log.warn(
+        `${committed.length} module(s) COMMITTED semantic on a branch vs ${since}: ` +
+          `${committed.join(', ')}. Under single-writer (ADR 0116 §1) PRs are static-only — ` +
+          `semantic belongs to the \`main\` main-pass. This is advisory (not a failure).`
+      );
+    }
+    log.success(
+      `Static-only PR path: \`present → absent\` is expected (semantic deferred to \`main\`, ` +
+        `ADR 0116 §4) — no semantic regression flagged.`
+    );
+  } else if (regressed.length > 0) {
+    log.error(
+      `${regressed.length} module(s) regressed semantic present→absent on \`main\` vs ` +
+        `${since}: ${regressed.join(', ')}. The single-writer main-pass must never lose ` +
+        `semantic — regenerate (provider-backed 'harness comprehend --all') and commit to main.`
+    );
+  } else {
+    log.success(`No semantic regressions on \`main\` vs ${since}.`);
+  }
+  return { regressed, refUnreadable: false };
+}
+
 async function runCheckMode(
   store: ComprehensionStore,
   reader: ReturnType<typeof createNodeModuleSourceReader>,
@@ -278,58 +362,13 @@ async function runCheckMode(
     logger.success('All comprehension units are source-fresh.');
   }
 
-  // ADR 0109 slice 4 / ADR 0116 §4 — token-free semantic-regression gate vs a base
-  // ref. Base and head are read the SAME way (committed shards via git + lenient
-  // frontmatter parse), so a shard cannot be counted as "present" on one side and
-  // dropped on the other. An unreadable ref fails LOUD — never a silent pass.
-  //
-  // The `context` reframes WHAT is a regression (ADR 0116 §4):
-  //  - `'main'` (default, post-merge): `present → absent` means `main` LOST
-  //    semantic — a real regression the single-writer main-pass must never produce.
-  //  - `'pr'` (the static-only PR path): `present → absent` is EXPECTED (semantic
-  //    deferred to `main`) and NEVER a regression — killing the per-PR false
-  //    positive. Instead we advisory-warn on any committed-semantic ADDITION, which
-  //    a static-only PR should not carry (single-writer, ADR 0116 §1).
+  // ADR 0109 slice 4 / ADR 0116 §4 — the `--since` semantic-regression gate. The
+  // whole narrative (ref reads, unreadable-ref refusal, pr-vs-main framing) lives
+  // in `reportSemanticRegression`; here we only feed it and consume its verdict.
   const context: RegressionContext = opts.context ?? 'main';
-  let regressed: string[] = [];
-  let refUnreadable = false;
-  if (opts.since) {
-    const deps = defaultRefReadDeps(opts.projectRoot);
-    const base = readSemanticMapAtRef(opts.since, deps);
-    const head = readSemanticMapAtRef('HEAD', deps);
-    if (base === null || head === null) {
-      refUnreadable = true;
-      const which = base === null ? `base ref '${opts.since}'` : "'HEAD'";
-      logger.error(
-        `Could not read ${which} for the semantic-regression check (unfetched / bad ref / ` +
-          `git error). Refusing to report a pass — fetch the ref and re-run.`
-      );
-    } else {
-      regressed = detectSemanticRegressions(base, head, context);
-      if (context === 'pr') {
-        const committed = detectCommittedSemanticOnBranch(base, head);
-        if (committed.length > 0) {
-          logger.warn(
-            `${committed.length} module(s) COMMITTED semantic on a branch vs ${opts.since}: ` +
-              `${committed.join(', ')}. Under single-writer (ADR 0116 §1) PRs are static-only — ` +
-              `semantic belongs to the \`main\` main-pass. This is advisory (not a failure).`
-          );
-        }
-        logger.success(
-          `Static-only PR path: \`present → absent\` is expected (semantic deferred to \`main\`, ` +
-            `ADR 0116 §4) — no semantic regression flagged.`
-        );
-      } else if (regressed.length > 0) {
-        logger.error(
-          `${regressed.length} module(s) regressed semantic present→absent on \`main\` vs ` +
-            `${opts.since}: ${regressed.join(', ')}. The single-writer main-pass must never lose ` +
-            `semantic — regenerate (provider-backed 'harness comprehend --all') and commit to main.`
-        );
-      } else {
-        logger.success(`No semantic regressions on \`main\` vs ${opts.since}.`);
-      }
-    }
-  }
+  const { regressed, refUnreadable } = opts.since
+    ? reportSemanticRegression(opts.since, context, defaultRefReadDeps(opts.projectRoot))
+    : { regressed: [] as string[], refUnreadable: false };
 
   // ADR 0116 §2 — refresh main-pass seam (best-effort; never changes the verdict).
   if (ciMode === 'refresh') {


### PR DESCRIPTION
## What

`runCheckMode` in `packages/cli/src/commands/comprehend.ts` opened as a tidy freshness reporter — resolve the CI mode, run the compile check, warn on skips, report stale units — and then dropped a full altitude into the `--since` semantic-regression narrative: base/head ref reads, unreadable-ref handling, `pr`-vs-`main` branching, and three logger calls, all inlined into the same function body.

That narrative now lives in `reportSemanticRegression(since, context, deps, log)`, which returns `{ regressed, refUnreadable }`. `runCheckMode` feeds it and consumes the verdict, so the outer function tells **one** story: "is the substrate fresh, and what is the exit verdict?"

```ts
const context: RegressionContext = opts.context ?? 'main';
const { regressed, refUnreadable } = opts.since
  ? reportSemanticRegression(opts.since, context, defaultRefReadDeps(opts.projectRoot))
  : { regressed: [] as string[], refUnreadable: false };
```

## Why it is safe

Behaviour-preserving by construction:

- The four moved logger message strings are **byte-identical** to base — only the receiver changed (`logger.x` → `log.x`).
- `runCheckMode`'s signature is unchanged, and the `ciMode`, `runComprehendCheck`, stale-reporting, `refresh` main-pass, and `process.exit` lines are untouched and in their original order.
- No CLI flag, command, or output string changed, so `docs/reference/*` does not drift (`generate-docs --check` is clean in pre-push).

## New coverage

Both seams are injected — the caller supplies `defaultRefReadDeps(projectRoot)`, the logger defaults to `logger` — which makes the `--since` gate unit-testable for the first time. Before this change the whole block sat behind a `process.exit` and `grep -rn "since" --include="*.test.ts"` over `tests/comprehension` and `tests/e2e` returned **nothing**.

Six cases pin the `{ regressed, refUnreadable }` contract with no git and no disk:

| Case | Pins |
| ---- | ---- |
| base ref unreadable | `refUnreadable: true`, error names the base ref, **no** success/warn — the "never report a false green" invariant |
| `HEAD` unreadable | `refUnreadable: true`, error names `'HEAD'` |
| `context: 'pr'` + committed-semantic addition | advisory warn + static-only success, `regressed: []` |
| `context: 'pr'` + `present → absent` | silent (no warn), `regressed: []` — the per-PR false-positive killer (ADR 0116 §4) |
| `context: 'main'` + regression | exactly the regressed modules returned and listed in the error |
| `context: 'main'` clean | success line, `regressed: []` |

## Assumptions made

1. **Autonomous fleet lane.** The `harness-brainstorming` human sign-off gate and its section-by-section spec review were satisfied by the roadmap-fleet lane brief, which pre-confirmed the route (`feature`) and the prescribed shape. The spec was therefore written in one pass rather than section-by-section.
2. **The extracted function stays *in* `comprehend.ts`** (exported for tests) rather than moving to `src/comprehension/regression.ts`. The finding scopes the surface as "within-unit, signature unchanged", and `regression.ts` is deliberately a **pure, logger-free** detection module — pushing user-facing logger prose into it would smear a boundary it currently holds cleanly.
3. **`RefReadDeps` is a required parameter**, supplied by the caller, rather than constructed internally — that is what keeps the extracted function git- and disk-free and testable without a fixture repo.
4. **The logger is an injected seam defaulting to `logger`**, typed `Pick<typeof logger, 'error' | 'warn' | 'success'>`, matching the file's existing convention (`stageCompiledUnits`, `resolveChangedScope`).
5. **The `if (opts.since)` guard and the `opts.context ?? 'main'` default both stay at the call site**, keeping the extracted function total (no "did nothing" third state) and keeping the verdict computation visible in `runCheckMode`.
6. **No roadmap mutation from this lane** — `manage_roadmap` is not worktree-aware (#1507), so the roadmap row is the conductor's to move.
7. **Scope held to one finding.** No neighbouring code in `runCheckMode` was opportunistically refactored; `git diff --stat` is exactly `comprehend.ts` + `comprehend.test.ts` (plus the `docs/changes/**` artifacts, the changeset, and the pre-commit-hook-staged comprehension shard).

## Verification

- `pnpm turbo build` — green
- `tsc --noEmit` (packages/cli) — clean
- `vitest run src/commands/comprehend.test.ts tests/comprehension` — 13 files, **202 passed / 1 skipped**; every pre-existing test passes **unmodified**
- `vitest run tests/e2e/comprehend-boundary.e2e.test.ts` — passed
- Full pre-push gauntlet green: format:check, coverage ratchet, `generate-docs --check`, tool-catalog check, arch, traceability

## Artifacts

- Spec: `docs/changes/comprehend-runcheckmode-altitude/proposal.md`
- Plan: `docs/changes/comprehend-runcheckmode-altitude/plans/2026-09-08-extract-report-semantic-regression-plan.md`
- Provenance: `docs/changes/comprehend-runcheckmode-altitude/provenance.json` (base SHA `418f5e188`)

Finding: `CODE-R003` — craft-fleet `code-craft` runId `0b56dbcd-7703-4b4e-aea9-4cdce91fe07c`, cite `packages/cli/src/commands/comprehend.ts:254-342`.

Closes #1743

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
