### PR TITLE
fix(cli): dashboard dies on Windows — `start` is a shell builtin, and --no-open cannot suppress it

### DIFF
--- a/.changeset/dashboard-windows-browser-open.md
+++ b/.changeset/dashboard-windows-browser-open.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix `harness dashboard` dying on Windows, and make `--no-open` actually work.
+
+Two defects compounded so that the dashboard could never start on Windows. The API
+server came up correctly and was then killed by the browser-launch step:
+
+```
+Dashboard API starting on http://localhost:3701
+Error: spawn start ENOENT
+    syscall: 'spawn start', path: 'start', spawnargs: [ 'http://localhost:3701' ]
+```
+
+`--no-open` was inert (#1956): Commander stores a `--no-x` flag under its positive
+key, so `opts.open` is `false` when the flag is passed and `noOpen` is never created.
+`runDashboard` read `opts.noOpen !== true`, which is always true. `DashboardOptions`
+is renamed to `open` rather than only flipping the comparison, following the
+`test-craft.ts` idiom from #1954 — declaring the field the other way round is what let
+the unreachable read typecheck.
+
+And `start` is a cmd.exe builtin, not an executable, so `spawn('start', …)` without
+`shell` can only raise ENOENT. With no `'error'` listener that became an unhandled
+`'error'` event, which is fatal. `openBrowser` now spawns through a shell on win32 and
+attaches a handler, so a failed browser launch can never take down the server.
+
+macOS and Linux never saw this: `open` and `xdg-open` are real executables, so the
+browser nobody asked for opened silently and nothing crashed.

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -17,14 +17,37 @@ interface DashboardOptions {
   port?: string;
   apiPort?: string;
   orchestratorUrl?: string;
-  noOpen?: boolean;
+  /**
+   * Commander stores a `--no-x` flag under its POSITIVE camelCase key: `open`
+   * is `false` when the flag is passed and `true` when it is not, and a
+   * `noOpen` key is never created. Declaring the field the other way round is
+   * what let the unreachable `opts.noOpen` read typecheck cleanly — so the
+   * name here is part of the fix, not cosmetic. Same idiom as `test-craft.ts`
+   * (#1882 / PR #1954), `install.ts`, `mcp.ts` and `adoption.ts`.
+   */
+  open?: boolean;
   cwd?: string;
 }
 
 function openBrowser(url: string): void {
   const cmd =
     process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-  spawn(cmd, [url], { detached: true, stdio: 'ignore' }).unref();
+  // `start` is a cmd.exe BUILTIN, not an executable -- there is no start.exe on
+  // any Windows install -- so spawning it without a shell can only ever raise
+  // ENOENT. A .cmd shim on PATH does not help either; `spawn` will not execute
+  // one without `shell`.
+  const child = spawn(cmd, [url], {
+    detached: true,
+    stdio: 'ignore',
+    shell: process.platform === 'win32',
+  });
+  // FAILING TO OPEN A BROWSER MUST NEVER TAKE DOWN THE SERVER. Without a
+  // listener, `spawn`'s asynchronous ENOENT is an unhandled 'error' event,
+  // which is fatal -- so on Windows the dashboard printed its ready banner and
+  // then died of a convenience feature. Losing the browser launch is a
+  // nuisance; losing the process the user asked for is the bug.
+  child.on('error', () => {});
+  child.unref();
 }
 
 /** Returns the built server entry or the dev TypeScript source, whichever exists first. */
@@ -118,7 +141,8 @@ function runDashboard(opts: DashboardOptions): void {
   console.log(`Dashboard API starting on http://localhost:${apiPort}`);
   console.log(`Open ${url} (pass --no-open to suppress)`);
 
-  if (opts.noOpen !== true) {
+  // `--no-open` arrives as `open: false`; its absence as `open: true`.
+  if (opts.open !== false) {
     setTimeout(() => openBrowser(url), 1_500);
   }
 }

--- a/packages/cli/tests/commands/dashboard.test.ts
+++ b/packages/cli/tests/commands/dashboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Command } from 'commander';
 
 const mockSpawn = vi.fn();
@@ -146,7 +146,13 @@ describe('dashboard action', () => {
     expect(vi.mocked(mockedSetTimeout)).toHaveBeenCalledWith(expect.any(Function), 1_500);
   });
 
-  it('passes --no-open through to the action', async () => {
+  // THIS TEST PASSED THROUGHOUT THE BUG IT IS NAMED FOR. It asserted
+  // `expect(mockSpawn).toHaveBeenCalled()` -- true because the SERVER was
+  // spawned -- and said so: "The action runs through regardless. We just
+  // verify it doesn't crash." Its own comment stated the Commander semantics
+  // the source got wrong, and then it declined to check them. A test named
+  // after a flag must assert what the flag DOES.
+  it('does not schedule a browser open when --no-open is passed', async () => {
     let callCount = 0;
     mockedExistsSync.mockImplementation(() => {
       callCount++;
@@ -156,9 +162,75 @@ describe('dashboard action', () => {
     const program = createProgram();
     await program.parseAsync(['node', 'test', 'dashboard', '--no-open']);
 
-    // Commander maps --no-open to opts.open = false.
-    // The action runs through regardless. We just verify it doesn't crash.
+    // Commander maps --no-open to opts.open === false.
+    expect(vi.mocked(mockedSetTimeout)).not.toHaveBeenCalled();
+    // ...and the server still starts. Suppressing the browser is not
+    // suppressing the dashboard.
     expect(mockSpawn).toHaveBeenCalled();
+  });
+
+  describe('openBrowser', () => {
+    const realPlatform = process.platform;
+
+    function setPlatform(value: string): void {
+      Object.defineProperty(process, 'platform', { value, configurable: true });
+    }
+
+    afterEach(() => {
+      setPlatform(realPlatform);
+    });
+
+    async function runAndFireBrowserOpen(): Promise<void> {
+      let callCount = 0;
+      mockedExistsSync.mockImplementation(() => {
+        callCount++;
+        return callCount === 1;
+      });
+      vi.mocked(mockedSetTimeout).mockImplementation(((cb: () => void) => {
+        cb();
+        return 0 as unknown as NodeJS.Timeout;
+      }) as unknown as typeof mockedSetTimeout);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'dashboard']);
+    }
+
+    // `start` is a cmd.exe BUILTIN. There is no start.exe on any Windows
+    // install, so without `shell` this call can only raise ENOENT -- and it
+    // did, on every Windows run of `harness dashboard`.
+    it('spawns the Windows opener through a shell', async () => {
+      setPlatform('win32');
+      await runAndFireBrowserOpen();
+
+      const browserCall = mockSpawn.mock.calls.find((call) => call[0] === 'start');
+      expect(browserCall).toBeDefined();
+      expect(browserCall?.[2]).toMatchObject({ shell: true });
+    });
+
+    it('does not use a shell on darwin, where the opener is a real binary', async () => {
+      setPlatform('darwin');
+      await runAndFireBrowserOpen();
+
+      const browserCall = mockSpawn.mock.calls.find((call) => call[0] === 'open');
+      expect(browserCall).toBeDefined();
+      expect(browserCall?.[2]).toMatchObject({ shell: false });
+    });
+
+    // The regression that actually cost a user their dashboard: `spawn`
+    // reports ENOENT asynchronously, and an 'error' event with no listener is
+    // FATAL. The banner printed, then the process died.
+    it('survives an opener that cannot be spawned', async () => {
+      setPlatform('win32');
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      await runAndFireBrowserOpen();
+
+      expect(child.on).toHaveBeenCalledWith('error', expect.any(Function));
+      const onError = child._handlers.error;
+      expect(onError).toBeDefined();
+      expect(() => onError?.(new Error('spawn start ENOENT'))).not.toThrow();
+    });
   });
 
   it('passes custom ports to environment', async () => {


### PR DESCRIPTION
## Summary

`harness dashboard` has never worked on Windows. Two defects compound: the documented escape hatch does not work, and the thing it would have escaped is fatal.

```
Dashboard API starting on http://localhost:3701
Open http://localhost:3701 (pass --no-open to suppress)
Serving dashboard client from ...\@harness-engineering\dashboard\dist\client
Error: spawn start ENOENT
    errno: -4058, syscall: 'spawn start', path: 'start',
    spawnargs: [ 'http://localhost:3701' ]
```

The server starts correctly and is then killed by a convenience feature.

**1. `--no-open` is inert (#1956).** Commander stores a `--no-x` flag under its *positive* key — `open: false` when passed, `open: true` otherwise — and never creates `noOpen`. `runDashboard` read `opts.noOpen !== true`, i.e. `undefined !== true`, always true. Per #1956 and the `test-craft.ts` precedent (#1882 / PR #1954), the `DashboardOptions` field is renamed rather than just the comparison flipped: declaring `noOpen?: boolean` is what let the unreachable read typecheck cleanly, so the name is part of the defect.

**2. `start` is a cmd.exe builtin, not an executable.** There is no `start.exe` on any Windows install, so `spawn('start', ...)` without `shell` can only raise ENOENT. (A `.cmd` shim on PATH does not rescue it either — `spawn` will not execute one without a shell. I tried.) Nothing listened for `'error'`, so the asynchronous ENOENT became an unhandled `'error'` event, which is fatal.

Either fix alone makes the dashboard usable. Both are here because they are independent: #1956 is cross-platform, and the missing handler would still turn any future opener failure into a dead server.

**Why this was invisible to maintainers.** On macOS and Linux, `open` and `xdg-open` are real executables — so the browser nobody asked for opens silently and nothing crashes. That is likely why a flag that has never worked went unnoticed.

## Changes

- `packages/cli/src/commands/dashboard.ts`
  - `DashboardOptions.noOpen?: boolean` → `open?: boolean`; `opts.noOpen !== true` → `opts.open !== false`
  - `openBrowser` spawns with `shell: process.platform === 'win32'` and attaches an `'error'` listener so a failed launch can never take down the server
- `packages/cli/tests/commands/dashboard.test.ts` — see below

### The test named for the flag passed throughout the bug

```ts
it('passes --no-open through to the action', async () => {
  // Commander maps --no-open to opts.open = false.
  // The action runs through regardless. We just verify it doesn't crash.
  expect(mockSpawn).toHaveBeenCalled();   // true — the SERVER was spawned
});
```

Its own comment states the Commander semantics the source got wrong, then declines to check them. It is now `does not schedule a browser open when --no-open is passed` and asserts that no browser open is scheduled while the server still starts.

Three further tests cover the opener directly: Windows spawns through a shell, darwin does not, and an opener that cannot be spawned does not take the process down.

## Testing

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes

**None of these are ticked, deliberately — I could not run them, and I would rather say so than let you assume they passed.** My machine is on Node 24.11.0; the repo pins Node 22 (`.nvmrc`), and under Node 24 `vitest@4.1.11` fails at startup with `ERR_PACKAGE_IMPORT_NOT_DEFINED: "#module-evaluator"` before collecting a single test. No nvm available to switch.

**So the four tests in this PR have never executed.** They mock `node:child_process` and override `process.platform`, which is exactly the kind of code that compiles and still fails to assert what you expect. Please run them before trusting them; I would treat that as the blocking review step.

What I *did* verify:

- **The diagnosis is confirmed end-to-end.** Running the dashboard server directly with the env `buildDashboardEnv` produces (`node dist/server/serve.js` + `DASHBOARD_API_PORT` / `DASHBOARD_CLIENT_PORT` / `HARNESS_PROJECT_PATH` / `ORCHESTRATOR_PORT`) starts and serves cleanly on Windows — `Hono server starting on http://127.0.0.1:3701`, `GET / 200`. The server was never at fault; only the opener.
- `grep` confirms no `noOpen` reads remain in `packages/cli/src`.
- `tsc --noEmit` attributes no errors to `dashboard.ts` (weak evidence only — I installed with `--ignore-scripts`, so unbuilt workspace packages produce many pre-existing `Cannot find module '@harness-engineering/core'` errors repo-wide).

## Related Issues

Closes #1956

The Windows crash (defect 2) has no issue that I could find — searches for `openBrowser`, `ENOENT`, `windows spawn` and `shell: true` returned nothing relevant. Happy to file one separately if you would rather keep the two tracked apart.
