### PR TITLE
security(deps): clear all eight active audit advisories

### DIFF
--- a/.changeset/security-clear-all-audit-advisories.md
+++ b/.changeset/security-clear-all-audit-advisories.md
@@ -1,0 +1,30 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+security(deps): clear all eight active audit advisories so `Reconcile audit exceptions` passes
+
+The `Reconcile audit exceptions` gate (issue #1324) was failing on `main` and on every open
+PR with eight active advisories and no covering register entries. This resolves all of them
+by upgrading, not by adding `auditExceptions` entries.
+
+| Advisory            | CVE            | Severity | Package                    | Vulnerable        | Resolved to |
+| ------------------- | -------------- | -------- | -------------------------- | ----------------- | ----------- |
+| GHSA-4r6h-5v86-94p3 | CVE-2026-69222 | high     | `liquidjs`                 | `<=10.27.1`       | `10.27.2`   |
+| GHSA-82fw-gwwq-j7x9 | CVE-2026-84373 | moderate | `vitest`, `@vitest/mocker` | `>=2.1.0 <4.1.11` | `4.1.11`    |
+| GHSA-2883-xcg3-v3hh | CVE-2026-84375 | high     | `js-yaml` (3.x)            | `>=3.0.0 <3.15.2` | `3.15.2`    |
+| GHSA-2883-xcg3-v3hh | CVE-2026-84375 | high     | `js-yaml` (4.x)            | `>=4.0.0 <4.3.2`  | `4.3.2`     |
+| GHSA-gqvv-2mrq-wpjv | CVE-2026-84365 | moderate | `hono`                     | `<4.13.5`         | `4.13.7`    |
+| GHSA-g6gw-c38x-mqfc | CVE-2026-84364 | moderate | `hono`                     | `<4.13.5`         | `4.13.7`    |
+| GHSA-crvj-82cr-hjcx | CVE-2026-84363 | moderate | `hono`                     | `<4.13.5`         | `4.13.7`    |
+
+`liquidjs` and `vitest` are lockfile-only re-resolutions inside ranges the manifests already
+declare. `hono` and `js-yaml` move via the root `pnpm.overrides` floors (`hono` `>=4.12.34`
+-> `>=4.13.5`; `js-yaml@3` `>=3.15.1` -> `>=3.15.2`; `js-yaml@4` `>=4.3.1` -> `>=4.3.2`).
+
+**Repo-local scope.** No published manifest range changes: `@harness-engineering/dashboard`
+still declares `"hono": "^4.12.18"` and `@harness-engineering/orchestrator` still declares
+`"liquidjs": "^10.26.0"`. Downstream consumers' declared ranges are unchanged — they already
+permit the patched versions, but this repo does not force them.
+
+Refs #2087.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "cpu-features"
     ],
     "overrides": {
-      "hono": ">=4.12.34",
+      "hono": ">=4.13.5",
       "@grpc/grpc-js": "^1.14.4",
       "@hono/node-server": ">=2.0.10",
       "postcss": ">=8.5.23",
@@ -112,8 +112,8 @@
       "@babel/core": "^7.29.6",
       "brace-expansion@2": ">=2.1.4 <3",
       "brace-expansion@5": ">=5.0.9 <6",
-      "js-yaml@3": ">=3.15.1 <4",
-      "js-yaml@4": ">=4.3.1 <5",
+      "js-yaml@3": ">=3.15.2 <4",
+      "js-yaml@4": ">=4.3.2 <5",
       "vite": ">=6.4.3 <7",
       "esbuild@0.27": ">=0.28.1",
       "uuid": "^11.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ neverBuiltDependencies:
   - cpu-features
 
 overrides:
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   '@grpc/grpc-js': ^1.14.4
   '@hono/node-server': '>=2.0.10'
   postcss: '>=8.5.23'
@@ -30,8 +30,8 @@ overrides:
   '@babel/core': ^7.29.6
   brace-expansion@2: '>=2.1.4 <3'
   brace-expansion@5: '>=5.0.9 <6'
-  js-yaml@3: '>=3.15.1 <4'
-  js-yaml@4: '>=4.3.1 <5'
+  js-yaml@3: '>=3.15.2 <4'
+  js-yaml@4: '>=4.3.2 <5'
   vite: '>=6.4.3 <7'
   esbuild@0.27: '>=0.28.1'
   uuid: ^11.1.1
@@ -90,7 +90,7 @@ importers:
         version: 1.6.4(@algolia/client-search@5.52.1)(search-insights@2.17.3)(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -102,13 +102,13 @@ importers:
         version: link:../../packages/core
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       glob:
         specifier: ^10.5.0
         version: 10.5.0
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -132,7 +132,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -141,7 +141,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/cli:
     dependencies:
@@ -238,13 +238,13 @@ importers:
         version: 7.7.1
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/core:
     dependencies:
@@ -290,10 +290,10 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       '@vitest/ui':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -302,7 +302,7 @@ importers:
         version: 4.23.11
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/dashboard:
     dependencies:
@@ -326,7 +326,7 @@ importers:
         version: link:../types
       '@hono/node-server':
         specifier: '>=2.0.10'
-        version: 2.0.11(hono@4.13.1)
+        version: 2.0.11(hono@4.13.7)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.2)
@@ -337,8 +337,8 @@ importers:
         specifier: ^13.0.6
         version: 13.0.6
       hono:
-        specifier: '>=4.12.34'
-        version: 4.13.1
+        specifier: '>=4.13.5'
+        version: 4.13.7
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@18.3.1)
@@ -393,7 +393,7 @@ importers:
         version: 4.7.0(vite@6.4.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       concurrently:
         specifier: ^9.1.0
         version: 9.2.1
@@ -414,7 +414,7 @@ importers:
         version: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(jsdom@29.0.1)(vite@6.4.3)
 
   packages/eslint-plugin:
     dependencies:
@@ -439,7 +439,7 @@ importers:
         version: 8.59.0(eslint@10.2.1)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       eslint:
         specifier: ^10.2.1
         version: 10.2.1
@@ -451,7 +451,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/graph:
     dependencies:
@@ -477,7 +477,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -486,7 +486,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/intelligence:
     dependencies:
@@ -515,13 +515,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/linter-gen:
     dependencies:
@@ -543,13 +543,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/local-models:
     dependencies:
@@ -565,13 +565,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/orchestrator:
     dependencies:
@@ -613,7 +613,7 @@ importers:
         version: 4.4.1(@types/react@18.3.28)(react@18.3.1)
       liquidjs:
         specifier: ^10.26.0
-        version: 10.27.1
+        version: 10.27.2
       openai:
         specifier: ^6.0.0
         version: 6.26.0(ws@8.21.0)(zod@3.25.76)
@@ -650,7 +650,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       testcontainers:
         specifier: ^11.14.0
         version: 11.14.0
@@ -659,7 +659,7 @@ importers:
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/signals:
     dependencies:
@@ -675,7 +675,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
@@ -684,7 +684,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+        version: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
 
   packages/types:
     dependencies:
@@ -694,13 +694,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.11(vitest@4.1.11)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(tsx@4.23.11)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3)
+        version: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
 
 packages:
 
@@ -1623,7 +1623,7 @@ packages:
     resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
     dev: true
 
   /@changesets/pre@2.0.2:
@@ -2475,13 +2475,13 @@ packages:
       yargs: 17.7.2
     dev: true
 
-  /@hono/node-server@2.0.11(hono@4.13.1):
+  /@hono/node-server@2.0.11(hono@4.13.7):
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
     dev: false
 
   /@humanfs/core@0.19.2:
@@ -2742,7 +2742,7 @@ packages:
       '@cfworker/json-schema':
         optional: true
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.13.1)
+      '@hono/node-server': 2.0.11(hono@4.13.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2752,7 +2752,7 @@ packages:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3924,17 +3924,17 @@ packages:
       vue: 3.5.31(typescript@5.9.3)
     dev: true
 
-  /@vitest/coverage-v8@4.1.5(vitest@4.1.5):
-    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+  /@vitest/coverage-v8@4.1.11(vitest@4.1.11):
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
     peerDependencies:
-      '@vitest/browser': 4.1.5
-      vitest: 4.1.5
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.11
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -3943,22 +3943,22 @@ packages:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3)
+      vitest: 4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3)
     dev: true
 
-  /@vitest/expect@4.1.5:
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  /@vitest/expect@4.1.11:
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
     dev: true
 
-  /@vitest/mocker@4.1.5(vite@6.4.3):
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  /@vitest/mocker@4.1.11(vite@6.4.3):
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=6.4.3 <7'
@@ -3968,57 +3968,57 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
     dev: true
 
-  /@vitest/pretty-format@4.1.5:
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  /@vitest/pretty-format@4.1.11:
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
     dependencies:
       tinyrainbow: 3.1.0
     dev: true
 
-  /@vitest/runner@4.1.5:
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  /@vitest/runner@4.1.11:
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
     dev: true
 
-  /@vitest/snapshot@4.1.5:
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  /@vitest/snapshot@4.1.11:
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
     dev: true
 
-  /@vitest/spy@4.1.5:
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  /@vitest/spy@4.1.11:
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
     dev: true
 
-  /@vitest/ui@4.1.5(vitest@4.1.5):
-    resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
+  /@vitest/ui@4.1.11(vitest@4.1.11):
+    resolution: {integrity: sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==}
     peerDependencies:
-      vitest: 4.1.5
+      vitest: 4.1.11
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.11
       fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3)
+      vitest: 4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3)
     dev: true
 
-  /@vitest/utils@4.1.5:
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  /@vitest/utils@4.1.11:
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
     dev: true
@@ -5912,7 +5912,7 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
     dependencies:
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -6015,8 +6015,8 @@ packages:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
     dev: false
 
-  /hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  /hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
     dev: false
 
@@ -6369,15 +6369,15 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  /js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  /js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  /js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  /js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
@@ -6645,8 +6645,8 @@ packages:
       yaml: 2.8.3
     dev: true
 
-  /liquidjs@10.27.1:
-    resolution: {integrity: sha512-ylE+1q2kSef1UxAyxqbyuWM3FRWS1v48JK1Y3CoW3bD6TSNXZh0+GsVnihujEpKyR+Jejx2aRAFfC3AHm9rElg==}
+  /liquidjs@10.27.2:
+    resolution: {integrity: sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
@@ -6774,7 +6774,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
     dev: true
 
   /mark.js@8.11.1:
@@ -8004,7 +8004,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       pify: 4.0.1
       strip-bom: 3.0.0
     dev: true
@@ -8274,7 +8274,6 @@ packages:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
 
   /send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
@@ -8817,14 +8816,6 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-    dev: true
-
   /tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -9309,20 +9300,20 @@ packages:
       - yaml
     dev: true
 
-  /vitest@4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.3):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  /vitest@4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@6.4.3):
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=6.4.3 <7'
@@ -9351,15 +9342,15 @@ packages:
         optional: true
     dependencies:
       '@types/node': 22.19.15
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.3)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/ui': 4.1.5(vitest@4.1.5)
-      '@vitest/utils': 4.1.5
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/ui': 4.1.11(vitest@4.1.11)
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -9369,7 +9360,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -9377,20 +9368,20 @@ packages:
       - msw
     dev: true
 
-  /vitest@4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  /vitest@4.1.11(@types/node@22.19.15)(@vitest/coverage-v8@4.1.11)(jsdom@29.0.1)(vite@6.4.3):
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=6.4.3 <7'
@@ -9419,14 +9410,14 @@ packages:
         optional: true
     dependencies:
       '@types/node': 22.19.15
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.3)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       jsdom: 29.0.1
@@ -9437,7 +9428,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.23.11)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -9445,20 +9436,20 @@ packages:
       - msw
     dev: true
 
-  /vitest@4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.3):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  /vitest@4.1.11(@vitest/coverage-v8@4.1.11)(vite@6.4.3):
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=6.4.3 <7'
@@ -9486,14 +9477,14 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.3)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21


### PR DESCRIPTION
## What

`Reconcile audit exceptions` — a **blocking** check — is failing on `main` and on all 11 open PRs. On `main`, `node scripts/audit-exceptions.mjs` reports:

```
audit-exceptions: 8 active advisories, 0 register entries.
```

This PR clears **all eight** by upgrading. **No `auditExceptions` entries are added** — nothing is masked, every advisory is actually resolved.

## Supersedes #2090, #2092, #2102, #2103

Each of those fixed a disjoint slice, so each still failed the gate on its own — only the union reaches zero. This is the union, rebuilt on current `main`.

They are left open deliberately; closing them is the operator's call.

## Advisories cleared

| Advisory | CVE | Severity | Package | Vulnerable | Resolved to |
| --- | --- | --- | --- | --- | --- |
| [GHSA-4r6h-5v86-94p3](https://github.com/advisories/GHSA-4r6h-5v86-94p3) | CVE-2026-69222 | high | `liquidjs` | `<=10.27.1` | **10.27.2** |
| [GHSA-82fw-gwwq-j7x9](https://github.com/advisories/GHSA-82fw-gwwq-j7x9) | CVE-2026-84373 | moderate | `vitest`, `@vitest/mocker` | `>=2.1.0 <4.1.11` | **4.1.11** |
| [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) | CVE-2026-84375 | high | `js-yaml` (3.x) | `>=3.0.0 <3.15.2` | **3.15.2** |
| [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) | CVE-2026-84375 | high | `js-yaml` (4.x) | `>=4.0.0 <4.3.2` | **4.3.2** |
| [GHSA-gqvv-2mrq-wpjv](https://github.com/advisories/GHSA-gqvv-2mrq-wpjv) | CVE-2026-84365 | moderate | `hono` | `<4.13.5` | **4.13.7** |
| [GHSA-g6gw-c38x-mqfc](https://github.com/advisories/GHSA-g6gw-c38x-mqfc) | CVE-2026-84364 | moderate | `hono` | `<4.13.5` | **4.13.7** |
| [GHSA-crvj-82cr-hjcx](https://github.com/advisories/GHSA-crvj-82cr-hjcx) | CVE-2026-84363 | moderate | `hono` | `<4.13.5` | **4.13.7** |

## How

The whole change is a 6-line `package.json` `pnpm.overrides` diff plus the resulting `pnpm-lock.yaml`.

```diff
-      "hono": ">=4.12.34",
+      "hono": ">=4.13.5",
...
-      "js-yaml@3": ">=3.15.1 <4",
-      "js-yaml@4": ">=4.3.1 <5",
+      "js-yaml@3": ">=3.15.2 <4",
+      "js-yaml@4": ">=4.3.2 <5",
```

`liquidjs` and `vitest` need no manifest change at all — the patched versions are already inside ranges the manifests declare (`liquidjs: ^10.26.0`, `vitest` devDependency), so they are pure lockfile re-resolutions.

## Honest disclosure: this is a repo-local fix

**No published manifest range changes.** `@harness-engineering/dashboard@0.16.6` still declares `"hono": "^4.12.18"`, and `@harness-engineering/orchestrator@0.24.1` still declares `"liquidjs": "^10.26.0"`. The `pnpm.overrides` floors apply to **this repository's** dependency resolution only.

Downstream consumers' declared ranges are therefore unchanged by this PR. Their existing carets already *permit* the patched versions, so a fresh install downstream will pick them up — but this PR does not *force* that, and it does not raise any published floor. If forcing the floor for consumers is wanted, that is a separate change to the per-package `dependencies` (and a minor, not a patch).

## Verification performed locally before pushing

Under Node 22.23.2 / pnpm 8.15.4 (`corepack`, so `pnpm.overrides` is actually honoured — the ambient pnpm 12 silently drops that field), at base `13c4e3513`:

1. **`node scripts/audit-exceptions.mjs`** — the exact CI command, exit **0**:
   ```
   audit-exceptions: 0 active advisories, 0 register entries.

   OK — no active advisories.
   ```
   (Same command on `main` reports the 8 failures above.)

2. **`pnpm install --frozen-lockfile`** — the exact CI install step — accepts the lockfile: `Lockfile is up to date, resolution step is skipped`.

3. **No vulnerable version survives anywhere in the lockfile.** Every resolution of the five packages, exhaustively:
   ```
   /@vitest/mocker@4.1.11        /hono@4.13.7        /js-yaml@3.15.2
   /js-yaml@4.3.2                /liquidjs@10.27.2   /vitest@4.1.11 (x3 peer variants)
   ```
   Single resolution per package — no stale duplicate copy left behind.

4. **`corepack pnpm install --lockfile-only` produces a byte-identical lockfile**, confirming the combined resolution is what pnpm would derive from the manifests rather than an artefact of merging four branches.

Refs #2087.
