### PR TITLE
fix(check-deps): stop reporting clean when the dependency analysis fails (Refs #1996, CLI-R006)

### DIFF
--- a/.changeset/check-deps-err-swallow-1996.md
+++ b/.changeset/check-deps-err-swallow-1996.md
@@ -1,0 +1,44 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(check-deps): stop reporting clean when the dependency analysis fails
+
+`runCheckDeps` consumed both analysis engines as bare success guards with no
+`else`:
+
+```ts
+const depsResult = await validateDependencies(layerConfig);
+if (depsResult.ok) {
+  /* push violations */
+}
+
+const circularResult = await detectCircularDepsInFiles(uniqueFiles, parser);
+if (circularResult.ok && circularResult.value.hasCycles) {
+  /* push cycles */
+}
+```
+
+An `Err` from either engine was discarded. `valid` stayed `true`, the finding
+lists stayed empty, and the command exited `SUCCESS` — a result byte-identical
+to a genuinely clean repo. `harness check-deps && deploy` would proceed, a
+`--json` consumer saw `layerViolations: []`, and the `--findings-json`
+maintenance contract reported `{ "findings": 0 }`.
+
+An engine failure now refuses to report clean, mirroring the zero-module
+abstention (#1188) already in this file: `valid` is set `false` and the reason is
+recorded in a new `analysisErrors: string[]` field, surfaced as an issue in every
+output mode and emitted in the JSON payload.
+
+**Exit-code behaviour change on the previously-silent failure path.** The command
+now distinguishes three outcomes instead of two:
+
+| Outcome                            | Before | After |
+| ---------------------------------- | ------ | ----- |
+| Check ran, no findings             | 0      | 0     |
+| Check ran, found violations/cycles | 1      | 1     |
+| Check could not run (engine `Err`) | **0**  | **2** |
+
+A path that previously exited `0` may now exit `2` (`ExitCode.ERROR`). Only that
+path changes: a genuinely clean run still exits `0` with identical output and no
+`analysisErrors` key, and a run with real findings still exits `1`.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '5f84ea3a892343e0a0f6b31ba40cb85de506aec8c52403aeb80096b52d4f662e'
+sourceHash: '56ddbdf3973463ee9664445954a57b1df6da1660698a5710f015562c573d7887'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/output/_module.md
+++ b/.harness/comprehension/packages/cli/src/output/_module.md
@@ -1,41 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/output'
-sourceHash: '482180e718698963d806cf145add05cb725776be221f157376807c3d4f81da13'
-compiledAt: '2026-08-28T01:22:09.301Z'
+sourceHash: '629e8411c9a49eedcffc37372f4642891f8f698ec5298666344f8788d73033b0'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
-model: 'claude-haiku-4-5-20251001'
-semantic: present
+model: null
+semantic: absent
 members: ['formatter.ts', 'logger.ts', 'prompt.ts']
 ---
-
-## Summary
-
-This module provides the CLI's output layer: rendering validation results, formatting data, and collecting user input. It's the primary interface between validation/execution logic and console presentation.
-
-**Core responsibility:** Adapt validation verdicts, issues, and logging to different output modes (JSON, TEXT, QUIET, VERBOSE) while preserving semantic distinction between failed checks and checks that couldn't run (incomplete reports).
-
-**Three files:**
-
-- **formatter.ts** — `OutputFormatter` class and `OutputMode` enum; renders validation results with issues and unavailable checks in mode-specific formatting
-- **logger.ts** — `logger` object with color-coded methods (info, success, warn, error, dim, raw) for direct console output
-- **prompt.ts** — `prompt()` helper for interactive stdin/stdout confirmation
-
-**Key APIs:**
-
-- `OutputFormatter.formatValidation(result)` — Renders a `ValidationResult` (valid boolean, issues array, optional unavailableChecks array) into human or JSON output, with mode-aware detail and coloring
-- `parseConventionalMarkdown(text)` — Extracts harness interaction patterns like `**[CRITICAL]** text` for structured data extraction from display-only output
-- `logger.{info,success,warn,error,dim,raw}(message)` — Direct colored logging with icons
-- `prompt(question)` — Blocks on readline for yes/no confirmations
-
-## Invariants
-
-- Unavailable ≠ Failed: A check that couldn't run must never render as passed or failed. When unavailableChecks is present and non-empty, the report is marked INCOMPLETE, preventing abstaining checks from masquerading as green verdicts.
-- Byte-identical optional field: unavailableChecks?: UnavailableCheckSummary[] is optional to ensure callers written before it existed see unchanged output — no breaking changes to JSON or QUIET output when the field is absent.
-- Abstention flips the headline, not the verdict: When unavailable checks exist but valid=true and issues are only advisories, the headline must say 'advisory findings,' not 'validation failed' — the incomplete state is what makes it non-green.
-- Suggestions gate on VERBOSE: Both issue and unavailable-check suggestions render only in VERBOSE mode. TEXT and other modes omit them to keep output concise.
-- Conventional markdown is single-pattern: parseConventionalMarkdown regex matches only **[TYPE]** title where TYPE ∈ {CRITICAL, IMPORTANT, SUGGESTION, STRENGTH, FIXED, Phase d/d}. Variations do not parse.
-- Prompt normalizes to lowercase: The prompt() helper always trims and lowercases the answer, making yes/no checking case-insensitive and predictable.
 
 ## Interface Contract
 

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'da58a667623dc1971daf31e9327deafc7bb36016aacf01edeee41967e472427c'
+sourceHash: '755283dc2c5b7362a3caf25f87bd1701730db2151f392108b49f2a2602facb28'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -26,6 +26,7 @@ members:
     'check-arch.test.ts',
     'check-deployment.test.ts',
     'check-deps-cov544b.test.ts',
+    'check-deps-err-swallow.test.ts',
     'check-deps.test.ts',
     'check-design-cov544.test.ts',
     'check-design.test.ts',
@@ -425,7 +426,7 @@ import { CraftCommandRun, DEFAULT_CWD, runCraftCommand } from './craft-command-h
 import { llmCalls, runCraftCommand } from './craft-command-harness.js'
 import { parseJsonStdout, runCommand } from './design-command-harness'
 import * as clack from '@clack/prompts'
-import { CiReviewResult, DiffInfo, Err, GoldenFileChange, GoldenSnapshot, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createFixes, createModelProposal, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateDecisionNumbers, validateKnowledgeMap, validatePulseConfig, validateRoadmapMode, validateSolutionsDir, validateStrategy, writeConfig } from '@harness-engineering/core'
+import { CiReviewResult, ConstraintError, DiffInfo, Err, GoldenFileChange, GoldenSnapshot, Ok, RefinementDemandReport, RollbackDecision, RunCiReviewOptions, SECURITY_SCAN_EXTENSIONS, SECURITY_SCAN_GLOB, applyFixes, archiveStream, buildSnapshot, checkTaint, clearTaint, createError, createFixes, createModelProposal, createProposal, createStream, detectDeadCode, detectDocDrift, extractBundle, generateSuggestions, listStreams, listTaintedSessions, loadStreamIndex, parseCiReviewVerdict, parseDiff, parseManifest, readAdoptionRecords, requestPeerReview, resetWaypointEmitterForTests, runReviewPipeline, setActiveStream, validateAgentConfigs, validateAgentsMap, validateDecisionNumbers, validateKnowledgeMap, validatePulseConfig, validateRoadmapMode, validateSolutionsDir, validateStrategy, writeConfig } from '@harness-engineering/core'
 import from '@harness-engineering/graph'
 import { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION, GuardianAnalysis, OutcomeVerdict, SkillRegressionFixture, SkillRegressionVerdict } from '@harness-engineering/intelligence'
 import { AnalysisRecord, MockBackend, RunMode, RunResult, SyncMainResult, TaskDefinition, renderAnalysisComment } from '@harness-engineering/orchestrator'

--- a/.harness/comprehension/packages/cli/tests/fixtures/deps-clean-layers/src/_module.md
+++ b/.harness/comprehension/packages/cli/tests/fixtures/deps-clean-layers/src/_module.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+module: 'packages/cli/tests/fixtures/deps-clean-layers/src'
+sourceHash: '5dd96a7406b6364bfd1d4c488e0bad0883563db677e0743a6630001aa9b796d8'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members: ['index.ts']
+---
+
+## Interface Contract
+
+```ts
+export value
+```
+
+## Dependency Slice
+
+```
+
+```

--- a/docs/changes/check-deps-err-swallow-1996/provenance.json
+++ b/docs/changes/check-deps-err-swallow-1996/provenance.json
@@ -1,0 +1,19 @@
+{
+  "issue": [1996],
+  "route": "bug",
+  "stages": ["debugging"],
+  "reproducingTest": "packages/cli/tests/commands/check-deps-err-swallow.test.ts",
+  "assumptions": [
+    "ExitCode has no INTERNAL_ERROR member. The available codes are SUCCESS 0, VALIDATION_FAILED 1, ERROR 2, ZERO_DENOMINATOR 3 (packages/cli/src/utils/errors.ts). Chose ExitCode.ERROR (2), whose existing doc comment is 'Command failed because of an unexpected error or misconfiguration' — the nearest existing distinct non-zero operational-failure code. ZERO_DENOMINATOR (3) was rejected: it means the check ran and examined nothing, which is the #1188 abstention already in this file, not an engine failure.",
+    "Reachability, measured on the pinned base: through the CLI's own call shape (no graphDependencyData, fallbackBehavior 'warn') neither engine Err branch is currently reachable. validateDependencies' three Err returns are gated on the graph-data path, on fallbackBehavior === 'error', and on buildDependencyGraph — which in the non-graph path skips unparseable files and returns Ok unconditionally. detectCircularDepsInFiles contains no Err of its own. The discard is therefore a real contract defect whose false-green is LATENT rather than presently live; the PR does not claim CI pipelines are silently passing today.",
+    "The reproducing tests drive the failure channel by mocking the two @harness-engineering/core exports. A Result's failure channel is part of the API contract regardless of which internal branch happens to produce it today, and this is the only way to test the branch without mutating shared engine code.",
+    "Corroborating precedent: packages/core/src/review/mechanical-checks.ts already handles !result.ok from validateDependencies by setting status 'fail' and emitting the error message as a finding. This change brings the CLI command in line with treatment the repo already applies one package over.",
+    "Clean-path output is unchanged: analysisErrors is left undefined (not an empty array) when every engine ran, so it is absent from the JSON payload and adds no issue rows. Guarded by three regression tests that pass both before and after the fix.",
+    "modulesAnalyzed counts the `src` directory itself as well as its files, because findFiles yields directory entries. Pre-existing, unrelated to this defect, deliberately untouched; the clean-path guard asserts output shape rather than an exact count so it does not encode the quirk."
+  ],
+  "closingKeyword": "Refs #1996",
+  "baseSha": "738b296c0a50cb9890474124d466f38903e468e2",
+  "scopeNote": "1 of 19 findings (CLI-R006 check-deps Err-swallow); remaining 18 are flag/help-text contract changes, deliberately out of scope",
+  "debugSession": ".harness/debug/resolved/check-deps-err-swallow-1996.md (gitignored; investigation log reproduced in the PR body)",
+  "deferredFinding": "validateDependencies returns Ok({ valid: true, violations: [], skipped: true, reason: 'Parser unavailable' }) under fallbackBehavior 'warn' when parser.health() is unhealthy. runCheckDeps ignores `skipped` entirely, so a repo with an unavailable TypeScript parser gets valid:true and exit 0 having validated nothing. Same 'reports success without running' class and reachable TODAY, but a distinct finding (Ok-with-skipped, not Err) with adopter-visible behaviour impact. Deliberately NOT fixed here; reported upward for filing."
+}

--- a/packages/cli/src/commands/check-deps.ts
+++ b/packages/cli/src/commands/check-deps.ts
@@ -34,6 +34,10 @@ interface CheckDepsResult {
   /** Set when layers are configured but zero modules were analyzed — the
    *  reason check-deps refuses to report clean (#1188). */
   analysisNote?: string;
+  /** Failures reported by an analysis engine — the reasons check-deps could not
+   *  complete, and therefore refuses to report clean (#1996). Absent (not an
+   *  empty array) when every engine ran, so a clean result is unchanged. */
+  analysisErrors?: string[];
   layerViolations: Array<{
     file: string;
     imports: string;
@@ -46,6 +50,31 @@ interface CheckDepsResult {
     /** Posix-relative path of the first module in the cycle (#1188). */
     file: string;
   }>;
+}
+
+/**
+ * Record an analysis-engine failure on the result (#1996).
+ *
+ * Both engines return a `Result`. Their failure channel used to be discarded,
+ * which left `valid` true and the finding lists empty — a result byte-identical
+ * to a genuinely clean repo. A check that could not run is not a check that
+ * passed, so an engine failure refuses to report clean and keeps its reason,
+ * mirroring the #1188 zero-module abstention.
+ *
+ * @param result - The in-progress check-deps result to mark as not-clean.
+ * @param stage - Human-readable name of the analysis that failed.
+ * @param error - The engine error whose code and message explain the failure.
+ */
+function recordAnalysisError(
+  result: CheckDepsResult,
+  stage: string,
+  error: { code: string; message: string }
+): void {
+  result.valid = false;
+  result.analysisErrors ??= [];
+  result.analysisErrors.push(
+    `check-deps could not complete ${stage}: ${error.code}: ${error.message}`
+  );
 }
 
 export async function runCheckDeps(
@@ -112,6 +141,8 @@ export async function runCheckDeps(
         message: violation.reason,
       });
     }
+  } else {
+    recordAnalysisError(result, 'layer validation', depsResult.error);
   }
 
   // Collect all files for circular dependency detection
@@ -135,7 +166,9 @@ export async function runCheckDeps(
   // Detect circular dependencies
   if (uniqueFiles.length > 0) {
     const circularResult = await detectCircularDepsInFiles(uniqueFiles, parser);
-    if (circularResult.ok && circularResult.value.hasCycles) {
+    if (!circularResult.ok) {
+      recordAnalysisError(result, 'circular-dependency detection', circularResult.error);
+    } else if (circularResult.value.hasCycles) {
       result.valid = false;
       for (const cycle of circularResult.value.cycles) {
         // Attribute each finding to the first module in the cycle as a
@@ -196,6 +229,12 @@ async function runCheckDepsAction(
     })),
   ];
 
+  // Surface engine failures as issues (#1996) — a check that could not run must
+  // never render, or be counted, as a clean pass.
+  for (const analysisError of result.value.analysisErrors ?? []) {
+    issues.push({ message: analysisError });
+  }
+
   // Surface the zero-module abstention reason as an issue (#1188).
   if (result.value.analysisNote) {
     issues.push({ message: result.value.analysisNote });
@@ -213,6 +252,8 @@ async function runCheckDepsAction(
     issues,
     modulesAnalyzed: result.value.modulesAnalyzed,
     layersConfigured: result.value.layersConfigured,
+    // Omitted entirely on a clean run, so the clean JSON payload is unchanged (#1996).
+    ...(result.value.analysisErrors ? { analysisErrors: result.value.analysisErrors } : {}),
   });
 
   if (output) {
@@ -224,7 +265,18 @@ async function runCheckDepsAction(
     console.log(formatFindingsContract(issues.length, 'check-deps'));
   }
 
-  process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
+  // Three outcomes, three codes (#1996): the check ran and passed (SUCCESS), the
+  // check ran and found violations (VALIDATION_FAILED), or the check could not
+  // run at all (ERROR). Collapsing the third into either of the first two is what
+  // let `harness check-deps && deploy` proceed on a broken analysis.
+  const analysisFailed = (result.value.analysisErrors?.length ?? 0) > 0;
+  process.exit(
+    analysisFailed
+      ? ExitCode.ERROR
+      : result.value.valid
+        ? ExitCode.SUCCESS
+        : ExitCode.VALIDATION_FAILED
+  );
 }
 
 export function createCheckDepsCommand(): Command {

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -68,6 +68,12 @@ interface ValidationResult {
   modulesAnalyzed?: number;
   /** Optional count of layers configured, surfaced in JSON output (#1188). */
   layersConfigured?: number;
+  /**
+   * Reasons an analysis engine could not complete, surfaced in JSON output so a
+   * machine consumer can tell "the check failed to run" from "the check ran and
+   * found nothing" (#1996). Omitted by callers with no engine failure to report.
+   */
+  analysisErrors?: string[];
 }
 
 /** Append formatted lines for a single validation issue into the lines array. */

--- a/packages/cli/tests/commands/check-deps-err-swallow.test.ts
+++ b/packages/cli/tests/commands/check-deps-err-swallow.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import * as path from 'path';
+import { Err, Ok, createError } from '@harness-engineering/core';
+import type { ConstraintError } from '@harness-engineering/core';
+import { createCheckDepsCommand, runCheckDeps } from '../../src/commands/check-deps';
+import { ExitCode } from '../../src/utils/errors';
+
+/**
+ * Regression coverage for #1996 / CLI-R006 — "check-deps exits 0 when its
+ * analysis fails".
+ *
+ * `validateDependencies` and `detectCircularDepsInFiles` both return a
+ * `Result`. `runCheckDeps` used to consume each of them as a bare success guard
+ * (`if (r.ok) { ... }`) with no `else`, so an `Err` was discarded: `valid`
+ * stayed `true`, `layerViolations` stayed empty, and the command exited
+ * SUCCESS. A caller — `harness check-deps && deploy`, a `--json` consumer, or
+ * the `--findings-json` maintenance contract — could not tell a check that
+ * failed to run from a genuinely clean repo.
+ *
+ * These tests drive the failure channel directly by mocking the two engine
+ * exports, because a `Result`'s failure channel is part of the contract
+ * regardless of which internal branch happens to produce it today.
+ */
+vi.mock('@harness-engineering/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@harness-engineering/core')>();
+  return {
+    ...actual,
+    // Default to the real implementations; individual tests override.
+    validateDependencies: vi.fn(actual.validateDependencies),
+    detectCircularDepsInFiles: vi.fn(actual.detectCircularDepsInFiles),
+  };
+});
+
+// Imported after the mock declaration so these bindings are the mocked ones.
+const { validateDependencies, detectCircularDepsInFiles } =
+  await import('@harness-engineering/core');
+
+/**
+ * A fixture with layers configured AND a module discoverable, that analyzes
+ * clean. Dedicated to this suite: the sibling `deps-node-modules-cycle` fixture
+ * is mutated at runtime by another test file, which makes its module count
+ * non-deterministic and unusable as an unchanged-output guard.
+ */
+const cleanWithLayers = path.join(__dirname, '../fixtures/deps-clean-layers');
+
+const DEPS_ENGINE_ERROR = createError<ConstraintError>(
+  'PARSER_UNAVAILABLE',
+  'Parser typescript is not available',
+  { parser: 'typescript' },
+  ['Install required runtime']
+);
+
+const CYCLE_ENGINE_ERROR = createError<ConstraintError>(
+  'PARSER_UNAVAILABLE',
+  'walker failed to enumerate module graph',
+  { parser: 'typescript' },
+  ['Install required runtime']
+);
+
+/** A clean, non-skipped success from the layer-validation engine. */
+function okDeps() {
+  return Ok({ valid: true, violations: [], graph: { nodes: [], edges: [] } });
+}
+
+/** A clean success from the cycle-detection engine. */
+function okCycles() {
+  return Ok({ hasCycles: false, cycles: [], largestCycle: 0 });
+}
+
+describe('check-deps does not report clean when its analysis failed (#1996 / CLI-R006)', () => {
+  beforeEach(() => {
+    vi.mocked(validateDependencies).mockReset();
+    vi.mocked(detectCircularDepsInFiles).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('runCheckDeps result', () => {
+    it('fails and records the error when validateDependencies returns Err', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(Err(DEPS_ENGINE_ERROR) as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      const result = await runCheckDeps({
+        cwd: cleanWithLayers,
+        configPath: path.join(cleanWithLayers, 'harness.config.json'),
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // The whole point: a discarded Err used to leave this `true`.
+      expect(result.value.valid).toBe(false);
+      expect(result.value.analysisErrors).toBeDefined();
+      expect(result.value.analysisErrors!.join('\n')).toContain(
+        'Parser typescript is not available'
+      );
+      // And it must not masquerade as a finding.
+      expect(result.value.layerViolations).toHaveLength(0);
+    });
+
+    it('fails and records the error when detectCircularDepsInFiles returns Err', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(okDeps() as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(Err(CYCLE_ENGINE_ERROR) as never);
+
+      const result = await runCheckDeps({
+        cwd: cleanWithLayers,
+        configPath: path.join(cleanWithLayers, 'harness.config.json'),
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(false);
+      expect(result.value.analysisErrors).toBeDefined();
+      expect(result.value.analysisErrors!.join('\n')).toContain(
+        'walker failed to enumerate module graph'
+      );
+      expect(result.value.circularDeps).toHaveLength(0);
+    });
+
+    it('leaves analysisErrors unset on a genuinely clean analysis', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(okDeps() as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      const result = await runCheckDeps({
+        cwd: cleanWithLayers,
+        configPath: path.join(cleanWithLayers, 'harness.config.json'),
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(true);
+      expect(result.value.analysisErrors).toBeUndefined();
+    });
+  });
+
+  describe('process exit code', () => {
+    let logs: string[];
+    let exitCode: number | null;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    let errSpy: ReturnType<typeof vi.spyOn>;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      logs = [];
+      exitCode = null;
+      logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+        logs.push(a.map(String).join(' '));
+      });
+      errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation(((c?: number) => {
+        exitCode = c ?? 0;
+        throw new Error(`__exit__:${exitCode}`);
+      }) as never);
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+
+    async function runAction(globals: string[] = [], localAfter: string[] = []) {
+      // The action resolves rootDir against process.cwd(); point it at the
+      // fixture so discovery actually sees the fixture's modules.
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cleanWithLayers);
+      const program = new Command();
+      program.option('--config <path>');
+      program.option('--json');
+      program.option('--verbose');
+      program.option('--quiet');
+      program.addCommand(createCheckDepsCommand());
+      try {
+        await program.parseAsync(
+          [
+            ...globals,
+            '--config',
+            path.join(cleanWithLayers, 'harness.config.json'),
+            'check-deps',
+            ...localAfter,
+          ],
+          { from: 'user' }
+        );
+      } catch (e) {
+        if (!(e instanceof Error) || !e.message.startsWith('__exit__')) throw e;
+      } finally {
+        cwdSpy.mockRestore();
+      }
+    }
+
+    it('exits with the operational-failure code (not 0, not VALIDATION_FAILED) when validateDependencies Errs', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(Err(DEPS_ENGINE_ERROR) as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      await runAction();
+
+      expect(exitCode).not.toBe(ExitCode.SUCCESS);
+      expect(exitCode).not.toBe(ExitCode.VALIDATION_FAILED);
+      expect(exitCode).toBe(ExitCode.ERROR);
+      expect(logs.join('\n')).toContain('Parser typescript is not available');
+    });
+
+    it('exits with the operational-failure code when detectCircularDepsInFiles Errs', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(okDeps() as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(Err(CYCLE_ENGINE_ERROR) as never);
+
+      await runAction();
+
+      expect(exitCode).not.toBe(ExitCode.SUCCESS);
+      expect(exitCode).not.toBe(ExitCode.VALIDATION_FAILED);
+      expect(exitCode).toBe(ExitCode.ERROR);
+      expect(logs.join('\n')).toContain('walker failed to enumerate module graph');
+    });
+
+    it('reports the analysis error in the --json payload rather than an empty clean result', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(Err(DEPS_ENGINE_ERROR) as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      await runAction(['--json']);
+
+      expect(exitCode).toBe(ExitCode.ERROR);
+      const payload = logs
+        .map((l) => {
+          try {
+            return JSON.parse(l) as Record<string, unknown>;
+          } catch {
+            return null;
+          }
+        })
+        .find((p): p is Record<string, unknown> => p !== null && 'valid' in p);
+
+      expect(payload).toBeDefined();
+      expect(payload!.valid).toBe(false);
+      expect(JSON.stringify(payload)).toContain('Parser typescript is not available');
+    });
+
+    it('counts the analysis error in the --findings-json maintenance contract', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(Err(DEPS_ENGINE_ERROR) as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      await runAction([], ['--findings-json']);
+
+      const contractLine = logs.find((l) => l.includes('"findings"'));
+      expect(contractLine).toBeDefined();
+      // A failed analysis must never render as `{ "findings": 0 }`.
+      expect(contractLine).not.toContain('"findings": 0');
+      expect(contractLine).not.toContain('"findings":0');
+    });
+
+    // Regression guard: the genuinely-clean path must be untouched by this fix.
+    it('still exits 0 with unchanged output when the analysis is genuinely clean', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(okDeps() as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      await runAction();
+
+      expect(exitCode).toBe(ExitCode.SUCCESS);
+      const out = logs.join('\n');
+      // Shape, not an exact count: `findFiles` also yields the `src` directory
+      // itself, a pre-existing quirk this change deliberately does not touch.
+      expect(out).toMatch(/^Analyzed \d+ module\(s\) across 1 layer\(s\)\.$/m);
+      expect(out).toContain('validation passed');
+      expect(out).not.toMatch(/could not run/i);
+    });
+
+    it('clean --json payload carries no analysisErrors key', async () => {
+      vi.mocked(validateDependencies).mockResolvedValue(okDeps() as never);
+      vi.mocked(detectCircularDepsInFiles).mockResolvedValue(okCycles() as never);
+
+      await runAction(['--json']);
+
+      expect(exitCode).toBe(ExitCode.SUCCESS);
+      const payload = logs
+        .map((l) => {
+          try {
+            return JSON.parse(l) as Record<string, unknown>;
+          } catch {
+            return null;
+          }
+        })
+        .find((p): p is Record<string, unknown> => p !== null && 'valid' in p);
+
+      expect(payload).toBeDefined();
+      expect(payload!.valid).toBe(true);
+      expect(payload).not.toHaveProperty('analysisErrors');
+      expect(payload).not.toHaveProperty('unavailableChecks');
+    });
+  });
+});

--- a/packages/cli/tests/fixtures/deps-clean-layers/harness.config.json
+++ b/packages/cli/tests/fixtures/deps-clean-layers/harness.config.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "rootDir": ".",
+  "layers": [{ "name": "app", "pattern": "src/**", "allowedDependencies": [] }]
+}

--- a/packages/cli/tests/fixtures/deps-clean-layers/src/index.ts
+++ b/packages/cli/tests/fixtures/deps-clean-layers/src/index.ts
@@ -1,0 +1,4 @@
+// A single self-contained module: one layer, one file, no imports — so the
+// analysis genuinely runs and genuinely comes back clean. Used as the
+// unchanged-clean-path regression guard for #1996.
+export const value = 1;


### PR DESCRIPTION
## What this is

Refs #1996 — **one** of that issue's 19 craft findings.

**Fixed here: `CLI-R006` — `packages/cli/src/commands/check-deps.ts`, "check-deps exits 0 when its analysis fails."** It is the single `foundational / large / high` finding on the issue and the only one that is a correctness defect rather than a taste call.

**The other 18 findings remain open.** They are flag renames, `addHelpText` rewrites, and help-text changes across `check-deps.ts`, `models.ts`, and `rollback.ts` — i.e. breaking changes to published CLI contracts. They are deliberately out of scope for this PR, which is why it references #1996 with `Refs` rather than any closing keyword. **Issue #1996 must remain open after this merges.** `models.ts` and `rollback.ts` are untouched.

## The defect

`runCheckDeps` consumed both analysis engines as bare success guards with no `else`:

```ts
const depsResult = await validateDependencies(layerConfig);
if (depsResult.ok) { /* push violations */ }          // <-- no else

const circularResult = await detectCircularDepsInFiles(uniqueFiles, parser);
if (circularResult.ok && circularResult.value.hasCycles) { /* push cycles */ }   // <-- no else
```

Both return a `Result`. The failure channel was dropped on the floor. `result.valid` is initialised `true` and only ever flipped to `false` by a *finding*, so an `Err` produced a result **byte-identical to a genuinely clean repo** — and `runCheckDepsAction` then reached `process.exit(valid ? SUCCESS : VALIDATION_FAILED)` with `SUCCESS`.

Consumers that could not tell this from clean: `harness check-deps && deploy` proceeds; `--json` shows `valid: true, issues: []`; `--findings-json` reports `{ "findings": 0 }`.

This is a member of a known recurring defect class in this repo: **a check that reports success without having run.**

## The fix

Mirrors the honest pattern this file already establishes one block down — the #1188 zero-module abstention, which sets `valid = false` plus an `analysisNote` rather than reporting clean on an empty denominator.

- New `recordAnalysisError(result, stage, error)` flips `valid` false and appends `check-deps could not complete <stage>: <code>: <message>` to a new first-class `analysisErrors?: string[]` on `CheckDepsResult`.
- The action surfaces `analysisErrors` in `issues` alongside the existing `analysisNote`, so they reach every output mode **and** are counted by the `--findings-json` maintenance contract.
- The array is forwarded into the JSON payload via a new optional `ValidationResult.analysisErrors` — the same shape precedent as `modulesAnalyzed` / `layersConfigured` (#1188) in that interface.
- The exit becomes three-way.

### Exit-code behaviour change

| Outcome | Before | After |
| --- | --- | --- |
| Check ran, no findings | `0` | `0` |
| Check ran, found violations/cycles | `1` | `1` |
| **Check could not run (engine `Err`)** | **`0`** | **`2`** |

Only the previously-silent failure path changes. `&&` chains, `jq` consumers, and the maintenance findings contract can now tell a passing check from a broken one.

**The genuinely-clean path is unchanged and guarded by tests**: `analysisErrors` is left `undefined` (not `[]`) when every engine ran, so it is absent from the JSON payload and adds no issue rows; a clean repo still exits `0` with identical output.

## Assumptions made

1. **`ExitCode.INTERNAL_ERROR` does not exist.** The available members are `SUCCESS 0`, `VALIDATION_FAILED 1`, `ERROR 2`, `ZERO_DENOMINATOR 3` (`packages/cli/src/utils/errors.ts`). I used **`ExitCode.ERROR` (2)** — the nearest existing distinct non-zero operational-failure code, already documented as *"Command failed because of an unexpected error or misconfiguration"*. `ZERO_DENOMINATOR` (3) was rejected: it means the check ran and examined nothing, which is the #1188 abstention already living in this file, not an engine failure.

2. **Reachability — please read, this PR deliberately does not overclaim.** I enumerated every `Err` return reachable through the CLI's own call shape (no `graphDependencyData`, `fallbackBehavior: 'warn'`) on the pinned base:
   - `dependencies.ts:276` — graph-data path; the CLI never passes `graphDependencyData`.
   - `dependencies.ts:310` — `PARSER_UNAVAILABLE`, gated on `fallbackBehavior === 'error'`; the CLI passes `'warn'`, which returns `Ok({ skipped: true })`.
   - `dependencies.ts:335` — propagates `buildDependencyGraph`, which in the non-graph path `continue`s past unparseable files and returns `Ok` unconditionally.
   - `circular-deps.ts` — contains no `Err(` of its own.

   So on this base, **neither `Err` branch is currently reachable through the CLI**. The discard is a real *contract* defect — a `Result`-returning API whose failure channel is discarded — and the false-green is **latent rather than presently live**. It becomes live the moment `buildDependencyGraph` gains an `Err` return or a caller switches `fallbackBehavior` to `'error'`, with no test standing in the way. I am not claiming CI pipelines are silently passing today.

3. **Corroborating precedent.** `packages/core/src/review/mechanical-checks.ts` calls the *same* `validateDependencies` (with the default `fallbackBehavior: 'error'`, where `PARSER_UNAVAILABLE` **is** reachable) and already handles `!result.ok` by setting status `fail` and emitting `result.error.message` as a finding. This change brings the CLI command in line with treatment the repo already applies one package over.

4. **Tests mock the two `@harness-engineering/core` exports** to drive the failure channel. Given (2), that is the only way to exercise the branch without mutating shared engine code — and a `Result`'s failure channel is part of the API contract regardless of which internal branch happens to produce it today.

5. **`modulesAnalyzed` counts the `src` directory itself** as well as its files, because `findFiles` yields directory entries. Pre-existing, unrelated, deliberately untouched — the clean-path guard asserts output *shape* rather than an exact count so it does not encode the quirk.

## Related finding NOT fixed here (worth filing separately)

`validateDependencies` returns `Ok({ valid: true, violations: [], skipped: true, reason: 'Parser unavailable' })` under `fallbackBehavior: 'warn'` when `parser.health()` is unhealthy. `runCheckDeps` ignores `skipped` entirely — so a repo whose TypeScript parser is unavailable gets `valid: true` and exit `0` having validated **nothing**.

Same "reports success without running" class, and unlike the `Err` path it **is reachable today**. But it is a distinct finding (`Ok`-with-`skipped`, not `Err`) with adopter-visible behaviour impact, so it is deliberately left alone rather than smuggled into this PR.

## Verification

Reproducing test: `packages/cli/tests/commands/check-deps-err-swallow.test.ts` (+ fixture `packages/cli/tests/fixtures/deps-clean-layers/`).

Proven RED-before / GREEN-after by stashing only the `src` change:

- fix stashed → **6 failed | 3 passed** (the 3 passing are the clean-path regression guards, which are supposed to pass in both states)
- fix restored → **9 passed**
- with the sibling `check-deps.test.ts` + `check-deps-cov544b.test.ts` suites → **25 passed** across all three files

Coverage: `validateDependencies` → `Err`; `detectCircularDepsInFiles` → `Err`; both asserted on `valid`, on `analysisErrors` content, on exit code (not `0`, not `VALIDATION_FAILED`, is `ERROR`), on the `--json` payload, and on the `--findings-json` count never rendering `{"findings":0}`. Plus three unchanged-clean-path guards.

Produced by the `harness-debugging` pipeline (investigate → analyze → hypothesize → fix). Provenance: `docs/changes/check-deps-err-swallow-1996/provenance.json`.

## CI note

`Reconcile audit exceptions` is red on every open PR in this repo (6 advisories against an empty `auditExceptions` register). This PR inherits it; it is not caused by this change and is not addressed here.
