### PR TITLE
fix(ci): bounded retry + leave-open abstain for the two merge-race call sites #2048 missed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,28 +152,114 @@ jobs:
           #    1 on every publish, so the release ran red even though the packages
           #    had already gone out, and the golden reference never advanced.
           echo "Direct push unavailable; opening a self-approved PR."
-          git fetch origin "$BASE" -q
           BRANCH="chore/golden-promote-$(git rev-parse --short "$OURS")-$(date +%s)"
-          git checkout -B "$BRANCH" "origin/$BASE"
-          git checkout "$OURS" -- "$MANIFEST"
-          git add "$MANIFEST"
-          if git diff --cached --quiet; then
+
+          # Re-derive the promotion branch on the CURRENT tip of the base. Factored
+          # into a function because the merge retry below re-derives on the NEW tip
+          # between attempts rather than blindly repeating a merge the base has
+          # already moved out from under. Returns non-zero when the latest base
+          # already carries this manifest (nothing left to propose).
+          #
+          # RE-DERIVE SAFETY (the question ci.yml answers differently): the manifest
+          # is written WHOLESALE by `golden-build promote` — it is a snapshot of the
+          # just-published tree, not an edit layered onto an existing file — and this
+          # step is that file's ONLY writer, serialized by the workflow-level Release
+          # concurrency group. So re-applying "ours" onto a newer base can neither
+          # conflict nor revert a concurrent writer. That is the same property that
+          # makes the ci.yml baseline re-derive safe, and it genuinely holds here.
+          rebuild_branch_on_base() {
+            git fetch origin "$BASE" -q
+            git checkout -B "$BRANCH" "origin/$BASE"
+            git checkout "$OURS" -- "$MANIFEST"
+            git add "$MANIFEST"
+            if git diff --cached --quiet; then
+              return 1
+            fi
+            git commit -m "chore: promote golden build reference state [skip ci]"
+          }
+
+          # Scope guard + self-approval, re-run after every force-push: a force-push
+          # can dismiss the inline approval applied to the previous head, and the
+          # fail-closed guard must gate every approval, not just the first.
+          approve_pr() {
+            # Defensive scope check: the PAT may only ever approve a diff confined to
+            # the golden manifest (mirrors the roadmap auto-done guard).
+            gh pr diff "$PR_URL" --name-only | node scripts/assert-diff-scope.mjs "$MANIFEST"
+            GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
+              --body "Auto-approved: golden-build reference promotion from github-actions[bot]."
+          }
+
+          # EXHAUSTION: leave the PR OPEN and warn — deliberately UNLIKE ci.yml, which
+          # CLOSES its superseded baseline PR. Closing is correct there only because
+          # (a) `.harness/**/baselines.json` carries a `merge=ours` driver, so landing
+          # a stale refresh would REVERT main, and (b) the very next merge to main
+          # regenerates one. NEITHER holds here: `.gitattributes` gives
+          # `.harness/golden/manifest.json` no merge driver (it merges normally, and a
+          # late landing is harmless), and nothing regenerates it until the NEXT
+          # publish, which may be days away. Closing would silently discard this
+          # release's reference state — the exact "unique work" case the conservative
+          # answer is reserved for. Exit 0 because the packages DID publish: a race on
+          # a bookkeeping promotion must not report the release as failed. The
+          # `::warning::` plus the still-open, already-approved PR are the visible,
+          # actionable record — this is an abstain, not a swallowed failure.
+          abstain_open() {
+            echo "::warning::Golden-build reference promotion could not be merged ($1). Leaving $PR_URL OPEN for a human to merge. The packages published successfully; only the reference-state promotion is pending."
+            # A failure to post the courtesy comment is itself reported, never
+            # swallowed — but it must not mask the abstain it is explaining.
+            gh pr comment "$PR_URL" --body "Auto-merge did not land ($1). Left OPEN deliberately: this manifest is the reference state for a release that already published, nothing regenerates it until the next publish, and it carries no \`merge=ours\` driver, so landing it late is safe. Please merge." \
+              || echo "::warning::Could not post the abstain comment on $PR_URL."
+            exit 0
+          }
+
+          if ! rebuild_branch_on_base; then
             echo "Base already carries this golden manifest; nothing to PR."
             exit 0
           fi
-          git commit -m "chore: promote golden build reference state [skip ci]"
           git push -u origin "$BRANCH"
           PR_URL=$(gh pr create \
             --title "chore: promote golden build reference state" \
             --body "Automated golden-build reference promotion after a successful publish. Opened because direct pushes to $BASE are blocked by branch protection." \
             --base "$BASE" \
             --head "$BRANCH")
-          # Defensive scope check: the PAT may only ever approve a diff confined to
-          # the golden manifest (mirrors the roadmap auto-done guard).
-          gh pr diff "$PR_URL" --name-only | node scripts/assert-diff-scope.mjs "$MANIFEST"
-          GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
-            --body "Auto-approved: golden-build reference promotion from github-actions[bot]."
-          gh pr merge "$PR_URL" --auto --squash --delete-branch
+          approve_pr
+
+          # BOUNDED MERGE RETRY — the same defect PR #2048 fixed in ci.yml's
+          # `refresh-baselines` job, at a structurally identical call site that the
+          # fix did not reach. This repo has NO `required_status_checks` branch rule
+          # (ruleset 14799222 carries only `deletion`, `non_fast_forward` and
+          # `pull_request` with one required approval); `approve_pr` has just
+          # satisfied that one requirement inline. `--auto` merely QUEUES when
+          # something is still pending, so with nothing left to wait on it attempts an
+          # IMMEDIATE merge. When the base advances between `gh pr create` and this
+          # call, the mergePullRequest mutation is rejected with "Base branch was
+          # modified", which under `bash -e` exits the step non-zero and fails the
+          # Release run for a race that loses no work at all.
+          #
+          # Retry on a freshly RE-DERIVED branch (same PR, same URL — never a second
+          # PR). `--auto` is kept so the job still behaves correctly if required
+          # checks are added later.
+          for attempt in 1 2 3; do
+            if gh pr merge "$PR_URL" --auto --squash --delete-branch; then
+              echo "Merged (or queued) $PR_URL on attempt $attempt."
+              exit 0
+            fi
+            echo "Merge attempt $attempt failed — the base likely moved; re-deriving on the new tip."
+            sleep 5
+            if ! rebuild_branch_on_base; then
+              # The base now carries this exact manifest, so the PR is provably an
+              # empty no-op. Closing an empty PR discards nothing.
+              echo "::notice::Base already carries this golden manifest; closing the now-empty $PR_URL."
+              gh pr close "$PR_URL" --delete-branch \
+                --comment "Closing: the base already carries this golden manifest, so this PR is now an empty no-op."
+              exit 0
+            fi
+            if ! git push --force-with-lease -u origin "$BRANCH"; then
+              abstain_open "the promotion branch was updated concurrently"
+            fi
+            approve_pr
+          done
+
+          abstain_open "3 merge attempts exhausted"
 
   docker:
     needs: release

--- a/.github/workflows/roadmap-auto-done.yml
+++ b/.github/workflows/roadmap-auto-done.yml
@@ -154,6 +154,12 @@ jobs:
           HUSKY: '0'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTOAPPROVE_PAT: ${{ secrets.BASELINE_AUTOAPPROVE_PAT }}
+          # The closing refs, carried as DATA (never interpolated into the script) so
+          # the PR-fallback path can RE-DERIVE the flip on a fresh base instead of
+          # copying its own roadmap snapshot over one. Exactly one of the two is
+          # non-empty — the step's `if:` is the same disjunction.
+          CLOSING_REFS: ${{ steps.closing.outputs.refs }}
+          FALLBACK_REFS: ${{ steps.fallback.outputs.refs }}
         run: |
           if [ -z "$(git status --porcelain docs/roadmap.d docs/roadmap.md)" ]; then
             echo "Reconcile produced no roadmap changes (rows already done); nothing to commit."
@@ -189,26 +195,133 @@ jobs:
           # 2) Direct push is blocked (branch protection) or lost every race. Open a
           #    self-approved PR, mirroring the baseline-refresh job in ci.yml.
           echo "Direct push unavailable; opening a self-approved PR."
-          git fetch origin "$BASE" -q
           BRANCH="chore/auto-done-pr${{ github.event.pull_request.number }}-$(date +%s)"
-          git checkout -B "$BRANCH" "origin/$BASE"
-          # Re-apply just the roadmap flips on top of the latest base.
-          git checkout "$OURS" -- $ROADMAP_PATHS
-          git add $ROADMAP_PATHS
-          if git diff --cached --quiet; then
+          REFS="$CLOSING_REFS"
+          [ -n "$REFS" ] || REFS="$FALLBACK_REFS"
+          if [ -z "$REFS" ]; then
+            # Unreachable while the step's `if:` matches the same disjunction. Loud
+            # rather than silent if that guard ever drifts: without the refs the flip
+            # cannot be re-derived, and guessing would be worse than failing.
+            echo "::error::No closing refs available to re-derive the roadmap flip."
+            exit 1
+          fi
+
+          # Re-derive the flip on the CURRENT tip of the base. Factored into a
+          # function because the merge retry below re-derives on the NEW tip between
+          # attempts rather than blindly repeating a merge the base has already moved
+          # out from under. Returns non-zero when the latest base already carries the
+          # flip (nothing left to propose).
+          #
+          # RE-DERIVE SAFETY — this is the load-bearing difference from ci.yml, and
+          # from the previous version of this block. ci.yml may re-apply "ours"
+          # wholesale because its baselines are REGENERATED wholesale, so "ours" is
+          # always the correct resolution. The roadmap is NOT that: `docs/roadmap.d/`
+          # is a shared, additively-edited shard tree, so copying our snapshot of it
+          # onto a newer base (the old `git checkout "$OURS" -- $ROADMAP_PATHS`) would
+          # REVERT any row another commit flipped in between. Re-running the
+          # reconciler instead is safe because `roadmap reconcile --from-refs` is a
+          # pure, OFFLINE, IDEMPOTENT function of the closing refs: it flips exactly
+          # the rows whose External-ID matches and is a no-op on rows already `done`,
+          # so running it against a newer base yields the SAME logical mutation
+          # without touching anyone else's rows.
+          rebuild_branch_on_base() {
+            git fetch origin "$BASE" -q
+            git checkout -B "$BRANCH" "origin/$BASE"
+            node packages/cli/dist/bin/harness.js roadmap reconcile --from-refs "$REFS"
+            # In sharded mode the reconcile writes only the shard(s); the aggregate is
+            # generated and must be regenerated before committing.
+            if [ -d docs/roadmap.d ]; then
+              node packages/cli/dist/bin/harness.js roadmap regen
+            fi
+            ROADMAP_PATHS="docs/roadmap.md"
+            if [ -d docs/roadmap.d ]; then ROADMAP_PATHS="$ROADMAP_PATHS docs/roadmap.d"; fi
+            git add $ROADMAP_PATHS
+            if git diff --cached --quiet; then
+              return 1
+            fi
+            git commit -m "chore(roadmap): auto-done from merged PR ${{ github.event.pull_request.number }} [skip ci]"
+          }
+
+          # Scope guard + self-approval, re-run after every force-push: a force-push
+          # can dismiss the inline approval applied to the previous head, and the
+          # fail-closed guard must gate every approval, not just the first.
+          approve_pr() {
+            # Defensive scope check: never self-approve a PR that reaches beyond the
+            # roadmap files, so BASELINE_AUTOAPPROVE_PAT stays scoped (mirrors #531).
+            gh pr diff "$PR_URL" --name-only | node scripts/assert-diff-scope.mjs docs/roadmap.md docs/roadmap.d/
+            GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
+              --body "Auto-approved: roadmap auto-done flip from github-actions[bot]."
+          }
+
+          # EXHAUSTION: leave the PR OPEN and warn — deliberately UNLIKE ci.yml, which
+          # CLOSES its superseded baseline PR. Closing is correct there only because a
+          # stale baseline PR is actively DANGEROUS (`merge=ours` driver would revert
+          # main) and because the very next merge regenerates one. Neither holds here.
+          # This flip is derived from ONE merge event that has already passed; nothing
+          # in CI re-fires it, so closing would silently drop a real roadmap mutation.
+          # Nor is landing it late dangerous: the shards under `docs/roadmap.d/` carry
+          # no merge driver and merge normally, and while `docs/roadmap.md` does carry
+          # `merge=ours`, it is a GENERATED aggregate that `roadmap regen` and the
+          # post-merge hook rebuild from those shards. Exit 0 because a merge race on
+          # post-merge bookkeeping must not red the default branch; the `::warning::`
+          # and the still-open, already-approved PR are the visible, actionable record
+          # — an abstain, not a swallowed failure.
+          abstain_open() {
+            echo "::warning::Roadmap auto-done flip could not be merged ($1). Leaving $PR_URL OPEN for a human to merge — closing it would drop a real roadmap mutation that nothing regenerates."
+            # A failure to post the courtesy comment is itself reported, never
+            # swallowed — but it must not mask the abstain it is explaining.
+            gh pr comment "$PR_URL" --body "Auto-merge did not land ($1). Left OPEN deliberately: this flip is derived from a single merged PR and nothing re-derives it, so closing would silently drop it. Landing it late is safe — the roadmap shards merge normally and the aggregate is regenerated. Please merge." \
+              || echo "::warning::Could not post the abstain comment on $PR_URL."
+            exit 0
+          }
+
+          if ! rebuild_branch_on_base; then
             echo "Base already carries these roadmap flips; nothing to PR."
             exit 0
           fi
-          git commit -m "chore(roadmap): auto-done from merged PR ${{ github.event.pull_request.number }} [skip ci]"
           git push -u origin "$BRANCH"
           PR_URL=$(gh pr create \
             --title "chore(roadmap): auto-done from merged PR ${{ github.event.pull_request.number }}" \
             --body "Automated roadmap auto-done flip. Opened because direct pushes to $BASE are blocked by branch protection." \
             --base "$BASE" \
             --head "$BRANCH")
-          # Defensive scope check: never self-approve a PR that reaches beyond the
-          # roadmap files, so BASELINE_AUTOAPPROVE_PAT stays scoped (mirrors #531).
-          gh pr diff "$PR_URL" --name-only | node scripts/assert-diff-scope.mjs docs/roadmap.md docs/roadmap.d/
-          GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
-            --body "Auto-approved: roadmap auto-done flip from github-actions[bot]."
-          gh pr merge "$PR_URL" --auto --squash --delete-branch
+          approve_pr
+
+          # BOUNDED MERGE RETRY — the same defect PR #2048 fixed in ci.yml's
+          # `refresh-baselines` job, at a structurally identical call site that the
+          # fix did not reach. This repo has NO `required_status_checks` branch rule
+          # (ruleset 14799222 carries only `deletion`, `non_fast_forward` and
+          # `pull_request` with one required approval); `approve_pr` has just
+          # satisfied that one requirement inline. `--auto` merely QUEUES when
+          # something is still pending, so with nothing left to wait on it attempts an
+          # IMMEDIATE merge. When the base advances between `gh pr create` and this
+          # call, the mergePullRequest mutation is rejected with "Base branch was
+          # modified", which under `bash -e` exits the step non-zero and reds the
+          # default branch for a race that loses no work at all.
+          #
+          # Retry on a freshly RE-DERIVED branch (same PR, same URL — never a second
+          # PR). `--auto` is kept so the job still behaves correctly if required
+          # checks are added later.
+          for attempt in 1 2 3; do
+            if gh pr merge "$PR_URL" --auto --squash --delete-branch; then
+              echo "Merged (or queued) $PR_URL on attempt $attempt."
+              exit 0
+            fi
+            echo "Merge attempt $attempt failed — the base likely moved; re-deriving on the new tip."
+            sleep 5
+            if ! rebuild_branch_on_base; then
+              # The base now carries these flips (another writer or an offline sweep
+              # got there first), so the PR is provably an empty no-op. Closing an
+              # empty PR discards nothing.
+              echo "::notice::Base already carries these roadmap flips; closing the now-empty $PR_URL."
+              gh pr close "$PR_URL" --delete-branch \
+                --comment "Closing: the base already carries these roadmap flips, so this PR is now an empty no-op."
+              exit 0
+            fi
+            if ! git push --force-with-lease -u origin "$BRANCH"; then
+              abstain_open "the auto-done branch was updated concurrently"
+            fi
+            approve_pr
+          done
+
+          abstain_open "3 merge attempts exhausted"

--- a/.harness/comprehension/tests/scripts/_module.md
+++ b/.harness/comprehension/tests/scripts/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'tests/scripts'
-sourceHash: 'f5f1dd0f1f898df82f626a27a512ee2615e9c61d47fea2d667f80c0f92c3062e'
+sourceHash: '6e544bf5055bb1ffc4b198faa35ed4a2f68fe27a8e15823ee20654c581ee0dfd'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -17,6 +17,7 @@ members:
     'main-health-check.test.mjs',
     'plugin-antigravity-target.test.mjs',
     'plugin-pin-sync.test.mjs',
+    'workflow-merge-race.test.mjs',
   ]
 ---
 

--- a/docs/changes/merge-race-surviving-call-sites/plans/plan.md
+++ b/docs/changes/merge-race-surviving-call-sites/plans/plan.md
@@ -1,0 +1,257 @@
+# Plan — the `gh pr merge --auto` merge race at the call sites PR #2048 did not reach (cicd-fleet)
+
+Trace of the `harness-workflow-audit` run (inventory → mechanical → judgment → report) and the
+remediation it produced, executed autonomously in a cicd-fleet remediation lane.
+
+Scope (two surviving call sites):
+
+- `.github/workflows/release.yml`, job `release`, step `Promote golden build reference state`
+- `.github/workflows/roadmap-auto-done.yml`, job `auto-done`, step `Commit and push the shard flip`
+
+Pinned base SHA: `738b296c0a50cb9890474124d466f38903e468e2`.
+
+## Provenance
+
+PR #2048 (`65b475bb004a4b40af3dde4f824404768d39a01e`) fixed this defect in `ci.yml`'s
+`refresh-baselines` job. Its diagnosis is reproduced below **as re-verified against the pinned
+base**, not taken on faith. It fixed exactly one of the three call sites that carry the shape.
+
+## Root cause (re-verified, not inherited)
+
+`gh pr merge --auto` only _queues_ a merge when something is still pending. When nothing is
+pending it attempts an **immediate** merge, and an immediate merge against a base that has moved
+is rejected with:
+
+```
+GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
+```
+
+Under `bash -e` that exits the step non-zero.
+
+**Verification performed in this lane** (`gh api repos/Intense-Visions/harness-engineering/...`):
+
+| Claim                               | Check                      | Result                                                   |
+| ----------------------------------- | -------------------------- | -------------------------------------------------------- |
+| no `required_status_checks` rule    | `rulesets/14799222`        | rules are `deletion`, `non_fast_forward`, `pull_request` |
+| one approving review required       | same                       | `required_approving_review_count: 1`                     |
+| no classic branch protection either | `branches/main/protection` | `404 Branch not protected`                               |
+
+So the single merge requirement is one approval, and at both call sites the PAT satisfies it
+**inline on the line immediately above the merge**. There is nothing left for `--auto` to wait on.
+
+Both surviving sites carry the identical five-line shape:
+
+```
+gh pr create → assert-diff-scope.mjs (fail-closed scope guard) → PAT self-approval → gh pr merge --auto
+```
+
+## Observed-vs-latent — stated plainly
+
+`ci.yml`'s site had **three reproduced red runs** (34227768312, 34042737396, 34042651655).
+These two sites do **not**. Evidence gathered in this lane:
+
+- `release.yml`: last 30 runs contain no `failure`. The 8 most recent historical failures
+  (33965602127, 33809503957, 33807408589, 33448269864, 33130776331, 32903965243, 32182980972, 31314325630) failed in `ci-gate: Run pnpm typecheck` or `docker / smoke-test`, **not** in the
+  promotion step.
+- `roadmap-auto-done.yml`: last 40 runs contain no `failure`; the most recent historical failure
+  (32992087338, 2026-08-26) failed in `Reconcile auto-done`, **not** at the merge.
+
+**This fix is therefore preventive, justified by structural identity with a reproduced defect —
+not by a reproduction at these two sites.** Both PR-fallback paths landed on 2026-08-09
+(`a05b6de4d`, extending #749's pattern), so the exposure window is short and the burst traffic
+that produced ci.yml's three reds is recent. Anyone reading this should not believe these two
+sites have failed in production; they have not, yet.
+
+One inherited premise **corrected**: #2048 says a red job "fires the Main Health Alarm".
+`main-health.yml` watches `workflows: [CI]` only, so a red **Release** or **Roadmap Auto-Done**
+run does _not_ fire the alarm. The redness is still real and still lands on the default branch;
+it is simply quieter, which arguably makes it worse.
+
+## Audit findings (harness-workflow-audit, scoped to the two steps)
+
+```
+WORKFLOW AUDIT: harness-engineering — release.yml + roadmap-auto-done.yml (merge-race scope)
+Workflows in tree: 22   Findings (in scope): 2 error, 2 warning, 1 info
+Gates that never fire: none in scope
+Documented-but-unwired gates: none in scope
+```
+
+### [ERROR] pushback-race — `.github/workflows/release.yml:176` (pre-fix line)
+
+`gh pr merge "$PR_URL" --auto --squash --delete-branch` is the terminal command of a `bash -e`
+step, with no retry and no tolerance for a concurrently-advancing base. **Effect:** a race on a
+bookkeeping promotion fails a Release run whose packages have _already published_ — the worst
+possible signal, because the failure implies the publish failed when it did not.
+
+**Patch:** applied — bounded retry with re-derivation, then leave-open abstain (below).
+
+### [ERROR] pushback-race — `.github/workflows/roadmap-auto-done.yml:214` (pre-fix line)
+
+Same call, same shape. **Effect:** a red run on the default branch for a race that loses no work.
+
+**Patch:** applied — bounded retry with re-derivation, then leave-open abstain (below).
+
+### [WARNING] pushback-clobber — `.github/workflows/roadmap-auto-done.yml:196` (pre-fix line)
+
+Pre-existing, and the reason the ci.yml idiom **cannot be copied blindly**. The PR-fallback branch
+was built with `git checkout "$OURS" -- $ROADMAP_PATHS` onto a freshly-fetched base: a _wholesale
+snapshot copy_ of our `docs/roadmap.d/` over a base that may have advanced. `docs/roadmap.d/` is a
+shared, additively-edited shard tree, so this **reverts any row another commit flipped in between**.
+A retry loop that re-derives this way would run that clobber up to three more times against
+successively newer tips, converting a latent hazard into a likely one.
+
+**Patch:** applied — the re-derive now re-runs the reconciler instead (below).
+
+### [WARNING] concurrency-cancellation — `.github/workflows/release.yml:7-9` — **NOT PATCHED**
+
+`concurrency: group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: false`.
+18 of the last 30 Release runs concluded `cancelled` (GitHub keeps at most one _pending_ run per
+group, so a third arrival cancels the previously-pending one). The same pattern gives
+`roadmap-auto-done.yml` cancelled runs, and there it can drop a roadmap flip outright.
+
+**Deliberately out of scope and NOT changed.** The per-SHA remedy applied elsewhere (#1867/#2049)
+is arguably _wrong_ for a publish path: it would permit concurrent `npm publish` runs and git-tag
+races. This is a genuine unresolved design fork parked for a human. Recorded here so the next
+reader does not mistake its absence for an oversight.
+
+### [INFO] injection-hygiene — `.github/workflows/roadmap-auto-done.yml`
+
+`${{ github.event.pull_request.number }}` is interpolated into `run:` in three places. It is an
+integer, so this is not exploitable; left as-is to keep the diff scoped. The new closing-refs
+value is passed as `env:` data (`CLOSING_REFS` / `FALLBACK_REFS`) rather than interpolated.
+
+## Remediation, per site
+
+Both sites gain the three functions the ci.yml idiom is built from — `rebuild_branch_on_base`,
+`approve_pr`, and an abstain — plus `for attempt in 1 2 3` around the merge, with the re-derived
+branch force-pushed to the **same** PR (never a second one) and `approve_pr` re-run after every
+force-push (a force-push can dismiss the inline approval applied to the previous head).
+
+`--auto` is retained at both sites so the jobs still behave correctly if `required_status_checks`
+is ever added. **Neither site's `assert-diff-scope.mjs` guard was weakened or removed**, and
+**no merge is silenced with `|| true`**.
+
+### Question 1 — is re-deriving on a fresh tip safe?
+
+| Site                    | Payload                                  | Can it conflict?                                                            | Is it idempotent?                                                                  | Verdict                                                            |
+| ----------------------- | ---------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `release.yml`           | `.harness/golden/manifest.json`          | No — single file, written wholesale by `golden-build promote`               | Yes — the snapshot is of an already-published tree and does not depend on the base | **Wholesale re-apply is safe** (ci.yml's property genuinely holds) |
+| `roadmap-auto-done.yml` | roadmap shard flip + generated aggregate | Wholesale copy cannot _conflict_, but it **reverts** concurrent shard edits | The _reconciler_ is idempotent; the snapshot copy is not                           | **Wholesale re-apply is NOT safe; re-run the reconciler instead**  |
+
+**`release.yml`:** ci.yml's justification transfers intact. The manifest is written wholesale, and
+this step is the file's only writer — serialized by the Release workflow's own concurrency group,
+so no concurrent run can be promoting a different manifest. Re-applying "ours" onto a newer base
+can neither conflict nor revert a concurrent writer. `git checkout "$OURS" -- "$MANIFEST"` is kept.
+
+**`roadmap-auto-done.yml`:** ci.yml's justification does **not** transfer, per the
+pushback-clobber finding above. The re-derive now re-runs
+`harness roadmap reconcile --from-refs "$REFS"` (plus `roadmap regen` when sharded) against the
+fresh base. That is safe because `--from-refs` is documented and implemented as a **pure, offline**
+operation (`packages/cli/src/commands/roadmap/reconcile.ts:111` — "NO network call: `--from-refs`
+carries each closing issue's own `owner/repo`"): it flips exactly the rows whose External-ID
+matches and is a no-op on rows already `done`. Re-running it against a newer base yields the same
+logical mutation while touching nobody else's rows. The refs reach the script as `env:` data.
+
+_This also removes the pre-existing clobber on the very first branch build_, since both the initial
+build and the retries now go through the one `rebuild_branch_on_base` function.
+
+### Question 2 — what should exhaustion do?
+
+`ci.yml` **closes** its superseded PR and exits 0. That is correct there for two reasons, and
+**neither reason holds at either site here**:
+
+1. `.harness/**/baselines.json` carries a `merge=ours` driver (`.gitattributes`), so landing a
+   stale refresh would **revert** main's newer baselines — the PR is actively dangerous, not
+   merely stale.
+2. The very next merge to main regenerates a fresh one, so closing loses nothing.
+
+| Site                    | Dangerous to land late?                                                                                                                                                                        | Regenerated automatically?                                                                    | Exhaustion behaviour chosen             |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `release.yml`           | No — `.gitattributes` gives `.harness/golden/manifest.json` no merge driver; it merges normally                                                                                                | Only by the **next publish**, which may be days away                                          | **Leave OPEN + `::warning::` + exit 0** |
+| `roadmap-auto-done.yml` | No — the shards under `docs/roadmap.d/` carry no merge driver; `docs/roadmap.md` does carry `merge=ours`, but it is a **generated** aggregate rebuilt by `roadmap regen` / the post-merge hook | No — the flip derives from one merge event that has already passed; nothing in CI re-fires it | **Leave OPEN + `::warning::` + exit 0** |
+
+Both payloads carry **unique work that nothing regenerates**, so closing would silently drop it.
+The conservative answer applies at both sites. `exit 0` is used because a lost merge race must not
+red the default branch (release.yml additionally must not report a successful publish as a failed
+release). This is a **visible abstain, not a swallowed failure**: a `::warning::` annotation, a
+comment on the PR, and a still-open, already-approved PR a human can merge in one click.
+
+**One narrow exception, at both sites:** if `rebuild_branch_on_base` returns non-zero mid-retry,
+the base provably already carries the payload and the PR is an empty no-op. Closing an empty PR
+discards nothing, so that path closes with a `::notice::`. The abstain function itself never
+closes — asserted by test.
+
+## Regression tests
+
+New file `tests/scripts/workflow-merge-race.test.mjs` (8 tests), **not** an addition to
+`tests/scripts/baseline-gating.test.mjs`. Justification: that file is documented end to end as the
+#671 baseline-jitter / refresh-race suite, and neither workflow here touches a baseline. The CI
+step "Baseline-gating regression test" runs `node --test 'tests/scripts/*.test.mjs'` — a directory
+glob — so a sibling file is CI-wired with **no workflow change**.
+
+Both steps already contained an unrelated `for attempt in 1 2 3` loop around their _direct push_
+before this fix, so "a bounded loop exists somewhere in the step" would have been a vacuous
+assertion. Every assertion is anchored to the merge call itself.
+
+### Pre-fix red proof (performed, not assumed)
+
+Workflow edits stashed (`git stash push -- .github/workflows/release.yml
+.github/workflows/roadmap-auto-done.yml`), leaving the two files byte-identical to the pinned base,
+then `node --test tests/scripts/workflow-merge-race.test.mjs`:
+
+| Test                                                                  | Pre-fix | First failing assertion                                                   |
+| --------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------- |
+| release/golden-promote: bounded retry that re-derives                 | ✖ FAIL  | the merge must be attempted inside the bounded retry, not once and bare   |
+| release/golden-promote: exhaustion abstains visibly and exits clean   | ✖ FAIL  | exhaustion must route through a named abstain                             |
+| release/golden-promote: not neutralised, guard gates every approval   | ✖ FAIL  | the fail-closed scope guard must live inside the re-runnable approval     |
+| roadmap-auto-done: bounded retry that re-derives                      | ✖ FAIL  | the merge must be attempted inside the bounded retry, not once and bare   |
+| roadmap-auto-done: exhaustion abstains visibly and exits clean        | ✖ FAIL  | exhaustion must route through a named abstain                             |
+| roadmap-auto-done: not neutralised, guard gates every approval        | ✖ FAIL  | the fail-closed scope guard must live inside the re-runnable approval     |
+| roadmap-auto-done: re-derive re-runs the reconciler, no snapshot copy | ✖ FAIL  | the re-derive must re-run the reconciler against the fresh base           |
+| release/golden-promote: re-derive is a wholesale manifest re-apply    | ✖ FAIL  | the golden manifest re-derive must re-apply our snapshot on the fresh tip |
+
+8/8 red pre-fix, 8/8 green post-fix; the whole `tests/scripts/` suite is 90/90 green.
+
+**Honest caveat about assertion granularity.** `node:test` aborts a test at its first failing
+assertion, so what is proven above is that every _test_ fails pre-fix. Two individual assertions
+inside those tests are **guard-rails that would pass pre-fix by construction** and exist only to
+prevent a future weakening:
+
+- `doesNotMatch(/gh pr merge[^\n]*\|\|\s*true/)` — no `|| true` today, at either site
+- `doesNotMatch(BARE_MERGE)` — vacuously true only once the bare form is gone
+
+Every other assertion is genuinely fix-specific. The same caveat applies to #2048's third test
+(`refresh-baselines: the merge is not neutralised and the #531 scope guard survives`), whose two
+assertions both held before that fix — so `65b475bb0`'s claim that "all three fail against the
+pre-fix workflow" is, strictly read, an overstatement for that one test. Recorded here rather than
+repeated silently.
+
+## Not changed
+
+- Any `concurrency:` block (see the parked finding above).
+- `ci.yml` — already fixed by #2048.
+- `holiday-confidence-track.yml:231`, the **fourth** bare `gh pr merge --auto` in the tree. It was
+  not in this item's scope and is not covered by these tests. It is the workflow #2048 credits as
+  the origin of the `for attempt in 1 2 3` idiom, and its ledger payload has its own re-derive
+  and exhaustion questions to answer. **Filed as a follow-up rather than silently included.**
+- Either site's `assert-diff-scope.mjs` scope guard — retained verbatim, now inside `approve_pr`
+  so it re-runs before every re-approval.
+
+## Assumptions made
+
+1. **The two sites' merge requirements are the same as ci.yml's.** Verified against ruleset
+   14799222 as of this lane's run; if a `required_status_checks` rule is added later, `--auto`
+   reverts to genuine queuing and the retry loop becomes dead code that costs nothing.
+2. **`BASELINE_AUTOAPPROVE_PAT` remains valid for repeat approvals within one run.** The retry
+   re-approves up to three times; `gh pr review --approve` on an already-approved head is accepted
+   by GitHub as a new review. Not exercised end-to-end here — there is no way to run these steps
+   outside a real Release / merge event.
+3. **`packages/cli/dist/bin/harness.js` survives `git checkout -B` inside the job.** `dist/` is
+   gitignored, and the same invocation already runs earlier in the same job after `pnpm build`.
+4. **Exactly one of `CLOSING_REFS` / `FALLBACK_REFS` is non-empty** whenever the commit step runs —
+   the step's `if:` is the same disjunction. An explicit `::error::` guard fails loudly rather than
+   guessing if that ever drifts.
+5. **`sleep 5` between attempts is adequate.** Copied unchanged from ci.yml; not independently
+   tuned.
+6. **No end-to-end execution.** These are workflow files; the remediation is verified by text
+   assertions, YAML parse, and `bash -n` over every `run:` block, not by a live race.

--- a/tests/scripts/workflow-merge-race.test.mjs
+++ b/tests/scripts/workflow-merge-race.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for the `gh pr merge --auto` merge race at the call sites
+ * PR #2048 did not reach.
+ *
+ * #2048 diagnosed the defect in ci.yml's `refresh-baselines` job: this repo has
+ * NO `required_status_checks` branch rule (ruleset 14799222 carries only
+ * `deletion`, `non_fast_forward`, and `pull_request` with one required approval),
+ * and that one approval is satisfied inline by the PAT on the line immediately
+ * above the merge. `gh pr merge --auto` only QUEUES when something is still
+ * pending, so with nothing left to wait on it attempts an IMMEDIATE merge; when
+ * the base advances in between, the mutation is rejected with
+ *
+ *   GraphQL: Base branch was modified. Review and try the merge again.
+ *   (mergePullRequest)
+ *
+ * and the step exits non-zero under `bash -e`, reddening the default branch for a
+ * race that loses no work at all. #2048 fixed ci.yml only. Two structurally
+ * identical call sites survived:
+ *
+ *   - .github/workflows/release.yml         (golden-build reference promotion)
+ *   - .github/workflows/roadmap-auto-done.yml (roadmap auto-done flip)
+ *
+ * These assert the ported remediation over the workflow TEXT — the same reason
+ * tests/scripts/baseline-gating.test.mjs asserts over ci.yml's text: the defect
+ * lives in the YAML, not in a script.
+ *
+ * This is a SIBLING of baseline-gating.test.mjs rather than an addition to it:
+ * that file is documented end to end as the #671 baseline-jitter/refresh-race
+ * suite, and neither of these workflows touches a baseline. `node --test
+ * 'tests/scripts/*.test.mjs'` (ci.yml's "Baseline-gating regression test" step)
+ * globs the directory, so a sibling file is CI-wired with no workflow change.
+ *
+ * Run with: node --test tests/scripts/
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+/** Slice one workflow step's text, from its `- name:` line to `end`. */
+function stepText(workflow, stepName, end) {
+  const yml = readFileSync(new URL(`../../.github/workflows/${workflow}`, import.meta.url), 'utf8');
+  const start = yml.indexOf(`- name: ${stepName}`);
+  assert.ok(start !== -1, `${workflow} must still carry the "${stepName}" step`);
+  if (end === undefined) return yml.slice(start);
+  const stop = yml.indexOf(end, start);
+  assert.ok(stop !== -1, `the "${stepName}" step must still be followed by ${JSON.stringify(end)}`);
+  return yml.slice(start, stop);
+}
+
+const goldenPromoteStep = stepText(
+  'release.yml',
+  'Promote golden build reference state',
+  '\n  docker:'
+);
+const autoDoneStep = stepText('roadmap-auto-done.yml', 'Commit and push the shard flip');
+
+/**
+ * Both steps already contained an unrelated `for attempt in 1 2 3` loop around
+ * their DIRECT PUSH before this fix, so "a bounded loop exists somewhere in the
+ * step" proves nothing. Every assertion below is anchored to the merge call
+ * itself.
+ */
+const RETRIED_MERGE =
+  /for attempt in 1 2 3; do\n\s*if gh pr merge "\$PR_URL" --auto --squash --delete-branch; then/;
+const BARE_MERGE = /^[ \t]*gh pr merge "\$PR_URL" --auto --squash --delete-branch[ \t]*$/m;
+const SILENCED_MERGE = /gh pr merge[^\n]*\|\|\s*true/;
+
+for (const [label, step] of [
+  ['release/golden-promote', goldenPromoteStep],
+  ['roadmap-auto-done', autoDoneStep],
+]) {
+  test(`${label}: the auto-merge call sits inside a bounded retry that re-derives`, () => {
+    assert.match(
+      step,
+      RETRIED_MERGE,
+      'the merge must be attempted inside the bounded retry, not once and bare'
+    );
+    assert.doesNotMatch(
+      step,
+      BARE_MERGE,
+      'no unguarded `gh pr merge --auto` may remain — that is the exact #2048 defect'
+    );
+    assert.match(
+      step,
+      /rebuild_branch_on_base/,
+      'each retry must re-derive the branch on the fresh base tip, not blindly repeat'
+    );
+    assert.match(
+      step,
+      /git push --force-with-lease -u origin "\$BRANCH"/,
+      'the re-derived branch must be force-pushed to the SAME PR, never open a second one'
+    );
+  });
+
+  test(`${label}: retry exhaustion abstains visibly and exits clean`, () => {
+    // Deliberately UNLIKE ci.yml, which CLOSES its superseded baseline PR: that is
+    // correct only because a stale baseline PR is actively dangerous under the
+    // `merge=ours` driver and the next merge regenerates one. Neither payload here
+    // regenerates itself, so closing would silently drop unique work.
+    assert.match(step, /abstain_open\(\) \{/, 'exhaustion must route through a named abstain');
+    assert.match(step, /::warning::/, 'the abstain must be announced in the run log, not silent');
+    assert.match(
+      step,
+      /\n\s*exit 0\n\s*\}/,
+      'the abstain path must exit 0 — a lost merge race is not a failed job'
+    );
+    assert.match(
+      step,
+      /\n\s*abstain_open "3 merge attempts exhausted"/,
+      'the loop must fall through to the abstain, never off the end of the step'
+    );
+    // Scope this to the abstain FUNCTION BODY: the retry loop legitimately closes
+    // the PR in the one case where the base provably already carries the payload,
+    // so a step-wide `gh pr close` search would be vacuous.
+    const abstainBody = step.match(/abstain_open\(\) \{([\s\S]*?)\n {10}\}/);
+    assert.ok(abstainBody, 'abstain_open must be a named function with a readable body');
+    assert.doesNotMatch(
+      abstainBody[1],
+      /gh pr close/,
+      'the abstain must LEAVE THE PR OPEN — closing would discard work nothing regenerates'
+    );
+  });
+
+  test(`${label}: the merge is not neutralised and the scope guard gates every approval`, () => {
+    assert.doesNotMatch(
+      step,
+      SILENCED_MERGE,
+      'the merge must never be silenced with `|| true` — that hides a real failure'
+    );
+    assert.match(
+      step,
+      /approve_pr\(\) \{[\s\S]*?assert-diff-scope\.mjs/,
+      'the fail-closed self-approval scope guard must live inside the re-runnable approval'
+    );
+    assert.ok(
+      (step.match(/^\s*approve_pr\s*$/gm) ?? []).length >= 2,
+      'approve_pr must be called again after every force-push — a force-push can dismiss ' +
+        'the inline approval applied to the previous head'
+    );
+  });
+}
+
+test('roadmap-auto-done: the re-derive re-runs the reconciler, never a wholesale snapshot copy', () => {
+  // The load-bearing difference from ci.yml. Baselines are regenerated wholesale,
+  // so re-applying "ours" onto a newer tip is always the correct resolution. The
+  // roadmap is a shared, additively-edited shard tree: copying our snapshot of
+  // docs/roadmap.d/ onto a newer base would REVERT any row another commit flipped
+  // in between. `roadmap reconcile --from-refs` is pure, offline and idempotent,
+  // so re-running it yields the same logical mutation and touches nothing else.
+  assert.match(
+    autoDoneStep,
+    /roadmap reconcile --from-refs "\$REFS"/,
+    'the re-derive must re-run the reconciler against the fresh base'
+  );
+  assert.doesNotMatch(
+    autoDoneStep,
+    /^\s*git checkout "\$OURS" -- \$ROADMAP_PATHS\s*$/m,
+    'the PR branch must never be built by copying our roadmap snapshot over a newer base'
+  );
+  assert.match(
+    autoDoneStep,
+    /CLOSING_REFS: \$\{\{ steps\.closing\.outputs\.refs \}\}/,
+    'the closing refs must reach the script as env DATA, not interpolated into it'
+  );
+});
+
+test('release/golden-promote: the re-derive is a wholesale manifest re-apply', () => {
+  // Safe here precisely because ci.yml's property genuinely holds: the manifest is
+  // written wholesale by `golden-build promote`, and this step is its only writer
+  // (serialized by the Release concurrency group), so re-applying "ours" can
+  // neither conflict nor revert a concurrent writer.
+  assert.match(
+    goldenPromoteStep,
+    /rebuild_branch_on_base\(\) \{[\s\S]*?git checkout "\$OURS" -- "\$MANIFEST"/,
+    'the golden manifest re-derive must re-apply our wholesale snapshot on the fresh tip'
+  );
+});


### PR DESCRIPTION
## Root cause

`gh pr merge --auto` only *queues* a merge when something is still pending. When nothing is pending it attempts an **immediate** merge, which a base that has moved rejects with:

```
GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
```

Under `bash -e` that exits the step non-zero.

**Re-verified against the pinned base in this lane, not inherited from #2048:**

| Claim | Check | Result |
| --- | --- | --- |
| no `required_status_checks` rule | `rulesets/14799222` | rules are `deletion`, `non_fast_forward`, `pull_request` |
| one approving review required | same | `required_approving_review_count: 1` |
| no classic branch protection either | `branches/main/protection` | `404 Branch not protected` |

So the single merge requirement is one approval — and at both sites the PAT satisfies it **inline on the line immediately above the merge**. `--auto` has nothing to wait on.

PR #2048 (`65b475bb0`) fixed this in `ci.yml`'s `refresh-baselines` job. Two structurally identical call sites survived, both with the same five-line shape (`gh pr create` → `assert-diff-scope.mjs` fail-closed guard → PAT self-approval → bare `gh pr merge --auto`):

- `.github/workflows/release.yml:176` — golden-build reference promotion
- `.github/workflows/roadmap-auto-done.yml:214` — roadmap auto-done flip

### Observed vs latent — stated plainly

`ci.yml` had three reproduced red runs. **These two sites do not.** The last 30 Release runs and last 40 Roadmap Auto-Done runs contain no `failure`; recent historical failures at both were unrelated (`ci-gate: Run pnpm typecheck`, `docker / smoke-test`, `Reconcile auto-done`). This is a **preventive port justified by structural identity with a reproduced defect**, not by a reproduction here.

One inherited premise **corrected**: #2048 says a red job fires the Main Health Alarm. `main-health.yml` watches `workflows: [CI]` only, so a red Release / Roadmap Auto-Done does *not* fire it. The redness is real and lands on the default branch; it is simply quieter.

## Per-site reasoning

Both sites gain `rebuild_branch_on_base` / `approve_pr` / an abstain, plus `for attempt in 1 2 3` around the merge, force-pushing the re-derived branch to the **same** PR and re-running the fail-closed scope guard before every re-approval (a force-push can dismiss the previous head's approval). `--auto` is kept so both still work if required checks are added later. **No `|| true`; neither `assert-diff-scope.mjs` guard weakened.**

### Is re-deriving on a fresh tip safe?

| Site | Payload | Conflict? | Idempotent? | Verdict |
| --- | --- | --- | --- | --- |
| `release.yml` | `.harness/golden/manifest.json` | No — single file written wholesale by `golden-build promote` | Yes — a snapshot of an already-published tree, independent of the base | **Wholesale re-apply is safe** |
| `roadmap-auto-done.yml` | roadmap shard flip + generated aggregate | Cannot *conflict*, but **reverts** concurrent shard edits | The *reconciler* is; the snapshot copy is not | **Wholesale re-apply is NOT safe** |

**`release.yml`** — ci.yml's justification transfers intact: the manifest is written wholesale and this step is its only writer (serialized by the Release concurrency group), so re-applying "ours" onto a newer base can neither conflict nor revert a concurrent writer. `git checkout "$OURS" -- "$MANIFEST"` is kept.

**`roadmap-auto-done.yml`** — it does **not**. `docs/roadmap.d/` is a shared, additively-edited shard tree, so the pre-existing `git checkout "$OURS" -- $ROADMAP_PATHS` copies our snapshot over a base that may have advanced and **reverts any row another commit flipped in between**. A retry loop would have run that clobber three more times against successively newer tips. The re-derive now re-runs `harness roadmap reconcile --from-refs "$REFS"` (+ `roadmap regen`) against the fresh base — a **pure, offline, idempotent** operation (`packages/cli/src/commands/roadmap/reconcile.ts:111`: "NO network call: `--from-refs` carries each closing issue's own `owner/repo`") that flips exactly the matching rows and no-ops on rows already `done`. The refs reach the script as `env:` **data** (`CLOSING_REFS` / `FALLBACK_REFS`), never interpolated. Routing the initial branch build through the same function removes the pre-existing clobber too.

### What should exhaustion do?

`ci.yml` **closes** its superseded PR, correctly, for two reasons — **neither of which holds at either site here**:

1. `.harness/**/baselines.json` carries a `merge=ours` driver, so landing a stale refresh would **revert** main. Actively dangerous, not merely stale.
2. The very next merge to main regenerates a fresh one, so closing loses nothing.

| Site | Dangerous to land late? | Regenerated automatically? | Chosen |
| --- | --- | --- | --- |
| `release.yml` | No — `.gitattributes` gives the golden manifest no merge driver | Only by the **next publish**, possibly days away | **Leave OPEN + `::warning::` + exit 0** |
| `roadmap-auto-done.yml` | No — shards carry no merge driver; `docs/roadmap.md` does carry `merge=ours` but is a **generated** aggregate rebuilt by `roadmap regen` | No — derived from one merge event already passed; nothing re-fires it | **Leave OPEN + `::warning::` + exit 0** |

Both payloads carry **unique work nothing regenerates**, so closing would silently drop it — the conservative answer applies at both. `exit 0` because a lost merge race must not red the default branch (and must not report an already-successful publish as a failed release). This is a **visible abstain, not a swallowed failure**: a `::warning::` annotation, a comment on the PR, and a still-open, already-approved PR a human can merge in one click.

One narrow exception at both sites: if `rebuild_branch_on_base` returns non-zero mid-retry, the base provably already carries the payload and the PR is an empty no-op, so that path closes with a `::notice::`. **The abstain function itself never closes — asserted by test.**

## Regression tests, and proof they fail pre-fix

New sibling file `tests/scripts/workflow-merge-race.test.mjs` (8 tests) rather than an addition to `baseline-gating.test.mjs`, which is documented end to end as the #671 baseline-jitter suite — neither workflow here touches a baseline. The CI step "Baseline-gating regression test" runs `node --test 'tests/scripts/*.test.mjs'`, a directory glob, so the sibling is **CI-wired with no workflow change**.

Both steps already contained an unrelated `for attempt in 1 2 3` loop around their *direct push*, so "a bounded loop exists somewhere" would have been vacuous. Every assertion is anchored to the merge call itself.

Workflow edits stashed (`git stash push -- .github/workflows/release.yml .github/workflows/roadmap-auto-done.yml`, leaving both byte-identical to the pinned base), then `node --test tests/scripts/workflow-merge-race.test.mjs`:

| Test | Pre-fix | First failing assertion |
| --- | --- | --- |
| release/golden-promote: bounded retry that re-derives | FAIL | the merge must be attempted inside the bounded retry, not once and bare |
| release/golden-promote: exhaustion abstains visibly and exits clean | FAIL | exhaustion must route through a named abstain |
| release/golden-promote: not neutralised, guard gates every approval | FAIL | the fail-closed scope guard must live inside the re-runnable approval |
| roadmap-auto-done: bounded retry that re-derives | FAIL | the merge must be attempted inside the bounded retry, not once and bare |
| roadmap-auto-done: exhaustion abstains visibly and exits clean | FAIL | exhaustion must route through a named abstain |
| roadmap-auto-done: not neutralised, guard gates every approval | FAIL | the fail-closed scope guard must live inside the re-runnable approval |
| roadmap-auto-done: re-derive re-runs the reconciler, no snapshot copy | FAIL | the re-derive must re-run the reconciler against the fresh base |
| release/golden-promote: re-derive is a wholesale manifest re-apply | FAIL | the golden manifest re-derive must re-apply our snapshot on the fresh tip |

**8/8 red pre-fix, 8/8 green post-fix; whole `tests/scripts/` suite 90/90 green.**

*Honest caveat about granularity.* `node:test` aborts a test at its first failing assertion, so what is proven is that every **test** fails pre-fix. Two individual assertions inside them are **guard-rails that would pass pre-fix by construction** and exist only to prevent a future weakening: `doesNotMatch(/gh pr merge.*\|\| true/)` and `doesNotMatch(BARE_MERGE)`. Every other assertion is genuinely fix-specific. The same caveat applies to #2048's third test, whose two assertions both held before that fix — so `65b475bb0`'s "all three fail against the pre-fix workflow" is, strictly read, an overstatement for that one test. Recorded rather than repeated silently.

## Explicitly NOT changed

- **Any `concurrency:` block.** `release.yml:7-9` (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: false`) leaves 18 of the last 30 Release runs `cancelled`. That is a separate, genuinely unresolved design fork parked for a human: the per-SHA remedy from #1867/#2049 is arguably **wrong** for a publish path, since it would permit concurrent `npm publish` runs and git-tag races.
- **`holiday-confidence-track.yml:231`**, the *fourth* bare `gh pr merge --auto` in the tree. Out of this item's scope and not covered by these tests. It is the workflow #2048 credits as the origin of the `for attempt in 1 2 3` idiom, and its ledger payload has its own re-derive and exhaustion questions. Flagged rather than silently swept in.
- `ci.yml` — already fixed by #2048.
- Either site's `assert-diff-scope.mjs` guard — retained verbatim, now inside `approve_pr` so it re-runs before every re-approval.
- `${{ github.event.pull_request.number }}` interpolation in `roadmap-auto-done.yml` — an integer, not exploitable; left alone to keep the diff scoped.

## Assumptions made

1. **The two sites' merge requirements match ci.yml's** — verified against ruleset 14799222 as of this run. If `required_status_checks` is added later, `--auto` reverts to genuine queuing and the retry becomes dead code that costs nothing.
2. **`BASELINE_AUTOAPPROVE_PAT` stays valid for repeat approvals within one run.** The retry re-approves up to three times; `gh pr review --approve` on an already-approved head is accepted as a new review. **Not exercised end to end** — these steps cannot run outside a real Release / merge event.
3. **`packages/cli/dist/bin/harness.js` survives `git checkout -B` inside the job** — `dist/` is gitignored and the same invocation already runs earlier in the job after `pnpm build`.
4. **Exactly one of `CLOSING_REFS` / `FALLBACK_REFS` is non-empty** when the commit step runs (the step's `if:` is the same disjunction). An explicit `::error::` guard fails loudly rather than guessing if that ever drifts.
5. **`sleep 5` between attempts is adequate** — copied unchanged from ci.yml, not independently tuned.
6. **No end-to-end execution.** Verified by text assertions, YAML parse, and `bash -n` over every `run:` block — not by a live race.

## Verification run

- `pnpm format:check` — clean over the whole tree.
- Both workflows parse as YAML; every `run:` block passes `bash -n` (with `${{ }}` placeholdered).
- Full pre-push gate passed with **no `--no-verify`**. `check:changesets` reported "No publishable package changes detected" — no changeset needed, matching `65b475bb0`.
- Note: `packages/cli/.harness/security/timeline.json` is rewritten by the pre-push security scan in a non-prettier shape on every push. Re-formatted locally to get through the gate; it is **not** part of this PR's diff and is unrelated drift.

Plan artifact: `docs/changes/merge-race-surviving-call-sites/plans/plan.md`

Refs #2045

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
