### PR TITLE
security(deps): bump liquidjs 10.27.1 -> 10.27.2 to clear GHSA-4r6h-5v86-94p3

### DIFF
--- a/.changeset/security-liquidjs-advisory-2087.md
+++ b/.changeset/security-liquidjs-advisory-2087.md
@@ -1,0 +1,27 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+security(orchestrator): resolve `liquidjs` to 10.27.2 to clear GHSA-4r6h-5v86-94p3
+
+[GHSA-4r6h-5v86-94p3](https://github.com/advisories/GHSA-4r6h-5v86-94p3) / `CVE-2026-69222`
+(high, published 2026-09-08T18:10Z) reports that LiquidJS's `join` filter charges
+`memoryLimit` by element count rather than by produced string length, so a template author
+can bypass `memoryLimit` and exhaust process memory. Affected: `liquidjs <= 10.27.1`;
+first patched: `10.27.2`.
+
+**Lockfile only — no manifest change.** `packages/orchestrator/package.json` already
+declares `"liquidjs": "^10.26.0"`, and the patched `10.27.2` is inside that range, so this
+is a three-line `pnpm-lock.yaml` resolution bump: no range edit, no `overrides` pin, and no
+`auditExceptions` entry. `10.27.2` carries an identical dependency shape to `10.27.1`
+(`commander: ^10.0.0`), the same `engines.node: >=16`, and the same `bin` map, so nothing
+transitive moves.
+
+**Evidence strength: `lockfile-only`, deliberately not inflated to `reached`.** The control
+the advisory bypasses is not in use here: `packages/orchestrator/src/prompt/renderer.ts:7`
+constructs `new Liquid({...})` with no `memoryLimit` configured, and no `join:` filter
+appears in any orchestrator template. The bump is still correct — a resolved version inside
+a published affected range is a concrete fact — but the practical exposure in this repo is
+low, and it should not be read as a reachable sink.
+
+Refs #2087.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,7 +613,7 @@ importers:
         version: 4.4.1(@types/react@18.3.28)(react@18.3.1)
       liquidjs:
         specifier: ^10.26.0
-        version: 10.27.1
+        version: 10.27.2
       openai:
         specifier: ^6.0.0
         version: 6.26.0(ws@8.21.0)(zod@3.25.76)
@@ -6645,8 +6645,8 @@ packages:
       yaml: 2.8.3
     dev: true
 
-  /liquidjs@10.27.1:
-    resolution: {integrity: sha512-ylE+1q2kSef1UxAyxqbyuWM3FRWS1v48JK1Y3CoW3bD6TSNXZh0+GsVnihujEpKyR+Jejx2aRAFfC3AHm9rElg==}
+  /liquidjs@10.27.2:
+    resolution: {integrity: sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Clears **[GHSA-4r6h-5v86-94p3](https://github.com/advisories/GHSA-4r6h-5v86-94p3)** / `CVE-2026-69222` (**high**, published 2026-09-08T18:10:35Z): LiquidJS's `join` filter charges `memoryLimit` by element count rather than by produced string length, so a template author can bypass `memoryLimit` and exhaust process memory. Affected `liquidjs <= 10.27.1`; first patched `10.27.2`.

Refs #2087.

## The change is three lockfile lines

`packages/orchestrator/package.json:65` already declares `"liquidjs": "^10.26.0"`, and `10.27.2` is **inside that range** — so this is a pure `pnpm-lock.yaml` resolution bump:

- **no manifest edit** (the range stays `^10.26.0`)
- **no `overrides` pin**
- **no `auditExceptions` entry** — an exception is the wrong remedy for an advisory that a patch bump already permitted by the manifest can fix

`10.27.2` carries an identical dependency shape to `10.27.1` (`commander: ^10.0.0`), the same `engines.node: >=16`, and the same `bin` map, so nothing transitive moves.

> A plain `pnpm update liquidjs --filter @harness-engineering/orchestrator` was tried first and rejected: it re-resolved the whole tree — pulling in `typescript@6.0.3`, `canary-test-cli` 5.4.0 -> 5.15.0, algolia, `nan`, and a duplicated `tsup`/`vitest` tree — for a 321-line diff, and rewrote the manifest range to `^10.27.2`. The surgical edit here is what a correctly-scoped resolver would emit. `pnpm install --frozen-lockfile` (the exact command CI runs) accepts it and installs cleanly, which is what proves the lockfile is internally consistent and integrity-verified.

## Evidence

- **Evidence class:** `advisory-match` — the resolved version `10.27.1` falls inside the published affected range. That is a concrete fact, not a guess.
- **Evidence strength:** `lockfile-only` — **deliberately not inflated to `reached`.** The control the advisory bypasses is not in use here: `packages/orchestrator/src/prompt/renderer.ts:7` constructs `new Liquid({...})` with **no `memoryLimit` configured**, and no `join:` filter appears in any orchestrator template. The bump is still correct, but the practical exposure in this repo is low and should not be read as a reachable sink.

**Evidence cleared** — verified by running the blocking gate's own script (`node scripts/audit-exceptions.mjs`) against both lockfiles at base `738b296c0`:

| | Active advisories reported |
| --- | --- |
| base `738b296c0` | `GHSA-4r6h-5v86-94p3` (high, liquidjs), `GHSA-82fw-gwwq-j7x9` (moderate, vitest + @vitest/mocker) |
| this branch | `GHSA-82fw-gwwq-j7x9` (moderate, vitest + @vitest/mocker) |

`GHSA-4r6h-5v86-94p3` is present before and **absent after**.

## :warning: This PR alone does NOT green `Reconcile audit exceptions`

#2087 attributes the repo-wide red check to liquidjs alone. That is **incomplete**. A **second** advisory is also uncovered on this same base:

**[GHSA-82fw-gwwq-j7x9](https://github.com/advisories/GHSA-82fw-gwwq-j7x9) / `CVE-2026-84373`** — *Vitest: Path Traversal / Arbitrary File Read via `@vitest/mocker` Redirect Mock*, **moderate**, published **2026-09-08T20:46:45Z** (2.5h after the liquidjs one). Affected `vitest` and `@vitest/mocker` `>= 2.1.0, < 4.1.11`; first patched **`4.1.11`**. The repo declares `vitest: ^4.1.5` and resolves `4.1.5`, so `4.1.11` is **also in range** — another lockfile-only bump in principle.

It is **not** folded into this PR on purpose: `vitest` is a devDependency of ~15 workspace packages, so bumping it re-resolves the whole `@vitest/*` tree and changes the test runner under every test in CI. That is a materially larger blast radius than a three-line change, it was not in this sweep's confirmed batch, and it deserves its own human read. **`Reconcile audit exceptions` will stay red on every open PR until it is also addressed.**

## Verification performed

- `pnpm install --frozen-lockfile` under the pinned Node 22 — clean, lockfile unchanged afterwards.
- Installed version confirmed at `packages/orchestrator/node_modules/liquidjs` = **10.27.2**.
- Gate script run against both lockfiles (table above).
- The full pre-push suite was run manually. One test failed — `comprehend-smoke.e2e.test.ts › idempotent: a second --refresh finds everything fresh and stages nothing`. It is **out of scope**: this diff touches zero source files, and the test **passes in isolation on both this branch and base `738b296c0`**, failing only under the full 738-file parallel coverage run. Load-sensitive flake, not a regression.

## Assumptions made

- Targeted `10.27.2` (the exact first-patched version) rather than the newest in-range `10.29.0`, to keep the blast radius minimal for a security patch.
- A `patch` changeset is included for `@harness-engineering/orchestrator` because `liquidjs` is a runtime dependency of that published package.

Base: `738b296c0a50cb9890474124d466f38903e468e2`. **Not merged, no auto-merge** — handed back open for review.