### PR TITLE
security(deps): raise the hono override floor to >=4.13.5, clearing three advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "cpu-features"
     ],
     "overrides": {
-      "hono": ">=4.12.34",
+      "hono": ">=4.13.5",
       "@grpc/grpc-js": "^1.14.4",
       "@hono/node-server": ">=2.0.10",
       "postcss": ">=8.5.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ neverBuiltDependencies:
   - cpu-features
 
 overrides:
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   '@grpc/grpc-js': ^1.14.4
   '@hono/node-server': '>=2.0.10'
   postcss: '>=8.5.23'
@@ -326,7 +326,7 @@ importers:
         version: link:../types
       '@hono/node-server':
         specifier: '>=2.0.10'
-        version: 2.0.11(hono@4.13.1)
+        version: 2.0.11(hono@4.13.7)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.2)
@@ -337,8 +337,8 @@ importers:
         specifier: ^13.0.6
         version: 13.0.6
       hono:
-        specifier: '>=4.12.34'
-        version: 4.13.1
+        specifier: '>=4.13.5'
+        version: 4.13.7
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@18.3.1)
@@ -2475,13 +2475,13 @@ packages:
       yargs: 17.7.2
     dev: true
 
-  /@hono/node-server@2.0.11(hono@4.13.1):
+  /@hono/node-server@2.0.11(hono@4.13.7):
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
     dev: false
 
   /@humanfs/core@0.19.2:
@@ -2742,7 +2742,7 @@ packages:
       '@cfworker/json-schema':
         optional: true
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.13.1)
+      '@hono/node-server': 2.0.11(hono@4.13.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2752,7 +2752,7 @@ packages:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6015,8 +6015,8 @@ packages:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
     dev: false
 
-  /hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  /hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
     dev: false
 


### PR DESCRIPTION
Clears **three** advisories in one bump — all published 2026-09-08, all affecting `hono < 4.13.5`, first patched **4.13.5**:

| Advisory | Sev | Summary |
| --- | --- | --- |
| [`GHSA-crvj-82cr-hjcx`](https://github.com/advisories/GHSA-crvj-82cr-hjcx) | moderate | Query parser reads parameters after the URL fragment, causing cache-key and proxy interpretation differentials |
| [`GHSA-g6gw-c38x-mqfc`](https://github.com/advisories/GHSA-g6gw-c38x-mqfc) | moderate | Unbounded dot-notation nesting in `parseBody()` can cause memory exhaustion |
| [`GHSA-gqvv-2mrq-wpjv`](https://github.com/advisories/GHSA-gqvv-2mrq-wpjv) | moderate | Incomplete fix for CVE-2026-39408: `toSSG()` still writes files outside the output directory |

Fourth in the series with #2090 (liquidjs) and #2092 (vitest). Refs #2087.

## Why this touches `package.json` and not only the lockfile

This one is **not** the same shape as #2090/#2092, and the difference matters.

hono's resolution is **not governed by the manifest range**. The root `package.json` `pnpm.overrides` block carries **27 security floors**, one of which is `hono: '>=4.12.34'` — and the lockfile records *that override* as the importer's specifier:

```yaml
hono:
  specifier: '>=4.12.34'      # <- the override, not dashboard's ^4.12.18
  version: 4.13.1
```

I tried the lockfile-only technique from the previous two PRs first: raising `packages/dashboard/package.json` from `^4.12.18` to `^4.13.5` and re-resolving. **The lockfile did not move** — the override supersedes the manifest specifier entirely, and 4.13.1 already satisfies `>=4.12.34`.

So the floor is the only lever. This raises it to the first patched version. That is the mechanism this repo **already uses for exactly this purpose** — it is an update to an existing pin, not a new one.

### :warning: This contradicts #2093 — `pnpm.overrides` is NOT ignored

#2093 reports the whole `pnpm.overrides` block is silently ignored, with `[WARN] The "pnpm" field in package.json is no longer read by pnpm`. **That does not reproduce with this repo's pinned toolchain**, and the evidence here is direct:

- `packageManager` pins **pnpm@8.15.4** (via corepack). At that version, `pnpm install --lockfile-only` emits **no such warning** — I grepped for it specifically.
- The lockfile's own `overrides:` block is present with all 27 entries, and the importer specifier above proves the override is what is being applied.
- **Decisive:** changing *only* the floor `>=4.12.34` -> `>=4.13.5` moved hono `4.13.1` -> `4.13.7`. An ignored field cannot move a resolution.

The warning in #2093 is real but almost certainly came from a **newer pnpm** (pnpm 10 dropped reading the `pnpm` field in favour of `pnpm-workspace.yaml`). Under the pinned 8.15.4 the overrides are load-bearing. Worth correcting there before someone migrates the block on the strength of it — or, more dangerously, concludes the 27 security floors are already inert.

## What moved

pnpm resolved **4.13.7** — the newest satisfying the new floor, which is how every other floor in this block behaves (`>=4.12.34` had likewise landed on 4.13.1). 4.13.7 is a **zero-dependency** package with unchanged `engines.node: >=16.9.0` and is not deprecated.

Blast radius is exactly hono plus the `@hono/node-server@2.0.11` peer-variant key that names it:

```
-  /@hono/node-server@2.0.11(hono@4.13.1):   +  /@hono/node-server@2.0.11(hono@4.13.7):
-  /hono@4.13.1:                             +  /hono@4.13.7:
```

Nothing else moved. No changeset — `scripts/check-changesets.mjs` reports *"No publishable package changes detected"*.

## Evidence

- **Class:** `advisory-match`. **Strength:** `lockfile-only`.
- **Evidence cleared / no new finding**, gate's own script run against both trees at base `738b296c0`:

| Tree | Rows | Distinct GHSAs |
| --- | --- | --- |
| base `738b296c0` | 8 | 6 |
| this branch | 5 | **3** (all three hono advisories gone) |

Strictly better than base; nothing introduced.

**hono is a runtime dependency of `packages/dashboard`**, so 4.13.1 -> 4.13.7 can carry real behaviour change. All-OS `build-and-test` results at the head SHA are reported in a follow-up comment rather than assumed.

Base: `738b296c0a50cb9890474124d466f38903e468e2`. **Not merged, no auto-merge.**