### PR TITLE
security(deps): bump vitest 4.1.5 -> 4.1.11 to clear GHSA-82fw-gwwq-j7x9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 1.6.4(@algolia/client-search@5.52.1)(search-insights@2.17.3)(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -102,13 +102,13 @@ importers:
         version: link:../../packages/core
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       glob:
         specifier: ^10.5.0
         version: 10.5.0
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -132,7 +132,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -141,7 +141,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/cli:
     dependencies:
@@ -238,13 +238,13 @@ importers:
         version: 7.7.1
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/core:
     dependencies:
@@ -290,10 +290,10 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       '@vitest/ui':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -302,7 +302,7 @@ importers:
         version: 4.23.11
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/dashboard:
     dependencies:
@@ -393,7 +393,7 @@ importers:
         version: 4.7.0(vite@6.4.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       concurrently:
         specifier: ^9.1.0
         version: 9.2.1
@@ -414,7 +414,7 @@ importers:
         version: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(jsdom@29.0.1)(vite@6.4.3)
 
   packages/eslint-plugin:
     dependencies:
@@ -439,7 +439,7 @@ importers:
         version: 8.59.0(eslint@10.2.1)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       eslint:
         specifier: ^10.2.1
         version: 10.2.1
@@ -451,7 +451,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/graph:
     dependencies:
@@ -477,7 +477,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -486,7 +486,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/intelligence:
     dependencies:
@@ -515,13 +515,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/linter-gen:
     dependencies:
@@ -543,13 +543,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/local-models:
     dependencies:
@@ -565,13 +565,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/orchestrator:
     dependencies:
@@ -650,7 +650,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       testcontainers:
         specifier: ^11.14.0
         version: 11.14.0
@@ -659,7 +659,7 @@ importers:
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/signals:
     dependencies:
@@ -675,7 +675,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -684,7 +684,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/types:
     dependencies:
@@ -694,13 +694,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
 
 packages:
 
@@ -3924,17 +3924,17 @@ packages:
       vue: 3.5.31(typescript@5.9.3)
     dev: true
 
-  /@vitest/coverage-v8@4.1.5(vitest@4.1.5):
-    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+  /@vitest/coverage-v8@4.1.11(vitest@4.1.11):
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
     peerDependencies:
-      '@vitest/browser': 4.1.5
-      vitest: 4.1.5
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.11
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -3943,22 +3943,22 @@ packages:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3)
+      vitest: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
     dev: true
 
-  /@vitest/expect@4.1.5:
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  /@vitest/expect@4.1.11:
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
     dev: true
 
-  /@vitest/mocker@4.1.5(vite@6.4.3):
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  /@vitest/mocker@4.1.11(vite@6.4.3):
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=6.4.3 <7'
@@ -3968,57 +3968,57 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
     dev: true
 
-  /@vitest/pretty-format@4.1.5:
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  /@vitest/pretty-format@4.1.11:
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
     dependencies:
       tinyrainbow: 3.1.0
     dev: true
 
-  /@vitest/runner@4.1.5:
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  /@vitest/runner@4.1.11:
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
     dev: true
 
-  /@vitest/snapshot@4.1.5:
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  /@vitest/snapshot@4.1.11:
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
     dev: true
 
-  /@vitest/spy@4.1.5:
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  /@vitest/spy@4.1.11:
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
     dev: true
 
-  /@vitest/ui@4.1.5(vitest@4.1.5):
-    resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
+  /@vitest/ui@4.1.11(vitest@4.1.11):
+    resolution: {integrity: sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==}
     peerDependencies:
-      vitest: 4.1.5
+      vitest: 4.1.11
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.11
       fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3)
+      vitest: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
     dev: true
 
-  /@vitest/utils@4.1.5:
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  /@vitest/utils@4.1.11:
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
     dev: true
@@ -6774,7 +6774,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
     dev: true
 
   /mark.js@8.11.1:
@@ -8274,7 +8274,6 @@ packages:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
 
   /send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
@@ -8817,14 +8816,6 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-    dev: true
-
   /tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -9309,20 +9300,20 @@ packages:
       - yaml
     dev: true
 
-  /vitest@4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  /vitest@4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3):
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=6.4.3 <7'
@@ -9351,15 +9342,15 @@ packages:
         optional: true
     dependencies:
       '@types/node': 22.19.15
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.3)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/ui': 4.1.5(vitest@4.1.5)
-      '@vitest/utils': 4.1.5
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/ui': 4.1.11(vitest@4.1.11)
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -9369,7 +9360,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -9377,20 +9368,20 @@ packages:
       - msw
     dev: true
 
-  /vitest@4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  /vitest@4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(jsdom@29.0.1)(vite@6.4.3):
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=6.4.3 <7'
@@ -9419,14 +9410,14 @@ packages:
         optional: true
     dependencies:
       '@types/node': 22.19.15
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.3)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       jsdom: 29.0.1
@@ -9437,7 +9428,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -9445,20 +9436,20 @@ packages:
       - msw
     dev: true
 
-  /vitest@4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  /vitest@4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3):
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=6.4.3 <7'
@@ -9486,14 +9477,14 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.3)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21


### PR DESCRIPTION
Clears **[GHSA-82fw-gwwq-j7x9](https://github.com/advisories/GHSA-82fw-gwwq-j7x9)** / `CVE-2026-84373` (**moderate**, published 2026-09-08T20:46:45Z): *"Vitest: Path Traversal / Arbitrary File Read via `@vitest/mocker` Redirect Mock"*. Affected `vitest` and `@vitest/mocker` `>= 2.1.0, < 4.1.11`; first patched `4.1.11`.

Companion to #2090 (liquidjs). Refs #2087. **Deliberately a separate PR** — #2090 is 2 files and already all-OS green; this one re-resolves the test runner and deserved its own signal.

## Lockfile only — no manifest change

Every manifest already declares `^4.1.5` and `4.1.11` is in range, so **nothing outside `pnpm-lock.yaml` changed**: all **28** `specifier:` fields in the lockfile still read `^4.1.5`. No `overrides` pin, no `auditExceptions` entry.

No changeset — `node scripts/check-changesets.mjs` reports *"No publishable package changes detected"*, because `vitest` is a devDependency everywhere. Adding one would have forced a spurious version bump on packages whose published contents are unchanged.

## Blast radius: the `@vitest/*` family, and nothing else

`@vitest/coverage-v8` and `@vitest/ui` pin an **exact** peer on vitest (`coverage-v8@4.1.11` peers `vitest: 4.1.11`), so the family has to move together. Every package entry that moved:

| Moved | Reason |
| --- | --- |
| `vitest` (3 peer-variants), `@vitest/coverage-v8`, `@vitest/ui`, `@vitest/expect`, `@vitest/mocker`, `@vitest/pretty-format`, `@vitest/runner`, `@vitest/snapshot`, `@vitest/spy`, `@vitest/utils` | 4.1.5 -> 4.1.11 |
| `tinyglobby@0.2.15` **removed** | vitest 4.1.11 wants `^0.2.15`; pnpm reused the `0.2.17` already present for tsup, leaving 0.2.15 unreferenced |

`typescript`, `algolia`, `nan`, `canary-test-cli` and `tsup` are **untouched** — verified by grepping the diff for them (0 hits).

> **How this was produced.** Not with `pnpm update`, which re-resolves the entire tree (a 321-line diff pulling `typescript@6.0.3`, `canary-test-cli` 5.4->5.15, algolia, `nan`, and a duplicated tsup/vitest tree) *and* rewrites the manifest range. Instead: temporarily raise the specifiers to `^4.1.11`, `pnpm install --lockfile-only` so **pnpm itself** computes the integrity hashes and dependency sets, then revert the manifests and re-resolve — pnpm keeps the 4.1.11 resolutions (they satisfy `^4.1.5`) and restores the recorded specifiers. Validated with `pnpm install --frozen-lockfile`, the exact command CI runs.

## Evidence

- **Class:** `advisory-match` — the resolved `4.1.5` falls inside the published affected range.
- **Strength:** `lockfile-only`.
- **Evidence cleared:** `GHSA-82fw-gwwq-j7x9` is present on base and absent here.
- **No new finding:** both lockfiles scanned at the same moment with the gate's own script:

| Lockfile | Rows | Distinct GHSAs |
| --- | --- | --- |
| base `738b296c0` | 8 | 5 |
| this branch | 6 | **4** (base minus the two vitest rows) |

Strictly better than base; nothing introduced.

## :warning: This does NOT green `Reconcile audit exceptions` either

**An advisory storm is in progress.** When #2090 was opened ~an hour before this, the tree carried 2 distinct advisories. It now carries **5**, four of them published today between 20:46 and 21:24 UTC. All are **pre-existing on this base and none is introduced by this change**:

| Advisory | Sev | Package | Published | Patched | Status |
| --- | --- | --- | --- | --- | --- |
| `GHSA-4r6h-5v86-94p3` | high | liquidjs | 18:10Z | 10.27.2 | fixed by #2090 (unmerged) |
| `GHSA-82fw-gwwq-j7x9` | moderate | vitest, @vitest/mocker | 20:46Z | 4.1.11 | **fixed by this PR** |
| `GHSA-2883-xcg3-v3hh` | **high** | js-yaml | 21:24Z | 4.3.2 / 3.15.2 | **unowned** |
| `GHSA-crvj-82cr-hjcx` | moderate | hono | 21:22Z | 4.13.5 | **unowned** |
| `GHSA-g6gw-c38x-mqfc` | moderate | hono | 21:23Z | 4.13.5 | **unowned** |
| `GHSA-gqvv-2mrq-wpjv` | moderate | hono | 21:23Z | 4.13.5 | **unowned** |

Landing **both** #2090 and this PR still leaves **four** uncovered advisories, so the blocking check stays red on every open PR. Fixing them one advisory per PR is a treadmill that the publication rate is currently outrunning. The register (`auditExceptions`) is still **absent entirely** from `package.json`. This needs a strategy decision, not another one-off bump — see #2087.

## Verification

The point of splitting this out: the bump changes the test runner under every test. Named-SHA all-OS results are recorded in the PR checks and in the lane report; `Reconcile audit exceptions` is expected to remain red for the reasons above, and the job log names which advisories.

Base: `738b296c0a50cb9890474124d466f38903e468e2`. **Not merged, no auto-merge** — handed back open.