### PR TITLE
fix(signals): budget the gh PR fetch as a network call, not a local process

### DIFF
--- a/.changeset/signals-gh-network-timeout.md
+++ b/.changeset/signals-gh-network-timeout.md
@@ -1,0 +1,23 @@
+---
+'@harness-engineering/signals': patch
+---
+
+Stop killing the `gh pr list` fetch at 5 seconds and reporting it as an auth failure.
+
+`defaultCommandRunner` applied one 5s budget to every command. That is a local-process
+budget — ample for `git log`, and far too tight for the paginated
+`gh pr list --limit 500 --json ...,reviews` network query the signal authorities make,
+which measures ~10-14s against a real repository. It was `SIGTERM`-killed every time, and
+because Node's timeout error is `Command failed: <argv>` with an empty stderr tail, both
+providers wrapped it as `gh unavailable or not authenticated` — a cause they never
+verified. `harness holiday-confidence` and the `pr-merged-without-multi-persona-review`
+signal silently degraded to `error` / `0/0` on any repository whose 30-day merged-PR list
+takes over 5s to fetch.
+
+`CommandRunner` now carries an optional `timeoutMs`, because the budget is a property of
+the call rather than of the runner; a mock that ignores it stays assignable. Both `gh` call
+sites pass the new `NETWORK_COMMAND_TIMEOUT_MS` (30s). A budget kill rejects with a message
+that names the timeout, so "too slow" is distinguishable from "broken or unauthenticated",
+and the providers report the underlying failure instead of asserting a cause.
+
+Adds `NETWORK_COMMAND_TIMEOUT_MS` and `DEFAULT_COMMAND_TIMEOUT_MS` to the package exports.

--- a/.harness/comprehension/packages/signals/src/_module.md
+++ b/.harness/comprehension/packages/signals/src/_module.md
@@ -1,39 +1,35 @@
 ---
 schemaVersion: 1
-module: "packages/signals/src"
-sourceHash: "1b711786e5b98bdc27a20231ce95af3b8e3ecbeac9d3fb6987347ebd8a3d0f18"
-compiledAt: "2026-08-28T01:22:12.775Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["command-runner.ts", "gather.ts", "holiday-confidence.ts", "index.ts", "registry.ts", "shared.ts", "timeline-store.ts", "types.ts"]
+module: 'packages/signals/src'
+sourceHash: '12f6ac77af29bdec3cc49b54bfd3ef48e11f0ba3802d0f8f423c4f7c12fb7d8e'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'command-runner.ts',
+    'gather.ts',
+    'holiday-confidence.ts',
+    'index.ts',
+    'registry.ts',
+    'shared.ts',
+    'timeline-store.ts',
+    'types.ts',
+  ]
 ---
-
-## Summary
-
-**`packages/signals/src`** is a metrics-collection system that monitors repository health via five curated signals computed over a rolling 30-day window. Each signal (e.g., PR review coverage, code coverage trend, complexity trend) is a `SignalProvider` that queries live data (git history, graph nodes, `gh` API) and persists daily data points to a time-series cache. The module composes these signals into a "Holiday Confidence" KPI—answering whether the codebase is safe to leave unwatched—by checking if merged PRs cleared all four gates: multi-persona review, post-merge eval success, no baseline auto-updates, and no signal breaches. Providers run concurrently with graceful degradation (one failure yields an `error` card, doesn't sink the others). All providers are injectable (`CommandRunner`, `GraphStore`) so tests can mock git/gh calls and the graph.
-
-## Invariants
-
-- Signal registry is canonical and ordered — signalRegistry array defines the five providers in display order (pr-review, coverage, complexity, baseline, eval). gatherSignals iterates this array with Promise.allSettled and maps results back by index; changing order or count changes the UI layout and composed Holiday Confidence logic.
-- Timeline store is atomic and self-healing — .harness/signals/timeline.json uses temp+rename writes to survive crashes. Corrupt/missing files soft-fail to empty (never throw), so a bad cache never blocks the panel. Each signal's history is capped at 30 points oldest-trimmed.
-- Assessment Marker is a shared constant — ASSESSMENT_MARKER ('## Assessment:') is emitted by core/src/review/output/format-github.ts and consumed by both pr-review signal and Holiday Confidence KPI. If the review pipeline changes its summary format, this single const must be updated or both will drift.
-- Per-PR outcome-eval linkage uses commit shas — Holiday Confidence matches PRs to execution_outcome graph nodes by head ref sha or merge commit sha. The graph connector must map non-SATISFIED verdict to result: 'failure' and store commit metadata under metadata.commit or metadata.headSha, or criterion (b) degrades to pass-with-note.
-- Trend is endpoint-delta, not slope — deriveEndpointTrend compares earliest to latest point in history (< 2 points → 'flat'), NOT a regression/best-fit. Providers needing value-aware delta (coverage, complexity) compute percentage-point/percentage change independently.
-- Provider errors are self-contained — toErrorResult wraps rejections as standalone cards (never re-thrown). Promise.allSettled guarantees all five results are returned; one provider throwing does not propagate.
-- Default window is 30 days, shared — DEFAULT_WINDOW_DAYS is used by every signal and Holiday Confidence KPI. Changing it changes the scope of all metrics; providers may override locally but new consumers should default to this constant.
-- Fetch limits are documented truncation guards — pr-review and Holiday Confidence both fetch up to 500 PRs from gh pr list --limit 500. If window has ≥500 PRs, the tail is silently dropped by gh. When returned count equals the limit, detail is annotated 'may be truncated' rather than reporting false low count.
 
 ## Interface Contract
 
 ```ts
 export ASSESSMENT_MARKER
 export CommandRunner
+export DEFAULT_COMMAND_TIMEOUT_MS
 export DEFAULT_WINDOW_DAYS
 export HolidayConfidenceCriteria
 export HolidayConfidenceInput
 export HolidayConfidenceResult
 export HolidayConfidenceStatus
+export NETWORK_COMMAND_TIMEOUT_MS
 export OutcomeQueryStore
 export SignalContext
 export SignalId
@@ -52,7 +48,7 @@ export signalRegistry
 ## Dependency Slice
 
 ```
-import { CommandRunner, defaultCommandRunner } from './command-runner'
+import { CommandRunner, NETWORK_COMMAND_TIMEOUT_MS, defaultCommandRunner } from './command-runner'
 import { baselineUpdatesProvider } from './providers/baseline-updates'
 import { complexityTrendProvider } from './providers/complexity-trend'
 import { coverageTrendProvider } from './providers/coverage-trend'

--- a/.harness/comprehension/packages/signals/src/providers/_module.md
+++ b/.harness/comprehension/packages/signals/src/providers/_module.md
@@ -1,43 +1,19 @@
 ---
 schemaVersion: 1
-module: "packages/signals/src/providers"
-sourceHash: "0cb9d5d96e8ee74623c1979943ecbdc649177a707038de0586eb50c93222767a"
-compiledAt: "2026-08-28T01:22:12.750Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["baseline-updates.ts", "complexity-trend.ts", "coverage-trend.ts", "eval-fail-rate.ts", "pr-review.ts"]
+module: 'packages/signals/src/providers'
+sourceHash: '58d8b16ded3940c31a3dd7e85199e327ff78b4875721c899512c3d72d5be0fa9'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'baseline-updates.ts',
+    'complexity-trend.ts',
+    'coverage-trend.ts',
+    'eval-fail-rate.ts',
+    'pr-review.ts',
+  ]
 ---
-
-## Summary
-
-The `packages/signals/src/providers` module implements five curated health signals for project monitoring over a rolling 30-day window. Each provider conforms to the `SignalProvider` interface—taking a `SignalContext` and returning a `SignalResult` with a status (ok/warn/alert/pending/error), value, trend, history, and human-readable detail.
-
-**The five providers:**
-
-1. **`prReviewProvider`** — Counts PRs merged without multi-persona review by querying `gh pr list` for merged PRs and checking reviews for the "## Assessment:" marker. Warns at ≥1, alerts at ≥3. Includes truncation guard if fetch hits gh's 500-PR cap.
-
-2. **`coverageTrendProvider`** — Derives line-coverage trend from git history of `coverage-baselines.json`. Shells to `git log --since=30d` then `git show <sha>:coverage-baselines.json` per commit. Aggregates by mean `lines%` across packages per commit, buckets by day (latest same-day commit wins), reports percentage-point delta. Warns at ≤−1pp, alerts at ≤−5pp.
-
-3. **`complexityTrendProvider`** — Reads architecture time-series from `.harness/arch/timeline.json`, extracts complexity metric over 30-day window, reports percentage rise `(latest − earliest) / earliest × 100`. Warns at +5%, alerts at +15%.
-
-4. **`baselineUpdatesProvider`** — Counts CI-driven baseline-refresh commits by shelling to `git log -- '*-baselines.json'` and filtering by BOTH author `github-actions[bot]` AND message prefix `chore: refresh baselines`. Warns at ≥1, alerts at ≥5.
-
-5. **`evalFailRateProvider`** — Post-merge evaluation failure rate from knowledge graph. Queries `execution_outcome` nodes by `metadata.result` ('success'|'failure') and `metadata.timestamp`, computes fail% = failures/(failures+successes)×100. Warns at >5%, alerts at >10%. Returns status `'pending'` if no nodes exist yet.
-
-## Invariants
-
-- Error/pending results never throw — all providers catch exceptions and return degraded `error`/`pending` `SignalResult` structs instead of crashing the panel
-- History is sorted chronologically — all providers sort daily buckets oldest→newest before returning as `SignalPoint[]`
-- Current value always appended to timeline store — every provider calls `ctx.timeline.appendPoint()` after computing to ensure steady-state continuity
-- Backfill is idempotent — providers call `ctx.timeline.backfill()` which is safe to call repeatedly with the same history
-- Date format is `YYYY-MM-DD` (UTC) — all buckets and points use this format via the `toDate()` helper which truncates ISO strings
-- Command runner is injectable — providers use `ctx.runCommand ?? defaultCommandRunner`, allowing test mocks to be passed via `SignalContext`
-- Thresholds are hardcoded per provider — each signal owns its `THRESHOLD` constant with `warn`/`alert` levels; no dynamic configuration
-- Coverage aggregates mean lines% — only metric bucketed for history; `aggregateCoverage()` documents the assumption and is the single point to change if team prefers weighted-by-LOC or `statements`
-- PR review marker is canonical — `ASSESSMENT_MARKER` ('## Assessment:') is imported from `shared.ts` so all consumers stay in sync
-- Truncation guard on PR fetches — when `gh pr list --limit 500` returns exactly 500 rows, result is annotated as lower bound not silently undercounted
-- All five providers registered in `signalRegistry` in canonical display order and executed concurrently via `Promise.allSettled`
 
 ## Interface Contract
 
@@ -52,7 +28,7 @@ export prReviewProvider
 ## Dependency Slice
 
 ```
-import { defaultCommandRunner } from '../command-runner'
+import { NETWORK_COMMAND_TIMEOUT_MS, defaultCommandRunner } from '../command-runner'
 import { ASSESSMENT_MARKER, bucketsToHistory, deriveEndpointTrend, round2, toDate } from '../shared'
 import { CommandRunner, SignalContext, SignalPoint, SignalProvider, SignalResult } from '../types'
 import { GraphNode } from '@harness-engineering/graph'

--- a/.harness/comprehension/packages/signals/tests/_module.md
+++ b/.harness/comprehension/packages/signals/tests/_module.md
@@ -1,26 +1,19 @@
 ---
 schemaVersion: 1
-module: "packages/signals/tests"
-sourceHash: "c7606eba1d53ab26a55afbcbcd69819ed53a0e7b4716f3824278019c28a3204b"
-compiledAt: "2026-08-28T01:22:12.797Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["command-runner.test.ts", "gather.test.ts", "holiday-confidence.test.ts", "shared.test.ts", "timeline-store.test.ts"]
+module: 'packages/signals/tests'
+sourceHash: '1b358f37e29e019208c9730e79027f96794ef95221ea7a24512213667de4691b'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'command-runner.test.ts',
+    'gather.test.ts',
+    'holiday-confidence.test.ts',
+    'shared.test.ts',
+    'timeline-store.test.ts',
+  ]
 ---
-
-## Summary
-
-The `packages/signals/tests` module validates a three-layer signal-collection and confidence-scoring system. The command-execution layer tests subprocess spawning with a 30-second budget to tolerate host load without masking genuine hangs. The signal-gathering layer validates collection of five curated signals from a registry with graceful isolation—a throwing provider surfaces as an error card without crashing siblings. The holiday-confidence layer validates a four-criterion safety gate for deployments: (a) multi-persona review via "## Assessment:" marker, (b) outcome-eval pass linked by commit SHA, (c) no baseline auto-updates, (d) no signal breaches. Confidence = (passing PRs / merged PRs in window) × 100; returns pending when no PRs merge, and degrades gracefully when dependencies unavailable.
-
-## Invariants
-
-- Subprocess timeout fixed at 30s to isolate slow-host noise from genuine hangs during parallel suite runs
-- Provider isolation: gather must catch and wrap individual provider failures as error cards; registry order preserved
-- Four-criterion conjunction for confidence: all gates must hold (not degraded) for any PR to count confident; any window-scope gate failure → 0% confidence
-- Commit SHA linkage: outcome-eval verdict tied to specific commit (headRefOid or mergeCommit.oid); missing graph store marks criterion (b) degraded but passes PRs
-- Window boundary: PRs merged before cutoff excluded; default 30 days from now
-- Review body pattern: multi-persona detection keyed on substring '## Assessment: Approve'; plain 'lgtm' rejects
 
 ## Interface Contract
 
@@ -31,7 +24,7 @@ The `packages/signals/tests` module validates a three-layer signal-collection an
 ## Dependency Slice
 
 ```
-import { CommandRunner, defaultCommandRunner } from '../src/command-runner'
+import { CommandRunner, DEFAULT_COMMAND_TIMEOUT_MS, NETWORK_COMMAND_TIMEOUT_MS, defaultCommandRunner } from '../src/command-runner'
 import from '../src/gather'
 import { OutcomeQueryStore, computeHolidayConfidence } from '../src/holiday-confidence'
 import { bucketsToHistory, deriveEndpointTrend, round2, toDate } from '../src/shared'

--- a/.harness/comprehension/packages/signals/tests/providers/_module.md
+++ b/.harness/comprehension/packages/signals/tests/providers/_module.md
@@ -1,30 +1,19 @@
 ---
 schemaVersion: 1
-module: "packages/signals/tests/providers"
-sourceHash: "46bb52ce9d6fa6d5317269153b957c27f2aaa94919a50ccdde269edd9aa48751"
-compiledAt: "2026-08-28T01:22:12.801Z"
-compiler: { static: "1.0.0", semantic: "1.0.0" }
-model: "claude-haiku-4-5-20251001"
-semantic: present
-members: ["baseline-updates.test.ts", "complexity-trend.test.ts", "coverage-trend.test.ts", "eval-fail-rate.test.ts", "pr-review.test.ts"]
+module: 'packages/signals/tests/providers'
+sourceHash: '6444457d577ce9f9cfadf1e05920cf78a12f24ae5d68db1259b7de9093a1d0f0'
+compiler: { static: '1.0.0', semantic: '1.0.0' }
+model: null
+semantic: absent
+members:
+  [
+    'baseline-updates.test.ts',
+    'complexity-trend.test.ts',
+    'coverage-trend.test.ts',
+    'eval-fail-rate.test.ts',
+    'pr-review.test.ts',
+  ]
 ---
-
-## Summary
-
-This test module validates a provider ecosystem that computes health signals about a codebase. Each provider observes a health dimension (baseline churn, complexity drift, coverage trends, eval failures, PR review load) and returns a standardized Signal record: current value, historical trend, and thresholds that trigger warn/alert states. baselineUpdatesProvider counts auto-refresh-baseline commits from github-actions[bot] in the past 30 days (thresholds: warn 1, alert 5); complexityTrendProvider reads architecture complexity snapshots from `.harness/arch/timeline.json` and detects percentage rises over 30 days (warn ≥5%, alert ≥15%). The module demonstrates strict data filtering, graceful degradation when dependencies fail, and a consistent signal contract across providers.
-
-## Invariants
-
-- Each provider exports a constant with id, label, and compute(ctx: SignalContext): Promise<Signal>
-- Git log parsing must handle newline-separated records with field separators (US = '\x1f'); field boundaries must not bleed across record lines
-- All trend providers use 30-day lookback from now; snapshots outside that window are excluded from trend calculation
-- History must bucket data daily across the full 30-day window; gaps are backfilled even if events are sparse
-- Latest value is always mirrored to the timeline store keyed by the current date, enabling cross-signal aggregation
-- When a dependency fails (git unavailable, file missing, command error), return status='error' with value=null and history=[] instead of throwing
-- Threshold comparison logic is semantic, not arithmetic—usually a percentage change or delta against a baseline, not a raw value comparison
-- History points appear in chronological order (earliest to latest)
-- Single snapshot in the window yields trend='flat' and status='ok'; trend detection requires ≥2 points
-- Providers that read from a file include source field (e.g., 'arch/timeline.json') in the Signal for auditability
 
 ## Interface Contract
 
@@ -35,6 +24,7 @@ This test module validates a provider ecosystem that computes health signals abo
 ## Dependency Slice
 
 ```
+import { DEFAULT_COMMAND_TIMEOUT_MS, NETWORK_COMMAND_TIMEOUT_MS } from '../../src/command-runner'
 import { baselineUpdatesProvider } from '../../src/providers/baseline-updates'
 import { complexityTrendProvider } from '../../src/providers/complexity-trend'
 import { coverageTrendProvider } from '../../src/providers/coverage-trend'

--- a/.harness/learnings.md
+++ b/.harness/learnings.md
@@ -66,3 +66,17 @@ When implementing directory traversal for code scanning/ingestion, ensure defaul
 - When a generated CI workflow runs `harness ci check`, it MUST first install the CLI (`npm install -g @harness-engineering/cli`). GitHub-hosted ubuntu runners ship Node+npm for any project language, so a global install works universally; omitting it fails the gate with exit 127 (command-not-found), not a real check failure.
 - In generated TS GitHub workflows, `pnpm/action-setup` must precede `actions/setup-node` — `setup-node`'s `cache: 'pnpm'` needs pnpm already on PATH. Mirror the dogfood `.github/workflows/ci.yml` ordering when disseminating it.
 - Single-generator rule (ADR 0037): both `harness init` (scaffold-time) and `harness ci init` (on-demand) route through one `generateCIConfig`; never add a second `templates/ci/` YAML source — it drifts.
+
+## Subprocess budgets: local vs network (2026-09-10, #2136)
+
+A single `execFile` timeout constant shared by local (`git log`) and network (`gh`) commands
+is a latent bug class. `packages/signals` applied a 5s local-process budget to a paginated
+`gh pr list --limit 500 --json ...,reviews` call that really takes ~10-14s, killing it every
+time. The budget belongs to the CALL SITE — if the injectable runner type cannot carry it,
+the "callers may pass a wider value" escape hatch is decorative.
+
+Diagnostic tell: Node's `execFile` timeout error message is `Command failed: <argv>\n<stderr>`
+with an **empty** stderr tail. An empty tail means SIGTERM-kill (timeout); a real non-zero exit
+carries stderr. Check the tail before believing a wrapper's asserted cause — here the wrapper
+said `gh unavailable or not authenticated: ${anyError}`, a cause it never verified, and that
+misdirection was the most expensive part of the investigation.

--- a/packages/signals/src/command-runner.ts
+++ b/packages/signals/src/command-runner.ts
@@ -2,27 +2,52 @@ import { execFile } from 'node:child_process';
 
 /**
  * Injectable runner for shelling out to git/gh. Returns trimmed stdout; rejects
- * on non-zero exit or spawn error. Mirrors the execFile pattern in
- * `server/identity.ts`. Providers depend on this type so tests can pass a mock
- * runner instead of touching the real git/gh binaries or the network.
+ * on non-zero exit, spawn error, or budget exhaustion. Mirrors the execFile
+ * pattern in `server/identity.ts`. Providers depend on this type so tests can
+ * pass a mock runner instead of touching the real git/gh binaries or the network.
+ *
+ * `timeoutMs` is part of the type — not just of the default implementation —
+ * because the budget is a property of the CALL, not of the runner: a local
+ * `git log` and a paginated `gh pr list` over the network do not belong on the
+ * same clock, and a consumer typed as `CommandRunner` must be able to say which
+ * one it is making. A mock that ignores the argument stays assignable.
  */
-export type CommandRunner = (cmd: string, args: string[]) => Promise<string>;
+export type CommandRunner = (cmd: string, args: string[], timeoutMs?: number) => Promise<string>;
 
 /** Default per-command timeout (ms) for {@link defaultCommandRunner}. */
 export const DEFAULT_COMMAND_TIMEOUT_MS = 5_000;
 
 /**
+ * Budget (ms) for a command that makes a network round-trip — in practice `gh`.
+ *
+ * {@link DEFAULT_COMMAND_TIMEOUT_MS} is a LOCAL-process budget: ample for a
+ * `git log`, and far too tight for `gh pr list --limit 500 --json ...,reviews`,
+ * which pages the GitHub API and measured ~10-14s against a real repository.
+ * Under the 5s budget that call was SIGTERM-killed every time, and the kill
+ * surfaced as Node's bare `Command failed: <argv>` with an empty stderr tail —
+ * which the signal providers then reported as "gh unavailable or not
+ * authenticated", sending the reader after an auth problem that did not exist.
+ *
+ * 30s leaves headroom for a slow link or a busy API without tolerating a genuine
+ * hang, which still hits the ceiling.
+ */
+export const NETWORK_COMMAND_TIMEOUT_MS = 30_000;
+
+/**
  * Default `execFile`-based runner.
  *
  * `timeoutMs` defaults to {@link DEFAULT_COMMAND_TIMEOUT_MS} (5s) — the budget
- * real git/gh calls run under in production. It is an optional escape hatch so a
- * caller on a heavily-loaded host (e.g. a full-suite parallel test run where many
- * workers each spawn a fresh subprocess) can widen it: under saturation even a
- * bare `node -e` launch can exceed 5s, so the fixed budget would kill an
- * otherwise-healthy child and surface a spurious failure. A larger budget only
- * tolerates a slow/loaded host — a genuine hang still hits the ceiling — so it
- * cannot mask a real defect. Direct callers may pass a wider value; callers that
- * consume the `CommandRunner` type keep the 5s default.
+ * local git calls run under in production. Callers making a network call should
+ * pass {@link NETWORK_COMMAND_TIMEOUT_MS}; a caller on a heavily-loaded host
+ * (e.g. a full-suite parallel test run where many workers each spawn a fresh
+ * subprocess) can widen it further, since under saturation even a bare `node -e`
+ * launch can exceed 5s and the fixed budget would kill an otherwise-healthy
+ * child. A larger budget only tolerates a slow/loaded host — a genuine hang
+ * still hits the ceiling — so it cannot mask a real defect.
+ *
+ * A budget kill rejects with a message that names the timeout, so callers can
+ * tell "too slow" from "broken or unauthenticated" instead of collapsing both
+ * into one misleading diagnosis.
  */
 export const defaultCommandRunner: CommandRunner = (
   cmd,
@@ -32,6 +57,11 @@ export const defaultCommandRunner: CommandRunner = (
   new Promise<string>((resolve, reject) => {
     execFile(cmd, args, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
       if (err) {
+        const e = err as NodeJS.ErrnoException & { killed?: boolean };
+        if (e.killed === true || e.code === 'ETIMEDOUT') {
+          reject(new Error(`Command \`${cmd} ${args.join(' ')}\` timed out after ${timeoutMs}ms`));
+          return;
+        }
         reject(err as Error);
         return;
       }

--- a/packages/signals/src/holiday-confidence.ts
+++ b/packages/signals/src/holiday-confidence.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { defaultCommandRunner } from './command-runner';
+import { NETWORK_COMMAND_TIMEOUT_MS, defaultCommandRunner } from './command-runner';
 import { ASSESSMENT_MARKER, DEFAULT_WINDOW_DAYS, round2 } from './shared';
 import type { CommandRunner, SignalResult } from './types';
 
@@ -148,21 +148,29 @@ async function fetchMergedPrs(
 ): Promise<{ ok: true; prs: PrRow[] } | { ok: false; detail: string }> {
   let stdout: string;
   try {
-    stdout = await runCommand('gh', [
-      'pr',
-      'list',
-      '--state',
-      'merged',
-      '--limit',
-      String(FETCH_LIMIT),
-      '--search',
-      `merged:>=${cutoffDate}`,
-      '--json',
-      'number,mergedAt,reviews,headRefOid,mergeCommit',
-    ]);
+    stdout = await runCommand(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--state',
+        'merged',
+        '--limit',
+        String(FETCH_LIMIT),
+        '--search',
+        `merged:>=${cutoffDate}`,
+        '--json',
+        'number,mergedAt,reviews,headRefOid,mergeCommit',
+      ],
+      // A paginated network query, not a local process — see NETWORK_COMMAND_TIMEOUT_MS.
+      NETWORK_COMMAND_TIMEOUT_MS
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, detail: `gh unavailable or not authenticated: ${message}` };
+    // Report the underlying failure rather than asserting a cause: gh can be
+    // missing, unauthenticated, rate-limited, or merely slow, and only the
+    // message distinguishes them.
+    return { ok: false, detail: `gh pr list failed: ${message}` };
   }
   let raw: unknown;
   try {

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -3,7 +3,11 @@ export { gatherSignals } from './gather.js';
 export type { SignalsResult } from './gather.js';
 export { signalRegistry } from './registry.js';
 export { SignalTimelineStore } from './timeline-store.js';
-export { defaultCommandRunner } from './command-runner.js';
+export {
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  NETWORK_COMMAND_TIMEOUT_MS,
+  defaultCommandRunner,
+} from './command-runner.js';
 export type { CommandRunner } from './command-runner.js';
 export { computeHolidayConfidence } from './holiday-confidence.js';
 export type {

--- a/packages/signals/src/providers/pr-review.ts
+++ b/packages/signals/src/providers/pr-review.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { defaultCommandRunner } from '../command-runner';
+import { NETWORK_COMMAND_TIMEOUT_MS, defaultCommandRunner } from '../command-runner';
 import { ASSESSMENT_MARKER, bucketsToHistory, deriveEndpointTrend, toDate } from '../shared';
 import type {
   CommandRunner,
@@ -59,21 +59,29 @@ type FetchOutcome = { ok: true; prs: PrList } | { ok: false; result: SignalResul
 async function fetchPrList(cutoffDate: string, runCommand: CommandRunner): Promise<FetchOutcome> {
   let stdout: string;
   try {
-    stdout = await runCommand('gh', [
-      'pr',
-      'list',
-      '--state',
-      'merged',
-      '--limit',
-      String(FETCH_LIMIT),
-      '--search',
-      `merged:>=${cutoffDate}`,
-      '--json',
-      'number,mergedAt,reviews',
-    ]);
+    stdout = await runCommand(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--state',
+        'merged',
+        '--limit',
+        String(FETCH_LIMIT),
+        '--search',
+        `merged:>=${cutoffDate}`,
+        '--json',
+        'number,mergedAt,reviews',
+      ],
+      // A paginated network query, not a local process — see NETWORK_COMMAND_TIMEOUT_MS.
+      NETWORK_COMMAND_TIMEOUT_MS
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { ok: false, result: errorResult(`gh unavailable or not authenticated: ${message}`) };
+    // Report the underlying failure rather than asserting a cause: gh can be
+    // missing, unauthenticated, rate-limited, or merely slow, and only the
+    // message distinguishes them.
+    return { ok: false, result: errorResult(`gh pr list failed: ${message}`) };
   }
 
   let raw: unknown;
@@ -189,7 +197,7 @@ export const prReviewProvider: SignalProvider = {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return errorResult(`gh unavailable or not authenticated: ${message}`);
+      return errorResult(`pr-review signal failed: ${message}`);
     }
   },
 };

--- a/packages/signals/tests/command-runner.test.ts
+++ b/packages/signals/tests/command-runner.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { defaultCommandRunner, type CommandRunner } from '../src/command-runner';
+import {
+  DEFAULT_COMMAND_TIMEOUT_MS,
+  NETWORK_COMMAND_TIMEOUT_MS,
+  defaultCommandRunner,
+  type CommandRunner,
+} from '../src/command-runner';
 
 // Widen the per-subprocess budget well past the 5s production default. These
 // tests spawn a real `node -e` child; under a full-suite parallel run (many
@@ -23,6 +28,24 @@ describe('defaultCommandRunner', () => {
       defaultCommandRunner('node', ['-e', 'process.exit(3)'], SUBPROCESS_BUDGET_MS)
     ).rejects.toBeInstanceOf(Error);
   });
+  it('rejects with a message that names the timeout when the child outlives its budget', async () => {
+    // Regression: a killed-on-timeout child surfaced Node's bare
+    // `Command failed: <argv>` message with an empty stderr tail, which callers
+    // then misreported as "gh unavailable or not authenticated". The rejection
+    // must say the budget was exceeded so a slow network call is not mistaken
+    // for a broken/unauthenticated binary.
+    await expect(
+      defaultCommandRunner('node', ['-e', 'setTimeout(() => {}, 30000)'], 250)
+    ).rejects.toThrow(/timed out after 250ms/);
+  });
+
+  it('budgets network commands well above the local-process default', () => {
+    // `gh pr list --limit 500 --json ...,reviews` is a paginated network query
+    // that measured ~10-14s against a real repo; the 5s local budget killed it.
+    expect(NETWORK_COMMAND_TIMEOUT_MS).toBeGreaterThan(DEFAULT_COMMAND_TIMEOUT_MS);
+    expect(NETWORK_COMMAND_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+  });
+
   it('satisfies the CommandRunner type', () => {
     const r: CommandRunner = defaultCommandRunner;
     expect(typeof r).toBe('function');

--- a/packages/signals/tests/holiday-confidence.test.ts
+++ b/packages/signals/tests/holiday-confidence.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeHolidayConfidence } from '../src/holiday-confidence';
 import type { OutcomeQueryStore } from '../src/holiday-confidence';
+import { DEFAULT_COMMAND_TIMEOUT_MS, NETWORK_COMMAND_TIMEOUT_MS } from '../src/command-runner';
 import type { CommandRunner, SignalId, SignalResult, SignalStatus } from '../src/types';
 
 const NOW = new Date('2026-06-22T00:00:00.000Z');
@@ -56,6 +57,42 @@ function graphWith(failedShas: string[]): OutcomeQueryStore {
 }
 
 describe('computeHolidayConfidence', () => {
+  it('gives the gh PR fetch a network-sized timeout budget', async () => {
+    // Regression: the fetch ran on the 5s local-process default, which SIGTERM-killed
+    // a ~10-14s paginated `gh pr list --limit 500 --json ...,reviews` network call and
+    // surfaced it as "gh unavailable or not authenticated".
+    let budget: number | undefined;
+    const runner: CommandRunner = async (_cmd, _args, timeoutMs) => {
+      budget = timeoutMs;
+      return '[]';
+    };
+    await computeHolidayConfidence({
+      projectPath: '/x',
+      now: NOW,
+      runCommand: runner,
+      graphStore: graphWith([]),
+      signals: healthySignals(),
+    });
+    expect(budget).toBe(NETWORK_COMMAND_TIMEOUT_MS);
+    expect(budget).toBeGreaterThan(DEFAULT_COMMAND_TIMEOUT_MS);
+  });
+
+  it('does not blame authentication when the fetch merely timed out', async () => {
+    const runner: CommandRunner = async () => {
+      throw new Error('Command `gh pr list` timed out after 30000ms');
+    };
+    const r = await computeHolidayConfidence({
+      projectPath: '/x',
+      now: NOW,
+      runCommand: runner,
+      graphStore: graphWith([]),
+      signals: healthySignals(),
+    });
+    expect(r.status).toBe('error');
+    expect(r.detail).not.toMatch(/not authenticated/);
+    expect(r.detail).toMatch(/timed out after 30000ms/);
+  });
+
   it('reports 100% when every merged PR cleared all four gates', async () => {
     const r = await computeHolidayConfidence({
       projectPath: '/x',

--- a/packages/signals/tests/providers/pr-review.test.ts
+++ b/packages/signals/tests/providers/pr-review.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { prReviewProvider } from '../../src/providers/pr-review';
 import { SignalTimelineStore } from '../../src/timeline-store';
+import { DEFAULT_COMMAND_TIMEOUT_MS, NETWORK_COMMAND_TIMEOUT_MS } from '../../src/command-runner';
 import type { SignalContext, CommandRunner } from '../../src/types';
 
 function tmpDir() {
@@ -27,6 +28,31 @@ describe('prReviewProvider', () => {
   });
   afterEach(() => {
     fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('gives the gh PR fetch a network-sized timeout budget', async () => {
+    // Regression: the fetch ran on the 5s local-process default, which SIGTERM-killed
+    // a ~10-14s paginated `gh pr list --limit 500 --json ...,reviews` network call.
+    let budget: number | undefined;
+    const runner: CommandRunner = async (_cmd, _args, timeoutMs) => {
+      budget = timeoutMs;
+      return ghPayload([]);
+    };
+    await prReviewProvider.compute(ctx(root, new Date('2026-06-22T00:00:00.000Z'), runner));
+    expect(budget).toBe(NETWORK_COMMAND_TIMEOUT_MS);
+    expect(budget).toBeGreaterThan(DEFAULT_COMMAND_TIMEOUT_MS);
+  });
+
+  it('does not blame authentication when the fetch merely timed out', async () => {
+    const runner: CommandRunner = async () => {
+      throw new Error('Command `gh pr list` timed out after 30000ms');
+    };
+    const r = await prReviewProvider.compute(
+      ctx(root, new Date('2026-06-22T00:00:00.000Z'), runner)
+    );
+    expect(r.status).toBe('error');
+    expect(r.detail).not.toMatch(/not authenticated/);
+    expect(r.detail).toMatch(/timed out after 30000ms/);
   });
 
   it('exposes the correct static contract', () => {


### PR DESCRIPTION
## The error message was lying

`harness holiday-confidence` reports `n/a (ERROR)` with `0/0 merged PRs` and blames authentication:

```
i Holiday Confidence: n/a (ERROR)
i Window: last 30 days · 0/0 merged PRs confident
gh unavailable or not authenticated: Command failed: gh pr list --state merged --limit 500 --search merged:>=2026-08-11 --json number,mergedAt,reviews,headRefOid,mergeCommit
```

`gh` is installed and authenticated. The call was **killed at 5 seconds**.

## Root cause

`defaultCommandRunner` applied `DEFAULT_COMMAND_TIMEOUT_MS = 5_000` to *every* command. That is a LOCAL-process budget — ample for `git log`, and far too tight for the two `gh` call sites, which make a paginated network query with `reviews` inlined:

- `packages/signals/src/holiday-confidence.ts:151`
- `packages/signals/src/providers/pr-review.ts:62`

Measured against a real repository, that query takes **~10-14s**. It was `SIGTERM`-killed every time.

Two compounding defects:

1. **The budget.** Reproduced 3/3 at 5000ms (`killed:true, signal:"SIGTERM"`, message byte-identical to the report); succeeded in 9955ms at 60000ms with 130,749 bytes of JSON.
2. **The diagnosis.** Node's timeout error is `Command failed: <argv>\n<stderr>` with an **empty** stderr tail. Both providers wrapped *any* runner rejection as `gh unavailable or not authenticated: ${message}` — a cause neither verified — so a slow call was reported as an auth failure that did not exist.

Why it survived: the `timeoutMs` escape hatch added by #1143 was unreachable. The exported `CommandRunner` type is 2-arg, so no production consumer could widen the budget. #1143 covered *tests* only; the network call sites were never reached.

For contrast, every other `gh` call site in the repo runs with a larger or unbounded budget — `packages/orchestrator/src/core/pr-detector.ts:78` allows `timeout: 10_000` for a one-field `--json number --jq length` query.

## Blast radius

Both signal authorities that read GitHub — the `pr-merged-without-multi-persona-review` provider, and `computeHolidayConfidence`, which reads that same authority. On any repository whose 30-day merged-PR list takes over 5s to fetch, both silently degraded to `error` / `0/0` and blamed gh auth. That includes this repo (451 merged PRs in the window).

## Changes

- Widen `CommandRunner` to `(cmd, args, timeoutMs?)`. The budget is a property of the **call**, not of the runner; a mock that ignores the argument stays assignable, so there is no test churn.
- Add `NETWORK_COMMAND_TIMEOUT_MS` (30s) and pass it at **both** `gh` call sites — they share one defect, so both are fixed.
- Reject a budget kill with `` Command `<argv>` timed out after <n>ms `` instead of Node's bare message, so "too slow" is distinguishable from "broken or unauthenticated".
- Stop asserting a cause in the provider detail: report the underlying failure (`gh pr list failed: …`).
- Export both budgets from the package index.

## Tests

Six regression tests, **each failing before the fix and passing after**:

| File | Guards |
|---|---|
| `tests/command-runner.test.ts` | the rejection names the timeout; the network budget exceeds the local default |
| `tests/holiday-confidence.test.ts` | the fetch is given the network budget; a timeout is not blamed on authentication |
| `tests/providers/pr-review.test.ts` | the same two, for the provider |

## Verification

- Signals package **92/92**, CLI holiday-confidence **14/14**, `tsc --noEmit` clean, prettier clean.
- End-to-end on the rebuilt CLI: `harness holiday-confidence` now returns real numbers (**451 merged PRs** in window) instead of `n/a (ERROR)`.
- `harness validate` (450 design-drift) and `check-deps` (1 circular dep) fail on **pre-existing, out-of-diff** issues: 0 validate hits in `packages/signals`; the circular dep is in `packages/core`.

Note the red herring in the original report: pasting the argv into zsh by hand fails with `zsh: 2026-08-11 not found` because unquoted `>=` is shell redirection. The harness uses `execFile` with no shell, so `>=` was never involved.

Refs #2136

https://claude.ai/code/session_019CjYGjGHr1vyduZ4f9uGuf