### PR TITLE
perf(core): bring detectDeploymentSurface under the complexity budget (30 -> <15)

### DIFF
--- a/.changeset/deploy-surface-complexity-budget.md
+++ b/.changeset/deploy-surface-complexity-budget.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/core': patch
+---
+
+Bring `detectDeploymentSurface` under the complexity budget
+
+`detectDeploymentSurface` carried a cyclomatic complexity of 30 against the
+repo's error threshold of 15 — a standing breach in an `entryPoints` package
+(`packages/core/src/index.ts`), not a new regression. The single 90-line body
+inlined four unrelated passes: CI/CD pipeline discovery, deploy-script
+discovery, `.env.*` discovery, and derived-signal accumulation.
+
+Each pass is now a module-private helper — `collectPipelineFiles`,
+`collectDeployScripts`, `collectEnvFiles`, `accumulateContentSignals` and
+`accumulateEnvFileSignals` — with the derived booleans and sets threaded
+through a single `DerivedSignals` accumulator instead of five loose locals.
+The duplicated inline `/\.ya?ml$/i` test also collapses onto the existing
+`isYamlPipeline` predicate.
+
+This is a behaviour-preserving extract-method refactor. The exported signature
+`(root: string, fsPort: DeploymentFsPort) => DeploymentSurface` is unchanged,
+accumulation order (and therefore `detectedEnvironments` ordering) is
+preserved, and `packages/core/tests/deployment/detect.test.ts` passes
+unmodified.
+
+Refs #2037.

--- a/.harness/comprehension/packages/core/src/deployment/_module.md
+++ b/.harness/comprehension/packages/core/src/deployment/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/deployment'
-sourceHash: '470b0caaf7825f630d96819be88cce009ec0f0de7245511bcce2ba6d90f4042e'
+sourceHash: '348a610d18e6ab4d14d5c29ff5229e50cc7543001f7932f23030e294a9e8e911'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/src/deployment/_module.md
+++ b/.harness/comprehension/packages/core/src/deployment/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/deployment'
-sourceHash: '464c791086fc412927b44c26ccde9b56d7d193d2f9f57643e961cfd8df6e62ee'
+sourceHash: '470b0caaf7825f630d96819be88cce009ec0f0de7245511bcce2ba6d90f4042e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/src/deployment/_module.md
+++ b/.harness/comprehension/packages/core/src/deployment/_module.md
@@ -1,26 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/deployment'
-sourceHash: '3a9f2ae98ff2ddeb2e2016bc42cf38dc18ed4e811ae95bf97cb695ae5238e0f0'
-compiledAt: '2026-08-28T01:22:10.331Z'
+sourceHash: 'bdee8f9afa4d8375d5c783f28b319ba03da015646fb72073409efc8f70725e1c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['detect.ts', 'evaluate.ts', 'exit-code.ts', 'index.ts', 'types.ts']
 ---
-
-## Summary
-
-`packages/core/src/deployment` detects and gates deployments by analyzing a repository's CI/CD surface and enforcing security/operational invariants. Detection (`detectDeploymentSurface`) is a pure, filesystem-abstracted scanner that discovers pipeline files (GitHub Actions, GitLab, Jenkins, CircleCI, Bitbucket, Azure), deploy scripts, and committed env files, heuristically extracting environment targets (prod/staging/dev), gating signals, rollback indicators, and pipeline stages. A single unparseable YAML is marked rather than thrown. Evaluation (`evaluateDeploymentGate`) is a pure classifier enforcing waivable and non-waivable rules against the surface; DEPLOY-SEC001 (hardcoded secret detection) is non-waivable and never consulted for rule overrides. Status routing shorts early: `disabled` (opted out), `abstained` (no surface), `blocked` (hard violations), or `pass`.
-
-## Invariants
-
-- DEPLOY-SEC001 is non-waivable — hardcoded secrets in pipelines/env files bypass the `rules` override map entirely and cannot be silenced via config.
-- Filesystem isolation enforced: all file reads flow through injected `DeploymentFsPort`, never direct `fs` imports; enables testability and defensive error handling.
-- Defensive capture, not throw — a single unparseable YAML pipeline is marked `unparseable: true` and included in the surface; the gate does not fail, allowing broken repos to be analyzed.
-- Production-reachable ungating is global — if ANY file in the surface carries a gating signal (job dependencies, manual approval, environment protection), production is marked gated even if other files lack it.
-- Status routing shorts all rules — `disabled` and `abstained` return early with empty findings, skipping all rule evaluation; only `pass`/`blocked` results run full classification.
-- Rollback signal is multi-source — satisfied by runbook filename, workflow/script naming pattern, regex match in content, or explicit config flag; any one source counts.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/core/src/deployment/_module.md
+++ b/.harness/comprehension/packages/core/src/deployment/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/deployment'
-sourceHash: '348a610d18e6ab4d14d5c29ff5229e50cc7543001f7932f23030e294a9e8e911'
+sourceHash: '8537704703656ffc59500b709b36966dfc55992bbb215286cb555d1e6d3a6736'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/core/src/deployment/_module.md
+++ b/.harness/comprehension/packages/core/src/deployment/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/deployment'
-sourceHash: 'bdee8f9afa4d8375d5c783f28b319ba03da015646fb72073409efc8f70725e1c'
+sourceHash: '464c791086fc412927b44c26ccde9b56d7d193d2f9f57643e961cfd8df6e62ee'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/core/src/deployment/detect.ts
+++ b/packages/core/src/deployment/detect.ts
@@ -132,19 +132,23 @@ function collectDeployScripts(fsPort: DeploymentFsPort): DeploymentFile[] {
   return deployScripts;
 }
 
-export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
-  void root; // paths are already root-relative for the injected port.
-
-  const pipelineFiles = collectPipelineFiles(fsPort);
-  const deployScripts = collectDeployScripts(fsPort);
+/** Discover committed environment files (`.env.*`) at the repository root. */
+function collectEnvFiles(fsPort: DeploymentFsPort): DeploymentFile[] {
   const envFiles: DeploymentFile[] = [];
-
-  // --- Committed env file discovery (.env.*) ---
   for (const entry of fsPort.listDir('.')) {
     if (!entry.startsWith('.env.')) continue;
     const f = capture(fsPort, entry, false);
     if (f) envFiles.push(f);
   }
+  return envFiles;
+}
+
+export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
+  void root; // paths are already root-relative for the injected port.
+
+  const pipelineFiles = collectPipelineFiles(fsPort);
+  const deployScripts = collectDeployScripts(fsPort);
+  const envFiles = collectEnvFiles(fsPort);
 
   // --- Derived signals ---
   const detected = new Set<string>();

--- a/packages/core/src/deployment/detect.ts
+++ b/packages/core/src/deployment/detect.ts
@@ -143,6 +143,54 @@ function collectEnvFiles(fsPort: DeploymentFsPort): DeploymentFile[] {
   return envFiles;
 }
 
+/**
+ * Mutable accumulator for the signals derived from the discovered files.
+ *
+ * Every discovery pass contributes to the same running totals, so one
+ * accumulator is threaded through them instead of being merged afterwards.
+ */
+interface DerivedSignals {
+  detected: Set<string>;
+  presentStages: Set<string>;
+  hasProductionTarget: boolean;
+  productionUngated: boolean;
+  rollbackSignalInFiles: boolean;
+  hasHealthCheck: boolean;
+}
+
+function emptySignals(): DerivedSignals {
+  return {
+    detected: new Set<string>(),
+    presentStages: new Set<string>(),
+    hasProductionTarget: false,
+    productionUngated: false,
+    rollbackSignalInFiles: false,
+    hasHealthCheck: false,
+  };
+}
+
+/**
+ * Accumulate environment, production-reach, rollback, health-check and stage
+ * signals from pipeline and deploy-script *contents*.
+ */
+function accumulateContentSignals(files: DeploymentFile[], into: DerivedSignals): void {
+  for (const file of files) {
+    collectEnvironments(file.content, into.detected);
+    const reachesProd = PROD_RE.test(file.content);
+    if (reachesProd) {
+      into.hasProductionTarget = true;
+      if (!hasGating(file.content)) into.productionUngated = true;
+    }
+    if (ROLLBACK_RE.test(file.path) || ROLLBACK_RE.test(file.content)) {
+      into.rollbackSignalInFiles = true;
+    }
+    if (HEALTHCHECK_RE.test(file.content)) into.hasHealthCheck = true;
+    for (const { stage, re } of STAGE_KEYWORDS) {
+      if (re.test(file.content)) into.presentStages.add(stage);
+    }
+  }
+}
+
 export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
   void root; // paths are already root-relative for the injected port.
 
@@ -151,56 +199,37 @@ export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort):
   const envFiles = collectEnvFiles(fsPort);
 
   // --- Derived signals ---
-  const detected = new Set<string>();
-  let hasProductionTarget = false;
-  let productionUngated = false;
-  let rollbackSignalInFiles = false;
-  let hasHealthCheck = false;
-  const presentStages = new Set<string>();
-
+  const signals = emptySignals();
   const contentFiles = [...pipelineFiles, ...deployScripts];
-  for (const file of contentFiles) {
-    collectEnvironments(file.content, detected);
-    const reachesProd = PROD_RE.test(file.content);
-    if (reachesProd) {
-      hasProductionTarget = true;
-      if (!hasGating(file.content)) productionUngated = true;
-    }
-    if (ROLLBACK_RE.test(file.path) || ROLLBACK_RE.test(file.content)) {
-      rollbackSignalInFiles = true;
-    }
-    if (HEALTHCHECK_RE.test(file.content)) hasHealthCheck = true;
-    for (const { stage, re } of STAGE_KEYWORDS) {
-      if (re.test(file.content)) presentStages.add(stage);
-    }
-  }
+  accumulateContentSignals(contentFiles, signals);
+
   for (const file of envFiles) {
-    collectEnvironments(file.content, detected);
+    collectEnvironments(file.content, signals.detected);
     // Environment name also comes from the file name (.env.production).
-    if (PROD_RE.test(file.path)) detected.add('production');
-    if (STAGING_RE.test(file.path)) detected.add('staging');
-    if (ROLLBACK_RE.test(file.path)) rollbackSignalInFiles = true;
+    if (PROD_RE.test(file.path)) signals.detected.add('production');
+    if (STAGING_RE.test(file.path)) signals.detected.add('staging');
+    if (ROLLBACK_RE.test(file.path)) signals.rollbackSignalInFiles = true;
   }
 
   // Runbook / rollback doc existence satisfies the rollback signal.
-  if (!rollbackSignalInFiles) {
-    rollbackSignalInFiles = RUNBOOK_CANDIDATES.some((c) => fsPort.exists(c));
+  if (!signals.rollbackSignalInFiles) {
+    signals.rollbackSignalInFiles = RUNBOOK_CANDIDATES.some((c) => fsPort.exists(c));
   }
 
   // A gating signal anywhere across the surface downgrades "ungated".
-  if (productionUngated && contentFiles.some((f) => hasGating(f.content))) {
-    productionUngated = false;
+  if (signals.productionUngated && contentFiles.some((f) => hasGating(f.content))) {
+    signals.productionUngated = false;
   }
 
   return {
     pipelineFiles,
     deployScripts,
     envFiles,
-    detectedEnvironments: [...detected],
-    hasProductionTarget,
-    productionUngated,
-    rollbackSignalInFiles,
-    hasHealthCheck,
-    presentStages: [...presentStages],
+    detectedEnvironments: [...signals.detected],
+    hasProductionTarget: signals.hasProductionTarget,
+    productionUngated: signals.productionUngated,
+    rollbackSignalInFiles: signals.rollbackSignalInFiles,
+    hasHealthCheck: signals.hasHealthCheck,
+    presentStages: [...signals.presentStages],
   };
 }

--- a/packages/core/src/deployment/detect.ts
+++ b/packages/core/src/deployment/detect.ts
@@ -96,16 +96,14 @@ const STAGE_KEYWORDS: Array<{ stage: string; re: RegExp }> = [
   { stage: 'post-deploy', re: /post[-\s]?deploy/i },
 ];
 
-export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
-  void root; // paths are already root-relative for the injected port.
-
+/**
+ * Discover CI/CD pipeline files: every YAML under `.github/workflows`, then the
+ * fixed-name pipelines of the other major CI providers.
+ */
+function collectPipelineFiles(fsPort: DeploymentFsPort): DeploymentFile[] {
   const pipelineFiles: DeploymentFile[] = [];
-  const deployScripts: DeploymentFile[] = [];
-  const envFiles: DeploymentFile[] = [];
-
-  // --- CI/CD pipeline discovery ---
   for (const entry of fsPort.listDir('.github/workflows')) {
-    if (!/\.ya?ml$/i.test(entry)) continue;
+    if (!isYamlPipeline(entry)) continue;
     const f = capture(fsPort, `.github/workflows/${entry}`, true);
     if (f) pipelineFiles.push(f);
   }
@@ -113,6 +111,15 @@ export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort):
     const f = capture(fsPort, fixed, true);
     if (f) pipelineFiles.push(f);
   }
+  return pipelineFiles;
+}
+
+export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
+  void root; // paths are already root-relative for the injected port.
+
+  const pipelineFiles = collectPipelineFiles(fsPort);
+  const deployScripts: DeploymentFile[] = [];
+  const envFiles: DeploymentFile[] = [];
 
   // --- Deploy script discovery ---
   for (const entry of fsPort.listDir('deploy')) {

--- a/packages/core/src/deployment/detect.ts
+++ b/packages/core/src/deployment/detect.ts
@@ -191,6 +191,20 @@ function accumulateContentSignals(files: DeploymentFile[], into: DerivedSignals)
   }
 }
 
+/**
+ * Accumulate signals from committed `.env.*` files. Their *file name* also
+ * names an environment (`.env.production`), so paths are matched as well as
+ * contents.
+ */
+function accumulateEnvFileSignals(files: DeploymentFile[], into: DerivedSignals): void {
+  for (const file of files) {
+    collectEnvironments(file.content, into.detected);
+    if (PROD_RE.test(file.path)) into.detected.add('production');
+    if (STAGING_RE.test(file.path)) into.detected.add('staging');
+    if (ROLLBACK_RE.test(file.path)) into.rollbackSignalInFiles = true;
+  }
+}
+
 export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
   void root; // paths are already root-relative for the injected port.
 
@@ -202,14 +216,7 @@ export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort):
   const signals = emptySignals();
   const contentFiles = [...pipelineFiles, ...deployScripts];
   accumulateContentSignals(contentFiles, signals);
-
-  for (const file of envFiles) {
-    collectEnvironments(file.content, signals.detected);
-    // Environment name also comes from the file name (.env.production).
-    if (PROD_RE.test(file.path)) signals.detected.add('production');
-    if (STAGING_RE.test(file.path)) signals.detected.add('staging');
-    if (ROLLBACK_RE.test(file.path)) signals.rollbackSignalInFiles = true;
-  }
+  accumulateEnvFileSignals(envFiles, signals);
 
   // Runbook / rollback doc existence satisfies the rollback signal.
   if (!signals.rollbackSignalInFiles) {

--- a/packages/core/src/deployment/detect.ts
+++ b/packages/core/src/deployment/detect.ts
@@ -114,14 +114,12 @@ function collectPipelineFiles(fsPort: DeploymentFsPort): DeploymentFile[] {
   return pipelineFiles;
 }
 
-export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
-  void root; // paths are already root-relative for the injected port.
-
-  const pipelineFiles = collectPipelineFiles(fsPort);
+/**
+ * Discover deploy scripts: everything under `deploy/`, plus the `deploy*`-named
+ * entries under `scripts/`.
+ */
+function collectDeployScripts(fsPort: DeploymentFsPort): DeploymentFile[] {
   const deployScripts: DeploymentFile[] = [];
-  const envFiles: DeploymentFile[] = [];
-
-  // --- Deploy script discovery ---
   for (const entry of fsPort.listDir('deploy')) {
     const f = capture(fsPort, `deploy/${entry}`, false);
     if (f) deployScripts.push(f);
@@ -131,6 +129,15 @@ export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort):
     const f = capture(fsPort, `scripts/${entry}`, false);
     if (f) deployScripts.push(f);
   }
+  return deployScripts;
+}
+
+export function detectDeploymentSurface(root: string, fsPort: DeploymentFsPort): DeploymentSurface {
+  void root; // paths are already root-relative for the injected port.
+
+  const pipelineFiles = collectPipelineFiles(fsPort);
+  const deployScripts = collectDeployScripts(fsPort);
+  const envFiles: DeploymentFile[] = [];
 
   // --- Committed env file discovery (.env.*) ---
   for (const entry of fsPort.listDir('.')) {


### PR DESCRIPTION
## What

`detectDeploymentSurface` (`packages/core/src/deployment/detect.ts`) carried a cyclomatic complexity of **30** against this repo's error threshold of **15** (`performance.complexity.thresholds.cyclomaticComplexity.error`). This is a behaviour-preserving extract-method refactor that brings it under budget.

The single 90-line body inlined four unrelated passes. Each is now a module-private helper:

| Helper | Pass |
| --- | --- |
| `collectPipelineFiles` | `.github/workflows/*.y[a]ml` + fixed-name provider pipelines |
| `collectDeployScripts` | `deploy/*` + `scripts/deploy*` |
| `collectEnvFiles` | root `.env.*` |
| `accumulateContentSignals` | env / prod-reach / rollback / health-check / stage signals from file contents |
| `accumulateEnvFileSignals` | the same signals derived from `.env.*` file *names* |

The five loose accumulator locals are replaced by one module-private `DerivedSignals` struct threaded through the two accumulation helpers. The duplicated inline `/\.ya?ml$/i` test collapses onto the pre-existing `isYamlPipeline` predicate.

Nothing new is exported. The helpers are un-exported; no test needed access to them.

## Evidence

Both runs are `harness check-perf --structural --severity error` on the same tree, same Node 22, same command.

**Before** (base `c74cda5f2`):

```
  * packages/core/src/deployment/detect.ts
    Function "detectDeploymentSurface" has cyclomatic complexity of 30 (error threshold: 15)
```

**After**: no finding for `detect.ts` at any severity. Re-running at `--severity warn` (warn threshold 10) also reports nothing for the file, so every extracted helper is under 10 — none of them landed near the line.

Diffing the two complete finding sets: total findings went **103 -> 102**, the only set difference being the removed `detectDeploymentSurface` line. **Zero new violations** anywhere, in the extracted helpers or otherwise.

`harness check-arch` reports `2 violation(s) resolved since baseline` and adds none; `detect.ts` does not appear in its findings. `harness check-deps` is byte-identical to the baseline run (the one pre-existing `scan-candidates` circular dependency, untouched).

## Verification

- `pnpm --filter @harness-engineering/core test` — **480 files / 5363 passed, 1 skipped**, identical before, after every one of the five extraction steps, and at the end.
- `packages/core/tests/deployment/detect.test.ts` **passes unmodified** — not one line of test changed.
- `tsc --noEmit` clean; `eslint` 0 errors (1 pre-existing unrelated warning in `entropy/entry-points.test.ts`).
- `pnpm format:check` clean; full pre-push gate chain passed first try.

## Assumptions made

- **Measured before/after.** Before: `detectDeploymentSurface` cyclomatic complexity **30**, error threshold **15**. After: **no finding at error or warn severity** — i.e. below **10**, the warn threshold. The tool reports only threshold breaches, so the exact post-refactor number is not printed; what is proven is `< 10`.
- **Ranking basis.** Tier-1 structural gate breach (error severity, not warn); located in an `entryPoint` package (`packages/core/src/index.ts`); and **source-confirmed genuine, not a detector artifact**. The confirmation matters: `detectDeploymentSurface` was the last top-level declaration in the 188-line file (declared at line 99, file ended at 188), so the brace-matching attribution was correct, and a hand-count of its decision points landed at ~22-25 against a reported 30 — the right order of magnitude for a real breach rather than a body run to EOF.
- **Extraction scope.** Bounded to the five natural seams listed above, inside the one file. No public API change: the exported signature `(root: string, fsPort: DeploymentFsPort) => DeploymentSurface` is unchanged, and the two consumers (`packages/core/src/deployment/index.ts` re-export, `packages/cli/src/commands/check-deployment.ts`) are untouched. Accumulation order is preserved exactly, which matters because `detectedEnvironments` and `presentStages` are `Set` spreads whose output order is insertion order — content files still accumulate before env files.
- **Standing breach, not a regression.** The baseline-relative delta for this finding is **0** — it was already at 30 on `main` before this branch. This PR removes a long-standing breach; it does not repair something a recent change broke.
- **No baseline or threshold was edited.** `.harness/arch/baselines.json` is untouched (`git status` clean for it), `harness.config.json` is untouched, and `harness check-arch --update-baseline` was never run. The only two files in the diff are `detect.ts` and its auto-generated comprehension shard `_module.md`, plus the changeset.
- **Pre-existing findings left alone.** `harness validate` (design-token drift in `packages/cli`) and `harness check-deps` (one `scan-candidates` circular dependency) were already failing on the base SHA. They are out of scope; this PR's delta against both is zero.

## Context

Most sibling complexity findings in the same sweep were dropped rather than fixed, because the repo's structural complexity detector is known-defective — regex brace-matching attributes a function body through to EOF, and bare control keywords get reported as phantom functions. The `after` run of this very command still shows `Function "if"`, `Function "for"` entries across `packages/orchestrator`, `packages/cli` and `scripts/`, which are those artifacts. This target was kept only because its attribution was verified correct by reading the source. Refs #2037.

## Not done

Not merged, auto-merge not enabled.
