### PR TITLE
fix(core-tests): give each SC2 property seed its own timeout budget (windows CI red)

### DIFF
--- a/.harness/comprehension/packages/core/tests/state/event-sourcing/_module.md
+++ b/.harness/comprehension/packages/core/tests/state/event-sourcing/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/core/tests/state/event-sourcing'
-sourceHash: 'edd1fb3dce26bc6a5abd979fde6fcef738ff195dee8cc23c40e9af852ea21466'
-compiledAt: '2026-08-28T01:22:11.105Z'
+sourceHash: '15f25bd8bf9b3960de4f5601683e9821cd7fbeefaa8ed96332912a4cbd828bf5'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'concurrency.test.ts',
@@ -21,28 +20,6 @@ members:
     'writer-id.test.ts',
   ]
 ---
-
-## Summary
-
-The event-sourcing test suite validates a concurrent, event-sourced state architecture where all state changes are immutable events. It tests schema validation, multi-process safe writing with blob spilling for large payloads, lane state machine transitions with guarded edges, snapshot materialization, event ordering, and projections. Core invariants enforce no event loss, no sequence repetition, correct blob handling under concurrency, snapshot consistency, transition table enforcement, and dependency/evidence/force guards for lane state changes.
-
-## Invariants
-
-- No event loss under concurrent N-process writes; each (seq, writerId) pair is unique
-- Global event ordering: sorted by (seq asc, writerId asc) regardless of write sequence
-- Blob spill succeeds under concurrent writes; identical payloads collapse to single content-addressed blob
-- Missing blob doesn't abort load; affected event is dropped, valid events remain readable
-- Snapshots materialize correctly, reflecting all state transitions (Truth #7)
-- Lane transition table: allowed edges (planned→claimed→in_progress→in_review→done); rework via in_review↔in_progress; any→{blocked,canceled}
-- Off-table transitions rejected unless forced with actor + reason
-- Entering in_progress requires all dependent tasks in done lane
-- Entering done requires non-empty evidence array
-- EventSchema validates type-payload match; StoredEventSchema recognizes new types on disk
-- Projections are additive: audit events don't change coreState/lanes byte-representation
-- Writer ID unique per process via HARNESS_EVENT_WRITER_ID; monotonic seq counters per writer
-- Snapshot staleness tracking; materialize() refreshes on-demand within debounce window
-- Event log/blob dir structure invariant (paths normalized; Windows posix-normalized)
-- Scope envelope fields (stream, session) can be undefined; schema accepts both
 
 ## Interface Contract
 

--- a/docs/changes/snapshot-property-per-seed-budget/plans/2026-09-08-snapshot-property-per-seed-budget-plan.md
+++ b/docs/changes/snapshot-property-per-seed-budget/plans/2026-09-08-snapshot-property-per-seed-budget-plan.md
@@ -1,0 +1,91 @@
+# Plan: split the SC2 snapshot property test into per-seed cases
+
+**Date:** 2026-09-08 · **Driver:** windows-latest CI timeout on `main` @ `8e7a59800` (run `34271802379`, job `102214934241`) · **Tasks:** 4 · **Integration Tier:** small · **Refs:** #2046 (same defect class, different shape)
+
+Produced by the `harness-debugging` pipeline (investigate → analyze → hypothesize → fix). Debug session: `.harness/debug/resolved/snapshot-property-win-timeout.md`.
+
+## Symptom
+
+```
+ FAIL  tests/state/event-sourcing/snapshot.property.test.ts > SC2 — reduce(events) === readSnapshot() (property) > holds over 200 randomized seeds on both the computed and fresh-hit paths
+Error: Test timed out in 60000ms.
+ ❯ tests/state/event-sourcing/snapshot.property.test.ts:121:3
+```
+
+The file reported `66925ms` for that single test. ubuntu and macOS were green; only `build-and-test (windows-latest, 22)` failed.
+
+## Root cause
+
+`packages/core/tests/state/event-sourcing/snapshot.property.test.ts:121` is **one** `it()` that loops `seed = 1..200`, and vitest's timeout budget is **per test**, not per unit of work. Every seed's real filesystem I/O is therefore billed to a single 60s budget, which makes the total wall-clock of 200 seeds an implicit, machine-speed-dependent assertion. The logic is fully deterministic (pinned mulberry32 seeds) — nothing about the _correctness_ of the property varies by platform. Only the _speed_ does.
+
+The I/O volume under that one budget, measured by replaying the pinned PRNG (`scratchpad/count-events.mjs`, reproduced in the session log):
+
+| Quantity                                          | Value    |
+| ------------------------------------------------- | -------- |
+| Seeds                                             | 200      |
+| Real `emitEvent` calls (each an `appendFileSync`) | **2974** |
+| Mean events per seed                              | 14.9     |
+| Max events in one seed                            | 30       |
+| Seeds that emit zero events                       | 12       |
+
+Each `emitEvent` is not one syscall. Reading the source at the pinned base:
+
+- `emitEvent` (`packages/core/src/state/event-sourcing/log.ts:199`) → `eventLogPaths` → `getStateDir` (`state-shared.ts:38`, at least one `existsSync` on the streams index), then `fs.mkdirSync`, then `readTailSeq`, then `fs.appendFileSync`.
+- `readTailSeq` (`log.ts:46`) is `existsSync` + a **full `readFileSync` of the growing log**, re-read on every append (`INV-2 helper ... Re-read every append`). Within a seed that is O(n²) in bytes read.
+
+Per seed there is additionally one `mkdtempSync`, one `loadEvents`, two `readSnapshot` (each re-reading the tail), one `materialize` (`loadEvents` + `writeFileSync` + `renameSync`), and one recursive `rmSync`. That puts the file on the order of ~18,000 filesystem syscalls inside a single 60s budget.
+
+Windows CI pays roughly 3.7ms per filesystem operation (66925ms / ~18,000) against roughly 0.1ms on this macOS host. That ratio — not any behavioural difference — is the entire failure. `vitest.config.ts` already sets `fileParallelism: false` on win32 and `testTimeout: 60_000`, so the runner was already serialized and already on a raised ceiling; the budget had simply been consumed by aggregation.
+
+**This is a defect in the test's structure, not in `snapshot.ts` or `log.ts`.** `readTailSeq`'s re-read-per-append is a deliberate multi-writer correctness choice (INV-2), documented as such, and 30 events is well inside its intended range. No product change is warranted.
+
+## Rejected alternatives
+
+1. **Raise `testTimeout` further.** Leaves the wall-clock assertion in place and merely moves the cliff. The budget would still be consumed by 200 aggregated seeds, so the next slower runner (or the next added seed) reintroduces the same failure with no new signal. This is the shape #2046 already tracks; adding to it is not a fix.
+2. **Reduce the seed count, `skip`, `skipIf(win32)`, or retry.** All remove or weaken coverage. The file's own header forbids it: "A failing seed is a real reducer/snapshot bug to fix — not a test to weaken."
+3. **`it.concurrent` over the seeds.** Would genuinely cut wall-clock, but `buildLog` mutates `process.env.HARNESS_EVENT_WRITER_ID` and the module-level writer-id cache — process-global state. Concurrent seeds would clobber each other's writer identity and produce false failures. Rejected as unsound.
+
+## Fix
+
+Split the single `it()` into `it.each(SEEDS)` — one case per seed.
+
+- Each seed gets **its own** 60s budget, so no single test's runtime is load-bearing. Total file wall-clock is unchanged (the same work runs), but vitest applies no per-file timeout, so the 66925ms Windows file no longer fails.
+- `afterEach` now reclaims **that seed's** temp dir immediately instead of holding all 200 live until the end of the run.
+- Failures name the seed (`... — seed 137`) rather than reporting one opaque aggregate failure.
+- Cases stay **sequential** (vitest's default within a file) — required, per rejected alternative 3.
+- **Coverage is identical: all 200 seeds still execute on every OS.** The reporter now shows 200 named cases, which is what makes that self-evident rather than asserted.
+
+Alongside, the four `if (!x.ok) return;` narrowing guards are replaced with a local `expectOk` helper that **throws**. At the pinned base those `return`s were unreachable (the preceding `expect(...).toBe(true)` throws first), but a `return` inside a per-seed case would exit that case _green_ having asserted nothing. `expectOk` removes that silently-green path by construction and surfaces the underlying `Result.error` message instead of a bare `expected false to be true`.
+
+## Observable Truths (Acceptance Criteria)
+
+1. The reporter lists 200 distinct passing cases for the file.
+   **Gate:** `pnpm vitest run tests/state/event-sourcing/snapshot.property.test.ts --reporter=verbose` → `Tests  200 passed (200)`.
+2. Seeds 1..200 are each named exactly once — no seed dropped by the refactor.
+   **Gate:** verbose output greps to 200 unique `seed N` labels covering 1..200.
+3. No single case is anywhere near its 60s budget.
+   **Gate:** slowest per-case duration from the verbose reporter is < 1000ms on this host, i.e. > 60x margin.
+4. Stable green across repeated runs.
+   **Gate:** 3 consecutive runs of the file, all green.
+5. No source file under `packages/*/src/` is modified (test-only change; no changeset required per `scripts/check-changesets.mjs` `SKIP_FILE`).
+   **Gate:** `git diff --name-only origin/main...HEAD`.
+6. Whole-tree formatting is clean.
+   **Gate:** `pnpm format:check` exits 0.
+
+## Tasks
+
+1. Replace the aggregate `it()` with `it.each(SEEDS)`; hoist the per-seed body unchanged.
+2. Add `expectOk` and replace the four `if (!x.ok) return;` guards.
+3. Verify truths 1–4 (verbose run + seed-coverage grep + 3x repeat).
+4. Verify truths 5–6 and push.
+
+## Assumptions
+
+- **The 66925ms is dominated by filesystem latency, not by a hang or a behavioural difference.** Supported by: ubuntu and macOS pass the same deterministic seeds; the per-op cost implied by the ratio (~3.7ms) is ordinary for Windows CI with real-time AV scanning of a temp directory. Not directly measured — see "Could not verify".
+- **vitest applies no per-file timeout**, only per-test (`testTimeout`) and per-hook (`hookTimeout`). If a per-file ceiling existed, the split would not help.
+- The Windows leg runs `pnpm test -- --continue` (no coverage instrumentation); coverage load is therefore not a contributing factor on that leg.
+
+## Could not verify
+
+- **The Windows timeout was not reproduced locally.** This work was done on macOS, the leg that passed in CI. The measured local wall-clock is ~0.4–1.9s against the 60000ms budget, so the margin here is ~30–150x and the failure cannot manifest. The evidence that the budget is the binding constraint is the measured Windows/macOS ratio plus the syscall accounting above, not a local reproduction.
+- Post-fix behaviour on windows-latest is confirmed only by this PR's own CI run, not locally.

--- a/packages/core/tests/state/event-sourcing/snapshot.property.test.ts
+++ b/packages/core/tests/state/event-sourcing/snapshot.property.test.ts
@@ -95,6 +95,23 @@ function randomEventInput(rng: () => number): EventInput {
   return BUILDERS[pick(rng, TYPES)](rng);
 }
 
+/**
+ * Narrow a Result to its value, failing the case loudly if it is an Err.
+ *
+ * Deliberately throws rather than `return`ing. Inside a per-seed case an early
+ * `return` would end that case GREEN having asserted nothing — a seed silently
+ * skipped while the suite reports success. Throwing removes that path by
+ * construction, and surfaces the underlying error message instead of a bare
+ * `expected false to be true`.
+ */
+function expectOk<T>(
+  result: { ok: true; value: T } | { ok: false; error: Error },
+  what: string
+): T {
+  if (!result.ok) throw new Error(`${what}: ${result.error.message}`);
+  return result.value;
+}
+
 const tmpDirs: string[] = [];
 afterEach(() => {
   __resetMaterializeTimersForTests();
@@ -117,10 +134,34 @@ async function buildLog(rng: () => number, dir: string): Promise<void> {
   }
 }
 
+/** Seeds 1..200 — the full property space, one vitest case each. */
+const SEEDS = Array.from({ length: 200 }, (_, i) => i + 1);
+
 describe('SC2 — reduce(events) === readSnapshot() (property)', () => {
-  it('holds over 200 randomized seeds on both the computed and fresh-hit paths', async () => {
-    const SEEDS = 200;
-    for (let seed = 1; seed <= SEEDS; seed++) {
+  /**
+   * One case PER SEED rather than one case looping all 200.
+   *
+   * vitest budgets timeouts per test, not per unit of work. Aggregating every
+   * seed under a single `it()` therefore turned the suite's total wall-clock
+   * into an implicit, machine-speed-dependent assertion: the same deterministic
+   * seeds passed on ubuntu/macOS but blew the 60s budget on windows-latest
+   * (66925ms), where each of this file's ~18k filesystem syscalls costs ~3.7ms.
+   * The seeds never disagreed — only the clock did.
+   *
+   * Splitting gives each seed its own budget, so no single test's runtime is
+   * load-bearing; `afterEach` reclaims that seed's temp dir immediately instead
+   * of holding 200 live at once; and a failure names the seed that broke. All
+   * 200 seeds still run on every OS — the reporter shows 200 named cases, which
+   * makes that visible rather than merely claimed.
+   *
+   * Cases stay SEQUENTIAL (vitest's default within a file). `it.concurrent`
+   * would be unsound here: `buildLog` mutates `process.env.HARNESS_EVENT_WRITER_ID`
+   * and the module-level writer-id cache, so concurrent seeds would clobber each
+   * other's writer identity.
+   */
+  it.each(SEEDS)(
+    'holds on both the computed and fresh-hit paths — seed %i',
+    async (seed: number) => {
       resetLocalCountersForTests();
       __resetMaterializeTimersForTests();
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), `esprop-${seed}-`));
@@ -129,27 +170,20 @@ describe('SC2 — reduce(events) === readSnapshot() (property)', () => {
 
       await buildLog(rng, dir);
 
-      const eventsResult = await loadEvents(dir);
-      expect(eventsResult.ok).toBe(true);
-      if (!eventsResult.ok) return;
-      const expected = reduce(eventsResult.value);
+      const events = expectOk(await loadEvents(dir), `seed ${seed} loadEvents errored`);
+      const expected = reduce(events);
 
       // (a) Computed path: no snapshot on disk yet → readSnapshot returns reduce(loadEvents).
-      const computed = await readSnapshot(dir);
-      expect(computed.ok, `seed ${seed} computed path errored`).toBe(true);
-      if (!computed.ok) return;
-      expect(computed.value, `seed ${seed} computed path mismatch`).toEqual(expected);
+      const computed = expectOk(await readSnapshot(dir), `seed ${seed} computed path errored`);
+      expect(computed, `seed ${seed} computed path mismatch`).toEqual(expected);
 
       // Cancel the background materialize the read just scheduled, then write explicitly.
       __resetMaterializeTimersForTests();
-      const mat = await materialize(dir);
-      expect(mat.ok, `seed ${seed} materialize errored`).toBe(true);
+      expectOk(await materialize(dir), `seed ${seed} materialize errored`);
 
       // (b) Fresh-hit path: an up-to-date snapshot on disk still deep-equals reduce(loadEvents).
-      const fresh = await readSnapshot(dir);
-      expect(fresh.ok, `seed ${seed} fresh-hit path errored`).toBe(true);
-      if (!fresh.ok) return;
-      expect(fresh.value, `seed ${seed} fresh-hit path mismatch`).toEqual(expected);
+      const fresh = expectOk(await readSnapshot(dir), `seed ${seed} fresh-hit path errored`);
+      expect(fresh, `seed ${seed} fresh-hit path mismatch`).toEqual(expected);
     }
-  });
+  );
 });


### PR DESCRIPTION
## Why

`main` @ `8e7a59800` is RED. CI run [`34271802379`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34271802379), job `build-and-test (windows-latest, 22)`:

```
 FAIL  tests/state/event-sourcing/snapshot.property.test.ts > SC2 — reduce(events) === readSnapshot() (property) > holds over 200 randomized seeds on both the computed and fresh-hit paths
Error: Test timed out in 60000ms.
 ❯ tests/state/event-sourcing/snapshot.property.test.ts:121:3
```

The file reported **66925ms** for that one test. ubuntu and macOS passed the identical pinned seeds. The three commits after `8e7a59800` are all `[skip ci]`, so the current tip `738b296c0` has never run CI.

## Root cause

`snapshot.property.test.ts:121` was **one** `it()` looping `seed = 1..200`. **vitest budgets timeouts per test, not per unit of work**, so aggregating 200 seeds of real filesystem I/O under a single `it()` turned the suite's total wall-clock into an implicit, machine-speed-dependent assertion sitting under a fixed 60s ceiling.

The logic is fully deterministic — the mulberry32 seeds are pinned. Nothing about the *correctness* of the property varies by platform; only the *speed* does.

I/O volume under that one budget, measured by replaying the pinned PRNG offline:

| Quantity | Value |
| --- | --- |
| Seeds | 200 |
| Real `emitEvent` calls (each an `appendFileSync`) | **2974** |
| Mean events per seed | 14.9 |
| Max events in one seed | 30 |

Each `emitEvent` is several syscalls, not one. `emitEvent` (`log.ts:199`) does `getStateDir` (`existsSync`) → `mkdirSync` → `readTailSeq` → `appendFileSync`, and `readTailSeq` (`log.ts:46`) is `existsSync` plus a **full `readFileSync` of the growing log, re-read on every append** (its INV-2 contract). Per seed there is additionally a `mkdtempSync`, a `loadEvents`, two `readSnapshot`, a `materialize` (`writeFileSync` + `renameSync`), and a recursive `rmSync`. That puts the file on the order of **~18,000 filesystem syscalls inside a single 60s budget**.

Implied per-op cost: **~3.7ms on windows-latest** (66925ms / ~18k) against **~0.1ms on this macOS host**. That ratio is the entire failure.

`vitest.config.ts` already sets `testTimeout: 60_000` and `fileParallelism: false` on win32, so the Windows leg was *already* serialized and *already* on a raised ceiling — the budget had simply been consumed by aggregation. The Windows leg also runs `pnpm test -- --continue` (no coverage), so coverage instrumentation is not a factor.

**This is a defect in the test's structure, not in `snapshot.ts` or `log.ts`.** `readTailSeq`'s re-read-per-append is a deliberate, documented multi-writer correctness choice (INV-2), and 30 events is well inside its intended range. No product change is warranted, and none is made here.

## Fix

Split the single `it()` into `it.each(SEEDS)` — one case per seed.

- Each seed carries **its own** 60s budget, so no single test's runtime is load-bearing. vitest applies no per-file timeout, so the ~67s Windows file no longer fails.
- `afterEach` reclaims **that seed's** temp dir immediately, instead of holding all 200 live until the end of the run.
- Failures name the seed (`… — seed 137`) instead of one opaque aggregate failure.
- Cases stay **sequential**. `it.concurrent` would genuinely cut wall-clock but is **unsound** here: `buildLog` mutates `process.env.HARNESS_EVENT_WRITER_ID` and the module-level writer-id cache, so concurrent seeds would clobber each other's writer identity.

**All 200 seeds still run on every OS.** Nothing is skipped, retried, reduced, or platform-gated — the file's header ("A failing seed is a real reducer/snapshot bug to fix — not a test to weaken") is respected. The reporter now shows 200 named cases, which is what makes full coverage *visible* rather than merely asserted.

Alongside, the four `if (!x.ok) return;` narrowing guards become an `expectOk` helper that **throws**. At the base those `return`s were unreachable (the preceding `expect(...).toBe(true)` throws first), but a `return` inside a per-seed case would end that case **green having asserted nothing**. `expectOk` removes that silently-green path by construction and surfaces the underlying `Result.error` message instead of a bare `expected false to be true`.

### Rejected: just raise `testTimeout`

That leaves the same wall-clock assertion in place and merely moves the cliff further away. The budget would still be consumed by 200 aggregated seeds, so the next slower runner — or the next seed added — reintroduces the identical failure with no new diagnostic signal. That is the shape #2046 already tracks; adding to it is not a fix. Splitting removes the coupling instead of widening it.

## Measurements

| | Before (aggregate `it()`) | After (`it.each`, 200 cases) |
| --- | --- | --- |
| windows-latest CI | **66925ms → FAIL** (60000ms budget) | pending this PR's CI |
| macOS local, run 1 | 2.46s total / 1.93s in tests | 505ms total / 351ms in tests |
| macOS local, run 2 | 836ms / 562ms | 514ms / 359ms |
| macOS local, run 3 | 552ms / 388ms | 506ms / 358ms |
| Slowest single test | the whole file (388–1930ms) vs 60000ms budget | **5ms** vs its 60000ms budget (~12,000x margin) |
| Tests reported | 1 | **200 passed (200)** |

Verified after the fix:
- 3 consecutive runs green (above).
- Every seed 1..200 named **exactly once**; 0 missing from the verbose reporter.
- 0 cases above 1000ms.
- Full event-sourcing suite: 14 files, 350 tests, green.
- Full orchestrator suite (touched by the pre-push gate): 2926 tests green.
- `pnpm lint`, `pnpm format:check`, and core `tsc --noEmit` all clean.

**Mutation check — the property still bites.** Injecting a mutant into `materialize` (`meta.lastSeq + 1`) turns **all 200 cases RED**, each naming its own seed:

```
⎯⎯⎯⎯⎯⎯ Failed Tests 200 ⎯⎯⎯⎯⎯⎯
AssertionError: seed 1 fresh-hit path mismatch: expected { schemaVersion: 2, …(4) } to deeply equal { schemaVersion: 2, …(4) }
AssertionError: seed 2 fresh-hit path mismatch: ...
```

This proves the refactor did not hollow out the property, and demonstrates the per-seed naming win. Mutant reverted; `snapshot.ts` is byte-identical to base.

## Assumptions made

- **The 66925ms is dominated by filesystem latency, not a hang or a behavioural difference.** Supported by ubuntu/macOS passing the same deterministic seeds and by the per-op cost the ratio implies (~3.7ms, ordinary for Windows CI with real-time AV scanning of a temp directory). Not directly measured — see below.
- **vitest applies no per-file timeout**, only per-test (`testTimeout`) and per-hook (`hookTimeout`). If a per-file ceiling existed, the split would not help.
- The Windows leg runs without coverage instrumentation, so v8 coverage load is not a contributing factor.

## What I could NOT verify

- **I could not reproduce the Windows-only timeout locally.** This work was done on macOS — the leg that *passed* in CI. Locally the file runs in 0.4–1.9s against a 60000ms budget (~30–150x margin), so the failure cannot manifest here. The evidence that the budget is the binding constraint is the measured Windows/macOS ratio plus the syscall accounting above, **not** a local reproduction.
- **Post-fix behaviour on windows-latest is confirmed only by this PR's own CI run**, not locally.

## Notes for the reviewer

- **Test-only change.** No file under `packages/*/src/` is touched, so no changeset is required — `scripts/check-changesets.mjs` `SKIP_FILE` excludes `tests/` and `*.test.ts`, and the gate confirmed "No publishable package changes detected."
- **`pnpm format:check` passes over the whole tree.** One unrelated file did trip it during pushing: the pre-push security-ledger step rewrites the tracked `packages/cli/.harness/security/timeline.json` with raw `JSON.stringify(…, 2)` output rather than prettier's formatting, and `.prettierignore`'s `.harness/security/` entry is root-anchored so it does not cover the `packages/cli/` copy. **I did not touch or commit that file** — I reverted the gate's local write. It looks like a latent repo papercut (every pushing contributor re-dirties it), worth a separate issue; flagging rather than silently fixing unrelated drift.
- Plan artifact from the `harness-debugging` pipeline: `docs/changes/snapshot-property-per-seed-budget/plans/2026-09-08-snapshot-property-per-seed-budget-plan.md`.

Refs #2046 — same defect class (wall-clock as an implicit assertion), different shape: there the assertion is explicit in the test body, here it was implicit in the runner's per-test budget. Deliberately **not** `Closes`, since this is not one of the seven wall-clock assertions that issue enumerates.

Base: `738b296c0a50cb9890474124d466f38903e468e2`

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
