### PR TITLE
fix(test): await the settle in the comprehend smoke E2E teardown (#2089)

### DIFF
--- a/.changeset/comprehend-smoke-ebusy-teardown-2089.md
+++ b/.changeset/comprehend-smoke-ebusy-teardown-2089.md
@@ -1,0 +1,55 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(test): stop the comprehend smoke E2E reding windows CI from its teardown
+
+`packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts` failed the
+`build-and-test (windows-latest, 22)` leg twice in four days from its `afterAll`,
+after every one of its assertions had already passed:
+
+```
+Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\comprehend-smoke-b9n120'
+ ❯ tests/comprehension/comprehend-smoke.e2e.test.ts:60:15
+Serialized Error: { errno: -4082, code: 'EBUSY', syscall: 'rmdir', path: '...' }
+
+Test Files  1 failed | 733 passed | 5 skipped
+```
+
+Zero failed tests. The `syscall` is `rmdir` — the only thing that failed was
+deleting a temp directory, so the run reported the product as broken when
+nothing about the product misbehaved.
+
+The block scaffolds a scratch repo with four `spawnSync('git', ...)` calls and
+then drives the real `harness comprehend` binary through eight more
+`spawnSync`s, all with `cwd: proj`. `spawnSync` returns when the child _exits_,
+but Windows releases that child's open file handles asynchronously afterwards
+and refuses to unlink a file while a handle to it is open — so the teardown can
+begin removing `proj` while handles under it are still live.
+
+The teardown already passed `force: true`, which reads like error tolerance but
+is not: Node documents `force` as ignoring exceptions **if `path` does not
+exist**. It suppresses `ENOENT` only and does nothing for a locked path, so the
+teardown had no tolerance at all.
+
+The removal now awaits the settle:
+
+```ts
+if (proj) rmSync(proj, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+```
+
+`maxRetries`/`retryDelay` make Node retry on exactly the `EBUSY`/`ENOTEMPTY`/
+`EPERM` class in play until the OS releases the handles. The values mirror the
+existing in-repo precedent at `packages/core/tests/state/gate.test.ts:21`.
+
+The nondeterminism is removed rather than hidden: no `skipIf(win32)`, no
+swallowing `try`/`catch`, no job-level retry, and no assertion changed. The
+retry costs only the actual settle time, and is a no-op on POSIX, where handles
+are released synchronously on exit.
+
+Test-only change; no product code, no public API, and no runtime behaviour is
+affected.
+
+Refs #2089 — the issue's structural half (a shared `removeTempDirSafely` helper
+and the migration of the four ad-hoc sites onto it) is deliberately not
+addressed here and remains open.

--- a/.harness/comprehension/packages/cli/tests/comprehension/_module.md
+++ b/.harness/comprehension/packages/cli/tests/comprehension/_module.md
@@ -1,13 +1,12 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/comprehension'
-sourceHash: 'b5fef8d003ee1ba4ec6c81cf0ab8ae50d0a812b79b5e7543e731f59b07860e46'
+sourceHash: '0c29e6a8de9842206790e790cacdd6552938ffe012a89b0f262a0adef4d50d7b'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
 members:
   [
-    'compile-run.test.ts',
     'comprehend-e2e.test.ts',
     'comprehend-flags.test.ts',
     'comprehend-smoke.e2e.test.ts',
@@ -18,7 +17,6 @@ members:
     'policy.test.ts',
     'refresh-gate.test.ts',
     'regression.test.ts',
-    'static-extractor.test.ts',
   ]
 ---
 
@@ -33,18 +31,18 @@ members:
 ```
 import { createComprehendCommand, formatCompiledUnits, resolveChangedScope, resolveCompileProvider, resolveMode, resolveStaticOnlyPosture, stageCompiledUnits } from '../../src/commands/comprehend'
 import { ChangedSurface } from '../../src/commands/validate-scope'
-import { ComprehendRunResult, mapWithConcurrency, runComprehend, runComprehendCheck, runComprehendStats } from '../../src/comprehension/compile-run'
+import { ComprehendRunResult, runComprehend, runComprehendCheck, runComprehendStats } from '../../src/comprehension/compile-run'
 import { comprehensionCli, comprehensionEndpoint, readComprehensionConfig, resolveComprehensionCiMode, selectSemanticModel } from '../../src/comprehension/config'
-import { REENTRANCY_ENV, isComprehensionReentrant, maybeCreateGenerateSemantic } from '../../src/comprehension/generate-semantic'
+import { maybeCreateGenerateSemantic } from '../../src/comprehension/generate-semantic'
 import { DEFAULT_DIGEST_CHAR_BUDGET, DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_SEMANTIC_MODEL, REENTRANCY_ENV, boundSourceDigest, buildSemanticPrompt, createGenerateSemantic, defaultSemanticModel, isComprehensionReentrant, maybeCreateGenerateSemantic, semanticResponseSchema, withComprehensionActive } from '../../src/comprehension/generate-semantic.js'
 import { shouldRunComprehendHook } from '../../src/comprehension/hook'
 import { enumerateModules, filesToModules } from '../../src/comprehension/invalidation'
 import { MAIN_BRANCH, committedSemanticAllowed, isMainPassContext, resolveComprehensionBranch } from '../../src/comprehension/policy'
 import { RefreshJobGateReason, explainInactiveRefreshGate, resolveRefreshJobGate } from '../../src/comprehension/refresh-gate'
 import { RefReadDeps, SemanticState, detectCommittedSemanticOnBranch, detectSemanticRegressions, parseModuleSemantic, readSemanticMapAtRef } from '../../src/comprehension/regression'
-import { createStaticExtractor, isStaticSupported, renderDependencySlice, renderInterfaceContract } from '../../src/comprehension/static-extractor'
+import { createStaticExtractor } from '../../src/comprehension/static-extractor'
 import { ComprehensionConfigSchema, HarnessConfig, HarnessConfigSchema } from '../../src/config/schema'
-import { ComprehensionListing, ComprehensionSourceFile, ComprehensionStore, ComprehensionUnit, Err, ExtractStatic, GenerateSemantic, Ok, SemanticInput, SourceFile, StaticExtraction, compileModule, computeSourceHash, createNodeComprehensionIO, createNodeModuleSourceReader, serveGate } from '@harness-engineering/core'
+import { ComprehensionStore, SemanticInput, SourceFile, StaticExtraction, compileModule, createNodeComprehensionIO, createNodeModuleSourceReader, serveGate } from '@harness-engineering/core'
 import { AnalysisProvider, AnalysisRequest, AnalysisResponse } from '@harness-engineering/intelligence'
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'

--- a/docs/changes/comprehend-smoke-ebusy-teardown/debug-session.md
+++ b/docs/changes/comprehend-smoke-ebusy-teardown/debug-session.md
@@ -1,0 +1,196 @@
+# Debug Session: comprehend-smoke.e2e.test.ts EBUSY teardown flake (windows-latest)
+
+Status: resolved
+Started: 2026-09-09
+Error: `Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\comprehend-smoke-b9n120'`
+CI: run [`34301348937`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34301348937), job `build-and-test (windows-latest, 22)`, sha `b169ca0dc`
+Prior occurrence: run [`34279126634`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34279126634) (PR #2085)
+Issue: #2089
+
+## Investigation Log
+
+### Step 1 — Entropy analysis (`harness cleanup`)
+
+Ran against the worktree. Findings are entirely pre-existing and unrelated to the failure site:
+documentation drift under `docs/standard/`, `docs/api/`, `docs/guides/` (RENAMED / NOT_FOUND
+symbol and link drift) and ~560 dead-code entries dominated by `templates/` and `examples/`
+scaffolding plus test `setup.ts` files. **Nothing** under `packages/cli/tests/comprehension/`.
+No entropy signal contributed to this fault.
+
+### Step 2 — Read the error carefully
+
+- The job reported `Test Files 1 failed | 733 passed | 5 skipped` with **ZERO failed tests**.
+  The prior occurrence on #2085 reported `8698 passed | 29 skipped`, again zero failures.
+- Every assertion in the file passed. The failure is thrown from `afterAll`, i.e. **after** the
+  `describe` block's assertions have all completed successfully.
+- Serialized error: `{ errno: -4082, code: 'EBUSY', syscall: 'rmdir', path: '...' }`.
+  `syscall: 'rmdir'` — the failing operation is directory removal, not any product code path.
+- Thrown at `comprehend-smoke.e2e.test.ts:60:15`, which was:
+  `if (proj) rmSync(proj, { recursive: true, force: true });`
+- Therefore: a **teardown** defect, not an assertion defect and not a product defect. The suite
+  reports the product as broken when nothing about the product misbehaved.
+
+### Step 3 — Reproduce
+
+**NOT reproducible on macOS (this dev host), and that is expected, not a gap.** The fault is a
+Windows file-locking behaviour: Windows does not permit unlinking a file while another process
+holds an open handle to it, and a just-exited child's handles are released asynchronously by the
+OS. POSIX unlinks regardless of open handles, so the race has no macOS analogue.
+
+Per the `windows-ephemeral-port-deflake` precedent, the evidence standard for this item is
+therefore: **the teardown now tolerates a locked handle, and the suite is stable across repeated
+runs** — NOT "the Windows fault was reproduced locally".
+
+To avoid resting the diagnosis on assertion alone, the _mechanism_ was verified experimentally on
+macOS using a deterministic stand-in for the lock (below).
+
+### Step 4 — Check recent changes
+
+`git log` for the file shows six commits, most recently `963422f28` (ADR 0116 docs) and
+`f7d965949` / `e610043ce` (single-writer semantic). None of them touched the `afterAll` teardown.
+The teardown has been unchanged since `e16942b16`, the commit that introduced the file. This is a
+latent defect that has been present since the file landed, surfacing only now as CI load and
+Windows runner contention shifted — consistent with it firing twice in four days.
+
+### Step 5/6 — Trace the fault to its source
+
+The failing `describe` block does two things that open Windows handles under `proj`:
+
+1. `comprehend()` (`:24`) runs `spawnSync(process.execPath, [BIN, 'comprehend', ...])` with
+   `cwd: proj`. Five of the block's assertions invoke it; the last one invokes it three times.
+   Each spawned CLI reads and writes files under `proj` (`.harness/comprehension/math/_module.md`).
+2. `beforeAll` (`:51-56`) runs four `spawnSync('git', ...)` calls with `cwd: proj`, creating a
+   real `.git` directory. `git commit` in particular leaves index/object files freshly written.
+
+`spawnSync` returns when the child exits, but on Windows the **kernel** releases that child's file
+handles asynchronously. So `afterAll` can begin `rmSync` inside the window where handles under
+`proj` are still open → `EBUSY` on `rmdir`.
+
+## Hypotheses
+
+### H1 (confirmed): `force: true` does not, and is not intended to, tolerate a locked path
+
+Node's `force` option is documented as "If `true`, exceptions will be ignored if `path` does not
+exist" — it suppresses `ENOENT` only. A locked path raises `EBUSY`/`ENOTEMPTY`/`EPERM`, which
+`force` does not touch.
+
+Falsifiable prediction: with `force: true` alone, a recursive `rmSync` over a tree containing an
+undeletable entry throws immediately rather than being suppressed.
+
+**Experiment.** On macOS, `chflags uchg` on a nested file makes `unlink` return `EPERM` — which is
+in exactly the same Node retry class as the Windows `EBUSY` (`EBUSY, EMFILE, ENFILE, ENOTEMPTY,
+EPERM`). This is a deterministic stand-in for the Windows lock.
+
+```
+A  force-only, locked entry:            THREW EPERM after 1ms
+```
+
+Confirmed. `force` did not suppress it, and it failed instantly — no tolerance whatsoever.
+
+### H2 (confirmed): `maxRetries` / `retryDelay` makes the teardown survive a _transient_ lock
+
+The real-world case is a lock that clears on its own within a few hundred milliseconds. The fix
+is only worth anything if it recovers from that, rather than merely failing more slowly.
+
+Falsifiable prediction: with an external process releasing the lock ~700ms in, the retrying
+`rmSync` completes and removes the tree; the non-retrying one fails.
+
+An initial attempt to test this released the lock from an in-process `setTimeout` and appeared to
+refute the hypothesis (`THREW EPERM after 24539ms`). **That was a flaw in the probe, not a
+property of the fix:** `rmSync` is synchronous and blocks the event loop, so the in-process timer
+could never fire. Re-run with an external `/bin/sh` unlocker — which correctly models the OS
+releasing an exited child's handles independently of our event loop:
+
+```
+C' transient lock + retries:     RECOVERED after 809ms; dir gone = true
+D' transient lock, force only:   THREW EPERM after 2ms   <-- the CI failure
+```
+
+Confirmed, and this pair is the revert protocol in mechanism form: the same transient lock is
+fatal without the options and survivable with them. The options are load-bearing, not decorative.
+
+Note the cost profile: the retry consumes only the _actual_ settle time (809ms here), not a fixed
+budget. It is not a sleep. On POSIX, where the lock never occurs, it costs nothing.
+
+### Recorded observation — the retry ceiling is higher than the nominal backoff
+
+A _permanently_ locked tree took `24148ms` to finally throw, not the ~5.5s a single linear
+`100..1000` backoff would predict, because `rmSync(recursive)` applies the retry budget at
+multiple levels of the tree (file, subdirectory, root). This is the worst case only when the lock
+never clears — a scenario in which the old code fails the suite anyway. Deferrable, recorded so
+the number is not a surprise to a future reader.
+
+## Uncertainty surfacing
+
+- **Assumption:** the Windows handle-retention window is shorter than the retry budget. The four
+  in-repo precedents all assume this and none has been observed to exhaust its retries; the
+  `gate.test.ts` budget is adopted unchanged rather than re-derived.
+- **Deferrable (reported, not fixed):** this same file contains **15** recursive `rmSync` teardown
+  sites, all structurally identical to line 60 and all reachable after a `spawnSync` of the CLI.
+  Only line 60 has been observed red. Per the explicit scope decision for this item, only line 60
+  was changed. See "Not fixed here" below.
+- **Deferrable:** #2089's structural recommendation (a shared helper) is deliberately out of scope.
+
+## Resolution
+
+Resolved: 2026-09-09
+
+**Root cause.** `comprehend-smoke.e2e.test.ts` scaffolds a scratch project with `git` and drives
+the real `harness comprehend` binary via `spawnSync`, both with `cwd: proj`. On Windows the OS
+releases an exited child's file handles asynchronously, so `afterAll`'s recursive `rmSync` can run
+while handles under `proj` are still open, and `rmdir` fails with `EBUSY`. `force: true` does not
+mitigate this — `force` suppresses "path does not exist", not "path is locked" — so the teardown
+had no tolerance at all and reded a suite in which every assertion had passed.
+
+**Fix.** `packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts:60` now reads:
+
+```ts
+if (proj) rmSync(proj, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+```
+
+with a rationale comment mirroring the in-repo precedent at
+`packages/core/tests/state/gate.test.ts:21`, whose option values (`maxRetries: 10`,
+`retryDelay: 100`) are adopted verbatim. Node retries on exactly the `EBUSY`/`ENOTEMPTY`/`EPERM`
+class in play, so the teardown waits for the OS to release the handles ("await the settle").
+
+This removes the nondeterminism rather than hiding it. Explicitly NOT done, per the fleet's Iron
+Law: the test is not skipped, not `skipIf(win32)`-ed, the teardown is not wrapped in a swallowing
+try/catch, and no job-level retry was added.
+
+**Regression test.** No new test file. The fault is an OS-level file-locking behaviour with no
+POSIX analogue; a test asserting that `rmSync` honours `maxRetries` would be testing Node, not
+this product, and would pass on the CI leg that never fails. The revert protocol is satisfied at
+the mechanism level instead, by the C'/D' probe pair above: the identical transient lock is fatal
+without the options (`THREW EPERM after 2ms`) and survivable with them (`RECOVERED after 809ms`).
+This matches the evidence standard set by `docs/changes/windows-ephemeral-port-deflake/`.
+
+**Verification.**
+
+- Target file: **5/5 consecutive green** — `Test Files 1 passed (1)`, `Tests 15 passed | 1 skipped (16)`.
+  The 1 skip is the `HARNESS_E2E_LIVE`-gated live block, skipped by design.
+- The suite genuinely executes rather than silently skipping: the whole file is
+  `describe.skipIf(!HAS_BIN)`, so `pnpm turbo build` was run first and the non-zero test count
+  confirms `dist/bin/harness.js` was present.
+- `tsc --noEmit` on `packages/cli`: exit 0.
+
+**Not fixed here, reported instead.** The same file has 14 further recursive `rmSync` teardown
+sites carrying the identical latent fault (lines 146, 217, 218, 276, 293, 319, 388, 403, 422, 442,
+466, 508, 522 and the `counter` unlink at 294). Every one of them tears down a directory that a
+`spawnSync`-ed CLI wrote into, so each is a future Windows red on the same mechanism. They were
+left untouched because the scope decision for this item named line 60 specifically, and because
+the precedent decision on the sibling item (`windows-ephemeral-port-deflake`, fork F5) chose
+"fix only the observed sites, route the rest". Routing these is the natural first customer for
+#2089's shared-helper half.
+
+**Learnings.**
+
+- `force: true` on `rm`/`rmSync` suppresses `ENOENT` **only**. It is routinely mistaken for
+  general error tolerance; it gives a teardown no protection against a locked path.
+- On Windows, an exited child's file handles are released asynchronously by the kernel.
+  `spawnSync` returning is NOT a guarantee that the child's files are unlocked. Any test that
+  spawns a process into a temp dir and then removes that dir recursively is a latent Windows flake.
+- A green test total with a red job means the failure was outside the assertion path — read past
+  the totals to the `syscall`. `syscall: 'rmdir'` names the culprit precisely.
+- When probing a **synchronous** fs API, never release the contended resource from an in-process
+  timer: `rmSync` blocks the event loop and the timer cannot fire. Use an external process, or the
+  probe will refute a correct hypothesis.

--- a/docs/changes/comprehend-smoke-ebusy-teardown/plans/2026-09-09-comprehend-smoke-ebusy-teardown-plan.md
+++ b/docs/changes/comprehend-smoke-ebusy-teardown/plans/2026-09-09-comprehend-smoke-ebusy-teardown-plan.md
@@ -1,0 +1,140 @@
+# Plan: make the comprehend-smoke teardown tolerate a locked Windows handle
+
+**Date:** 2026-09-09 · **Trigger:** CI run [`34301348937`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34301348937), job `build-and-test (windows-latest, 22)`, sha `b169ca0dc` · **Issue:** #2089 · **Tasks:** 3 · **Time:** ~30 min · **Integration Tier:** small
+
+Remediation for a Windows-only **teardown** failure in an otherwise fully green leg. The job
+reported `Test Files 1 failed | 733 passed | 5 skipped` with **zero failed tests** — every
+assertion passed and the suite was reded by a failed `rmdir`.
+
+## Goal
+
+Make `packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts`'s `afterAll` wait for the OS
+to release the file handles its spawned children held, instead of failing the instant it finds one
+still open — so a passing suite stops reporting the product as broken.
+
+## Root cause
+
+The `describe` block spawns processes into its temp project at two points, both with `cwd: proj`:
+
+- `beforeAll` (`:51-56`) runs four `spawnSync('git', ...)` calls to scaffold a real repo.
+- `comprehend()` (`:24`) runs `spawnSync(process.execPath, [BIN, 'comprehend', ...])`; the block's
+  assertions invoke it eight times in total.
+
+`spawnSync` returns when the child **exits**, but on Windows the kernel releases that child's open
+file handles asynchronously afterwards. Windows also refuses to unlink a file while a handle to it
+is open. So `afterAll`'s recursive removal can start inside the window where handles under `proj`
+are still live, and `rmdir` fails:
+
+```
+Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\comprehend-smoke-b9n120'
+ ❯ tests/comprehension/comprehend-smoke.e2e.test.ts:60:15
+    59|   afterAll(() => {
+    60|     if (proj) rmSync(proj, { recursive: true, force: true });
+       |               ^
+Serialized Error: { errno: -4082, code: 'EBUSY', syscall: 'rmdir', path: '...' }
+```
+
+The teardown already passed `force: true`, which reads like error tolerance but is not. Node
+documents `force` as "exceptions will be ignored if `path` does not exist" — it suppresses
+`ENOENT` only. Against a _locked_ path it does nothing, so the teardown had **zero** tolerance.
+
+POSIX unlinks a file regardless of open handles, which is why this can only ever fire on the
+Windows leg.
+
+### This is the same fault the repo has already fixed four times
+
+| File                                                                       | Remedy                                                          |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `packages/core/tests/state/gate.test.ts:21`                                | `rmSync(..., { force: true, maxRetries: 10, retryDelay: 100 })` |
+| `packages/cli/tests/commands/validate.roadmap-abstention.test.ts:78`       | same options, `retryDelay: 50`, wrapped best-effort             |
+| `packages/orchestrator/tests/integration/orchestrator-sentinel.test.ts:92` | hand-rolled 3-attempt loop, 500ms backoff                       |
+| `packages/orchestrator/tests/integration/claim-coordination.test.ts:126`   | hand-rolled 3-attempt loop, 500ms backoff                       |
+
+(`packages/core/src/solutions/scan-candidates/*.test.ts` and `rework.test.ts` carry a third
+variant, `maxRetries: 3, retryDelay: 100`.) The remedy is settled in this codebase; it had simply
+never been applied to this file.
+
+## Reproduction
+
+**The Windows fault does not reproduce on macOS, and cannot.** It arises from Windows' refusal to
+unlink files with open handles plus asynchronous handle release on process exit; POSIX has no
+analogue. Per the `windows-ephemeral-port-deflake` precedent, the evidence standard here is:
+
+> the teardown now tolerates a locked handle, and the suite is stable across repeated runs
+
+and explicitly **not** "the Windows fault was reproduced locally".
+
+The _mechanism_ was nevertheless verified experimentally rather than asserted. On macOS,
+`chflags uchg` on a nested file makes `unlink` return `EPERM` — the same Node retry class as the
+Windows `EBUSY` (`EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM`) — giving a deterministic stand-in for
+the lock. With the lock released by an **external** process ~700ms in (modelling the OS releasing
+an exited child's handles):
+
+| Probe | Options                                                         | Result                                   |
+| ----- | --------------------------------------------------------------- | ---------------------------------------- |
+| D'    | `{ recursive, force }` (current code)                           | `THREW EPERM after 2ms` — the CI failure |
+| C'    | `{ recursive, force, maxRetries: 10, retryDelay: 100 }` (fixed) | `RECOVERED after 809ms`, tree removed    |
+
+That pair is the revert protocol in mechanism form: identical lock, fatal without the options,
+survivable with them. The probe was scratch-only and is not in the diff.
+
+## Observable Truths (Acceptance Criteria)
+
+1. The observed teardown tolerates a transiently locked path.
+   **Gate:** line 60 carries `maxRetries` / `retryDelay`; the C'/D' probe pair above shows the
+   options are load-bearing rather than decorative.
+2. No assertion is weakened, skipped, or removed; the test count is unchanged.
+   **Gate:** `Tests 15 passed | 1 skipped (16)` before and after. The 1 skip is the
+   `HARNESS_E2E_LIVE`-gated live block, skipped by design in both.
+3. The suite actually runs rather than silently skipping.
+   **Gate:** the file is `describe.skipIf(!HAS_BIN)` against `dist/bin/harness.js`, so a missing
+   build would report 0 tests and look green. `pnpm turbo build` precedes every run and the
+   non-zero test count is the proof.
+4. The suite is stable across repeated runs.
+   **Gate:** 5 consecutive green runs of the affected file.
+5. The nondeterminism is removed, not hidden.
+   **Gate:** the diff contains no `skipIf(win32)`, no swallowing try/catch, no job-level retry, no
+   `it.skip`, and no change to any assertion.
+
+## Tasks
+
+1. Add `maxRetries: 10` / `retryDelay: 100` to the `rmSync` at `:60`, with a rationale comment
+   mirroring `packages/core/tests/state/gate.test.ts:21`.
+2. Add a patch changeset describing the deflake.
+3. Write the plan and debug-session artifacts (this file and its sibling).
+
+## Assumptions and tradeoffs
+
+- **Recommended-default taken: option values adopted verbatim from `gate.test.ts:21`**
+  (`maxRetries: 10`, `retryDelay: 100`) rather than re-derived, and rather than the `retryDelay: 50`
+  of the `validate.roadmap-abstention.test.ts` variant or the `maxRetries: 3` of the
+  `scan-candidates` variant. `gate.test.ts` is the site the scope decision named as the precedent
+  to mirror, and matching it exactly keeps the eventual shared-helper extraction a pure move.
+- **Recommended-default taken: no `try`/`catch` wrapper.** The sibling precedent at
+  `validate.roadmap-abstention.test.ts:78` wraps its retrying `rmSync` in a swallowing `catch` on
+  the reasoning that leaking a temp dir beats failing a green suite. That is not adopted here: a
+  bare catch would make a _permanent_ lock invisible, and the fleet's Iron Law requires the
+  nondeterminism to be removed rather than hidden. If the retries are ever exhausted, that is a new
+  and different fault and it should be loud.
+- **Assumption:** the Windows handle-retention window fits inside the retry budget. Unverifiable
+  from macOS. All four in-repo precedents rest on the same assumption and none has been observed to
+  exhaust its retries.
+- **Recorded cost:** on a _permanently_ locked tree the call takes ~24s before throwing (measured),
+  because `rmSync(recursive)` applies the retry budget at each level of the tree rather than once.
+  This only applies where the old code fails the suite outright anyway. On POSIX, and on any
+  Windows run where no handle is held, the options cost nothing.
+- **Classified a flake by failure MODE, not by a rerun flip.** The classification rests on the
+  failure being `syscall: 'rmdir'` in `afterAll` with zero failed assertions across two independent
+  occurrences (runs `34301348937` and `34279126634`), not on a same-SHA green.
+
+## Not fixed here, reported instead
+
+- **14 further sites in this same file.** Lines 146, 217, 218, 276, 293, 294, 319, 388, 403, 422,
+  442, 466, 508 and 522 are structurally identical recursive `rmSync` teardowns, each removing a
+  directory a `spawnSync`-ed CLI wrote into. Every one carries the same latent Windows fault; only
+  line 60 has been observed red. They are left untouched because the scope decision for this item
+  named line 60 specifically, and because the precedent decision on the sibling
+  `windows-ephemeral-port-deflake` item (fork F5) chose "fix only the observed sites, route the
+  rest". Surfaced here for routing — they are the natural first customer for the shared helper.
+- **#2089's structural half.** The shared `removeTempDirSafely(dir)` helper and the migration of
+  the four ad-hoc sites are deliberately out of scope for this PR. #2089 stays **open**.

--- a/docs/changes/comprehend-smoke-ebusy-teardown/provenance.json
+++ b/docs/changes/comprehend-smoke-ebusy-teardown/provenance.json
@@ -1,0 +1,45 @@
+{
+  "issues": [2089],
+  "fleet": "cicd-fleet",
+  "item": "A — comprehend-smoke.e2e.test.ts EBUSY teardown flake on windows-latest (CI run 34301348937)",
+  "classification": "flake",
+  "stages": ["investigate", "analyze", "hypothesize", "fix", "verify"],
+  "skill": "harness-debugging",
+  "baseSha": "02a18a5ecef77a733a606e7de67cff745656e9f3",
+  "branch": "fc4/cicd-comprehend-smoke-ebusy-2089",
+  "planArtifact": "docs/changes/comprehend-smoke-ebusy-teardown/plans/2026-09-09-comprehend-smoke-ebusy-teardown-plan.md",
+  "sessionRecord": "docs/changes/comprehend-smoke-ebusy-teardown/debug-session.md",
+  "ciEvidence": {
+    "runId": "34301348937",
+    "job": "build-and-test (windows-latest, 22)",
+    "sha": "b169ca0dc",
+    "failure": "EBUSY: resource busy or locked, rmdir '...comprehend-smoke-b9n120' thrown from afterAll at comprehend-smoke.e2e.test.ts:60",
+    "testFailures": 0,
+    "priorOccurrence": {
+      "runId": "34279126634",
+      "pr": 2085,
+      "note": "same file, same afterAll, same EBUSY rmdir; 8698 assertions passed, 0 failed"
+    }
+  },
+  "assumptions": [
+    "Implemented the human's decided remedy exactly: added maxRetries/retryDelay to the single rmSync at line 60 with a rationale comment, mirroring packages/core/tests/state/gate.test.ts:21. Adopted that precedent's option values verbatim (maxRetries: 10, retryDelay: 100) rather than the retryDelay:50 variant in validate.roadmap-abstention.test.ts or the maxRetries:3 variant in packages/core/src/solutions/scan-candidates/*.test.ts, so a later shared-helper extraction is a pure move.",
+    "RECOMMENDED DEFAULT TAKEN: no try/catch wrapper. The sibling precedent at validate.roadmap-abstention.test.ts:78 wraps its retrying rmSync in a swallowing catch. That was NOT adopted — a bare catch would make a permanent lock invisible, and the fleet's Iron Law requires the nondeterminism to be removed rather than hidden. If the retries are ever exhausted that is a new fault and it must be loud.",
+    "OUT OF SCOPE BY DECISION, honoured: no shared removeTempDirSafely(dir) helper was extracted, and the four ad-hoc sites in other files (packages/core/tests/state/gate.test.ts, packages/cli/tests/commands/validate.roadmap-abstention.test.ts, packages/orchestrator/tests/integration/orchestrator-sentinel.test.ts, packages/orchestrator/tests/integration/claim-coordination.test.ts) were not migrated. Issue #2089 stays OPEN for that structural half; the PR says so explicitly and uses Refs, not Closes.",
+    "SURFACED FINDING, deliberately not acted on: the SAME file carries 14 further structurally identical recursive rmSync teardown sites (lines 146, 217, 218, 276, 293, 294, 319, 388, 403, 422, 442, 466, 508, 522), each removing a directory a spawnSync-ed CLI wrote into, so each is the same latent Windows fault. Only line 60 has been observed red. Left untouched because the scope decision named line 60 specifically and because the precedent decision on the sibling windows-ephemeral-port-deflake item (fork F5) chose 'fix only the observed sites, route the rest'. Reported for routing rather than edited.",
+    "The Windows EBUSY fault is NOT reproducible on macOS: it arises from Windows refusing to unlink a file with an open handle plus asynchronous handle release on child exit; POSIX has no analogue. Per the windows-ephemeral-port-deflake precedent the evidence standard is 'the teardown now tolerates a locked handle and the suite is stable across repeated runs', NOT 'the Windows fault was reproduced'. Windows behaviour is verified by CI on the PR.",
+    "The MECHANISM was verified experimentally rather than asserted, using macOS `chflags uchg` (which makes unlink return EPERM — the same Node retry class as the Windows EBUSY) as a deterministic stand-in for the lock. With the lock released by an EXTERNAL process ~700ms in: force-only THREW EPERM after 2ms (the CI failure); force+maxRetries:10+retryDelay:100 RECOVERED after 809ms with the tree removed. That pair is the revert protocol at the mechanism level. An earlier probe that released the lock from an in-process setTimeout appeared to refute the fix; that was a flaw in the probe — rmSync is synchronous and blocks the event loop so the timer could never fire. Probes were scratch-only and are not in the diff.",
+    "No new regression TEST file was added. The fault is OS-level file-locking behaviour with no POSIX analogue; a test asserting that rmSync honours maxRetries would be testing Node rather than this product and would pass on the CI leg that never fails. Same standard as the windows-ephemeral-port-deflake precedent.",
+    "Recorded cost, not hidden: on a PERMANENTLY locked tree the call takes ~24s before throwing (measured), because rmSync(recursive) applies the retry budget at each level of the tree rather than once. That only applies where the old code fails the suite outright anyway; on POSIX and on unlocked Windows runs the options cost nothing.",
+    "Classified a flake by failure MODE, not by a rerun flip: syscall 'rmdir' thrown from afterAll with zero failed assertions, across two independent occurrences (runs 34301348937 and 34279126634). There is no same-SHA green to point at."
+  ],
+  "verification": {
+    "typecheck": "clean (tsc --noEmit on packages/cli, exit 0)",
+    "affectedFileConsecutiveRuns": 5,
+    "affectedFileResult": "5/5 green — Test Files 1 passed (1), Tests 15 passed | 1 skipped (16)",
+    "suiteActuallyRan": "the file is describe.skipIf(!HAS_BIN) against dist/bin/harness.js, so a missing build would report 0 tests and look green; pnpm turbo build was run first and the non-zero test count is the proof",
+    "skipRationale": "the 1 skip is the HARNESS_E2E_LIVE-gated live block, skipped by design both before and after",
+    "revertProtocol": "mechanism-level: identical transient lock is fatal without the options (THREW EPERM after 2ms) and survivable with them (RECOVERED after 809ms)",
+    "ironLaw": "no skipIf(win32), no swallowing try/catch, no job-level retry, no test skipped/deleted/weakened, no assertion changed"
+  },
+  "closingKeyword": null
+}

--- a/packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts
+++ b/packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts
@@ -57,7 +57,17 @@ describe.skipIf(!HAS_BIN)('harness comprehend — E2E smoke (static, no LLM)', (
   });
 
   afterAll(() => {
-    if (proj) rmSync(proj, { recursive: true, force: true });
+    // Windows: a just-exited `harness comprehend` subprocess (spawned by
+    // comprehend() via spawnSync) — and the `git` child used to scaffold this
+    // repo — can briefly retain handles on files under `proj`, so a plain
+    // recursive rmSync intermittently throws EBUSY / ENOTEMPTY / EPERM and
+    // reds the whole suite from teardown after every assertion has passed.
+    // `force` does NOT cover this: it suppresses "path does not exist", not
+    // "path is locked". `force` + `maxRetries`/`retryDelay` makes Node retry
+    // until the OS releases the handles ("await the settle"), removing the
+    // teardown-race nondeterminism rather than hiding it. A no-op on POSIX,
+    // where handles are released synchronously on exit. See #2089.
+    if (proj) rmSync(proj, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   });
 
   it('compiles a static-only unit with valid provenance + interface contract', () => {


### PR DESCRIPTION
Deflakes `packages/cli/tests/comprehension/comprehend-smoke.e2e.test.ts`, which reded the
`build-and-test (windows-latest, 22)` leg **from its teardown** after every one of its assertions
had already passed.

## CI evidence

| | |
| --- | --- |
| Run | [`34301348937`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34301348937) — job `build-and-test (windows-latest, 22)`, sha `b169ca0dc` |
| Prior occurrence | [`34279126634`](https://github.com/Intense-Visions/harness-engineering/actions/runs/34279126634) (PR #2085) |
| Result | `Test Files 1 failed \| 733 passed \| 5 skipped` — **zero failed tests** |

```
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\comprehend-smoke-b9n120'
 ❯ tests/comprehension/comprehend-smoke.e2e.test.ts:60:15
    59|   afterAll(() => {
    60|     if (proj) rmSync(proj, { recursive: true, force: true });
       |               ^
Serialized Error: { errno: -4082, code: 'EBUSY', syscall: 'rmdir', path: '...' }
```

`syscall: 'rmdir'`. The only thing that failed was deleting a temp directory — the run reported the
product as broken when nothing about the product misbehaved.

## Remediation actions / assumptions made

### Root cause (verified, not assumed)

The `describe` block spawns processes into its temp project at two points, both with `cwd: proj`:
`beforeAll` runs four `spawnSync('git', ...)` calls to scaffold a real repo, and `comprehend()`
runs `spawnSync(process.execPath, [BIN, 'comprehend', ...])` — eight times across the block's
assertions.

`spawnSync` returns when the child **exits**, but Windows releases that child's open file handles
asynchronously afterwards, and refuses to unlink a file while a handle to it is open. So `afterAll`
can begin removing `proj` inside the window where handles under it are still live.

The teardown already passed `force: true`, which reads like error tolerance but is not. Node
documents `force` as ignoring exceptions **if `path` does not exist** — it suppresses `ENOENT` only
and does nothing for a locked path. The teardown therefore had *no* tolerance at all.

### Fix

One line, at `:60`, plus a rationale comment mirroring the in-repo precedent at
`packages/core/tests/state/gate.test.ts:21`:

```ts
if (proj) rmSync(proj, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
```

Node retries on exactly the `EBUSY`/`ENOTEMPTY`/`EPERM` class in play, so the teardown waits for
the OS to release the handles ("await the settle"). The nondeterminism is **removed, not hidden**:
no `skipIf(win32)`, no swallowing `try`/`catch`, no job-level retry, no test skipped or deleted,
and no assertion changed. Test-only diff; no product code and no runtime behaviour is affected.

### Recommended-option defaults taken

- **Option values adopted verbatim from `gate.test.ts:21`** (`maxRetries: 10`, `retryDelay: 100`)
  rather than re-derived, and rather than the `retryDelay: 50` variant in
  `validate.roadmap-abstention.test.ts` or the `maxRetries: 3` variant in
  `packages/core/src/solutions/scan-candidates/*.test.ts`. Matching the named precedent exactly
  keeps a later shared-helper extraction a pure move.
- **No `try`/`catch` wrapper.** The sibling precedent at `validate.roadmap-abstention.test.ts:78`
  wraps its retrying `rmSync` in a swallowing `catch`. Not adopted: a bare catch would make a
  *permanent* lock invisible, and the Iron Law requires the nondeterminism to be removed rather
  than hidden. If the retries are ever exhausted, that is a new fault and it should be loud.
- **No new regression test file.** The fault is OS-level file-locking behaviour with no POSIX
  analogue; a test asserting that `rmSync` honours `maxRetries` would be testing Node, not this
  product, and would pass on the very leg that never fails. Same standard as
  `docs/changes/windows-ephemeral-port-deflake/`.

### Evidence standard — stated honestly

**This is a Windows-only fault and the work was done on macOS, so it was not reproduced locally.**
Per the `windows-ephemeral-port-deflake` precedent the standard is *"the teardown now tolerates a
locked handle, and the suite is stable across repeated runs"* — not *"the Windows fault was
reproduced"*. Windows behaviour is verified by CI on this PR.

The *mechanism* was still verified experimentally rather than asserted. On macOS, `chflags uchg`
makes `unlink` return `EPERM` — the same Node retry class as the Windows `EBUSY` — a deterministic
stand-in for the lock. With the lock released by an **external** process ~700ms in (modelling the
OS releasing an exited child's handles):

| Probe | Options | Result |
| --- | --- | --- |
| D' | `{ recursive, force }` (before) | `THREW EPERM after 2ms` — the CI failure |
| C' | `+ maxRetries: 10, retryDelay: 100` (after) | `RECOVERED after 809ms`, tree removed |

That pair is the revert protocol at the mechanism level: identical lock, fatal without the options,
survivable with them. The probes were scratch-only and are not in the diff.

> An earlier probe released the lock from an in-process `setTimeout` and appeared to *refute* the
> fix. That was a flaw in the probe, not the fix — `rmSync` is synchronous and blocks the event
> loop, so the timer could never fire. Recorded in the session artifact rather than quietly dropped.

**Recorded cost, not hidden:** on a *permanently* locked tree the call takes ~24s before throwing
(measured), because `rmSync(recursive)` applies the retry budget at each level of the tree rather
than once. That only applies where the old code fails the suite outright anyway. On POSIX, and on
any Windows run where no handle is held, the options cost nothing.

**Classified a flake by failure MODE, not by a rerun flip:** `syscall: 'rmdir'` thrown from
`afterAll` with zero failed assertions, across two independent occurrences. There is no same-SHA
green to point at.

### Verification

- Affected file: **5/5 consecutive green** — `Test Files 1 passed (1)`, `Tests 15 passed | 1 skipped (16)`.
  The 1 skip is the `HARNESS_E2E_LIVE`-gated live block, skipped by design before and after.
- The suite **genuinely executes**: the file is `describe.skipIf(!HAS_BIN)` against
  `dist/bin/harness.js`, so a missing build would report 0 tests and look green. `pnpm turbo build`
  preceded every run; the non-zero test count is the proof.
- `tsc --noEmit` on `packages/cli`: exit 0. Whole-tree `format:check`: clean.
- `harness cleanup` (skill Phase 1) found no entropy near the failure site.

## #2089's structural recommendation is deliberately NOT addressed here and remains open

**This PR does not extract the shared `removeTempDirSafely(dir)` helper, and does not migrate the
four ad-hoc sites** (`packages/core/tests/state/gate.test.ts`,
`packages/cli/tests/commands/validate.roadmap-abstention.test.ts`,
`packages/orchestrator/tests/integration/orchestrator-sentinel.test.ts`,
`packages/orchestrator/tests/integration/claim-coordination.test.ts`) onto it. That structural half
of #2089 stays **open** — hence `Refs`, not `Closes`.

### Also surfaced for routing, not fixed here

The **same file** carries **14 further** structurally identical recursive `rmSync` teardown sites —
lines 146, 217, 218, 276, 293, 294, 319, 388, 403, 422, 442, 466, 508, 522 — each removing a
directory a `spawnSync`-ed CLI wrote into, so each is the same latent Windows red on the same
mechanism. Only line 60 has ever been observed failing. They were left untouched because the scope
decision for this item named line 60 specifically, and because the precedent decision on the
sibling `windows-ephemeral-port-deflake` item chose "fix only the observed sites, route the rest".
They are the natural first customer for #2089's shared helper.

## Pipeline artifacts

Produced by the real `harness-debugging` skill (investigate → analyze → hypothesize → fix → verify):

- `docs/changes/comprehend-smoke-ebusy-teardown/plans/2026-09-09-comprehend-smoke-ebusy-teardown-plan.md`
- `docs/changes/comprehend-smoke-ebusy-teardown/debug-session.md`
- `docs/changes/comprehend-smoke-ebusy-teardown/provenance.json`

Refs #2089

https://claude.ai/code/session_019CjYGjGHr1vyduZ4f9uGuf
