### PR TITLE
fix(ci): bounded retry + clean abstain for the refresh-baselines merge race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,30 +333,71 @@ jobs:
             exit 0
           fi
           echo "Direct push blocked by branch protection. Creating PR instead."
+          BRANCH="chore/refresh-baselines-$(date +%s)"
+
           # Fix B: base the PR branch on the CURRENT tip of origin/main, not the
           # (possibly stale) event SHA this run checked out. Concurrent refresh runs
           # otherwise branch from divergent commits and conflict on the same baseline
           # lines; GitHub auto-merge cannot resolve content conflicts, so the loser
           # sits open forever (this was the #671 failure mode).
-          git fetch origin main
-          BRANCH="chore/refresh-baselines-$(date +%s)"
-          git checkout -B "$BRANCH" origin/main
-          # Re-apply our freshly generated baselines on top of latest main. The files
-          # are regenerated wholesale, so "ours" is always the correct resolution and
-          # this re-apply can never conflict.
-          git checkout "$OURS" -- $BASELINE_FILES
-          git add $BASELINE_FILES
-          # Re-apply the transient-allowance cleanup on top of latest main (the merge may
-          # have carried allowance files onto main). --ignore-unmatch keeps this a no-op
-          # when none are present.
-          for d in $ALLOWANCE_DIRS; do
-            git rm -q -r --ignore-unmatch "$d" >/dev/null 2>&1 || true
-          done
-          if git diff --cached --quiet; then
+          #
+          # Factored into a function because the merge retry below re-derives on the
+          # NEW tip between attempts rather than blindly repeating a merge that main
+          # has already moved out from under. Returns non-zero when the latest main
+          # already carries these baselines (nothing left to propose).
+          rebuild_branch_on_main() {
+            git fetch origin main
+            git checkout -B "$BRANCH" origin/main
+            # Re-apply our freshly generated baselines on top of latest main. The files
+            # are regenerated wholesale, so "ours" is always the correct resolution and
+            # this re-apply can never conflict.
+            git checkout "$OURS" -- $BASELINE_FILES
+            git add $BASELINE_FILES
+            # Re-apply the transient-allowance cleanup on top of latest main (the merge may
+            # have carried allowance files onto main). --ignore-unmatch keeps this a no-op
+            # when none are present.
+            for d in $ALLOWANCE_DIRS; do
+              git rm -q -r --ignore-unmatch "$d" >/dev/null 2>&1 || true
+            done
+            if git diff --cached --quiet; then
+              return 1
+            fi
+            git commit -m "chore: refresh baselines after merge [skip ci]"
+          }
+
+          # Scope guard + self-approval. Re-run after every force-push, because a
+          # force-push can dismiss the inline approval applied to the previous head.
+          approve_pr() {
+            # Defensive scope check (#531): the branch is constructed to contain only
+            # baseline files, but never self-approve a PR whose diff reaches beyond
+            # them. $BASELINE_FILES is the single source of truth for the allowlist.
+            # Fails closed — any unexpected path (or an empty diff) aborts before approval.
+            gh pr diff "$PR_URL" --name-only | node scripts/assert-baseline-only-diff.mjs $SCOPE_ALLOW
+            # Approve inline with the PAT. Events triggered by GITHUB_TOKEN do not start
+            # workflow runs, so a separate auto-approve workflow on pull_request_target
+            # would never fire for this PR.
+            GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
+              --body "Auto-approved: baseline refresh from github-actions[bot]."
+          }
+
+          # Close the PR and abstain cleanly. `.harness/**/baselines.json` uses a
+          # `merge=ours` custom merge driver, so a STALE baseline PR resolves in the
+          # PR's favour — landing it later would REVERT main's newer baselines. A
+          # superseded baseline-refresh PR is therefore actively DANGEROUS, not merely
+          # stale, so it must not be left open to accumulate. Closing is correct
+          # because the very next merge to main regenerates a fresh one: nothing is
+          # lost, and the outcome is visible in the run log and on the closed PR.
+          abstain_superseded() {
+            echo "::notice::Baseline refresh superseded by concurrent merges to main ($1); closing $PR_URL. The next merge to main regenerates it."
+            gh pr close "$PR_URL" --delete-branch \
+              --comment "Closing: superseded by concurrent merges to main ($1). The next merge to main regenerates a fresh baseline refresh. Not landed because \`.harness/**/baselines.json\` uses a \`merge=ours\` driver, so landing a stale refresh would revert main's newer baselines."
+            exit 0
+          }
+
+          if ! rebuild_branch_on_main; then
             echo "Latest main already carries these baselines; nothing to PR."
             exit 0
           fi
-          git commit -m "chore: refresh baselines after merge [skip ci]"
           git push -u origin "$BRANCH"
           # Create the PR as github-actions[bot] so the PAT owner (a human) can approve it
           # without hitting GitHub's self-approval block.
@@ -365,17 +406,38 @@ jobs:
             --body "Auto-generated baseline refresh. Created because direct pushes to main are blocked by branch protection. Branch is based on the current tip of main to avoid concurrent-refresh conflicts." \
             --base main \
             --head "$BRANCH")
-          # Defensive scope check (#531): the branch is constructed to contain only
-          # baseline files, but never self-approve a PR whose diff reaches beyond
-          # them. $BASELINE_FILES is the single source of truth for the allowlist.
-          # Fails closed — any unexpected path (or an empty diff) aborts before approval.
-          gh pr diff "$PR_URL" --name-only | node scripts/assert-baseline-only-diff.mjs $SCOPE_ALLOW
-          # Approve inline with the PAT. Events triggered by GITHUB_TOKEN do not start
-          # workflow runs, so a separate auto-approve workflow on pull_request_target
-          # would never fire for this PR.
-          GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
-            --body "Auto-approved: baseline refresh from github-actions[bot]."
-          gh pr merge "$PR_URL" --auto --squash --delete-branch
+          approve_pr
+
+          # BOUNDED MERGE RETRY. This repo has NO `required_status_checks` branch rule —
+          # only a ruleset requiring one approving review, which `approve_pr` just
+          # satisfied inline. `--auto` merely QUEUES when something is still pending, so
+          # with nothing left to wait on it attempts an IMMEDIATE merge. Under a merge
+          # burst main routinely advances between `gh pr create` and this call, and the
+          # mergePullRequest mutation is then rejected with "Base branch was modified",
+          # which under `bash -e` exited the step non-zero and REDDENED main (runs
+          # 34227768312, 34042737396, 34042651655) plus fired the main-health alarm.
+          #
+          # Retry on a freshly RE-DERIVED branch (same PR, same URL — never a second PR),
+          # matching the `for attempt in 1 2 3` + re-fetch idiom already used by
+          # holiday-confidence-track.yml's "Commit the trend ledger" step. `--auto` is
+          # kept so the job still behaves correctly if required checks are added later.
+          for attempt in 1 2 3; do
+            if gh pr merge "$PR_URL" --auto --squash --delete-branch; then
+              echo "Merged (or queued) $PR_URL on attempt $attempt."
+              exit 0
+            fi
+            echo "Merge attempt $attempt failed — main likely moved; re-deriving on the new tip."
+            sleep 5
+            if ! rebuild_branch_on_main; then
+              abstain_superseded "latest main already carries these baselines"
+            fi
+            if ! git push --force-with-lease -u origin "$BRANCH"; then
+              abstain_superseded "the refresh branch was updated concurrently"
+            fi
+            approve_pr
+          done
+
+          abstain_superseded "3 merge attempts exhausted"
         env:
           HUSKY: '0'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '17aee439742a3d7b0a86d183bb576689635aabc041f53aa72703f40ed6d8065a'
+sourceHash: '5f84ea3a892343e0a0f6b31ba40cb85de506aec8c52403aeb80096b52d4f662e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -135,6 +135,7 @@ export CURSOR_CURATED_TOOLS
 export DEFAULT_FIXTURES_DIR
 export DEFAULT_OPERATIONAL_DRIFT_POLICY
 export GIT_MAX_BUFFER_BYTES
+export INGEST_TOKEN_ENV
 export OUTCOME_BLOCK_ON_LEVELS
 export SCOPED_WALKERS
 export SKILL_REGRESSION_BLOCK_ON
@@ -316,6 +317,7 @@ export readReview
 export referencesTargetPr
 export refreshExitCode
 export renderTable
+export reportSemanticRegression
 export resolveBaseRef
 export resolveCandidates
 export resolveChangedScope
@@ -417,7 +419,7 @@ import { shouldRunComprehendHook } from '../comprehension/hook'
 import { enumerateModules, filesToModules } from '../comprehension/invalidation'
 import { committedSemanticAllowed } from '../comprehension/policy'
 import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../comprehension/refresh-gate'
-import { RegressionContext, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
+import { RefReadDeps, RegressionContext, SemanticState, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
 import { createStaticExtractor } from '../comprehension/static-extractor'
 import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js'
 import { findConfigFile, loadConfig, resolveConfig } from '../config/loader'
@@ -530,7 +532,7 @@ import { createCleanupSessionsCommand } from './cleanup-sessions'
 import { createCliErgonomicsCraftCommand } from './cli-ergonomics-craft'
 import { createCodeCraftCommand } from './code-craft'
 import { createCompoundCommand } from './compound'
-import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
+import { createComprehendCommand, formatCompiledUnits, reportSemanticRegression, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
 import { createComprehensionMergeDriverCommand } from './comprehension-merge-driver'
 import { createContextDictionaryCommand } from './context-dictionary'
 import { createCopyCraftCommand } from './copy-craft'

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '119bdb5b982afb6ff2d7ae963971718e682c0450f0af09430d49605c00a25d4c'
+sourceHash: 'da58a667623dc1971daf31e9327deafc7bb36016aacf01edeee41967e472427c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -199,6 +199,7 @@ members:
     'validate.roadmap-health.test.ts',
     'validate.roadmap-mode.test.ts',
     'validate.test.ts',
+    'waypoint-ship.test.ts',
     'waypoint.test.ts',
   ]
 ---

--- a/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands/roadmap'
-sourceHash: '6da780b73a0b9c5309307def5411c39102c22d9ce468c7ee7ba7441df9c38e44'
+sourceHash: '5e9927551af9e10d8d828561dde3fcbec94d98e7c12fbab97d187ffa58158309'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -21,6 +21,7 @@ members:
     'shard-io.test.ts',
     'shard-roundtrip.e2e.test.ts',
     'shard.test.ts',
+    'sync-deps-pnyon.test.ts',
     'sync-report.test.ts',
     'sync-wiring.test.ts',
     'sync.test.ts',
@@ -48,12 +49,13 @@ import { ALLOW_UNREADABLE_HISTORY_ENV, runRoadmapRegen } from '../../../src/comm
 import { runRoadmapShard } from '../../../src/commands/roadmap/shard'
 import { createNodeShardIO } from '../../../src/commands/roadmap/shard-io'
 import { buildSyncOptions, createRoadmapSyncCommand, runRoadmapSync } from '../../../src/commands/roadmap/sync'
+import { resolveAdapter, resolveConfig } from '../../../src/commands/roadmap/sync-deps'
 import { buildReport, logSyncReport } from '../../../src/commands/roadmap/sync-report'
 import { BrainstormReportRow, TriageReportRow, buildPrecedentLookup, buildShapeHistory, createRoadmapTriageCommand, isPlausibleForModel, renderBrainstormHuman, renderBrainstormJson, renderHuman, renderJson, runApproveCommand, runBrainstormReport, runTriageReport, selectActionableFeatures } from '../../../src/commands/roadmap/triage'
 import { runRoadmapUnshard } from '../../../src/commands/roadmap/unshard'
 import { logger } from '../../../src/output/logger'
 import { ExitCode } from '../../../src/utils/errors'
-import { Err, ExternalTicket, ExternalTicketState, NewFeatureInput, Ok, Result, RoadmapFeature, RoadmapMeta, RoadmapTrackerClient, Shard, ShardStore, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, parseRoadmap, regenerate, resolveRoadmapStore, serializeMeta, serializeShard } from '@harness-engineering/core'
+import { Err, ExternalTicket, ExternalTicketState, GitHubIssuesSyncAdapter, NewFeatureInput, Ok, PnyonSyncAdapter, Result, RoadmapFeature, RoadmapMeta, RoadmapTrackerClient, Shard, ShardStore, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, parseRoadmap, regenerate, resolveRoadmapStore, serializeMeta, serializeShard } from '@harness-engineering/core'
 import { TriageVerdict } from '@harness-engineering/orchestrator'
 import { Roadmap, RoadmapFeature } from '@harness-engineering/types'
 import { Command } from 'commander'

--- a/.harness/comprehension/tests/scripts/_module.md
+++ b/.harness/comprehension/tests/scripts/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'tests/scripts'
-sourceHash: '77a5fe31fa6736431ac3ccd1e69043fde61e9a3927dfda8631c2246c4a383a8f'
+sourceHash: 'f5f1dd0f1f898df82f626a27a512ee2615e9c61d47fea2d667f80c0f92c3062e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/docs/changes/refresh-baselines-merge-race/plans/plan.md
+++ b/docs/changes/refresh-baselines-merge-race/plans/plan.md
@@ -1,0 +1,179 @@
+# Plan — `refresh-baselines` reds `main` on an auto-merge race (cicd-fleet R1)
+
+Trace of the `harness-workflow-audit` run (inventory → mechanical → judgment → report) and the
+remediation it produced, executed autonomously in a cicd-fleet remediation lane.
+
+Scope: `.github/workflows/ci.yml`, job `refresh-baselines`, step `Commit refreshed baselines`.
+Pinned base SHA: `db9c6739da57f6dd38a2e9d83bf94a1bfce9ca7b`.
+
+## Symptom (observed, not inferred)
+
+The `refresh-baselines` job has reddened `main` three times in three days:
+
+| Run           | Date       | main SHA   |
+| ------------- | ---------- | ---------- |
+| `34227768312` | 2026-09-08 | `fe2895b5` |
+| `34042737396` | 2026-09-06 | `c83050a3` |
+| `34042651655` | 2026-09-06 | `9eed8eb0` |
+
+Each failed with the identical verbatim error:
+
+```
+GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
+##[error]Process completed with exit code 1.
+```
+
+The failing command was the **last line** of the `Commit refreshed baselines` step:
+
+```sh
+gh pr merge "$PR_URL" --auto --squash --delete-branch
+```
+
+A red `refresh-baselines` also fires the `Main Health Alarm` workflow, so the noise is not
+confined to one run's log.
+
+## Root cause
+
+This repository has **no `required_status_checks` branch rule at all** — only a ruleset requiring
+one approving review. `gh pr merge --auto` (GitHub auto-merge) only _queues_ the merge when there
+is something still pending to wait on. Here the single requirement (one approval) is satisfied
+**inline on the line immediately above** by the PAT self-approval, so at the moment `--auto` is
+called there is nothing left to wait for and GitHub attempts an **immediate** merge.
+
+If `main` advanced between the earlier `gh pr create` and this merge call — which happens
+constantly under a merge burst — the `mergePullRequest` GraphQL mutation is rejected with
+"Base branch was modified", the step exits non-zero under `bash -e`, and **`main` goes red**.
+
+Aggravating factor (workflow-level, deliberate, and **not** changed here): `ci.yml`'s concurrency
+group is per-**commit** on the `push` event (`github.sha`), specifically so that a merge burst
+cannot cancel a previous commit's verification. A necessary consequence is that
+`refresh-baselines` runs **concurrently** across commits in a burst, so several runs are racing
+the same `main` tip. See the pushback-serialization finding below.
+
+## Audit findings (harness-workflow-audit, scoped to the `refresh-baselines` job)
+
+```
+WORKFLOW AUDIT: harness-engineering — .github/workflows/ci.yml (job: refresh-baselines)
+Workflows in tree: 22   Findings (this job): 1 error, 2 warning
+Gates that never fire: none in this job
+Documented-but-unwired gates: none in this job
+```
+
+### [ERROR] pushback-race — `.github/workflows/ci.yml:379` (pre-fix line number)
+
+`gh pr merge "$PR_URL" --auto --squash --delete-branch` is the terminal command of a `bash -e`
+step, with no retry and no tolerance for a concurrently-advancing base. With no
+`required_status_checks` rule, `--auto` degrades to an immediate merge, so the documented
+GitHub failure mode "Base branch was modified" propagates straight out as a red job on `main`.
+Evidence: the three runs above, all with the same verbatim GraphQL error.
+
+**Effect:** a post-merge bookkeeping job fails the default branch and trips the main-health alarm,
+for a race that carries no lost work whatsoever.
+
+**Patch:** applied — bounded retry with re-derivation, then close-and-abstain (below).
+
+### [WARNING] pushback-serialization — `.github/workflows/ci.yml:31`
+
+The push-event concurrency group is per-commit by design (documented at length in the file, with
+measured evidence: 22 of the last 30 push runs concluded `cancelled` under the old per-ref group).
+The side effect is that the _push-back_ job `refresh-baselines` is unserialized and races itself.
+A **job-level** `concurrency:` group on `refresh-baselines` alone (`cancel-in-progress: false`)
+would serialize the refreshes without touching the deliberate per-commit verification behaviour.
+
+**Not applied here** — out of scope for this item, and it would not fully close the race anyway
+(`main` also advances from ordinary PR merges, not only from other refresh runs). Recorded as an
+adjacent finding for a follow-up issue.
+
+### [WARNING] ratchet-refresh-fragility — `.github/workflows/ci.yml:302`
+
+The single authoritative post-merge baseline updater has no abstain path: every failure mode in
+its tail is a red `main`. The remediation gives it one for the race case specifically.
+
+Mechanical checks that came back **clean** for this job: M2 permission scoping (`contents: write`
+and `pull-requests: write` are both exercised — direct push, and `gh pr create`/`review`/`merge`);
+M3 pinning (all `actions/*` first-party, tag-pinned per repo convention); M4.2 re-trigger guard
+(`[skip ci]` present in the commit subject); M5 secret handling (`AUTOAPPROVE_PAT` reaches `gh`
+through `env:` and is never echoed); J1 injection (no `github.event.*` interpolation in this job's
+`run:` scripts).
+
+## The one design fork, and the human's decision
+
+> **F1 — what happens to the baseline-refresh PR when the retries are exhausted?**
+> (a) close it and exit clean, or (b) leave it open for a human.
+
+The human chose **(a) close the superseded baseline PR and exit clean; the next merge regenerates
+it.**
+
+Rationale (preserved verbatim in the workflow comment): `.harness/**/baselines.json` uses a
+`merge=ours` custom merge driver, so a **stale** baseline PR resolves in the PR's favour — landing
+it later would **REVERT** `main`'s newer baselines. A superseded baseline-refresh PR is therefore
+_actively dangerous_, not merely stale. Leaving it open to accumulate is the wrong answer; closing
+it is correct because the very next merge to `main` regenerates a fresh one.
+
+## Fix applied
+
+In `Commit refreshed baselines`, the PR-fallback tail is restructured into two shell functions plus
+a bounded retry loop, matching the house style already proven in
+`.github/workflows/holiday-confidence-track.yml` (step `Commit the trend ledger`, which uses
+`for attempt in 1 2 3` with a re-fetch and a hard reset between attempts).
+
+1. **`rebuild_branch_on_main`** — factors out the existing "Fix B" branch construction (fetch
+   `origin/main`, `checkout -B "$BRANCH" origin/main`, re-apply `$BASELINE_FILES` from `$OURS`,
+   re-apply the transient-allowance deletions, commit). Returns non-zero when the new tip already
+   carries these baselines, i.e. nothing is left to propose. Used both for the initial PR branch
+   and for each retry, so a retry re-derives on the newer tip instead of blindly repeating.
+   Safe by construction: the baseline files are regenerated **wholesale**, so "ours" is always the
+   correct resolution and the re-apply cannot conflict.
+2. **`approve_pr`** — the unchanged #531 scope guard
+   (`assert-baseline-only-diff.mjs`, fail-closed) followed by the PAT self-approval. Re-run after
+   each force-push, because a force-push can dismiss the inline approval.
+3. **Retry loop** — `for attempt in 1 2 3`, `sleep 5` between attempts (the existing idiom).
+   On a merge failure: re-derive on the fresh tip, `git push --force-with-lease` the same branch
+   (same PR, same URL — never a second PR), re-approve, retry.
+4. **Abstain paths** — if a re-derivation finds `main` already carries these baselines, or the
+   force-push loses its lease, or all three attempts are exhausted: emit a `::notice::`,
+   `gh pr close --delete-branch` with an explanatory comment, and `exit 0`.
+
+### Why this is an abstain, not a swallowed failure
+
+Nothing is lost: the baseline content this run computed is, by then, either already on `main` or
+superseded by a fresher refresh that a later merge will regenerate. The outcome is stated in the
+run log as a `::notice::` annotation and as a comment on the closed PR, so it is visible rather
+than hidden. This is the same posture `holiday-confidence-track.yml` already takes when its KPI
+abstains.
+
+### Explicitly NOT done (gate violations for this fleet)
+
+- No `|| true` appended to the merge.
+- The `assert-baseline-only-diff.mjs` scope guard (#531) is unchanged and still fails closed; it is
+  re-run on every retry rather than skipped.
+- The PAT self-approval guard is unchanged.
+- The deliberate per-commit push concurrency group is untouched.
+
+## Regression guard
+
+`tests/scripts/baseline-gating.test.mjs` already exists specifically as the "refresh-baselines
+auto-merge race" regression test (its header documents #671). Three assertions are added there over
+the workflow text, since the defect lives in the YAML rather than in a script:
+
+- the `gh pr merge` call is inside a bounded `for attempt in 1 2 3` retry;
+- retry exhaustion closes the PR and exits 0 (abstain), rather than leaving it open;
+- the merge is not neutralised with `|| true`, and the `#531` scope guard is still invoked.
+
+Run with `node --test 'tests/scripts/*.test.mjs'` — already wired into `ci.yml` as the
+"Baseline-gating regression test" step.
+
+## Deviation from the audit skill's gate
+
+`harness-workflow-audit` states "Do not modify workflow files — this skill audits and proposes
+patches." This lane's mandate is remediation, so the proposed patch is applied here in a lane
+branch and lands only through a human-reviewed PR; it is never auto-merged. The audit's intent
+(no unreviewed auto-application of CI changes) is preserved.
+
+## Follow-ups (not in this diff)
+
+- File an issue for the **job-level concurrency group** on `refresh-baselines`
+  (`concurrency: { group: refresh-baselines, cancel-in-progress: false }`) to serialize refreshes
+  and shrink the race window that this retry loop absorbs.
+- Consider whether the repo _should_ have a `required_status_checks` rule at all — its absence is
+  what turns `--auto` into an immediate merge here, and it has broader implications than this job.

--- a/tests/scripts/baseline-gating.test.mjs
+++ b/tests/scripts/baseline-gating.test.mjs
@@ -279,7 +279,9 @@ test('mergeCoverageBaselines: a 0.2% cli branch move is adopted (beyond its 0.1%
 });
 
 test('mergeCoverageBaselines: an explicit tolerance argument overrides the per-package map', () => {
-  const committed = { 'packages/cli': { lines: 80, branches: 80.5, functions: 84, statements: 79 } };
+  const committed = {
+    'packages/cli': { lines: 80, branches: 80.5, functions: 84, statements: 79 },
+  };
   const measured = { 'packages/cli': { lines: 80, branches: 80.7, functions: 84, statements: 79 } };
 
   // With an explicit 0.5% tolerance, the +0.2% cli move is treated as noise.
@@ -325,4 +327,74 @@ test('benchmark: new and placeholder-zero baselines adopt fresh values', () => {
 
   assert.deepEqual(merged.existing, { mean: 0.5, p99: 0.6 }); // zero placeholder -> adopt
   assert.deepEqual(merged.fresh, { mean: 0.1, p99: 0.2 }); // new key -> adopt
+});
+
+// ---------------------------------------------------------------------------
+// Second race in the same job, same file: the AUTO-MERGE call itself.
+//
+// The jitter gate above stops refresh PRs from CONFLICTING. It does nothing for
+// the merge race: this repo has no `required_status_checks` branch rule, so
+// `gh pr merge --auto` has nothing to wait on once the PAT approval lands inline
+// and attempts an IMMEDIATE merge. When main advances between `gh pr create` and
+// that call, the mergePullRequest mutation is rejected with "Base branch was
+// modified" and the step exits non-zero, reddening main (runs 34227768312,
+// 34042737396, 34042651655). The fix is a bounded retry that re-derives on the
+// new tip, then a clean close-and-abstain on exhaustion.
+//
+// The defect lives in the workflow YAML rather than in a script, so these assert
+// over the workflow text — the same reason this file exists at all.
+
+const refreshBaselinesStep = (() => {
+  const yml = readFileSync(new URL('../../.github/workflows/ci.yml', import.meta.url), 'utf8');
+  const start = yml.indexOf('- name: Commit refreshed baselines');
+  assert.ok(start !== -1, 'ci.yml must still carry the "Commit refreshed baselines" step');
+  const end = yml.indexOf('\n        env:', start);
+  assert.ok(end !== -1, 'the step must still end with its env: block');
+  return yml.slice(start, end);
+})();
+
+test('refresh-baselines: the auto-merge call sits inside a bounded retry', () => {
+  assert.match(
+    refreshBaselinesStep,
+    /for attempt in 1 2 3; do/,
+    'the merge must be retried a bounded number of times, not attempted once'
+  );
+  assert.match(
+    refreshBaselinesStep,
+    /rebuild_branch_on_main/,
+    'each retry must re-derive the branch on the new origin/main tip, not blindly repeat'
+  );
+});
+
+test('refresh-baselines: retry exhaustion closes the superseded PR and exits clean', () => {
+  // A stale baseline PR must never be left open: .harness/**/baselines.json uses a
+  // `merge=ours` driver, so landing it later would REVERT main's newer baselines.
+  assert.match(
+    refreshBaselinesStep,
+    /gh pr close "\$PR_URL" --delete-branch/,
+    'exhaustion must close the superseded refresh PR, never leave it open to accumulate'
+  );
+  assert.match(
+    refreshBaselinesStep,
+    /::notice::/,
+    'the abstain must be announced in the run log, not silent'
+  );
+  assert.match(
+    refreshBaselinesStep,
+    /\n\s*exit 0\n\s*}/,
+    'the abstain path must exit 0 — a superseded refresh is not a failure'
+  );
+});
+
+test('refresh-baselines: the merge is not neutralised and the #531 scope guard survives', () => {
+  assert.doesNotMatch(
+    refreshBaselinesStep,
+    /gh pr merge[^\n]*\|\|\s*true/,
+    'the merge must never be silenced with `|| true` — that hides a real failure'
+  );
+  assert.match(
+    refreshBaselinesStep,
+    /assert-baseline-only-diff\.mjs/,
+    'the fail-closed self-approval scope guard (#531) must still run before every approval'
+  );
 });


### PR DESCRIPTION
## Summary

The `refresh-baselines` job in `.github/workflows/ci.yml` has reddened `main` three times in three days. This makes its final auto-merge call survive a concurrently-advancing base: a bounded retry that re-derives on the fresh tip, then a clean close-and-abstain on exhaustion.

Produced by the `cicd-fleet` remediation lane (item R1), via the `harness-workflow-audit` pipeline. Plan artifact: [`docs/changes/refresh-baselines-merge-race/plans/plan.md`](docs/changes/refresh-baselines-merge-race/plans/plan.md).

## Remediation actions / assumptions made

### Root cause

This repo has **no `required_status_checks` branch rule at all** — only a ruleset requiring one approving review, and that review is applied inline by the PAT on the line immediately above the merge. `gh pr merge --auto` only *queues* when something is still pending to wait on; with nothing left to wait for it attempts an **immediate** merge. Under a merge burst `main` advances between the earlier `gh pr create` and this call, the `mergePullRequest` GraphQL mutation is rejected, the step exits non-zero under `bash -e`, and **`main` goes red** (which also fires the `Main Health Alarm` workflow) — for a race that loses no work whatsoever.

### Evidence (three CI runs, identical verbatim failure)

| Run | Date | main SHA |
| --- | --- | --- |
| [`34227768312`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34227768312) | 2026-09-08 | `fe2895b5` |
| [`34042737396`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34042737396) | 2026-09-06 | `c83050a3` |
| [`34042651655`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34042651655) | 2026-09-06 | `9eed8eb0` |

```
GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
##[error]Process completed with exit code 1.
```

### The fix

The PR-fallback tail of `Commit refreshed baselines` is restructured into two shell functions plus a bounded retry loop, matching the house style already proven in `.github/workflows/holiday-confidence-track.yml` → `Commit the trend ledger` (`for attempt in 1 2 3` with a re-fetch between attempts), so the repo's two commit-back jobs stay recognisably the same shape.

- **`rebuild_branch_on_main`** — the existing "Fix B" branch construction (fetch `origin/main`, `checkout -B` from its tip, re-apply `$BASELINE_FILES` from `$OURS`, re-apply the transient-allowance deletions, commit), factored out so a retry **re-derives on the newer tip** rather than blindly repeating. Safe by construction: the baseline files are regenerated wholesale, so "ours" is always the correct resolution and the re-apply cannot conflict. Returns non-zero when the new tip already carries these baselines.
- **`approve_pr`** — the unchanged `#531` fail-closed scope guard (`assert-baseline-only-diff.mjs`) followed by the PAT self-approval, re-run after each force-push because a force-push can dismiss the inline approval.
- **Retry loop** — `for attempt in 1 2 3` with `sleep 5` between attempts. On failure: re-derive, `git push --force-with-lease` **the same branch** (same PR, same URL — never a second PR), re-approve, retry. `--auto` is kept so the job still behaves correctly if required checks are ever added.

### F1 decision (human, taken as given): close the superseded PR on exhaustion

The one design fork was what happens to the refresh PR when the retries are exhausted: **(a)** close it and exit clean, or **(b)** leave it open for a human. The human chose **(a)**.

Rationale, preserved in the workflow comment: `.harness/**/baselines.json` uses a **`merge=ours`** custom merge driver, so a *stale* baseline PR resolves in the PR's favour — landing it later would **REVERT** `main`'s newer baselines. A superseded baseline-refresh PR is therefore *actively dangerous*, not merely stale, and leaving it open to accumulate is the wrong answer. Closing is correct because the very next merge to `main` regenerates a fresh one.

On exhaustion (or when a re-derivation finds `main` already carries these baselines, or the force-push loses its lease) the job emits a `::notice::`, closes the PR with an explanatory comment via `gh pr close --delete-branch`, and exits 0. **This is a visible abstain, not a swallowed failure** — nothing is lost and the outcome is stated in the run log and on the closed PR, the same posture `holiday-confidence-track.yml` already takes when its KPI abstains.

### Explicitly NOT done

- No `|| true` appended to the merge.
- The `assert-baseline-only-diff.mjs` scope guard (#531) is unchanged, still fails closed, and is now re-run before *every* approval rather than once.
- The PAT self-approval guard is unchanged.
- The deliberate per-commit `push` concurrency group (`ci.yml:31`) is untouched.

## Regression guard

Three assertions added to `tests/scripts/baseline-gating.test.mjs` — already the home of the `#671` refresh-race regression tests, and already CI-wired as the `Baseline-gating regression test` step (`node --test 'tests/scripts/*.test.mjs'`). They assert over the workflow text, since the defect lives in the YAML rather than in a script:

1. the `gh pr merge` call sits inside a bounded `for attempt in 1 2 3` retry that re-derives via `rebuild_branch_on_main`;
2. exhaustion closes the superseded PR (`gh pr close --delete-branch`), announces it with `::notice::`, and exits 0;
3. the merge is not neutralised with `|| true` and the `#531` scope guard still runs.

All three **fail against the pre-fix workflow** (verified against `git show HEAD~1:.github/workflows/ci.yml`), so they are not vacuous. Full file: 19/19 pass under Node 22.

## Also in this diff

Four `.harness/comprehension/**/_module.md` shards were regenerated by the repo's own pre-commit comprehension hook (source-hash refreshes; three of them are pre-existing drift on `main` that the hook picks up on any commit). Not hand-edited.

## Adjacent findings, filed as follow-ups rather than widening this diff

- A **job-level** `concurrency:` group on `refresh-baselines` (`cancel-in-progress: false`) would serialize the refresh runs and shrink the race window this retry loop absorbs, without touching the deliberate per-commit verification concurrency. It would not fully close the race (`main` also advances from ordinary PR merges), so it complements rather than replaces this fix.
- Whether the repo *should* carry a `required_status_checks` rule at all — its absence is precisely what turns `--auto` into an immediate merge here, and that has implications well beyond this job.

---

**Do not auto-merge** — this branch is handed to a human to land.

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
