### PR TITLE
fix(persona): stop generated persona workflows cancelling main's verification (#1867)

### DIFF
--- a/.changeset/persona-workflow-concurrency-1867.md
+++ b/.changeset/persona-workflow-concurrency-1867.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Persona CI-workflow generator: split the generated `concurrency` group by event so a push to a
+trunk branch no longer cancels the previous commit's verification.
+
+The generator emitted `group: ${{ github.workflow }}-${{ github.ref }}` with an unconditional
+`cancel-in-progress: true`. A persona declaring an `on_commit` trigger generates `push:` to a trunk
+branch, where `github.ref` is constant across every commit — so each push cancelled the still-running
+run for the preceding commit, concluding `cancelled` rather than `failure` and alarming nothing.
+
+Generated workflows now use the shape established in #1865 for the hand-written workflows:
+push keys the group on `github.sha` (per commit, never cancelled), while `pull_request` keeps the
+per-ref group with cancellation on, so PR supersession and PR runner spend are unchanged.
+
+Refs #1867.

--- a/.github/workflows/persona-architecture-enforcer.yml
+++ b/.github/workflows/persona-architecture-enforcer.yml
@@ -19,8 +19,8 @@ on:
   schedule:
     - cron: 0 6 * * 1
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/persona-codebase-health-analyst.yml
+++ b/.github/workflows/persona-codebase-health-analyst.yml
@@ -13,8 +13,8 @@ on:
     - cron: 0 6 * * 1
   pull_request: {}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/persona-documentation-maintainer.yml
+++ b/.github/workflows/persona-documentation-maintainer.yml
@@ -17,8 +17,8 @@ on:
     branches:
       - main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/persona-entropy-cleaner.yml
+++ b/.github/workflows/persona-entropy-cleaner.yml
@@ -12,8 +12,8 @@ on:
   schedule:
     - cron: 0 6 * * 1
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/persona-graph-maintainer.yml
+++ b/.github/workflows/persona-graph-maintainer.yml
@@ -15,8 +15,8 @@ on:
     branches:
       - main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/persona-performance-guardian.yml
+++ b/.github/workflows/persona-performance-guardian.yml
@@ -16,8 +16,8 @@ on:
   schedule:
     - cron: 0 6 * * 1
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/persona-task-executor.yml
+++ b/.github/workflows/persona-task-executor.yml
@@ -18,8 +18,8 @@ on:
       - main
       - develop
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '17aee439742a3d7b0a86d183bb576689635aabc041f53aa72703f40ed6d8065a'
+sourceHash: '5f84ea3a892343e0a0f6b31ba40cb85de506aec8c52403aeb80096b52d4f662e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -135,6 +135,7 @@ export CURSOR_CURATED_TOOLS
 export DEFAULT_FIXTURES_DIR
 export DEFAULT_OPERATIONAL_DRIFT_POLICY
 export GIT_MAX_BUFFER_BYTES
+export INGEST_TOKEN_ENV
 export OUTCOME_BLOCK_ON_LEVELS
 export SCOPED_WALKERS
 export SKILL_REGRESSION_BLOCK_ON
@@ -316,6 +317,7 @@ export readReview
 export referencesTargetPr
 export refreshExitCode
 export renderTable
+export reportSemanticRegression
 export resolveBaseRef
 export resolveCandidates
 export resolveChangedScope
@@ -417,7 +419,7 @@ import { shouldRunComprehendHook } from '../comprehension/hook'
 import { enumerateModules, filesToModules } from '../comprehension/invalidation'
 import { committedSemanticAllowed } from '../comprehension/policy'
 import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../comprehension/refresh-gate'
-import { RegressionContext, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
+import { RefReadDeps, RegressionContext, SemanticState, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
 import { createStaticExtractor } from '../comprehension/static-extractor'
 import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js'
 import { findConfigFile, loadConfig, resolveConfig } from '../config/loader'
@@ -530,7 +532,7 @@ import { createCleanupSessionsCommand } from './cleanup-sessions'
 import { createCliErgonomicsCraftCommand } from './cli-ergonomics-craft'
 import { createCodeCraftCommand } from './code-craft'
 import { createCompoundCommand } from './compound'
-import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
+import { createComprehendCommand, formatCompiledUnits, reportSemanticRegression, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
 import { createComprehensionMergeDriverCommand } from './comprehension-merge-driver'
 import { createContextDictionaryCommand } from './context-dictionary'
 import { createCopyCraftCommand } from './copy-craft'

--- a/.harness/comprehension/packages/cli/src/persona/generators/_module.md
+++ b/.harness/comprehension/packages/cli/src/persona/generators/_module.md
@@ -1,30 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/persona/generators'
-sourceHash: '882e5170027d5272cfdc25c160774f1def1af12ecb2ec75526b5df45122e573f'
-compiledAt: '2026-08-28T01:22:09.308Z'
+sourceHash: '49daa649270757ce1dcb9fc81d3420d8a9875008fca92ebabcf4db3404d0fad7'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['agents-md.ts', 'ci-workflow.ts', 'repo-workflows.ts', 'runtime.ts']
 ---
-
-## Summary
-
-`packages/cli/src/persona/generators` synthesizes CI workflows and documentation from persona YAML declarations. It bridges dormant persona trigger definitions into committed, runnable GitHub Actions and GitLab CI workflows. The module exports three main generators: markdown documentation (`generateAgentsMd`) that formats roles/triggers/skills into AGENTS.md fragments; CI workflows (`generateCIWorkflow`) that translate persona triggers into platform-specific YAML (GitHub `on:` blocks, GitLab `rules:` with `$CI_PIPELINE_SOURCE` gates); and workflow I/O functions (`writePersonaWorkflows`, `checkPersonaWorkflows`) that persist and validate against persona declarations as a drift guard. It handles two CLI modes (npx for adopters, workspace for dogfooding), advisory-mode output wrapping (warnings instead of failures), and selective severity-flag injection (only `check-security` accepts `--severity`). Skill steps are intentionally excluded from CI (require runtime), and GitLab cron definitions are dropped (stored in project settings, not YAML).
-
-## Invariants
-
-- SEVERITY_AWARE_COMMANDS gate is exhaustive — --severity appends ONLY to check-security; appending to others hard-errors and silently skips subsequent steps with continue-on-error
-- Advisory mode is conditional output wrapping, not semantic change — wraps to emit ::warning:: annotations but never fails; blocking promotion requires re-generating without advisory=true
-- Platform trigger mapping is exclusive and exhaustive — each trigger event (on_pr, on_commit, scheduled, manual) maps to exactly one platform-specific structure; manual triggers have NO CI representation
-- Runner choice determines setup footprint — workspace runner includes full git history, pnpm install, Node 22, and pnpm build (required for history-dependent commands); npx runner skips setup
-- GitLab cron is UI-only, intentionally dropped — cron lives in project schedule settings, not YAML; generator gates on $CI_PIPELINE_SOURCE == "schedule" only
-- Skill steps never reach CI — only command steps are emitted; personas with only skill steps fall back to echo "No command steps to run in CI"
-- Concurrency cancellation is workspace-only — only workspace runner emits concurrency.cancel-in-progress: true (mirrors harness.yml dogfooding); npx adopters don't cancel advisory runs
-- Least-privilege token scope — all GitHub workflows set permissions.contents: 'read'
-- Path/branch/cron conditions default to 'all' — omitting conditions.paths on on_pr defaults to 'all files'; omitting conditions.branches on on_commit defaults to 'all branches'
-- Markdown trigger strings are deterministic — formatTrigger joins descriptors in declaration order (no sorting); output is fixed: ## {name} → Role → Triggers → Skills → remediation
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '119bdb5b982afb6ff2d7ae963971718e682c0450f0af09430d49605c00a25d4c'
+sourceHash: 'da58a667623dc1971daf31e9327deafc7bb36016aacf01edeee41967e472427c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -199,6 +199,7 @@ members:
     'validate.roadmap-health.test.ts',
     'validate.roadmap-mode.test.ts',
     'validate.test.ts',
+    'waypoint-ship.test.ts',
     'waypoint.test.ts',
   ]
 ---

--- a/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands/roadmap'
-sourceHash: '6da780b73a0b9c5309307def5411c39102c22d9ce468c7ee7ba7441df9c38e44'
+sourceHash: '5e9927551af9e10d8d828561dde3fcbec94d98e7c12fbab97d187ffa58158309'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -21,6 +21,7 @@ members:
     'shard-io.test.ts',
     'shard-roundtrip.e2e.test.ts',
     'shard.test.ts',
+    'sync-deps-pnyon.test.ts',
     'sync-report.test.ts',
     'sync-wiring.test.ts',
     'sync.test.ts',
@@ -48,12 +49,13 @@ import { ALLOW_UNREADABLE_HISTORY_ENV, runRoadmapRegen } from '../../../src/comm
 import { runRoadmapShard } from '../../../src/commands/roadmap/shard'
 import { createNodeShardIO } from '../../../src/commands/roadmap/shard-io'
 import { buildSyncOptions, createRoadmapSyncCommand, runRoadmapSync } from '../../../src/commands/roadmap/sync'
+import { resolveAdapter, resolveConfig } from '../../../src/commands/roadmap/sync-deps'
 import { buildReport, logSyncReport } from '../../../src/commands/roadmap/sync-report'
 import { BrainstormReportRow, TriageReportRow, buildPrecedentLookup, buildShapeHistory, createRoadmapTriageCommand, isPlausibleForModel, renderBrainstormHuman, renderBrainstormJson, renderHuman, renderJson, runApproveCommand, runBrainstormReport, runTriageReport, selectActionableFeatures } from '../../../src/commands/roadmap/triage'
 import { runRoadmapUnshard } from '../../../src/commands/roadmap/unshard'
 import { logger } from '../../../src/output/logger'
 import { ExitCode } from '../../../src/utils/errors'
-import { Err, ExternalTicket, ExternalTicketState, NewFeatureInput, Ok, Result, RoadmapFeature, RoadmapMeta, RoadmapTrackerClient, Shard, ShardStore, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, parseRoadmap, regenerate, resolveRoadmapStore, serializeMeta, serializeShard } from '@harness-engineering/core'
+import { Err, ExternalTicket, ExternalTicketState, GitHubIssuesSyncAdapter, NewFeatureInput, Ok, PnyonSyncAdapter, Result, RoadmapFeature, RoadmapMeta, RoadmapTrackerClient, Shard, ShardStore, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, parseRoadmap, regenerate, resolveRoadmapStore, serializeMeta, serializeShard } from '@harness-engineering/core'
 import { TriageVerdict } from '@harness-engineering/orchestrator'
 import { Roadmap, RoadmapFeature } from '@harness-engineering/types'
 import { Command } from 'commander'

--- a/.harness/comprehension/packages/cli/tests/persona/generators/_module.md
+++ b/.harness/comprehension/packages/cli/tests/persona/generators/_module.md
@@ -1,27 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/persona/generators'
-sourceHash: '9503edc637d9e27c9ac21df4474cabfa8915b7739644fc8f52319f0269197a24'
-compiledAt: '2026-08-28T01:22:09.867Z'
+sourceHash: '0ea9562a475076595a34de0cb9a2cb87c64aabf5012244ee43ffb49fbf4dc811'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['agents-md.test.ts', 'ci-workflow.test.ts', 'repo-workflows.test.ts', 'runtime.test.ts']
 ---
-
-## Summary
-
-The `packages/cli/tests/persona/generators` module tests a suite of generators that convert Persona definitions (structured role/trigger/command specs) into three deployment artifacts: (1) **generateAgentsMd** transforms Personas into markdown documentation with sections for role, skills, triggers, and remediation steps, handling both v1 (command-only) and v2 (command + skill hybrid) formats; (2) **generateCIWorkflow** compiles Personas into platform-specific CI definitions (GitHub Actions YAML or GitLab CI YAML), translating abstract triggers (`on_pr`, `on_commit`, `scheduled`) into platform syntax with path/branch filters, emitting only command steps (not skill steps) in CI, and supporting pluggable runners (`npx` for published harness, `workspace` for local builds) and an `advisory` mode for warn-not-fail behavior; (3) **Repo-workflows** (imported) manages persona workflows at the repository level. All generators return Result-typed values and are platform-aware.
-
-## Invariants
-
-- Severity flag selectivity: only check-security accepts --severity flag; other commands emitted bare. Tests verify both inclusion and omission per command.
-- CI skips skills: workflow generators emit only command-type steps; skill-type steps filtered out entirely (v2 personas can mix both, but skills are persona-local, not CI-facing).
-- Result-based error handling: all generators return Result<string> with {ok: boolean, value: string}, never throw. Callers must check .ok before accessing .value.
-- Advisory wrapping protocol: in advisory mode, every command step wrapped with || echo '::warning::'; non-advisory (blocking) mode omits wrapping entirely.
-- Runner isolation: npx runner produces minimal CI (no build/install steps); workspace runner builds locally and invokes compiled dist entry point—each adopter chooses deployment model.
-- Trigger syntax translation: abstract triggers[].event values (on_pr, on_commit, scheduled) map one-to-one to platform-specific keys (pull_request, push, schedule), preserving path/branch/cron conditions verbatim.
-- Permissions principle: generated workflows set least-privilege read-only permissions ({contents: 'read'}).
 
 ## Interface Contract
 

--- a/docs/changes/persona-workflow-cancel-1867/plans/2026-09-08-persona-workflow-cancel-plan.md
+++ b/docs/changes/persona-workflow-cancel-1867/plans/2026-09-08-persona-workflow-cancel-plan.md
@@ -1,0 +1,190 @@
+# Plan — persona CI workflows cancel main's own verification (#1867)
+
+- **Date:** 2026-09-08
+- **Issue:** #1867
+- **Precedent:** #1865 — `fix(ci): stop merge bursts from cancelling main's verification` (merge commit `93bc0788f`)
+- **Pipeline:** `harness-workflow-audit` (inventory → mechanical → judgment → report), then remediation
+- **Base SHA:** `db9c6739da57f6dd38a2e9d83bf94a1bfce9ca7b`
+- **Branch:** `cicd/persona-workflow-cancel-1867`
+
+---
+
+## 1. Audit findings
+
+`harness-workflow-audit` run scoped to `.github/workflows/persona-*.yml` (7 files) and their
+generator `packages/cli/src/persona/generators/ci-workflow.ts`.
+
+```
+WORKFLOW AUDIT: harness-engineering (scope: persona-*.yml + generator)
+Workflows audited: 7   Findings: 2 error, 1 info
+Gates that never fire: persona-architecture-enforcer.yml (pull_request, dead path filter)
+Documented-but-unwired gates: none in scope
+```
+
+### [ERROR] concurrency-cancels-trunk-verification — generator `ci-workflow.ts:202` (this change)
+
+All 7 generated workflows carry:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Four of the seven also trigger on `push:` to `main`:
+
+| generated workflow                     | `push`                  | `pull_request` | `schedule` | affected by the push defect |
+| -------------------------------------- | ----------------------- | -------------- | ---------- | --------------------------- |
+| `persona-architecture-enforcer.yml`    | yes (`main`, `develop`) | yes            | yes        | **yes**                     |
+| `persona-documentation-maintainer.yml` | yes (`main`)            | yes            | no         | **yes**                     |
+| `persona-graph-maintainer.yml`         | yes (`main`)            | no             | yes        | **yes**                     |
+| `persona-task-executor.yml`            | yes (`main`, `develop`) | yes            | no         | **yes**                     |
+| `persona-codebase-health-analyst.yml`  | no                      | yes            | yes        | no                          |
+| `persona-entropy-cleaner.yml`          | no                      | no             | yes        | no                          |
+| `persona-performance-guardian.yml`     | no                      | yes            | yes        | no                          |
+
+On a push, `github.ref` is `refs/heads/main` for **every** commit, so all main pushes share one
+concurrency group and each new merge cancels the still-running verification of the previous
+commit. The run concludes `cancelled`, not `failure`, so nothing alarms — the verification is
+destroyed silently.
+
+**Live evidence at the pinned base.** On the `75eade4ee` main push, three persona runs were
+cancelled when `2f1e5bd04` landed four minutes later:
+
+| workflow                 | run id        | conclusion  |
+| ------------------------ | ------------- | ----------- |
+| Documentation Maintainer | `34239670105` | `cancelled` |
+| Graph Maintainer         | `34239670102` | `cancelled` |
+| Task Executor            | `34239670064` | `cancelled` |
+
+**The repo already documents the symptom.** `scripts/main-health-check.mjs:32` — _"`cancel-in-progress: true`,
+so rapid merges leave a trail of cancelled runs"_ — and `DECISIVE_CONCLUSIONS` excludes
+`cancelled` to work around it.
+
+**Root cause is the generator, not the files.** The seven `.yml` files are generated and guarded
+by `pnpm generate:persona-workflows:check` in CI. #1865 fixed the same defect in the hand-written
+`ci.yml` / `harness.yml` but explicitly deferred the generated set (#1865 body, follow-up 1:
+_"Same concurrency defect in the 4 generated persona workflows → fix via their generator"_).
+#1867 is that follow-up.
+
+### [ERROR] path-filter-dead — `persona-architecture-enforcer.yml:14` (OUT OF SCOPE — filed as follow-up)
+
+`paths: src/**` resolves to **0 tracked files** (`git ls-files src/` → 0; there is no top-level
+`src/` in this repo — code lives under `packages/*/src/`). The `pull_request` trigger for
+Architecture Enforcer has therefore **never fired**. Three sibling workflows carry the same dead
+glob but survive because a second glob matches:
+
+| workflow                               | globs                          | live?                  |
+| -------------------------------------- | ------------------------------ | ---------------------- |
+| `persona-architecture-enforcer.yml`    | `src/**`                       | **dead — 0 matches**   |
+| `persona-documentation-maintainer.yml` | `src/**`, `docs/**` (2082)     | live via `docs/**`     |
+| `persona-performance-guardian.yml`     | `src/**`, `packages/**` (4332) | live via `packages/**` |
+| `persona-task-executor.yml`            | `src/**`, `packages/**` (4332) | live via `packages/**` |
+
+The globs originate in the persona source YAML (`agents/personas/*.yaml` `triggers.conditions.paths`),
+**not** in the concurrency logic this change touches. Fixing it means editing persona sources and
+regenerating — a different blast radius and a different defect. Deliberately **not** folded in;
+filed as a follow-up. Per the skill's escalation rule for a long-dead gate: re-arming it should be
+preceded by one manual run against the current tree, because it will surface a backlog.
+
+### [INFO] action pinning — persona workflows
+
+`pnpm/action-setup@v5` is third-party on a mutable major tag. The repo SHA-pins **nothing**
+(`grep -rE 'uses: [^ ]+@[0-9a-f]{40}' .github/workflows/` → 0 hits), so tag pinning is the
+established convention. No action; recorded for completeness.
+
+### Checks that came back clean
+
+- **M2 permissions** — every persona workflow declares `permissions: { contents: read }`. Least-privilege, correct.
+- **M4 self-trigger / push-back** — no `git push` or `git commit` in any persona workflow; they are read-only advisory jobs. No re-trigger guard needed.
+- **M5 / J1 injection** — no `${{ github.event.* }}` interpolation into any `run:` step. No `pull_request_target`.
+- **J4 fork-PR degradation** — jobs neither comment nor label; read-only `GITHUB_TOKEN` suffices.
+
+---
+
+## 2. Decision (F2) — binding, taken by the human
+
+**Chosen: (a) fix the generator and regenerate the seven files.**
+
+Rejected: (b) also fix `packages/cli/src/commands/ci/init.ts:107`, the second, adopter-facing
+emitter carrying the identical defect. Rationale: (b) changes scaffolding output for **every
+adopter** — a materially larger blast radius than a change to this repo's own dogfooded
+workflows. It is a real defect and the repo's known dual-source-of-truth hazard, so it is filed
+as a follow-up rather than dropped.
+
+---
+
+## 3. The fix
+
+Apply #1865's blessed shape at the generator, so all seven regenerate with it:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+- **push → per-COMMIT group (`github.sha`), never cancelled** — every commit landing on `main`
+  reaches its own persona verdict.
+- **PR → per-REF group, cancel-in-progress ON** — a new push to a PR still supersedes the old
+  run. PR runner spend unchanged.
+
+Consistency with #1865 is the point: the same expression, verbatim, in the third place this
+defect lives. #1865 already validated that `cancel-in-progress` officially accepts an expression
+and that the `A && B || C` idiom runs on this repo's runners.
+
+### Consequence for the three non-`push` workflows
+
+`persona-codebase-health-analyst`, `persona-entropy-cleaner` and `persona-performance-guardian`
+have no `push` trigger, so their behaviour changes only on the `schedule` path: previously a new
+scheduled run cancelled an in-flight one; now it queues behind it (group keyed on `github.sha`,
+`cancel-in-progress` false). These are weekly/daily crons on advisory jobs — the change is
+immaterial, and it is the identical trade #1865 accepted for `ci.yml` / `harness.yml`, which are
+also non-PR on their scheduled path.
+
+### Runner spend
+
+Main-branch spend rises with burst size, exactly as in #1865. That increase **is** the fix:
+verifying every commit necessarily costs more than verifying one in four. These are
+single-job `ubuntu-latest` advisory workflows, so the absolute cost is far below #1865's
+three-OS matrix.
+
+---
+
+## 4. Observable truths and their gates
+
+| #   | Truth                                                        | Gate                                                              |
+| --- | ------------------------------------------------------------ | ----------------------------------------------------------------- |
+| 1   | Generator no longer emits `cancel-in-progress: true` literal | new unit test in `ci-workflow.test.ts`                            |
+| 2   | Generator emits the event-conditional group expression       | new unit test asserts the exact string                            |
+| 3   | PR event still cancels superseded runs                       | test asserts the `pull_request` branch of the expression          |
+| 4   | Push event is keyed on `github.sha`, not `github.ref`        | test asserts `github.sha` present, bare `github.ref }}` absent    |
+| 5   | All 7 committed workflows match generator output             | `pnpm generate:persona-workflows:check` (CI, ubuntu)              |
+| 6   | Every regenerated file still parses as YAML                  | `generate:persona-workflows:check` + prettier                     |
+| 7   | No unrelated file changed                                    | `git diff --stat` is exactly generator + 7 yml + test + this plan |
+| 8   | `ci/init.ts` untouched                                       | `git diff --name-only` excludes it                                |
+| 9   | Existing generator behaviour unregressed                     | full `ci-workflow.test.ts` suite green                            |
+| 10  | Repo gates pass without `--no-verify`                        | pre-commit + pre-push clean                                       |
+
+---
+
+## 5. Change delta
+
+| path                                                        | change                                                                                    |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `packages/cli/src/persona/generators/ci-workflow.ts`        | event-split concurrency + a comment citing #1865/#1867                                    |
+| `.github/workflows/persona-*.yml` (7)                       | regenerated                                                                               |
+| `packages/cli/tests/persona/generators/ci-workflow.test.ts` | update the stale `cancel-in-progress === true` assertion; add a dedicated regression test |
+| `docs/changes/persona-workflow-cancel-1867/plans/`          | this plan                                                                                 |
+
+Explicitly **not** touched: `packages/cli/src/commands/ci/init.ts`, `agents/personas/*.yaml`,
+`scripts/main-health-check.mjs`.
+
+---
+
+## 6. Follow-ups (filed, not done here)
+
+1. `packages/cli/src/commands/ci/init.ts:107` — adopter-facing emitter with the identical
+   defect (dual source of truth with the persona generator).
+2. `persona-architecture-enforcer.yml` `paths: src/**` — dead PR path filter, gate has never
+   fired; fix at the persona source YAML.

--- a/packages/cli/src/persona/generators/ci-workflow.ts
+++ b/packages/cli/src/persona/generators/ci-workflow.ts
@@ -195,11 +195,33 @@ export function generateCIWorkflow(
       on: buildGitHubTriggers(persona.triggers),
     };
     if (runner === 'workspace') {
-      // Cancel superseded runs on rapid pushes so advisory jobs don't pile up
-      // (matches harness.yml / pr-advisory-checks.yml).
+      // Concurrency is SPLIT BY EVENT on purpose — do not "simplify" this back to a
+      // plain `${{ github.workflow }}-${{ github.ref }}` + `cancel-in-progress: true`.
+      //
+      // A persona can declare an `on_commit` trigger, which generates `push:` to a
+      // trunk branch. On a push, `github.ref` is `refs/heads/main` for EVERY commit,
+      // so a per-ref group puts all main pushes in ONE bucket and each new merge
+      // cancels the still-running verification of the previous commit. The run
+      // concludes `cancelled`, not `failure`, so nothing alarms — the verdict is
+      // destroyed silently. Observed on the 75eade4ee main push: Documentation
+      // Maintainer (34239670105), Graph Maintainer (34239670102) and Task Executor
+      // (34239670064) were all cancelled when 2f1e5bd04 landed four minutes later.
+      // See also scripts/main-health-check.mjs, whose DECISIVE_CONCLUSIONS has to
+      // exclude `cancelled` to work around this very trail.
+      //
+      //   push  -> per-COMMIT group (github.sha), never cancelled, so every commit
+      //            that lands on a trunk branch reaches its own persona verdict.
+      //   PR    -> per-REF group, cancel-in-progress ON, so a new push to a PR still
+      //            supersedes the old run. PR runner spend is unchanged.
+      //
+      // This is the shape #1865 established for the hand-written ci.yml/harness.yml;
+      // #1867 brings the generated persona workflows onto it. `cancel-in-progress`
+      // officially accepts an expression, and the `A && B || C` idiom is already
+      // proven on this repo's runners (ci.yml `Test` step).
       workflow.concurrency = {
-        group: '${{ github.workflow }}-${{ github.ref }}',
-        'cancel-in-progress': true,
+        group:
+          "${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}",
+        'cancel-in-progress': "${{ github.event_name == 'pull_request' }}",
       };
     }
     // These jobs only read the tree; least-privilege token.

--- a/packages/cli/tests/persona/generators/ci-workflow.test.ts
+++ b/packages/cli/tests/persona/generators/ci-workflow.test.ts
@@ -143,9 +143,62 @@ describe('generateCIWorkflow (options)', () => {
     expect(cmdSteps[1].run).toBe('node packages/cli/dist/bin/harness.js validate');
     // Node 22 (not the npx default of 20) and a concurrency guard.
     expect(workflow.on).toBeDefined();
-    expect(workflow.concurrency['cancel-in-progress']).toBe(true);
+    expect(workflow.concurrency).toBeDefined();
     const nodeStep = uses.find((s: { uses: string }) => s.uses === 'actions/setup-node@v6');
     expect(nodeStep.with['node-version']).toBe(22);
+  });
+
+  // Regression: #1867. The generator emitted a per-ref group with an unconditional
+  // `cancel-in-progress: true`. A persona with an `on_commit` trigger generates
+  // `push:` to a trunk branch, where `github.ref` is constant across every commit,
+  // so each merge cancelled the previous commit's still-running verification — the
+  // run concluded `cancelled`, not `failure`, so nothing alarmed. Fixed by adopting
+  // the event-split shape #1865 established for ci.yml / harness.yml.
+  it('does not emit a cancelling concurrency group for the push-to-trunk path (#1867)', () => {
+    // mockPersona declares on_pr + on_commit(main), so it generates BOTH push: and
+    // pull_request: — the exact trigger pair that produced the defect.
+    const result = generateCIWorkflow(mockPersona, 'github', { runner: 'workspace' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const workflow = YAML.parse(result.value);
+    expect(workflow.on.push).toBeDefined();
+    expect(workflow.on.pull_request).toBeDefined();
+
+    // cancel-in-progress must be conditional on the event, never a bare `true`.
+    // A literal true here is the defect: it cancels main's own verification.
+    const cancel = workflow.concurrency['cancel-in-progress'];
+    expect(cancel).not.toBe(true);
+    expect(cancel).toBe("${{ github.event_name == 'pull_request' }}");
+
+    // The group must key on github.sha (per-commit) off the PR path, so two main
+    // commits never share a bucket. A bare `github.ref` group is the defect.
+    const group = workflow.concurrency.group as string;
+    expect(group).toBe(
+      "${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}"
+    );
+    expect(group).toContain('github.sha');
+    expect(group).not.toBe('${{ github.workflow }}-${{ github.ref }}');
+  });
+
+  it('still cancels superseded runs on the pull_request path (#1867)', () => {
+    // The fix must not disable PR supersession — that would be a runner-spend
+    // regression, and per-ref cancellation is correct behaviour for a PR.
+    const prOnly: Persona = {
+      ...mockPersona,
+      triggers: [{ event: 'on_pr' as const, conditions: { paths: ['packages/**'] } }],
+    };
+    const result = generateCIWorkflow(prOnly, 'github', { runner: 'workspace' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const workflow = YAML.parse(result.value);
+    // Both halves of the expression are present, so a pull_request event resolves to
+    // the per-ref group with cancellation ON.
+    expect(workflow.concurrency.group).toContain(
+      "github.event_name == 'pull_request' && github.ref"
+    );
+    expect(workflow.concurrency['cancel-in-progress']).toBe(
+      "${{ github.event_name == 'pull_request' }}"
+    );
   });
 
   it('appends --severity only to check-security, the one command that accepts it', () => {


### PR DESCRIPTION
## Summary

The persona CI-workflow **generator** emits a per-ref concurrency group with an unconditional `cancel-in-progress: true`. Four of the seven generated workflows also trigger on `push:` to a trunk branch, where `github.ref` is `refs/heads/main` for **every** commit — so all main pushes share one concurrency group and each merge **cancels the still-running verification of the previous commit**.

The run concludes `cancelled`, not `failure`, so **nothing alarms**. The verdict is destroyed silently.

This is #1865's defect in its third home. #1865 fixed the hand-written `ci.yml` / `harness.yml` and explicitly deferred the generated set (its follow-up 1: *"Same concurrency defect in the 4 generated persona workflows → fix via their generator"*). #1867 is that follow-up.

Refs #1867. Precedent: #1865 (merge commit `93bc0788f`).

## Evidence

Live, at the pinned base `db9c6739d`. On the `75eade4ee` main push, three persona runs were cancelled when `2f1e5bd04` landed four minutes later:

| workflow | run id | conclusion |
| --- | --- | --- |
| Documentation Maintainer | `34239670105` | `cancelled` |
| Graph Maintainer | `34239670102` | `cancelled` |
| Task Executor | `34239670064` | `cancelled` |

**The repo already documents the symptom.** `scripts/main-health-check.mjs:32` — *"`cancel-in-progress: true`, so rapid merges leave a trail of cancelled runs"* — and its `DECISIVE_CONCLUSIONS` has to exclude `cancelled` to work around it.

### Which of the seven are actually affected

All 7 carry the defective block; **4** have a `push` trigger and are therefore hit by the trunk-cancellation defect. Correcting the brief I was given (which said 7 trigger on push) — #1867's own title says 4, and 4 is right:

| generated workflow | `push` | `pull_request` | `schedule` | hit by the defect |
| --- | --- | --- | --- | --- |
| `persona-architecture-enforcer.yml` | yes (`main`, `develop`) | yes | yes | **yes** |
| `persona-documentation-maintainer.yml` | yes (`main`) | yes | no | **yes** |
| `persona-graph-maintainer.yml` | yes (`main`) | no | yes | **yes** |
| `persona-task-executor.yml` | yes (`main`, `develop`) | yes | no | **yes** |
| `persona-codebase-health-analyst.yml` | no | yes | yes | no |
| `persona-entropy-cleaner.yml` | no | no | yes | no |
| `persona-performance-guardian.yml` | no | yes | yes | no |

## The fix

Applied at `packages/cli/src/persona/generators/ci-workflow.ts` — #1865's blessed shape, verbatim, so all seven regenerate with it:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **push → per-COMMIT group (`github.sha`), never cancelled** — every commit landing on a trunk branch reaches its own persona verdict.
- **PR → per-REF group, cancel-in-progress ON** — a new push to a PR still supersedes the old run. **PR runner spend is unchanged.**

The emitted block carries a comment citing the three cancelled run IDs and both issues, so the next reader does not "simplify" it back — matching how #1865 annotated `ci.yml` / `harness.yml`.

Consistency with the already-blessed fix was the goal, not a new approach. #1865 had already validated that `cancel-in-progress` officially accepts an expression and that the `A && B || C` idiom runs on this repo's runners.

## Tests

Two regression tests in `packages/cli/tests/persona/generators/ci-workflow.test.ts`:

1. `does not emit a cancelling concurrency group for the push-to-trunk path (#1867)` — asserts `cancel-in-progress` is never a literal `true` and the group keys on `github.sha`.
2. `still cancels superseded runs on the pull_request path (#1867)` — guards against over-correcting into a PR runner-spend regression.

**Both were verified to fail against the pre-fix generator** (stashed the fix, ran `-t 1867` → `2 failed`; restored → `20 passed`). A generator defect that regenerates silently is exactly what let this survive #1865, so a test that cannot fail would have been worthless here.

One pre-existing assertion (`expect(workflow.concurrency['cancel-in-progress']).toBe(true)`) encoded the defect as expected behaviour and was updated.

## Remediation actions / assumptions made

1. **Root cause: the generator, not the seven files.** The `.yml` files are generated and guarded by `pnpm generate:persona-workflows:check` in CI. Hand-patching them would have been reverted by the next regeneration.

2. **F2 — the human's binding decision: fix the generator only.** `packages/cli/src/commands/ci/init.ts:107` is a **second, adopter-facing emitter carrying the identical defect** (this repo's known dual-source-of-truth hazard). Option (b), fixing it too, was **explicitly not taken, on blast-radius grounds**: it changes scaffolding output for every adopter, which is materially larger than a change to this repo's own dogfooded workflows. It is a real defect, so it is **filed as a follow-up, not dropped** — see below.

3. **Applied the shape unconditionally rather than only when a `push` trigger is present.** Keeps generated output uniform and identical to #1865. Consequence for the three non-`push` workflows: on their `schedule` path a new run now queues behind an in-flight one instead of cancelling it. These are weekly/daily crons on advisory single-job workflows — immaterial, and the same trade #1865 accepted.

4. **Runner spend on trunk rises with burst size — stated plainly.** That increase *is* the fix: verifying every commit necessarily costs more than verifying one in four. These are single-job `ubuntu-latest` advisory workflows, so the absolute cost is far below #1865's three-OS matrix.

5. **Did not touch `scripts/main-health-check.mjs`.** Its comment goes partially stale, but its logic stays correct (excluding `cancelled` is still right; there will just be far fewer). Out of scope — already a #1865 follow-up.

6. **Five `_module.md` comprehension shards are in the diff.** These are written by the repo's pre-commit comprehension hook, not by hand; three cover directories this change does not touch (the known local-only driver behaviour). Called out so they are not mistaken for scope creep.

## Second finding from the same audit — filed, not fixed here

The `harness-workflow-audit` run surfaced an **independent error-severity defect**, reported rather than folded in:

**`persona-architecture-enforcer.yml:14` — `paths: src/**` resolves to 0 tracked files.** There is no top-level `src/` in this repo (code lives under `packages/*/src/`); `git ls-files src/` → **0**. The Architecture Enforcer `pull_request` gate has therefore **never fired**. Three siblings carry the same dead glob but survive on a second one (`docs/**` → 2082 files, `packages/**` → 4332).

Out of scope: those globs come from `agents/personas/*.yaml`, not from the concurrency logic. Filed separately. Per the audit skill's escalation rule, re-arming a long-dead gate should be preceded by one manual run against the current tree — it will surface a backlog.

## Verification

- `pnpm generate:persona-workflows:check` (the CI drift guard) → **`OK — 7 persona workflows are up to date`**
- All 7 regenerated files re-parse as YAML; programmatic assert that none retains `cancel-in-progress: true` and all key on `github.sha`
- `grep` for the defective group/flag across the 7 → **zero residual occurrences**
- `ci-workflow.test.ts` → **20 passed** (was 18)
- `tsc --noEmit` on `@harness-engineering/cli` → clean
- `pnpm format:check` (whole tree) → all files match Prettier style
- Committed and pushed through **all** pre-commit and pre-push gates with **no `--no-verify`** (arch gate, traceability, lint-staged, comprehension compile, changeset check, `generate-docs --check`, tool-catalog check)
- Explicitly **not** touched: `packages/cli/src/commands/ci/init.ts`, `agents/personas/*.yaml`, `scripts/main-health-check.mjs`

## Plan artifact

`docs/changes/persona-workflow-cancel-1867/plans/2026-09-08-persona-workflow-cancel-plan.md` — full audit output (inventory / mechanical / judgment / report), the clean checks, the F2 decision record, 10 observable truths with their gates, and the change delta.

## Follow-ups (filed, not done here)

1. `packages/cli/src/commands/ci/init.ts:107` — adopter-facing emitter, identical defect.
2. `persona-architecture-enforcer.yml` `paths: src/**` — dead PR path filter; fix at the persona source YAML.

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
