### PR TITLE
craft(core): name the artifact — rehearsalTierFor -> rehearsalTierForScore, with a deprecated alias

### DIFF
--- a/.changeset/rehearsal-tier-for-score.md
+++ b/.changeset/rehearsal-tier-for-score.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/core': minor
+---
+
+`rehearsalTierFor` is now `rehearsalTierForScore`; the old name stays as a deprecated alias
+
+The old name predicted its return type but left its input unnamed — `For` what? At a
+call site like `rehearsalTierFor(value)` a reader could not tell whether the argument was
+a score, a run, an attempt record, or a config without opening the signature.
+`rehearsalTierForScore(score)` names the artifact being mapped from.
+
+`@harness-engineering/core` is published, so a bare rename would be a breaking change.
+`rehearsalTierFor` is retained as a `@deprecated` alias — a `const` binding to the same
+function, so `rehearsalTierFor === rehearsalTierForScore` holds and existing imports keep
+working unchanged. That makes this release MINOR, not MAJOR. The alias will be removed in
+a future MAJOR release.

--- a/.changeset/rehearsal-tier-for-score.md
+++ b/.changeset/rehearsal-tier-for-score.md
@@ -14,3 +14,7 @@ a score, a run, an attempt record, or a config without opening the signature.
 function, so `rehearsalTierFor === rehearsalTierForScore` holds and existing imports keep
 working unchanged. That makes this release MINOR, not MAJOR. The alias will be removed in
 a future MAJOR release.
+
+The one observable difference: because the alias is a binding to the same function rather
+than a wrapper, `rehearsalTierFor.name` now reports `'rehearsalTierForScore'`. Nothing that
+calls the function is affected.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '17aee439742a3d7b0a86d183bb576689635aabc041f53aa72703f40ed6d8065a'
+sourceHash: '5f84ea3a892343e0a0f6b31ba40cb85de506aec8c52403aeb80096b52d4f662e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -135,6 +135,7 @@ export CURSOR_CURATED_TOOLS
 export DEFAULT_FIXTURES_DIR
 export DEFAULT_OPERATIONAL_DRIFT_POLICY
 export GIT_MAX_BUFFER_BYTES
+export INGEST_TOKEN_ENV
 export OUTCOME_BLOCK_ON_LEVELS
 export SCOPED_WALKERS
 export SKILL_REGRESSION_BLOCK_ON
@@ -316,6 +317,7 @@ export readReview
 export referencesTargetPr
 export refreshExitCode
 export renderTable
+export reportSemanticRegression
 export resolveBaseRef
 export resolveCandidates
 export resolveChangedScope
@@ -417,7 +419,7 @@ import { shouldRunComprehendHook } from '../comprehension/hook'
 import { enumerateModules, filesToModules } from '../comprehension/invalidation'
 import { committedSemanticAllowed } from '../comprehension/policy'
 import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../comprehension/refresh-gate'
-import { RegressionContext, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
+import { RefReadDeps, RegressionContext, SemanticState, defaultRefReadDeps, detectCommittedSemanticOnBranch, detectSemanticRegressions, readSemanticMapAtRef } from '../comprehension/regression'
 import { createStaticExtractor } from '../comprehension/static-extractor'
 import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js'
 import { findConfigFile, loadConfig, resolveConfig } from '../config/loader'
@@ -530,7 +532,7 @@ import { createCleanupSessionsCommand } from './cleanup-sessions'
 import { createCliErgonomicsCraftCommand } from './cli-ergonomics-craft'
 import { createCodeCraftCommand } from './code-craft'
 import { createCompoundCommand } from './compound'
-import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
+import { createComprehendCommand, formatCompiledUnits, reportSemanticRegression, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from './comprehend'
 import { createComprehensionMergeDriverCommand } from './comprehension-merge-driver'
 import { createContextDictionaryCommand } from './context-dictionary'
 import { createCopyCraftCommand } from './copy-craft'

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: '119bdb5b982afb6ff2d7ae963971718e682c0450f0af09430d49605c00a25d4c'
+sourceHash: 'da58a667623dc1971daf31e9327deafc7bb36016aacf01edeee41967e472427c'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -199,6 +199,7 @@ members:
     'validate.roadmap-health.test.ts',
     'validate.roadmap-mode.test.ts',
     'validate.test.ts',
+    'waypoint-ship.test.ts',
     'waypoint.test.ts',
   ]
 ---

--- a/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/roadmap/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands/roadmap'
-sourceHash: '6da780b73a0b9c5309307def5411c39102c22d9ce468c7ee7ba7441df9c38e44'
+sourceHash: '5e9927551af9e10d8d828561dde3fcbec94d98e7c12fbab97d187ffa58158309'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -21,6 +21,7 @@ members:
     'shard-io.test.ts',
     'shard-roundtrip.e2e.test.ts',
     'shard.test.ts',
+    'sync-deps-pnyon.test.ts',
     'sync-report.test.ts',
     'sync-wiring.test.ts',
     'sync.test.ts',
@@ -48,12 +49,13 @@ import { ALLOW_UNREADABLE_HISTORY_ENV, runRoadmapRegen } from '../../../src/comm
 import { runRoadmapShard } from '../../../src/commands/roadmap/shard'
 import { createNodeShardIO } from '../../../src/commands/roadmap/shard-io'
 import { buildSyncOptions, createRoadmapSyncCommand, runRoadmapSync } from '../../../src/commands/roadmap/sync'
+import { resolveAdapter, resolveConfig } from '../../../src/commands/roadmap/sync-deps'
 import { buildReport, logSyncReport } from '../../../src/commands/roadmap/sync-report'
 import { BrainstormReportRow, TriageReportRow, buildPrecedentLookup, buildShapeHistory, createRoadmapTriageCommand, isPlausibleForModel, renderBrainstormHuman, renderBrainstormJson, renderHuman, renderJson, runApproveCommand, runBrainstormReport, runTriageReport, selectActionableFeatures } from '../../../src/commands/roadmap/triage'
 import { runRoadmapUnshard } from '../../../src/commands/roadmap/unshard'
 import { logger } from '../../../src/output/logger'
 import { ExitCode } from '../../../src/utils/errors'
-import { Err, ExternalTicket, ExternalTicketState, NewFeatureInput, Ok, Result, RoadmapFeature, RoadmapMeta, RoadmapTrackerClient, Shard, ShardStore, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, parseRoadmap, regenerate, resolveRoadmapStore, serializeMeta, serializeShard } from '@harness-engineering/core'
+import { Err, ExternalTicket, ExternalTicketState, GitHubIssuesSyncAdapter, NewFeatureInput, Ok, PnyonSyncAdapter, Result, RoadmapFeature, RoadmapMeta, RoadmapTrackerClient, Shard, ShardStore, SyncResult, TrackedFeature, TrackerSyncAdapter, TrackerSyncConfig, parseRoadmap, regenerate, resolveRoadmapStore, serializeMeta, serializeShard } from '@harness-engineering/core'
 import { TriageVerdict } from '@harness-engineering/orchestrator'
 import { Roadmap, RoadmapFeature } from '@harness-engineering/types'
 import { Command } from 'commander'

--- a/.harness/comprehension/packages/core/src/rehearsal/_module.md
+++ b/.harness/comprehension/packages/core/src/rehearsal/_module.md
@@ -1,28 +1,21 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/rehearsal'
-sourceHash: '4d8fc87f3d9b998f5cc9868e27387cd69c27ad23586fd90c871dc4a1599935ec'
-compiledAt: '2026-08-28T01:22:10.460Z'
+sourceHash: '4f66abd9b5c9fea055eb30aaafcb9c565899d832668be043c3a1439744f59f5d'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
-members: ['catalog.test.ts', 'catalog.ts', 'index.ts', 'scoring.test.ts', 'scoring.ts', 'types.ts']
+model: null
+semantic: absent
+members:
+  [
+    'catalog.test.ts',
+    'catalog.ts',
+    'index.ts',
+    'public-entry.test.ts',
+    'scoring.test.ts',
+    'scoring.ts',
+    'types.ts',
+  ]
 ---
-
-## Summary
-
-The `rehearsal` module provides a deterministic scoring system for evaluating whether an agent successfully detected and recovered from deliberately-planted failure scenarios. It has two layers: a catalog layer (`catalog.ts`) that discovers and validates fixture manifests from the filesystem, and a scoring layer (`scoring.ts`) that grades recovery attempts against manifests' rubrics. Each fixture directory contains a `rehearsal.json` describing one planted failure (e.g., hardcoded secrets, layer violations) with expected check/fix instructions. Recovery scoring is pure, deterministic, and offline—no IO or LLM involved. Scoring maps five weighted dimensions (detected, correctCheck, fixed, noCollateral, identifiedFailureMode) to tiers: pass (≥80), partial (50–79), fail (<50). Bad fixtures degrade gracefully; the catalog skips malformed entries and returns empty when the fixtures root is absent.
-
-## Invariants
-
-- ID ↔ directory name bijection: a fixture's manifest ID must exactly match its parent directory name; violations rejected at load time to ensure `rehearse score --fixture <id>` resolves uniquely
-- Manifest schema is authoritative: all fixtures pass Zod schema validation; schema-invalid fixtures return errors and never load
-- Bad fixtures degrade gracefully: loadCatalog skips directories without valid manifests and returns empty list when fixtures root is absent; broken fixtures surface only when explicitly loaded via findFixture
-- Detection credit is conditional on match: if an agent names a failure mode differing from the manifest's expected mode, detection credit is withheld—confidence in wrong diagnosis is penalized
-- Check citation is normalized but not lenient: 'check-security' and 'harness check-security' are equivalent (prefix-stripped), but substring matches (e.g., bare 'check' for 'check-arch') do not credit
-- Collateral damage always costs: the noCollateral dimension penalizes any collateral damage, even on otherwise perfect recoveries
-- Tiers are banded, not graduated: score bands are absolute (≥80 pass, 50–79 partial, <50 fail); no continuous gradient per tier
-- Result types prevent throws: all I/O operations (loadManifest, findFixture) return Result<T, Error>, never throw—callers decide how to handle missing/malformed data
 
 ## Interface Contract
 
@@ -34,12 +27,14 @@ export findFixture
 export loadCatalog
 export loadManifest
 export rehearsalTierFor
+export rehearsalTierForScore
 export scoreRecovery
 ```
 
 ## Dependency Slice
 
 ```
+import { rehearsalTierFor, rehearsalTierForScore } from '../index'
 import { Err, Ok, Result } from '../shared/result'
 import { MANIFEST_FILENAME, findFixture, loadCatalog, loadManifest } from './catalog'
 import { REHEARSAL_WEIGHTS, rehearsalTierFor, scoreRecovery } from './scoring'

--- a/.harness/comprehension/packages/core/src/rehearsal/_module.md
+++ b/.harness/comprehension/packages/core/src/rehearsal/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/core/src/rehearsal'
-sourceHash: '4f66abd9b5c9fea055eb30aaafcb9c565899d832668be043c3a1439744f59f5d'
+sourceHash: '955513ef14381d08c9a8afeeacbde37040cba837985f1bdabc9d4bfc0a48c2ab'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -37,7 +37,7 @@ export scoreRecovery
 import { rehearsalTierFor, rehearsalTierForScore } from '../index'
 import { Err, Ok, Result } from '../shared/result'
 import { MANIFEST_FILENAME, findFixture, loadCatalog, loadManifest } from './catalog'
-import { REHEARSAL_WEIGHTS, rehearsalTierFor, scoreRecovery } from './scoring'
+import { REHEARSAL_WEIGHTS, rehearsalTierForScore, scoreRecovery } from './scoring'
 import { RecoveryRecord, RehearsalManifest, RehearsalManifestSchema, RehearsalScore, RehearsalTier, ScoreDimension } from './types'
 import * as fs from 'fs'
 import * as os from 'os'

--- a/docs/changes/craft-naming-core-rehearsal/plans/2026-09-08-rename-with-deprecated-alias-plan.md
+++ b/docs/changes/craft-naming-core-rehearsal/plans/2026-09-08-rename-with-deprecated-alias-plan.md
@@ -1,0 +1,591 @@
+# Plan: `rehearsalTierFor` → `rehearsalTierForScore` (rename with deprecated alias)
+
+**Date:** 2026-09-08
+**Spec:** `docs/changes/craft-naming-core-rehearsal/proposal.md`
+**Issue:** [#2009](https://github.com/Intense-Visions/harness-engineering/issues/2009)
+**Base SHA:** `b501db7d8e1ec613644e5d745453a273aa39c3b2`
+**Tasks:** 7 | **Checkpoints:** 1 | **Time:** ~22 min | **Integration Tier:** medium
+**Rigor:** standard (skeleton pass not required — 7 tasks < 8 threshold)
+
+## Goal
+
+Rename `rehearsalTierFor` to `rehearsalTierForScore` in `packages/core/src/rehearsal`, keeping
+`rehearsalTierFor` reachable from the published `@harness-engineering/core` public entry as a
+deprecated `const` alias, so the change ships semver-MINOR rather than MAJOR.
+
+Decisions D1–D7 were settled at a human gate in the spec and are **not** re-litigated here.
+
+## Ground truth (verified at base SHA `b501db7`)
+
+Every location below was re-read at this SHA, not carried forward from the brief.
+
+| Location                                                           | Verified content                                                                    |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `packages/core/src/rehearsal/scoring.ts:24`                        | `export function rehearsalTierFor(score: number): RehearsalTier {`                  |
+| `packages/core/src/rehearsal/scoring.ts:120`                       | `    tier: rehearsalTierFor(score),`                                                |
+| `packages/core/src/rehearsal/index.ts:10`                          | `export { REHEARSAL_WEIGHTS, rehearsalTierFor, scoreRecovery } from './scoring';`   |
+| `packages/core/src/index.ts:380`                                   | `export * from './rehearsal';`                                                      |
+| `packages/core/src/rehearsal/scoring.test.ts:2`                    | `import { scoreRecovery, rehearsalTierFor, REHEARSAL_WEIGHTS } from './scoring';`   |
+| `packages/core/src/rehearsal/scoring.test.ts:41,43,44,45,46,47,48` | `describe('rehearsalTierFor', ...)` + 6 assertions                                  |
+| `scripts/generate-core-barrel.mjs`                                 | zero matches for `rehearsal` — confirms **D7** (no allowlist edit needed)           |
+| `packages/core/package.json`                                       | `@harness-engineering/core@0.48.0`, `private` unset, `exports["."] -> dist/index.*` |
+
+**Complete reference inventory.** A repo-wide grep for `rehearsalTierFor` (excluding
+`node_modules`, `dist`, `.git`) returns exactly **11 code references across 3 source files**
+(`scoring.ts` ×2, `index.ts` ×1, `scoring.test.ts` ×8), plus the spec document and the generated
+comprehension shard. **There are no other importers anywhere in the monorepo** — in particular,
+zero references in `packages/orchestrator`, which the scope limit puts off-limits. The file map
+below is therefore provably complete.
+
+**`.harness/comprehension/packages/core/src/rehearsal/_module.md`** contains two stale references
+(`:36`, `:45`). It is a **generated artifact** — do NOT hand-edit it. The pre-commit comprehension
+driver refreshes it; the execution agent stages whatever the hook rewrites.
+
+## Baseline measurements (captured at base SHA, Node 22.23.2)
+
+Measured with `cmd > /tmp/out 2>&1; echo $?` — never through a pipe.
+
+| Command                                                                 | Exit | Signature                                                                                                                       | Gate quality    |
+| ----------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `pnpm run generate:barrels:check`                                       | `0`  | "Command registry is up to date. Core barrel is up to date."                                                                    | **clean gate**  |
+| `pnpm --filter @harness-engineering/core exec vitest run src/rehearsal` | `0`  | 2 files, 20 tests passed, 118ms                                                                                                 | **clean gate**  |
+| `pnpm --filter @harness-engineering/core run typecheck`                 | `0`  | `tsc --noEmit` silent                                                                                                           | **clean gate**  |
+| `npx eslint src/rehearsal` (in `packages/core`)                         | `0`  | no output                                                                                                                       | **clean gate**  |
+| `harness validate`                                                      | `1`  | `x Validation failed (450 issues)`; 450 `^  \* ` bullets                                                                        | **AMBIENT RED** |
+| `harness check-deps`                                                    | `1`  | exactly **1** `Circular dependency` line, in `packages/core/src/solutions/scan-candidates/`; **0** lines mentioning `rehearsal` | **AMBIENT RED** |
+
+The first four gates are **green at baseline**, so any non-zero exit from them after this change is
+a genuine regression — no differential reasoning needed. The last two are ambiently red for reasons
+disjoint from `src/rehearsal`, so they are verified **differentially** against the signatures above,
+not by exit code.
+
+**Feasibility probe (resolves the spec's Risk 3).** Importing the full core public entry from source
+under Node 22 was measured directly: `import('packages/core/src/index.ts')` exits `0` in **799 ms**
+and resolves both `rehearsalTierFor` and `scoreRecovery` as functions. The public-entry reachability
+test required by SC-3 is therefore cheap and safe; Risk 3 is retired with evidence, not assumed away.
+
+## Observable truths (acceptance criteria, EARS-framed)
+
+| ID       | Truth                                                                                                                                                                                                                               | Delivered by  |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| **SC-1** | The system shall export `rehearsalTierForScore` from `packages/core/src/rehearsal/scoring.ts` as the sole implementation, and `scoring.ts:120` shall call it.                                                                       | Task 2        |
+| **SC-2** | When a consumer imports `rehearsalTierFor` from `@harness-engineering/core`, the system shall resolve it to a callable — i.e. it is present in `rehearsal/index.ts`'s named list.                                                   | Task 3        |
+| **SC-3** | While both names are imported from the package public entry, the system shall resolve them to the identical function reference; and if the alias is dropped from the `rehearsal/index.ts` named list, then the test shall **fail**. | Tasks 1, 3, 6 |
+| **SC-4** | The system shall carry both `@deprecated` and `@public` in `rehearsalTierFor`'s JSDoc.                                                                                                                                              | Task 2        |
+| **SC-5** | The system shall include a MINOR changeset for `@harness-engineering/core`.                                                                                                                                                         | Task 5        |
+| **SC-6** | `pnpm run generate:barrels:check` shall exit `0` with no barrel regeneration required.                                                                                                                                              | Task 7        |
+| **SC-7** | `packages/core` typecheck and the `rehearsal` test suite shall pass, and the system shall introduce no new findings relative to the ambiently-red baseline.                                                                         | Task 7        |
+
+Note the **second clause of SC-3** ("it fails if the alias is dropped"). A test that merely passes
+does not prove this. Task 6 is a negative control that empirically demonstrates the failure mode; it
+is the only step that actually satisfies SC-3 in full.
+
+## NFR targets
+
+None elicited. This lane runs unattended (fleet-dispatched), so every NFR dimension takes its
+documented default:
+
+- **Performance** — no new hot path; the change is a compile-time rename. Existing `check-perf`
+  budgets stand.
+- **Security** — no untrusted input, no secrets. `check-security` runs at its configured floor.
+- **Scalability** — no load characteristics change.
+- **Resilience** — no new failure mode; the alias is a same-reference binding (D3), so it cannot
+  diverge behaviourally from the implementation.
+
+The one perf-adjacent question (cost of importing the full core barrel in a unit test) was measured
+above at 799 ms and is recorded as a concern, not an NFR task.
+
+## Knowledge baseline
+
+Skipped deliberately. The spec declares **Knowledge Impact: None** and **Documentation Updates:
+none**; no PRD or business-domain document is in scope for a single-symbol rename. This is a
+conscious skip, not an omission.
+
+## Uncertainties
+
+- **[RESOLVED]** Whether importing `../index` in a `packages/core` unit test is feasible and
+  affordable. Measured: exit `0`, 799 ms, both symbols resolve. Was the only candidate blocker.
+- **[ASSUMPTION]** The pre-commit comprehension driver refreshes
+  `.harness/comprehension/packages/core/src/rehearsal/_module.md` automatically. If it does not fire,
+  the shard keeps stale `rehearsalTierFor` lines — cosmetic, non-blocking, and must still **not** be
+  hand-edited. Regenerate via the normal comprehension tooling if needed.
+- **[ASSUMPTION]** `harness` on `PATH` resolves to the global install
+  (`/Users/cwarner/.nvm/versions/node/v24.15.0/bin/harness`), not this worktree's `dist`. All
+  baseline signatures above were captured with that binary. Task 7 must use **the same** binary or
+  the differential is invalid.
+- **[DEFERRABLE]** Exact `@deprecated` message wording. A concrete draft is supplied in Task 2;
+  minor rewording is fine as long as `@deprecated` and `@public` both survive (SC-4).
+- **[DEFERRABLE]** New test filename. Plan uses `public-entry.test.ts`.
+
+No blocking uncertainties.
+
+## File map
+
+Exactly 5 files. Complete — proved by the repo-wide grep above.
+
+```
+MODIFY packages/core/src/rehearsal/scoring.ts        (rename decl :24, call site :120, add alias)
+MODIFY packages/core/src/rehearsal/index.ts          (:10 named-export list — LOAD-BEARING, D4)
+MODIFY packages/core/src/rehearsal/scoring.test.ts   (:2 import, :41-48 describe block)
+CREATE packages/core/src/rehearsal/public-entry.test.ts   (SC-3 reachability test)
+CREATE .changeset/rehearsal-tier-for-score.md        (MINOR, @harness-engineering/core)
+```
+
+**Explicitly NOT touched** (hard scope limit):
+
+- `packages/orchestrator/src/core/**` — owned by a concurrent sibling lane. Zero references anyway.
+- `scripts/generate-core-barrel.mjs` — D7; `rehearsal` is not a `SELECTIVE_EXPORTS` key. Proved
+  mechanically by SC-6 rather than by editing.
+- `docs/roadmap.md` / roadmap shards — no roadmap mutation in this lane.
+- `.harness/comprehension/**` — generated; hook-refreshed, never hand-edited.
+
+## Commit strategy
+
+Tasks 1–3 form **one atomic commit**. This is a deliberate, documented deviation from
+one-commit-per-task: the whole point of D4/D5 is that the intermediate states are _supposed_ to be
+red (Task 1 red because the new name does not exist; Task 2 **still** red because the barrel has not
+been extended — that red is the D4 silent-MAJOR trap made visible). Committing those states would
+put a red tree in history. The tasks stay separate so the execution agent records each red
+observation; the commit lands at the end of Task 3, when the tree is green. Tasks 4 and 5 commit
+independently. Tasks 6 and 7 are verification-only and leave the tree unchanged.
+
+## Tasks
+
+---
+
+### Task 1: Add the public-entry reachability test (RED)
+
+**Depends on:** none | **Files:** `packages/core/src/rehearsal/public-entry.test.ts` | **Owns:** `packages/core/src/rehearsal/**`
+**Delivers:** SC-3 (first clause)
+
+1. Create `packages/core/src/rehearsal/public-entry.test.ts` with exactly:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { rehearsalTierFor, rehearsalTierForScore } from '../index';
+
+/**
+ * Guards D4/D5: `packages/core/src/rehearsal/index.ts` is a *named* export list,
+ * not `export *`. A symbol declared in `scoring.ts` but omitted from that list
+ * compiles, passes every direct-import test, and is still absent from the
+ * published package surface. Only an import through the public entry
+ * (`scoring.ts` -> `rehearsal/index.ts` -> `core/index.ts`) exercises that chain.
+ */
+describe('rehearsal public entry surface', () => {
+  it('exports rehearsalTierForScore from the package public entry', () => {
+    expect(typeof rehearsalTierForScore).toBe('function');
+    expect(rehearsalTierForScore(80)).toBe('pass');
+    expect(rehearsalTierForScore(50)).toBe('partial');
+    expect(rehearsalTierForScore(49)).toBe('fail');
+  });
+
+  it('keeps the deprecated rehearsalTierFor alias reachable from the public entry', () => {
+    expect(typeof rehearsalTierFor).toBe('function');
+  });
+
+  it('resolves both names to the identical function reference', () => {
+    expect(rehearsalTierFor).toBe(rehearsalTierForScore);
+  });
+});
+```
+
+2. Run and **observe failure** (`rehearsalTierForScore` does not exist yet):
+
+```
+export PATH=/Users/cwarner/.nvm/versions/node/v22.23.2/bin:$PATH
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal/public-entry.test.ts > /tmp/t1.out 2>&1; echo $?
+```
+
+Expect a **non-zero** exit. Record the failure message. **Do not commit.**
+
+---
+
+### Task 2: Rename in `scoring.ts` and add the deprecated `@public` alias
+
+**Depends on:** Task 1 | **Files:** `packages/core/src/rehearsal/scoring.ts` | **Owns:** `packages/core/src/rehearsal/**`
+**Delivers:** SC-1, SC-4
+
+1. In `packages/core/src/rehearsal/scoring.ts`, replace line 24's declaration and append the alias
+   immediately below the closing brace of the function (before the next JSDoc block):
+
+```ts
+/** Pass at >= 80, partial at >= 50, fail below. Exported so the boundary is testable. */
+export function rehearsalTierForScore(score: number): RehearsalTier {
+  if (score >= 80) return 'pass';
+  if (score >= 50) return 'partial';
+  return 'fail';
+}
+
+/**
+ * Map a recovery score to its tier.
+ *
+ * @deprecated Use `rehearsalTierForScore` instead. The old name left its input
+ * unnamed — `For` what? — so a reader at a call site could not tell whether the
+ * argument was a score, a run, an attempt record, or a config. This alias is the
+ * same function reference and is retained for API compatibility; it will be
+ * removed in a future MAJOR release.
+ * @public
+ */
+export const rehearsalTierFor = rehearsalTierForScore;
+```
+
+The `@public` tag is load-bearing (D6): `packages/core/src/entropy/detectors/dead-code.ts:405`
+matches `/@public(Api)?\b/i` in the nearest preceding JSDoc to exempt an intentionally-public export
+from `PUBLIC_API_UNUSED`. The alias has zero internal callers by construction.
+
+2. Change the internal call site at `scoring.ts:120`:
+
+```ts
+    tier: rehearsalTierForScore(score),
+```
+
+3. Confirm no `rehearsalTierFor(` **call** remains in `scoring.ts` (the alias _declaration_ is the
+   only surviving occurrence of the bare name):
+
+```
+grep -n "rehearsalTierFor" /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009/packages/core/src/rehearsal/scoring.ts
+```
+
+Expect exactly two lines: the alias JSDoc's `rehearsalTierForScore` mention and
+`export const rehearsalTierFor = rehearsalTierForScore;`.
+
+4. Run the existing suite — it must stay **green** (it imports the alias, which still resolves):
+
+```
+export PATH=/Users/cwarner/.nvm/versions/node/v22.23.2/bin:$PATH
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal/scoring.test.ts > /tmp/t2a.out 2>&1; echo $?
+```
+
+Expect `0`.
+
+5. Re-run the reachability test — it must **still fail**:
+
+```
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal/public-entry.test.ts > /tmp/t2b.out 2>&1; echo $?
+```
+
+Expect **non-zero**. This is the D4 trap made visible: the alias and the new name both exist in
+`scoring.ts`, everything compiles, the direct-import tests pass — and the new name is _still_ absent
+from the public surface. **Do not commit.**
+
+---
+
+### Task 3: Extend the `rehearsal/index.ts` named-export list (GREEN + commit)
+
+**Depends on:** Task 2 | **Files:** `packages/core/src/rehearsal/index.ts` | **Owns:** `packages/core/src/rehearsal/**`
+**Delivers:** SC-2, SC-3 (first clause)
+
+1. Replace `packages/core/src/rehearsal/index.ts:10` with:
+
+```ts
+export {
+  REHEARSAL_WEIGHTS,
+  rehearsalTierForScore,
+  rehearsalTierFor,
+  scoreRecovery,
+} from './scoring';
+```
+
+Multi-line is correct: the single-line form is 102 characters and `.prettierrc.json` sets
+`printWidth: 100`, so prettier will not collapse it.
+
+2. Reachability test must now pass:
+
+```
+export PATH=/Users/cwarner/.nvm/versions/node/v22.23.2/bin:$PATH
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal > /tmp/t3.out 2>&1; echo $?
+```
+
+Expect `0`, and **3 test files / 23 tests** (baseline 2 files / 20 tests, plus the 3 new ones).
+
+3. Commit Tasks 1–3 together (see Commit strategy):
+
+```
+git add packages/core/src/rehearsal/scoring.ts \
+        packages/core/src/rehearsal/index.ts \
+        packages/core/src/rehearsal/public-entry.test.ts
+git commit -m "feat(core): rename rehearsalTierFor to rehearsalTierForScore with deprecated alias"
+```
+
+If the pre-commit comprehension driver rewrites
+`.harness/comprehension/packages/core/src/rehearsal/_module.md`, stage the **regenerated** file and
+re-commit. Do not hand-edit it. If a pre-commit hook reformats any file, re-add and re-commit.
+
+---
+
+### Task 4: Retarget `scoring.test.ts` to the new name
+
+**Depends on:** Task 3 | **Files:** `packages/core/src/rehearsal/scoring.test.ts` | **Owns:** `packages/core/src/rehearsal/**`
+**Delivers:** SC-1 (unit tests exercise the implementation, not the alias)
+
+1. Line 2 becomes:
+
+```ts
+import { scoreRecovery, rehearsalTierForScore, REHEARSAL_WEIGHTS } from './scoring';
+```
+
+2. Lines 41–48: rename the `describe` label and all 6 assertions:
+
+```ts
+describe('rehearsalTierForScore', () => {
+  it('maps scores to tiers at the documented boundaries', () => {
+    expect(rehearsalTierForScore(100)).toBe('pass');
+    expect(rehearsalTierForScore(80)).toBe('pass');
+    expect(rehearsalTierForScore(79)).toBe('partial');
+    expect(rehearsalTierForScore(50)).toBe('partial');
+    expect(rehearsalTierForScore(49)).toBe('fail');
+    expect(rehearsalTierForScore(0)).toBe('fail');
+  });
+```
+
+Keep the existing `it(...)` title if it differs — only the symbol references and the `describe`
+label change. Alias coverage now lives in `public-entry.test.ts`, which is where it belongs.
+
+3. Verify no `rehearsalTierFor` reference survives outside the alias declaration and the reachability
+   test:
+
+```
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+grep -rn "rehearsalTierFor\b" packages/core/src --include="*.ts"
+```
+
+Expect exactly 2 hits: `scoring.ts` (alias declaration), `public-entry.test.ts` (import + assertions).
+
+4. Run and commit:
+
+```
+export PATH=/Users/cwarner/.nvm/versions/node/v22.23.2/bin:$PATH
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal > /tmp/t4.out 2>&1; echo $?
+git add packages/core/src/rehearsal/scoring.test.ts
+git commit -m "test(core): retarget rehearsal scoring tests to rehearsalTierForScore"
+```
+
+Expect exit `0`, 3 files / 23 tests.
+
+---
+
+### Task 5: Add the MINOR changeset
+
+**Depends on:** none (independent of Tasks 1–4; may run in parallel) | **Files:** `.changeset/rehearsal-tier-for-score.md` | **Owns:** `.changeset/**`
+**Delivers:** SC-5
+
+1. Create `.changeset/rehearsal-tier-for-score.md`:
+
+```md
+---
+'@harness-engineering/core': minor
+---
+
+`rehearsalTierFor` is now `rehearsalTierForScore`; the old name stays as a deprecated alias
+
+The old name predicted its return type but left its input unnamed — `For` what? At a
+call site like `rehearsalTierFor(value)` a reader could not tell whether the argument was
+a score, a run, an attempt record, or a config without opening the signature.
+`rehearsalTierForScore(score)` names the artifact being mapped from.
+
+`@harness-engineering/core` is published, so a bare rename would be a breaking change.
+`rehearsalTierFor` is retained as a `@deprecated` alias — a `const` binding to the same
+function, so `rehearsalTierFor === rehearsalTierForScore` holds and existing imports keep
+working unchanged. That makes this release MINOR, not MAJOR. The alias will be removed in
+a future MAJOR release.
+```
+
+2. Verify format (single quotes and `minor` match `.changeset/config.json`, which sets
+   `"linked": []`, `"fixed": []`, `"ignore": []` — no special handling for core):
+
+```
+head -3 /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009/.changeset/rehearsal-tier-for-score.md
+```
+
+3. Commit:
+
+```
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+git add .changeset/rehearsal-tier-for-score.md
+git commit -m "docs(core): add MINOR changeset for rehearsalTierForScore rename"
+```
+
+---
+
+### Task 6: Negative control — prove SC-3's failure clause
+
+**Depends on:** Task 4 | **Files:** `packages/core/src/rehearsal/index.ts` (temporary, reverted) | **Category:** verification
+**Delivers:** SC-3 (second clause — "it fails if the alias is dropped")
+
+A passing test does not prove it would fail. This step demonstrates the failure mode empirically and
+leaves the tree byte-identical.
+
+1. Temporarily delete the `rehearsalTierFor,` line from the named-export list in
+   `packages/core/src/rehearsal/index.ts`.
+
+2. Run the reachability test and **observe failure**:
+
+```
+export PATH=/Users/cwarner/.nvm/versions/node/v22.23.2/bin:$PATH
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal/public-entry.test.ts > /tmp/t6-red.out 2>&1; echo $?
+```
+
+Expect **non-zero** — importing a name the module does not export is a link-time error, so the test
+file fails to load. Record the message.
+
+3. Restore and confirm the tree is clean:
+
+```
+git checkout -- packages/core/src/rehearsal/index.ts
+git status --porcelain packages/core/src/rehearsal/index.ts
+```
+
+Expect **empty** output.
+
+4. Re-run green:
+
+```
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal/public-entry.test.ts > /tmp/t6-green.out 2>&1; echo $?
+```
+
+Expect `0`. **No commit** — the working tree is unchanged.
+
+---
+
+### Task 7: Verification sweep against the recorded baseline `[checkpoint:human-verify]`
+
+**Depends on:** Tasks 5, 6 | **Files:** none (read-only) | **Category:** verification
+**Delivers:** SC-6, SC-7, and final SC-1..SC-7 traceability
+
+Run each command with `cmd > /tmp/out 2>&1; echo $?` — never through a pipe, which would report the
+pipe's exit status.
+
+**Clean gates — assert exit `0` directly (all four were green at baseline):**
+
+```
+export PATH=/Users/cwarner/.nvm/versions/node/v22.23.2/bin:$PATH
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+
+pnpm run generate:barrels:check > /tmp/v-barrels.out 2>&1; echo "BARRELS=$?"
+# SC-6: expect 0 + "Core barrel is up to date." -> proves D7 (no allowlist edit needed)
+
+pnpm --filter @harness-engineering/core run typecheck > /tmp/v-tsc.out 2>&1; echo "TSC=$?"
+# SC-7: expect 0
+
+pnpm --filter @harness-engineering/core exec vitest run src/rehearsal > /tmp/v-test.out 2>&1; echo "TEST=$?"
+# SC-7: expect 0, "Test Files 3 passed (3)", "Tests 23 passed (23)"
+
+cd packages/core && npx eslint src/rehearsal > /tmp/v-lint.out 2>&1; echo "LINT=$?"
+# expect 0 (baseline was clean)
+```
+
+**Ambiently-red gates — assert the signature is UNCHANGED, not exit 0.** Use the same `harness`
+binary that produced the baseline (`which harness` -> the global install, not this worktree's dist):
+
+```
+cd /Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009
+
+harness check-deps > /tmp/v-deps.out 2>&1; echo "DEPS=$?"          # expect 1 (baseline)
+grep -c "Circular dependency" /tmp/v-deps.out                       # expect exactly 1
+grep -c "rehearsal" /tmp/v-deps.out                                 # expect exactly 0
+
+harness validate > /tmp/v-validate.out 2>&1; echo "VALIDATE=$?"     # expect 1 (baseline)
+grep -c "^  \* " /tmp/v-validate.out                                # expect exactly 450
+grep -c "rehearsal" /tmp/v-validate.out                             # expect exactly 2 (roadmap rows only)
+```
+
+A count above 450, or any `rehearsal` line in `check-deps`, is a **real regression**. The two
+`rehearsal` mentions in `validate` are roadmap rows ("...is 'planned' with no spec and no plan"),
+not code findings — one of them is issue #2009 itself. They persist because roadmap mutation is out
+of this lane's scope (the conductor owns it), so **450 remains the correct expected count**.
+
+**Public-surface spot check** (independent of the test runner — SC-1/SC-2/SC-3 end to end):
+
+```
+node --import tsx -e "import('/Users/cwarner/Projects/iv/harness-lanes/fc2-rm-2009/packages/core/src/index.ts').then(m => console.log('new=', typeof m.rehearsalTierForScore, 'old=', typeof m.rehearsalTierFor, 'identical=', m.rehearsalTierFor === m.rehearsalTierForScore))" > /tmp/v-surface.out 2>&1; echo $?
+```
+
+Expect exit `0` and `new= function old= function identical= true`.
+
+**SC-4 spot check:**
+
+```
+grep -B8 "export const rehearsalTierFor = rehearsalTierForScore" packages/core/src/rehearsal/scoring.ts | grep -cE "@deprecated|@public"
+```
+
+Expect `2`.
+
+**Traceability table — fill in and present to the human:**
+
+| SC   | Verified by                                           | Result |
+| ---- | ----------------------------------------------------- | ------ |
+| SC-1 | `grep` + `TEST=0` (Task 4 step 3)                     |        |
+| SC-2 | `/tmp/v-surface.out` `old= function`                  |        |
+| SC-3 | `TEST=0` + Task 6 negative control non-zero           |        |
+| SC-4 | JSDoc grep returns `2`                                |        |
+| SC-5 | `.changeset/rehearsal-tier-for-score.md` exists       |        |
+| SC-6 | `BARRELS=0`                                           |        |
+| SC-7 | `TSC=0`, `TEST=0`, deps/validate signatures unchanged |        |
+
+**[checkpoint:human-verify]** — present the filled table and the git log (3 commits), then stop and
+wait for sign-off before opening a PR.
+
+---
+
+## Sequencing and parallelism
+
+| Wave | Tasks | Notes                                                       |
+| ---- | ----- | ----------------------------------------------------------- |
+| 1    | 1, 5  | Task 5 (changeset) shares no files with the code path       |
+| 2    | 2     | depends on Task 1's red observation                         |
+| 3    | 3     | the load-bearing barrel edit; commit boundary for Tasks 1–3 |
+| 4    | 4     |                                                             |
+| 5    | 6     |                                                             |
+| 6    | 7     | depends on 5 and 6                                          |
+
+Tasks 1, 2, 3, 4, 6 all own `packages/core/src/rehearsal/**` and overlap on files, so they are
+strictly serial. Only Task 5 is genuinely parallelizable.
+
+## Integration tier: medium
+
+Per the harness-planning heuristics: new feature within an existing package, **one new public
+export**, 5 files. Not `small` (small requires no new exports).
+
+| Integration point       | Status                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| Entry points            | `packages/core/src/index.ts:380` via `rehearsal/index.ts:10` — Task 3                                  |
+| Registrations required  | `rehearsal/index.ts` named list (D4) — Task 3. No `generate-core-barrel.mjs` edit (D7), proved by SC-6 |
+| Documentation updates   | None. No `docs/` page names this symbol (verified by repo-wide grep)                                   |
+| Changelog               | Changeset — Task 5                                                                                     |
+| Graph / comprehension   | `_module.md` shard refreshed by the pre-commit driver, never hand-edited                               |
+| Architectural decisions | None. D2 applies an existing semver convention                                                         |
+| Knowledge impact        | None                                                                                                   |
+| Roadmap                 | **Out of lane scope** — deferred to the conductor                                                      |
+
+## Concerns
+
+1. **The barrel edit is the only thing standing between MINOR and MAJOR.** If Task 3 is skipped or
+   partially applied, everything compiles, `scoring.test.ts` passes, and the package silently ships a
+   breaking change labelled MINOR. Tasks 1, 2 and 6 exist solely to make this failure mode
+   observable. Do not let an executing agent "optimize" them away.
+2. **`.harness/comprehension/.../rehearsal/_module.md` is generated.** It holds two stale references
+   (`:36`, `:45`). Hand-editing it will churn against the driver. The driver is local-only, so if it
+   does not fire the shard stays stale — cosmetic and non-blocking.
+3. **Ambient baseline is red and must not be "fixed."** `harness validate` exits 1 with 450 findings
+   (hardcoded colors in test fixtures) and `harness check-deps` exits 1 with 1 circular dep in
+   `packages/core/src/solutions/scan-candidates/`. Both are disjoint from `src/rehearsal`. Task 7
+   verifies signatures, not exit codes. An agent that tries to green these has left the lane.
+4. **`harness` on PATH is the global install**, not this worktree's `dist`. Baselines were captured
+   with it; Task 7 must use the same binary or the differential is meaningless.
+5. **Node 22 is required.** Node 24 (the shell default) produces roughly 14 phantom sqlite failures
+   in `packages/core`. Every command in this plan prepends
+   `/Users/cwarner/.nvm/versions/node/v22.23.2/bin` to `PATH`.
+6. **Concurrent sibling lane owns `packages/orchestrator/src/core`.** This plan touches zero files
+   there (and needs none — grep confirms no orchestrator reference to the symbol). Do not expand scope.
+7. **The alias will have zero internal callers by design**, so the dead-code detector would flag
+   `PUBLIC_API_UNUSED` without D6's `@public` tag. That finding is advisory-only
+   (`persona-entropy-cleaner.yml:33` is non-blocking), but dropping `@public` reintroduces recurring
+   noise on every future sweep.
+8. **Tasks 1–3 share one commit.** Deliberate: the intermediate states are supposed to be red.
+   Documented in Commit strategy above so it is not mistaken for sloppiness.
+9. **The reachability test imports the whole core barrel** (~799 ms measured). Acceptable for one
+   narrow test; do not propagate this import pattern into other test files.

--- a/docs/changes/craft-naming-core-rehearsal/proposal.md
+++ b/docs/changes/craft-naming-core-rehearsal/proposal.md
@@ -1,0 +1,141 @@
+# Name the artifact being mapped from: `rehearsalTierFor` → `rehearsalTierForScore`
+
+**Issue:** [#2009](https://github.com/Intense-Visions/harness-engineering/issues/2009) — `craft: identifier naming in packages/core/src/rehearsal`
+**Route:** feature (ADR 0103 rubric fallback — no pre-existing spec)
+**Upstream critique:** `naming-craft` runId `f7927dfb-4051-4e15-93dd-0e3db3e5d05e`, rubric `NAME-R001` (polish / small / medium)
+
+## Overview
+
+`packages/core/src/rehearsal/scoring.ts:24` exports `rehearsalTierFor(score: number): RehearsalTier`. The
+name predicts its return type well but leaves its _input_ unnamed — the trailing preposition dangles.
+The upstream `naming-craft` critique, verbatim:
+
+> The name mostly predicts well — a stranger reading `rehearsalTierFor(...)` correctly expects a
+> RehearsalTier back — but the trailing preposition dangles: `For` what? At a call site like
+> `rehearsalTierFor(value)` the reader can't tell whether the input is a score, a run, an attempt
+> record, or a config until they open the signature. Naming the artifact closes that gap:
+> `rehearsalTierForScore(score)`. If callers may later pass a whole result object,
+> `rehearsalTierFromScore` reads slightly better as a pure mapping; either way, name the thing being
+> mapped from.
+
+**Goal:** rename the symbol to `rehearsalTierForScore` **without breaking the published package's API**.
+
+This advances the STRATEGY.md `Ceiling-raising via LLM judgment` track — `naming-craft` is one of the six
+shipped craft skills, and this is the first of its findings on `packages/core/src/rehearsal` to be applied
+[evidence: `STRATEGY.md#tracks`].
+
+### Non-goals (YAGNI)
+
+- Renaming any other identifier in `packages/core/src/rehearsal`. The craft run surfaced exactly **one**
+  finding above the noise floor; nothing else in the module is in scope.
+- Adopting the critique's secondary suggestion `rehearsalTierFromScore`. The critique itself makes it
+  conditional on "callers may later pass a whole result object" — speculative, so cut.
+- Removing the deprecated alias. Removal is a MAJOR change and belongs to a future release decision.
+
+## Decisions made
+
+| #   | Decision                                                                                                                                                               | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Rename the real symbol to **`rehearsalTierForScore`** (not `rehearsalTierFromScore`)                                                                                   | Both close the gap the critique names. `For` preserves the existing call-site reading and is the critique's primary recommendation; `From` was conditioned on a speculative future signature change (YAGNI).                                                                                                                                                                                                                                      |
+| D2  | **Keep `rehearsalTierFor` as a deprecated alias.** MINOR changeset, not MAJOR                                                                                          | `@harness-engineering/core` is published (v0.48.0, `private` unset) [evidence: `packages/core/package.json`] and `rehearsalTierFor` reaches the public surface via `packages/core/src/index.ts:380` `export * from './rehearsal';`. A bare rename is a breaking change for external consumers. Additive rename + deprecated alias is semver-MINOR.                                                                                                |
+| D3  | Implement the alias as a **`const` binding** (`export const rehearsalTierFor = rehearsalTierForScore;`), not a wrapper function                                        | A wrapper would be a _different_ function object, so the reachability test (SC-3) could not assert reference identity, and a consumer doing `fn === core.rehearsalTierForScore` would see behaviour change. A const binding is the same reference.                                                                                                                                                                                                |
+| D4  | **`packages/core/src/rehearsal/index.ts` must be edited explicitly.**                                                                                                  | This is the load-bearing constraint. That barrel is a _named_ export list — `export { REHEARSAL_WEIGHTS, rehearsalTierFor, scoreRecovery } from './scoring';` at `packages/core/src/rehearsal/index.ts:10` — **not** `export *`. An alias declared only in `scoring.ts` would compile, pass every existing test, and still be **absent from the package's public surface** — silently converting this MINOR-compatible rename into a MAJOR break. |
+| D5  | Prove D4 with a test that imports **both** names from the package public entry (`packages/core/src/index.ts`) and asserts `rehearsalTierFor === rehearsalTierForScore` | Existing `scoring.test.ts` imports from `./scoring` directly, so it can never catch a missing barrel re-export. Only a public-entry import exercises the full chain `scoring.ts → rehearsal/index.ts → core/index.ts`.                                                                                                                                                                                                                            |
+| D6  | The alias's JSDoc carries **both** `@deprecated` and `@public`                                                                                                         | `packages/core/src/entropy/detectors/dead-code.ts:405` matches `/@public(Api)?\b/i` in the nearest preceding JSDoc (within 15 lines) to exempt an intentionally-public export from the `PUBLIC_API_UNUSED` finding. The alias will have zero internal callers by construction, so without `@public` it would generate a (non-blocking) entropy finding on every future sweep.                                                                     |
+| D7  | No `scripts/generate-core-barrel.mjs` allowlist edit                                                                                                                   | `rehearsal` has its own `index.ts` and is star-exported by core's index; it is **not** a key in that script's `SELECTIVE_EXPORTS` map [evidence: `scripts/generate-core-barrel.mjs:33-123`], so the curated-allowlist silent-no-op trap does not apply. Verified mechanically via `pnpm run generate:barrels:check`.                                                                                                                              |
+
+## Technical design
+
+### `packages/core/src/rehearsal/scoring.ts`
+
+```ts
+/** Pass at >= 80, partial at >= 50, fail below. Exported so the boundary is testable. */
+export function rehearsalTierForScore(score: number): RehearsalTier { ... }   // was rehearsalTierFor (:24)
+
+/**
+ * @deprecated Use `rehearsalTierForScore` instead. ...
+ * @public
+ */
+export const rehearsalTierFor = rehearsalTierForScore;
+```
+
+Internal call site at `scoring.ts:120` (`tier: rehearsalTierFor(score)`) moves to `rehearsalTierForScore`.
+
+### `packages/core/src/rehearsal/index.ts:10`
+
+Named list extended with **both** symbols:
+
+```ts
+export {
+  REHEARSAL_WEIGHTS,
+  rehearsalTierForScore,
+  rehearsalTierFor,
+  scoreRecovery,
+} from './scoring';
+```
+
+### Tests
+
+- `packages/core/src/rehearsal/scoring.test.ts` — existing `describe('rehearsalTierFor')` block (`:41-48`)
+  retargets to `rehearsalTierForScore`.
+- **New** public-entry reachability test asserting both names import from `packages/core/src/index.ts`,
+  are defined, and are the same function reference.
+
+### Changeset
+
+MINOR for `@harness-engineering/core`, describing the rename and the deprecation.
+
+## Integration points
+
+- **Entry Points:** `@harness-engineering/core` public barrel (`packages/core/src/index.ts:380`, via
+  `packages/core/src/rehearsal/index.ts:10`). One new exported name, one existing name retained as an alias.
+- **Registrations Required:** `packages/core/src/rehearsal/index.ts` named-export list (D4). No
+  `generate-core-barrel.mjs` allowlist change (D7) — confirmed by `generate:barrels:check`.
+- **Documentation Updates:** none. No `docs/` page names this symbol. The comprehension shard
+  `.harness/comprehension/packages/core/src/rehearsal/_module.md` is a generated artifact, refreshed by the
+  normal comprehension tooling, not hand-edited.
+- **Architectural Decisions:** None. Small change; D2 (deprecated-alias-over-break) applies an existing
+  semver convention rather than establishing a new one.
+- **Knowledge Impact:** None.
+
+## Success criteria
+
+- **SC-1** `rehearsalTierForScore` is exported from `packages/core/src/rehearsal/scoring.ts` and is the sole
+  implementation; `scoring.ts:120` calls it.
+- **SC-2** When a consumer imports `rehearsalTierFor` from `@harness-engineering/core`, the system shall
+  still resolve it to a callable — i.e. it is present in `packages/core/src/rehearsal/index.ts`'s named list.
+- **SC-3** A test importing **both** names from the package public entry asserts they are the identical
+  function reference, and it fails if the alias is dropped from the `rehearsal/index.ts` named list.
+- **SC-4** `rehearsalTierFor`'s JSDoc contains `@deprecated` and `@public`.
+- **SC-5** A MINOR changeset for `@harness-engineering/core` exists.
+- **SC-6** `pnpm run generate:barrels:check` passes with no barrel regeneration required.
+- **SC-7** `packages/core` typecheck and the `rehearsal` test suite pass; no new findings relative to the
+  ambiently-red baseline.
+
+## Alternatives considered
+
+|          | A) Rename + deprecated alias (**chosen**)                                            | B) Bare rename                                | C) Leave as-is                  |
+| -------- | ------------------------------------------------------------------------------------ | --------------------------------------------- | ------------------------------- |
+| **How**  | New name is the implementation; old name a `const` alias re-exported from the barrel | Rename everywhere, delete old name            | Close #2009 as won't-fix        |
+| **Pros** | Fixes the naming defect; no consumer breakage; semver-MINOR                          | Smallest diff; no lingering alias             | Zero risk                       |
+| **Cons** | One extra exported symbol to retire later                                            | **Breaks the published API** — requires MAJOR | Leaves the critique unaddressed |
+| **Risk** | Low — the one real risk is the alias not reaching the barrel (D4/D5 mitigate)        | High                                          | —                               |
+
+**[IMPORTANT]** B is only viable if `@harness-engineering/core` were private. It is not (v0.48.0, published),
+so B was rejected at the human gate. **Chosen: A.**
+
+## Risks
+
+| Risk                                                                                          | Mitigation                                                                                                                                              |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Alias declared but not re-exported → silent MAJOR break disguised as MINOR                    | D4 + SC-3: explicit barrel edit **and** a public-entry reference-identity test that fails if the barrel entry is dropped                                |
+| Alias flagged `PUBLIC_API_UNUSED` by the dead-code detector (zero internal callers by design) | D6: `@public` annotation, which `dead-code.ts:405` honours. Advisory-only in CI regardless (`persona-entropy-cleaner.yml:33` is non-blocking)           |
+| Importing the full core barrel in a unit test pulls heavy/sqlite-backed modules               | The reachability test only reads two bindings; if the import proves costly, it stays a single narrow test rather than being pushed into every test file |
+
+## Implementation order
+
+1. Rename in `scoring.ts` (declaration + internal call site); add the deprecated `@public` alias.
+2. Extend the `rehearsal/index.ts` named-export list with both symbols.
+3. Retarget `scoring.test.ts` to the new name; add the public-entry reachability test (SC-3).
+4. Add the MINOR changeset.
+5. Verify: `generate:barrels:check`, typecheck, rehearsal test suite.

--- a/docs/changes/craft-naming-core-rehearsal/provenance.json
+++ b/docs/changes/craft-naming-core-rehearsal/provenance.json
@@ -1,0 +1,123 @@
+{
+  "issues": [2009],
+  "route": "feature",
+  "routeRationale": "ADR 0103 rubric fallback — no spec existed for this item, so the craft critique in issue #2009 was treated as the requirement and run through the real brainstorming -> autopilot pipeline.",
+  "fleet": "roadmap-fleet",
+  "wave": 4,
+  "branch": "fc2/craft-naming-core-rehearsal-2009",
+  "baseSha": "fef03ac5ea510de1b109a76536c68c92a17f6771",
+  "specPath": "docs/changes/craft-naming-core-rehearsal/proposal.md",
+  "planArtifactPath": "docs/changes/craft-naming-core-rehearsal/plans/2026-09-08-rename-with-deprecated-alias-plan.md",
+  "upstreamCritique": {
+    "skill": "naming-craft",
+    "runId": "f7927dfb-4051-4e15-93dd-0e3db3e5d05e",
+    "rubricId": "NAME-R001",
+    "tier": "polish",
+    "impact": "small",
+    "confidence": "medium",
+    "location": "packages/core/src/rehearsal/scoring.ts:24"
+  },
+  "stages": [
+    {
+      "stage": "brainstorming",
+      "skill": "harness-brainstorming",
+      "outcome": "spec written and committed",
+      "artifact": "docs/changes/craft-naming-core-rehearsal/proposal.md",
+      "commit": "b501db7d8e1ec613644e5d745453a273aa39c3b2"
+    },
+    {
+      "stage": "autopilot",
+      "skill": "harness-autopilot",
+      "outcome": "one phase run end-to-end: PLAN -> APPROVE_PLAN -> EXECUTE -> VERIFY -> REVIEW",
+      "sessionDir": ".harness/sessions/changes--craft-naming-core-rehearsal--proposal/",
+      "substages": [
+        {
+          "state": "PLAN",
+          "persona": "harness-planner",
+          "artifact": "docs/changes/craft-naming-core-rehearsal/plans/2026-09-08-rename-with-deprecated-alias-plan.md",
+          "commit": "ba42582fc",
+          "detail": "7 tasks / 3 commits / integration tier medium / 9 concerns / no blocking uncertainties"
+        },
+        {
+          "state": "APPROVE_PLAN",
+          "decision": "auto-approved",
+          "rationale": "Autonomous run; the human approved the item and its single fork at the fleet CONFIRM gate. Concerns were guardrails, not open questions; the plan recorded 'No blocking uncertainties'."
+        },
+        {
+          "state": "EXECUTE",
+          "persona": "harness-task-executor",
+          "commits": [
+            "7f6c3439ac64c2bd02956e9d10fbdf75f5d66698",
+            "9f2f92c8a46f7e89c51b1655967a7e25c89bd3ed",
+            "0e4f43024ae6130237ee02e479ab836fcb3e8be6"
+          ],
+          "detail": "Tasks 1-7. TDD red-red-green: the reachability test stayed red after the scoring.ts rename+alias and only went green after the barrel edit, making the silent-MAJOR trap observable rather than assumed."
+        },
+        { "state": "VERIFY", "persona": "harness-verifier" },
+        { "state": "REVIEW", "persona": "harness-code-reviewer" }
+      ]
+    }
+  ],
+  "fork": {
+    "id": "FORK 1",
+    "question": "Bare rename, or rename plus a deprecated alias?",
+    "answer": "(a) rename + keep a DEPRECATED ALIAS re-export of the old name; MINOR changeset",
+    "settledBy": "human, at the fleet CONFIRM gate",
+    "why": "@harness-engineering/core is published (v0.48.0, private unset) and rehearsalTierFor reaches the public surface via packages/core/src/index.ts:380 `export * from './rehearsal'`, so a bare rename would be a breaking change."
+  },
+  "aliasReachabilityProof": {
+    "why": "The human called out the exact recurring failure mode: an alias that exists but is not re-exported converts (a) silently into (b).",
+    "trap": "packages/core/src/rehearsal/index.ts is a NAMED export list, not `export *`. An alias declared only in scoring.ts compiles, passes every direct-import test, and is still absent from the published surface.",
+    "chain": "scoring.ts -> packages/core/src/rehearsal/index.ts -> packages/core/src/index.ts (export * from './rehearsal') -> packages/core/dist/index.{js,d.ts}",
+    "evidence": [
+      "packages/core/src/rehearsal/public-entry.test.ts imports BOTH names from the package public entry and asserts rehearsalTierFor === rehearsalTierForScore",
+      "Negative control re-run independently by the lane: removing rehearsalTierFor from the named export list turns the test RED (exit 1, 2 assertion failures: 'expected undefined to be [Function rehearsalTierForScore]'); restored via git checkout, tree clean, suite back to exit 0",
+      "Built-artifact runtime proof from packages/core/dist/index.js: typeof rehearsalTierForScore === 'function', typeof rehearsalTierFor === 'function', rehearsalTierFor === rehearsalTierForScore is true, behaviour pass/partial/fail preserved",
+      "Built type surface: packages/core/dist/index.d.ts declares `const rehearsalTierFor: typeof rehearsalTierForScore` and both names appear in the terminal export list"
+    ]
+  },
+  "assumptions": [
+    "Route is `feature` per the fleet's human-approved CONFIRM gate; not re-litigated.",
+    "FORK 1 answer (a) — rename plus deprecated alias, MINOR changeset — was settled by the human and implemented exactly as stated.",
+    "The critique's secondary suggestion `rehearsalTierFromScore` was deliberately NOT adopted: the critique itself conditioned it on callers later passing a whole result object, which is speculative (YAGNI).",
+    "Scope held to the single finding above the craft run's noise floor. No other identifier in packages/core/src/rehearsal was renamed.",
+    "The deprecated alias is retained indefinitely in this change; its removal is a future MAJOR decision and is explicitly out of scope.",
+    "The alias JSDoc carries `@public` in addition to `@deprecated` so the dead-code detector (packages/core/src/entropy/detectors/dead-code.ts:405, /@public(Api)?\\b/i) does not raise a recurring advisory PUBLIC_API_UNUSED finding — the alias has zero internal callers by design.",
+    "scripts/generate-core-barrel.mjs was NOT edited: `rehearsal` has its own index.ts and is star-exported, and is not a SELECTIVE_EXPORTS key. Re-verified mechanically — `pnpm run generate:barrels:check` exits 0 with 'Core barrel is up to date.'",
+    "The roadmap was deliberately NOT mutated (out of lane scope). One of the two `rehearsal` mentions in `harness validate` is issue #2009 itself and therefore persists after this change; 450 findings remains the correct expected count.",
+    ".harness/comprehension/packages/core/src/rehearsal/_module.md is a GENERATED artifact; it was refreshed by the pre-commit comprehension driver and auto-staged, never hand-edited.",
+    "The ambient baseline is red and was not 'fixed': `harness validate` exit 1 / 450 findings and `harness check-deps` exit 1 / 1 circular dep in packages/core/src/solutions/scan-candidates/ are both disjoint from src/rehearsal and match their pre-change signatures exactly.",
+    "A tsx-based probe of the core entry that the plan recorded as a baseline was found to be BLIND (it drops the whole rehearsal star-export chain and its `identical=` sentinel is vacuously true when both sides are undefined). It was discarded; the authoritative evidence is the vitest public-entry test plus the built-bundle runtime check."
+  ],
+  "verification": {
+    "nodeVersion": "22.23.2",
+    "note": "Exit codes measured as `cmd > /tmp/out 2>&1; echo $?`, never through a pipe.",
+    "beforeAfter": [
+      {
+        "check": "vitest run src/rehearsal (packages/core)",
+        "before": "exit 0, 2 files / 20 tests",
+        "after": "exit 0, 3 files / 23 tests"
+      },
+      {
+        "check": "tsc --noEmit -p tsconfig.json (packages/core)",
+        "before": "exit 0",
+        "after": "exit 0"
+      },
+      {
+        "check": "pnpm run generate:barrels:check",
+        "before": "exit 0, Core barrel is up to date.",
+        "after": "exit 0, Core barrel is up to date."
+      },
+      {
+        "check": "harness check-deps",
+        "before": "exit 1, 1 circular dep, 0 rehearsal mentions",
+        "after": "exit 1, 1 circular dep, 0 rehearsal mentions"
+      },
+      {
+        "check": "turbo build --filter=@harness-engineering/core",
+        "before": "exit 0",
+        "after": "exit 0"
+      }
+    ]
+  }
+}

--- a/packages/core/src/rehearsal/index.ts
+++ b/packages/core/src/rehearsal/index.ts
@@ -7,5 +7,10 @@
  * known-bad recovery map to stable, testable scores.
  */
 export * from './types';
-export { REHEARSAL_WEIGHTS, rehearsalTierFor, scoreRecovery } from './scoring';
+export {
+  REHEARSAL_WEIGHTS,
+  rehearsalTierForScore,
+  rehearsalTierFor,
+  scoreRecovery,
+} from './scoring';
 export { MANIFEST_FILENAME, loadManifest, loadCatalog, findFixture } from './catalog';

--- a/packages/core/src/rehearsal/public-entry.test.ts
+++ b/packages/core/src/rehearsal/public-entry.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { rehearsalTierFor, rehearsalTierForScore } from '../index';
+
+/**
+ * Guards D4/D5: `packages/core/src/rehearsal/index.ts` is a *named* export list,
+ * not `export *`. A symbol declared in `scoring.ts` but omitted from that list
+ * compiles, passes every direct-import test, and is still absent from the
+ * published package surface. Only an import through the public entry
+ * (`scoring.ts` -> `rehearsal/index.ts` -> `core/index.ts`) exercises that chain.
+ */
+describe('rehearsal public entry surface', () => {
+  it('exports rehearsalTierForScore from the package public entry', () => {
+    expect(typeof rehearsalTierForScore).toBe('function');
+    expect(rehearsalTierForScore(80)).toBe('pass');
+    expect(rehearsalTierForScore(50)).toBe('partial');
+    expect(rehearsalTierForScore(49)).toBe('fail');
+  });
+
+  it('keeps the deprecated rehearsalTierFor alias reachable from the public entry', () => {
+    expect(typeof rehearsalTierFor).toBe('function');
+  });
+
+  it('resolves both names to the identical function reference', () => {
+    expect(rehearsalTierFor).toBe(rehearsalTierForScore);
+  });
+});

--- a/packages/core/src/rehearsal/scoring.test.ts
+++ b/packages/core/src/rehearsal/scoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scoreRecovery, rehearsalTierFor, REHEARSAL_WEIGHTS } from './scoring';
+import { scoreRecovery, rehearsalTierForScore, REHEARSAL_WEIGHTS } from './scoring';
 import type { RehearsalManifest, RecoveryRecord } from './types';
 
 const manifest: RehearsalManifest = {
@@ -38,14 +38,14 @@ const badRecovery: RecoveryRecord = {
   collateralDamage: false,
 };
 
-describe('rehearsalTierFor', () => {
+describe('rehearsalTierForScore', () => {
   it('maps score bands to tiers at the boundaries', () => {
-    expect(rehearsalTierFor(100)).toBe('pass');
-    expect(rehearsalTierFor(80)).toBe('pass');
-    expect(rehearsalTierFor(79)).toBe('partial');
-    expect(rehearsalTierFor(50)).toBe('partial');
-    expect(rehearsalTierFor(49)).toBe('fail');
-    expect(rehearsalTierFor(0)).toBe('fail');
+    expect(rehearsalTierForScore(100)).toBe('pass');
+    expect(rehearsalTierForScore(80)).toBe('pass');
+    expect(rehearsalTierForScore(79)).toBe('partial');
+    expect(rehearsalTierForScore(50)).toBe('partial');
+    expect(rehearsalTierForScore(49)).toBe('fail');
+    expect(rehearsalTierForScore(0)).toBe('fail');
   });
 });
 

--- a/packages/core/src/rehearsal/scoring.ts
+++ b/packages/core/src/rehearsal/scoring.ts
@@ -21,11 +21,23 @@ export const REHEARSAL_WEIGHTS = {
 } as const;
 
 /** Pass at >= 80, partial at >= 50, fail below. Exported so the boundary is testable. */
-export function rehearsalTierFor(score: number): RehearsalTier {
+export function rehearsalTierForScore(score: number): RehearsalTier {
   if (score >= 80) return 'pass';
   if (score >= 50) return 'partial';
   return 'fail';
 }
+
+/**
+ * Map a recovery score to its tier.
+ *
+ * @deprecated Use `rehearsalTierForScore` instead. The old name left its input
+ * unnamed — `For` what? — so a reader at a call site could not tell whether the
+ * argument was a score, a run, an attempt record, or a config. This alias is the
+ * same function reference and is retained for API compatibility; it will be
+ * removed in a future MAJOR release.
+ * @public
+ */
+export const rehearsalTierFor = rehearsalTierForScore;
 
 /**
  * Normalise a harness check string for comparison: lowercase, collapse
@@ -117,7 +129,7 @@ export function scoreRecovery(manifest: RehearsalManifest, record: RecoveryRecor
     fixtureId: manifest.id,
     failureMode: manifest.failureMode,
     score,
-    tier: rehearsalTierFor(score),
+    tier: rehearsalTierForScore(score),
     dimensions,
   };
 }


### PR DESCRIPTION
## What

`packages/core/src/rehearsal/scoring.ts` exported `rehearsalTierFor(score)`. The name predicted its
return type but left its **input** unnamed — the trailing preposition dangled. From the `naming-craft`
critique in #2009, verbatim:

> the trailing preposition dangles: `For` what? At a call site like `rehearsalTierFor(value)` the reader
> can't tell whether the input is a score, a run, an attempt record, or a config until they open the
> signature. Naming the artifact closes that gap: `rehearsalTierForScore(score)`.

This renames the symbol to **`rehearsalTierForScore`** and keeps `rehearsalTierFor` as a **deprecated
alias**, so the published package's API does not break.

Closes #2009

## Why this is MINOR and not MAJOR

`@harness-engineering/core` is published (v0.48.0, `private` unset) and `rehearsalTierFor` reaches the
public surface via `packages/core/src/index.ts:380` `export * from './rehearsal';`. A bare rename would be
a breaking change for external consumers. So the old name is retained as
`export const rehearsalTierFor = rehearsalTierForScore;` with `@deprecated` + `@public` JSDoc — a `const`
binding, not a wrapper, so reference identity holds.

## The trap this change had to clear

`packages/core/src/rehearsal/index.ts` is a **named export list**, not `export *`. An alias declared only
in `scoring.ts` would compile, pass every existing test, and still be **absent from the published
surface** — silently turning a compatible rename into a breaking one. So the barrel was edited explicitly,
and the reachability is **proven, not assumed**:

- `packages/core/src/rehearsal/public-entry.test.ts` imports **both** names from the package public entry
  and asserts `rehearsalTierFor === rehearsalTierForScore`.
- **Negative control, run for real (twice — by the executor and again independently):** deleting
  `rehearsalTierFor` from the named export list turns that test **red** (exit 1, `expected undefined to be
  [Function rehearsalTierForScore]`). Restored; tree clean; suite back to green. A guard that cannot fail
  is not a guard.
- **Built-artifact proof**, not just source: in `packages/core/dist/index.js` (CJS) and `dist/index.mjs`
  (ESM) both names resolve as functions, are `===` identical, and behaviour is preserved; `dist/index.d.ts`
  declares `const rehearsalTierFor: typeof rehearsalTierForScore` and carries both names in the terminal
  export list. A simulated external TS consumer typechecks clean under `--strict`.

## Verification (Node 22; exit codes measured directly, never through a pipe)

| check | before | after |
| --- | --- | --- |
| `vitest run src/rehearsal` | exit 0, 2 files / 20 tests | **exit 0, 3 files / 23 tests** |
| `tsc --noEmit` (packages/core) | exit 0 | exit 0 |
| `pnpm run generate:barrels:check` | exit 0 | exit 0 — "Core barrel is up to date." |
| `harness check-deps` | exit 1, 1 cycle in `solutions/scan-candidates`, 0 rehearsal | **identical** |
| `harness validate` | exit 1, 450 findings | **identical (0 of the 450 from this diff)** |
| `turbo build --filter=core` | exit 0 | exit 0 |

No test was deleted or weakened — `scoring.test.ts` still has 12 tests with all six boundary assertions
intact, retargeted to the new name. The delta is exactly the 3 new reachability tests.

The ambient baseline is red at this base (hardcoded-color findings in test fixtures; one pre-existing
circular dependency in `packages/core/src/solutions/scan-candidates/`). Both are disjoint from
`src/rehearsal` and match their pre-change signatures exactly. Neither was "fixed" here.

## Pipeline

Route `feature` (ADR 0103 rubric fallback — no spec existed). Real pipeline, not hand-built:
`harness-brainstorming` → spec, then `harness-autopilot` → `harness-planner` (7-task plan, TDD
red-red-green so the barrel trap is *observed*), `harness-task-executor`, `harness-verifier` (PASS on
SC-1..SC-7), `harness-code-reviewer` (**Approve**, no critical findings).

- Spec: `docs/changes/craft-naming-core-rehearsal/proposal.md`
- Plan: `docs/changes/craft-naming-core-rehearsal/plans/2026-09-08-rename-with-deprecated-alias-plan.md`
- Provenance: `docs/changes/craft-naming-core-rehearsal/provenance.json`

## Assumptions made

- **Route `feature`** and **the rename-plus-deprecated-alias fork (MINOR, not a bare rename)** were both
  settled by the human at the fleet CONFIRM gate and were implemented as stated, not re-litigated.
- **The critique's secondary suggestion `rehearsalTierFromScore` was deliberately not adopted.** The
  critique conditioned `From` on callers later passing a whole result object — speculative, so cut (YAGNI).
- **Scope held to the single finding above the craft run's noise floor.** No other identifier in
  `packages/core/src/rehearsal` was touched.
- **The alias is retained indefinitely here; its removal is a future MAJOR decision** and is explicitly out
  of scope. Nothing currently tracks that removal — worth a follow-up issue.
- **`@public` sits alongside `@deprecated` deliberately.** The alias has zero internal callers by
  construction, and `packages/core/src/entropy/detectors/dead-code.ts:405` matches `/@public(Api)?\b/i` to
  exempt intentionally-public exports from a recurring `PUBLIC_API_UNUSED` advisory.
- **`scripts/generate-core-barrel.mjs` was not edited.** `rehearsal` has its own `index.ts` and is
  star-exported; it is not a `SELECTIVE_EXPORTS` key. Re-verified mechanically rather than trusted —
  `generate:barrels:check` exits 0.
- **The roadmap was not mutated** (out of lane scope). One of the two `rehearsal` mentions in
  `harness validate` is #2009 itself, so it persists after this change and 450 remains the expected count.
- **`.harness/comprehension/**/_module.md` shards are generated** and were refreshed by the pre-commit
  driver, never hand-edited. The `rehearsal` shard goes `semantic: present → absent`: this is the designed
  static-only PR path (ADR 0116 §4 — `comprehend --check --context pr` exits 0 and says so explicitly), it
  is `continue-on-error` in CI, and 142 shards were already in that state at this base. It could not be
  healed from this lane (no provider credential); the main-pass writer restores it post-merge.
- **A `tsx`-based probe recorded in the plan as a baseline was found to be blind and was discarded.** It
  drops the whole `rehearsal` star-export chain and its `identical=` sentinel is vacuously true when both
  sides are `undefined` — it would have printed "pass" had the alias never been written. Authoritative
  evidence is the vitest public-entry test plus the built-bundle runtime check above.

## Reviewer finding passed forward, deliberately not acted on

The code reviewer argued the reachability test could import `'./index'` (the rehearsal barrel) instead of
the full core barrel — same soundness, 40–200x cheaper — because `packages/core/src/index.ts` is
auto-generated and CI-checked, so the `export *` link is mechanically guaranteed. That is a good argument,
but importing from the **package public entry** was the human's explicit instruction at the gate, so it
was not changed unilaterally. Flagging it here for the reviewer to decide.

## Not done

Never merged — opened for human review.
