### PR TITLE
fix(ci): stop the scaffolded adopter workflow cancelling its own trunk verification

### DIFF
--- a/.changeset/ci-init-trunk-concurrency.md
+++ b/.changeset/ci-init-trunk-concurrency.md
@@ -1,0 +1,44 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(ci): stop the scaffolded adopter workflow from cancelling its own trunk verification
+
+The GitHub Actions workflow emitted by `harness ci init` (and by the `harness init`
+project scaffold, which calls the same generator) triggered on both `push:` to `main`
+and `pull_request:`, but guarded them with a single per-ref concurrency group:
+
+```yaml
+concurrency:
+  group: harness-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+On a push, `github.ref` is `refs/heads/main` for **every** commit, so all trunk pushes
+landed in one concurrency bucket and each new merge cancelled the still-running
+verification of the previous commit. The cancelled run concluded `cancelled`, not
+`failure`, so nothing alarmed — the adopter's board stayed green while the commit went
+unverified. Under a merge burst, most commits reaching trunk were never verified at all.
+
+Concurrency is now split by event, matching the shape already used for this repo's own
+workflows and for the generated persona workflows:
+
+```yaml
+concurrency:
+  group: harness-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+A push resolves to a per-commit group that is never cancelled, so every commit landing
+on trunk reaches its own verdict. A pull request keeps the per-ref group with
+cancellation on, so pushing to a PR still supersedes the older run.
+
+**Adopter trunk runner spend rises with merge-burst size, and that increase is the fix.**
+Previously a burst of N merges cost roughly one full verification because the earlier
+runs were killed; now it costs N, because each of those N commits is actually verified.
+PR runner spend is unchanged. Adopters who regenerate their workflow, or who copy the
+new concurrency block into an existing one, should expect trunk Actions minutes to scale
+with merge volume rather than staying artificially flat.
+
+This only affects the emitted template; no existing adopter workflow is rewritten in
+place. Regenerate with `harness ci init --platform github` to pick up the fix.

--- a/.harness/comprehension/packages/cli/src/commands/ci/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/ci/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands/ci'
-sourceHash: 'a51c4cc6257042739dd7ab39c9b3a920607e189766248e418ecda71e17492bcc'
+sourceHash: 'ed9fe3b5c4b1b15b3c490545a942e9e44f891700aee51a697c7c33167cf2f511'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/ci/_module.md
+++ b/.harness/comprehension/packages/cli/tests/ci/_module.md
@@ -1,11 +1,10 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/ci'
-sourceHash: 'ab0bb1d23d9bedfeecf40711fb2c7aaee7173cd7c0a99d4f6d45c6de578f33be'
-compiledAt: '2026-08-28T01:22:09.600Z'
+sourceHash: 'cec4d44f4fdd23d08b7a92ca9bc28e414e61374928ce6db56034591dc92dcf75'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members:
   [
     'baseline-diff-guard.test.ts',
@@ -18,21 +17,6 @@ members:
     'vitest-prepush-reporter.test.ts',
   ]
 ---
-
-## Summary
-
-**`packages/cli/tests/ci`** validates the CI infrastructure ecosystem: PR diff scoping guards, CI check command routing, workflow automation, and test failure reporting. The module tests baseline governance (self-approval guards ensure PRs changing only baseline snapshots are auto-approved with scope validation before approval), CI check command (wraps `@harness-engineering/core`'s check runner with option parsing, config resolution, and multi-format output), CI config generation (template system for GitHub Actions, GitLab CI, and shell scripts with language-aware setup), scope guards (exact-path and directory-prefix matching to validate PR diff scope), roadmap automation (GitHub workflow marks roadmap items done on PR merge with rebase-retry push and closing-issue detection), and test failure reporting (Vitest JSON report parsing and summarization for pre-push gates).
-
-## Invariants
-
-- Baseline PRs fail closed — Empty diffs and files outside the allowlist are rejected before self-approval; protects against phantom PRs and drift
-- Scope guards run before approval — assert-baseline-only-diff.mjs executes before gh pr review in the CI workflow; approval without scope validation is a security hole
-- Allowance dirs are transient — Per-PR allowance files are deleted after merge; they never accumulate on main
-- Exact matching, not globs — Bare baselines.json must pass; a \*-baselines.json glob would wrongly reject them
-- Stage validation at parse time — Unrecognized --stage values reject immediately with ExitCode.ERROR; silently running all stages is a footgun
-- Roadmap-auto-done gates on merged — Workflow checks github.event.pull_request.merged == true; running on closed-but-unmerged PRs flips roadmap state incorrectly
-- Rebase with hard-reset retry — Direct push retries fetch + rebase + push with git reset --hard between attempts; absorbs concurrent merges without leaving dirty trees
-- Test reports gracefully degrade — Missing packages dir returns [], not an error; reporter JSON output only activates on exact HARNESS_PREPUSH=1
 
 ## Interface Contract
 
@@ -58,5 +42,5 @@ import { tmpdir } from 'node:os'
 import * as path, { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { parse } from 'yaml'
+import YAML, { parse } from 'yaml'
 ```

--- a/docs/changes/ci-init-cancel-2050/provenance.json
+++ b/docs/changes/ci-init-cancel-2050/provenance.json
@@ -1,0 +1,32 @@
+{
+  "issue": [2050],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/cli/tests/ci/init.test.ts",
+  "reproducingTestSuite": "generateCIConfig — trunk concurrency (#2050)",
+  "reproducingTestEvidence": {
+    "protocol": "git stash push -- packages/cli/src/commands/ci/init.ts, run, restore, run",
+    "beforeFix": "3 failed | 17 skipped (20)",
+    "afterFix": "3 passed | 17 skipped (20)"
+  },
+  "rootCause": "generateGitHubActions() in packages/cli/src/commands/ci/init.ts emitted a static concurrency block keyed on `github.ref` with a literal `cancel-in-progress: true`. The template triggers on both push-to-main and pull_request; on a push `github.ref` is `refs/heads/main` for every commit, so all trunk pushes shared one concurrency group and each merge cancelled the previous commit's still-running verification. The run concluded `cancelled`, not `failure`, so nothing alarmed and the adopter's board read green while the commit went unverified.",
+  "fix": "Mirror the event-split shape already landed for this repo's hand-written workflows (#1865) and the persona generator (#1867 / PR #2049): group `harness-${{ github.event_name == 'pull_request' && github.ref || github.sha }}` and `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. Push resolves to a per-commit group that is never cancelled; pull_request keeps per-ref supersession. Carried over the explanatory comment block so the three emitters agree.",
+  "blastRadius": "generateCIConfig has two production callers — `harness ci init` (packages/cli/src/commands/ci/init.ts) and the project scaffold `harness init` (packages/cli/src/commands/init.ts:163). Both emitted the defective file, so every scaffolded adopter project inherited it, not only explicit `ci init` users. One emitter fix covers both.",
+  "otherEmittersChecked": {
+    "method": "grep -rn cancel-in-progress packages/ --include=*.ts --include=*.mjs --include=*.js --include=*.yml --include=*.yaml --include=*.hbs --include=*.json",
+    "result": "Only two non-test emitters exist: packages/cli/src/commands/ci/init.ts (this fix) and packages/cli/src/persona/generators/ci-workflow.ts (already fixed by #1867). Test occurrences at packages/cli/tests/ci/roadmap-auto-done-workflow.test.ts:115 and packages/cli/tests/rollback/workflow-yaml.test.ts:69 already assert false. The gitlab template emits `rules:` and never sets `interruptible` (GitLab defaults to non-interruptible); the generic template is a bash script with no concurrency concept. No other adopter-facing template is defective — satisfies the issue's final checklist item.",
+    "verifiedAt": "738b296c0a50cb9890474124d466f38903e468e2"
+  },
+  "assumptions": [
+    "GitHub Actions evaluates `concurrency.cancel-in-progress` as an expression when given `${{ }}`. Officially supported, and already proven on real runners by the landed #1865 and #1867 changes.",
+    "The existing adopter group prefix `harness-` is retained rather than switching to `${{ github.workflow }}-` (which the persona generator uses). Changing the prefix is a behaviour change beyond this defect and would churn adopter files for no correctness gain.",
+    "Adopter trunk runner spend rises with merge-burst size, because every trunk commit now runs to completion instead of being cancelled. This increase IS the fix, not a regression; PR runner spend is unchanged.",
+    "Deferred, not acted on: the gitlab template could opt into `interruptible: true` for merge requests as a spend optimisation. Out of scope — not a correctness defect and not what #2050 asks for."
+  ],
+  "verification": {
+    "manualEndToEnd": "Built CLI run in a clean temp dir: `node packages/cli/dist/bin/harness.js ci init --platform github --language typescript` emits the corrected concurrency block with `${{ }}` unescaped correctly and single quotes intact.",
+    "languageVariants": "All five language variants (typescript, python, go, rust, java) carry the fix — asserted by a dedicated test, since the concurrency block lives in the shared template rather than the per-language step mapping."
+  },
+  "closingKeyword": "Closes #2050",
+  "baseSha": "738b296c0a50cb9890474124d466f38903e468e2"
+}

--- a/packages/cli/src/commands/ci/init.ts
+++ b/packages/cli/src/commands/ci/init.ts
@@ -81,6 +81,29 @@ function stepsForLanguage(language?: string): LanguageSteps {
   }
 }
 
+// The `concurrency:` block this emits is SPLIT BY EVENT on purpose — do not
+// "simplify" it back to a plain `harness-${{ github.ref }}` + `cancel-in-progress: true`.
+//
+// The emitted template triggers on BOTH `push:` to main and `pull_request:`. On a push,
+// `github.ref` is `refs/heads/main` for EVERY commit, so a per-ref group puts all main
+// pushes in ONE bucket and each new merge cancels the still-running verification of the
+// previous commit. The run concludes `cancelled`, not `failure`, so nothing alarms — the
+// adopter's board reads green while the commit went unverified. Under a merge burst most
+// trunk commits are never verified at all.
+//
+//   push  -> per-COMMIT group (github.sha), never cancelled, so every commit that lands
+//            on the adopter's trunk reaches its own verdict.
+//   PR    -> per-REF group, cancel-in-progress ON, so a new push to a PR still supersedes
+//            the old run. PR runner spend is unchanged.
+//
+// Trunk runner spend rises with merge-burst size; that increase IS the fix — it is the
+// cost of every trunk commit actually being verified.
+//
+// This is the shape #1865 established for this repo's hand-written ci.yml/harness.yml and
+// #1867 / PR #2049 brought the generated persona workflows onto (see
+// src/persona/generators/ci-workflow.ts); #2050 brings the adopter-facing template onto it
+// too, so all three emitters agree. `cancel-in-progress` officially accepts an expression,
+// and the `A && B || C` idiom is already proven on GitHub's runners.
 function generateGitHubActions(skipFlag: string, language?: string): string {
   const steps = stepsForLanguage(language);
 
@@ -94,6 +117,7 @@ function generateGitHubActions(skipFlag: string, language?: string): string {
   }
   commandSteps.push(`      - name: Test\n        run: ${steps.test}`);
 
+  // Concurrency is split by event — see the block comment above this function.
   return `name: CI
 
 on:
@@ -102,9 +126,11 @@ on:
   pull_request:
     branches: [main]
 
+# Split by event: pushes to main get a per-commit group so a merge burst never
+# cancels the previous commit's verification; PRs keep per-ref supersession.
 concurrency:
-  group: harness-\${{ github.ref }}
-  cancel-in-progress: true
+  group: harness-\${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: \${{ github.event_name == 'pull_request' }}
 
 jobs:
   ci:

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import YAML from 'yaml';
 import { generateCIConfig, createInitCommand } from '../../src/commands/ci/init';
 
 describe('generateCIConfig', () => {
@@ -158,5 +159,80 @@ describe('generateCIConfig — language', () => {
     const s2 = generateCIConfig({ platform: 'generic', language: 'go' });
     if (!s1.ok || !s2.ok) return;
     expect(s2.value.content).toBe(s1.value.content);
+  });
+});
+
+describe('generateCIConfig — trunk concurrency (#2050)', () => {
+  // Regression: #2050. The adopter-facing GitHub template emitted a per-ref group
+  // (`harness-${{ github.ref }}`) with an unconditional `cancel-in-progress: true`.
+  // The template triggers on BOTH push-to-main and pull_request, and on a push
+  // `github.ref` is `refs/heads/main` for every commit — so every trunk push shared
+  // one concurrency bucket and each new merge cancelled the previous commit's
+  // still-running verification. The run concluded `cancelled`, not `failure`, so the
+  // adopter's board stayed green while the commit went unverified.
+  //
+  // Same defect class as #1865 (this repo's hand-written workflows) and #1867 /
+  // PR #2049 (the persona generator). These two tests mirror the pair added there.
+  it('does not emit a cancelling concurrency group for the push-to-trunk path', () => {
+    const result = generateCIConfig({ platform: 'github' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const workflow = YAML.parse(result.value.content) as {
+      on: Record<string, unknown>;
+      concurrency: { group: string; 'cancel-in-progress': unknown };
+    };
+
+    // Both triggers are present — the exact pair that produced the defect.
+    expect(workflow.on.push).toBeDefined();
+    expect(workflow.on.pull_request).toBeDefined();
+
+    // `cancel-in-progress` must be conditional on the event, never a bare `true`.
+    // A literal true here is the defect: it cancels main's own verification.
+    const cancel = workflow.concurrency['cancel-in-progress'];
+    expect(cancel).not.toBe(true);
+    expect(cancel).toBe("${{ github.event_name == 'pull_request' }}");
+
+    // The group must key on github.sha (per-commit) off the PR path, so two main
+    // commits never share a bucket. A bare `github.ref` group is the defect.
+    const group = workflow.concurrency.group;
+    expect(group).toBe(
+      "harness-${{ github.event_name == 'pull_request' && github.ref || github.sha }}"
+    );
+    expect(group).toContain('github.sha');
+    expect(group).not.toBe('harness-${{ github.ref }}');
+  });
+
+  it('still cancels superseded runs on the pull_request path', () => {
+    // The fix must not disable PR supersession — that would be a runner-spend
+    // regression, and per-ref cancellation is correct behaviour for a PR.
+    const result = generateCIConfig({ platform: 'github' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const workflow = YAML.parse(result.value.content) as {
+      concurrency: { group: string; 'cancel-in-progress': unknown };
+    };
+    // Both halves of the expression are present, so a pull_request event resolves to
+    // the per-ref group with cancellation ON.
+    expect(workflow.concurrency.group).toContain(
+      "github.event_name == 'pull_request' && github.ref"
+    );
+    expect(workflow.concurrency['cancel-in-progress']).toBe(
+      "${{ github.event_name == 'pull_request' }}"
+    );
+  });
+
+  it('applies the trunk-safe concurrency shape for every language variant', () => {
+    // The concurrency block lives in the shared template, not the per-language step
+    // mapping — every language variant must carry the fix.
+    for (const language of ['typescript', 'python', 'go', 'rust', 'java']) {
+      const result = generateCIConfig({ platform: 'github', language });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const workflow = YAML.parse(result.value.content) as {
+        concurrency: { group: string; 'cancel-in-progress': unknown };
+      };
+      expect(workflow.concurrency.group).toContain('github.sha');
+      expect(workflow.concurrency['cancel-in-progress']).not.toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Closes #2050

## The defect

`harness ci init` scaffolds an adopter CI workflow that silently cancels the adopter's own `main` verification.

The emitted template triggers on **both** push-to-main and pull_request, but guarded them with a single per-ref concurrency group:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]

concurrency:
  group: harness-${{ github.ref }}
  cancel-in-progress: true
```

On a push, `github.ref` is `refs/heads/main` for **every** commit. So all trunk pushes shared one concurrency bucket, and each new merge cancelled the still-running verification of the previous commit. The cancelled run concludes `cancelled`, not `failure` — so nothing alarms. The adopter's board reads green while the commit went unverified. Under a merge burst, most commits reaching trunk were never verified at all.

This is the same defect class already fixed in #1865 (this repo's hand-written workflows) and #1867 / PR #2049 (`packages/cli/src/persona/generators/ci-workflow.ts`). This was the last emitter left; #1867's F2 fork deliberately deferred it on blast radius.

## The fix

```yaml
concurrency:
  group: harness-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **push** → per-COMMIT group (`github.sha`), never cancelled, so every commit landing on the adopter's trunk reaches its own verdict.
- **PR** → per-REF group with cancellation ON, so a new push to a PR still supersedes the old run. PR runner spend is unchanged.

The explanatory comment block from the persona generator is carried over (as a block comment above `generateGitHubActions`, so it does not inflate the function past the complexity threshold), and a two-line comment now ships **inside the emitted YAML** so an adopter reading their own `ci.yml` does not "simplify" it back either. All three emitters now agree and cross-reference each other.

## Blast radius — wider than the issue title suggests

`generateCIConfig` has **two** production callers: `harness ci init` and the `harness init` project scaffold (`packages/cli/src/commands/init.ts:163`). Both emitted the defective file, so every scaffolded adopter project inherited it, not only explicit `ci init` users. One emitter fix covers both.

No existing adopter workflow is rewritten in place — adopters pick this up by regenerating, or by copying the new concurrency block into an existing workflow.

## Issue checklist: "check whether any other adopter-facing template emits the same pair"

`grep -rn cancel-in-progress packages/ --include=*.ts --include=*.mjs --include=*.js --include=*.yml --include=*.yaml --include=*.hbs --include=*.json` at the pinned base:

- `packages/cli/src/commands/ci/init.ts` — **this fix**
- `packages/cli/src/persona/generators/ci-workflow.ts` — already fixed (#1867)
- `tests/ci/roadmap-auto-done-workflow.test.ts:115`, `tests/rollback/workflow-yaml.test.ts:69` — tests, both already assert `false`

The **gitlab** template emits `rules:` and never sets `interruptible` (GitLab defaults to non-interruptible), and the **generic** template is a bash script with no concurrency concept. Verified by grep: zero `interruptible` occurrences. **No other adopter-facing template is defective.**

## Runner-spend note (called out in the issue, and in the changeset)

Adopter **trunk** runner spend rises with merge-burst size, and **that increase is the fix**. Previously a burst of N merges cost roughly one full verification because the earlier runs were killed; now it costs N, because each of those N commits is actually verified. PR runner spend is unchanged.

## Reproducing test

`packages/cli/tests/ci/init.test.ts` → suite `generateCIConfig — trunk concurrency (#2050)` (3 tests), mirroring the pair PR #2049 added to `tests/persona/generators/ci-workflow.test.ts`, plus a third that sweeps all five language variants (the concurrency block lives in the shared template, not the per-language step mapping). Every assertion runs against the **YAML-parsed** emitted template, so they also prove the `\${{ }}` escaping in the template literal.

Proven to fail before the fix and pass after, via the revert-and-fail protocol:

```
git stash push -- packages/cli/src/commands/ci/init.ts
  -> Tests  3 failed | 17 skipped (20)     [RED, fix absent]
git stash pop
  -> Tests  3 passed | 17 skipped (20)     [GREEN, fix present]
```

## Verification

- Targeted `#2050` suite: 3 passed.
- Full `@harness-engineering/cli` suite: **738 files, 8728 passed**, 0 failed.
- `tsc --noEmit`: clean.
- Manual end-to-end through the **real built CLI** in a clean temp dir — `node packages/cli/dist/bin/harness.js ci init --platform github --language typescript` emits the corrected block with `${{ }}` intact and single quotes preserved.
- Full pre-push gauntlet passed (changeset, format:check, coverage ratchet, reference-docs freshness, tool catalog).

## Assumptions made

1. **GitHub Actions evaluates `concurrency.cancel-in-progress` as an expression** when given `${{ }}`. Officially supported, and already proven on real runners by the landed #1865 and #1867 changes.
2. **The existing adopter group prefix `harness-` is retained**, rather than switching to `${{ github.workflow }}-` (which the persona generator uses). Changing the prefix is a behaviour change beyond this defect and would churn adopter files for no correctness gain.
3. **The trunk runner-spend increase is intended, not a regression.** It is the cost of every trunk commit actually being verified. Documented in the changeset so adopters are not surprised by rising Actions minutes.
4. **Deferred, not acted on:** the gitlab template could arguably opt into `interruptible: true` for merge requests as a spend optimisation. Out of scope — it is not a correctness defect and not what #2050 asks for.

## Known-inherited CI red

`Reconcile audit exceptions` is currently **red on every open PR in this repo** — 6 advisories (liquidjs, vitest/@vitest/mocker, js-yaml, hono x3) against an empty `auditExceptions` register. This PR inherits that red; it is **not** caused by this diff (which touches only a CI template string, its tests, a changeset, and a provenance artifact) and is not addressed here.

## Pipeline provenance

Route `bug` → real `harness-debugging` pipeline (investigate → analyze → hypothesize → fix). Artifact: `docs/changes/ci-init-cancel-2050/provenance.json`. Base SHA `738b296c0a50cb9890474124d466f38903e468e2`. A bug lane leaves no `plans/` directory.

https://claude.ai/code/session_01JGepYh7MX1tayxHML88sgg
