### PR TITLE
fix(scripts): generate-docs and the pre-push hook cannot run on Windows

### DIFF
--- a/.changeset/distortion-posix-path-defaults.md
+++ b/.changeset/distortion-posix-path-defaults.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Spell `distortion`'s path defaults as POSIX literals so the generated CLI reference
+is the same on every platform.
+
+`DEFAULT_INPUT`, `DEFAULT_MODEL_OUT` and `REFINEMENT_EVENTS` were built with
+`path.join('.harness', 'metrics', …)`. The first two are option defaults, so they are
+printed in `--help` and embedded verbatim in `docs/reference/cli-commands.md` — and a
+Windows regeneration emitted `.harness\metrics\…` where a Linux one emitted
+`.harness/metrics/…`, failing the reference-docs drift gate for whoever regenerated
+second.
+
+Node's fs accepts forward slashes on Windows, so the spelling is fixed at the source
+rather than teaching the doc generator to normalise separators, which would have to
+tell a path from any other backslash in the text.
+
+No behaviour change: the same files are read and written.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: 'db809aaa5ba617b18554e552a550ca8ac8f1f34575b6b13f1b032b0ed012acd8'
+sourceHash: '7d5a4498cd843a59c95ff83c8967d60269ab9aefce86407cc92c17475b612750'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/scripts/_module.md
+++ b/.harness/comprehension/scripts/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'scripts'
-sourceHash: '781829badf43d391700cff6e41cfb322dc6c066299df5116fc88f5e10c3c3e33'
+sourceHash: 'f2819d9a6ff367b1663d4237ad14de7bb50ac9a29710744e716830ceb6fd08d2'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -81,7 +81,7 @@ import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readd
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path, { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import from 'playwright'
 import { parseYaml } from 'yaml'
 ```

--- a/.harness/comprehension/scripts/_module.md
+++ b/.harness/comprehension/scripts/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'scripts'
-sourceHash: 'f2819d9a6ff367b1663d4237ad14de7bb50ac9a29710744e716830ceb6fd08d2'
+sourceHash: '9f1889b7f8fa6d58cee1169a99bd11d4ac429fabd330a8c63d8699808651449f'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/src/commands/distortion.ts
+++ b/packages/cli/src/commands/distortion.ts
@@ -12,12 +12,20 @@ import { logger } from '../output/logger';
  * compaction path — it reads observations and writes a report.
  */
 
+// POSIX LITERALS, NOT `path.join`. These are option DEFAULTS: they are printed
+// in `--help` and embedded verbatim in `docs/reference/cli-commands.md`, so
+// joining them made the generated docs platform-specific -- a Windows run
+// emitted `.harness\metrics\...` where a Linux run emitted `.harness/metrics/...`
+// and the reference-docs drift gate then failed for whoever regenerated second.
+// Node's fs accepts forward slashes on Windows, so nothing is lost by fixing
+// the spelling rather than teaching the generator to normalise it.
+
 /** Default input: pre-recorded ablation-replay observations (one per line). */
-const DEFAULT_INPUT = path.join('.harness', 'metrics', 'ablation-replays.jsonl');
+const DEFAULT_INPUT = '.harness/metrics/ablation-replays.jsonl';
 /** Default output: the fitted distortion model. */
-const DEFAULT_MODEL_OUT = path.join('.harness', 'metrics', 'distortion-model.json');
+const DEFAULT_MODEL_OUT = '.harness/metrics/distortion-model.json';
 /** Optional #1632 refinement-demand log, foldable as an advisory prior. */
-const REFINEMENT_EVENTS = path.join('.harness', 'metrics', 'refinement-events.jsonl');
+const REFINEMENT_EVENTS = '.harness/metrics/refinement-events.jsonl';
 
 type ReplayObservation = import('@harness-engineering/core').ReplayObservation;
 type InformationClass = import('@harness-engineering/core').InformationClass;

--- a/scripts/generate-agent-setup-prompt.mjs
+++ b/scripts/generate-agent-setup-prompt.mjs
@@ -30,13 +30,25 @@ const HEADER =
  * node-version.ts, so the generated prompt cannot drift from the CLI.
  */
 function loadInputs() {
-  const tsx = join(ROOT, 'node_modules', '.bin', 'tsx');
-  if (!existsSync(tsx)) {
-    console.error(`Missing tsx at ${tsx}. Run \`pnpm install\` first.`);
-    process.exit(1);
-  }
+  // `node --import tsx`, NOT `node_modules/.bin/tsx`. pnpm writes three shims
+  // there -- `tsx` (a POSIX shell script), `tsx.CMD` and `tsx.ps1` -- and
+  // Windows cannot execute the extensionless one, so `execFileSync` raised
+  // `ENOENT: spawn ...\node_modules\.bin\tsx` and took `pnpm run generate-docs`
+  // (and with it the pre-push hook) down on every Windows machine.
+  //
+  // The `existsSync` guard this replaces made it worse rather than better: the
+  // POSIX shim IS present, so the check passed and gave false confidence, and
+  // the failure landed later and less legibly than the "run pnpm install"
+  // message it was written to produce. **Presence is not executability.**
+  //
+  // Resolving `tsx.CMD` instead would work on Windows and need `shell: true`,
+  // which then needs every path quoted. `--import` sidesteps the shim entirely:
+  // one code path, no shell, no quoting, same on all three platforms.
   const emitter = join(ROOT, 'packages', 'cli', 'src', 'setup', 'print-clients.ts');
-  const json = execFileSync(tsx, [emitter], { cwd: ROOT, encoding: 'utf-8' });
+  const json = execFileSync(process.execPath, ['--import', 'tsx', emitter], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+  });
   return JSON.parse(json);
 }
 

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -15,6 +15,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve, join, basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { execSync, execFileSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
 
@@ -52,9 +53,21 @@ if (!existsSync(REFERENCE_DIR)) {
 
 // ─── CLI Command Reference ───────────────────────────────────────────────────
 
+// `pathToFileURL`, NOT a bare absolute path. A dynamic import() of
+// `C:\...\index.js` is rejected by the ESM loader -- "Only URLs with a scheme
+// in: file, data, and node are supported ... Received protocol 'c:'" -- because
+// Windows reads the drive letter as a URL scheme. POSIX absolute paths start
+// with `/` and happen to work, which is why this survived.
+//
+// **THE MESSAGE IT PRODUCED POINTED AT THE WRONG FIX**: the catch below reports
+// "CLI reference skipped (build CLI first: pnpm build)", so on Windows the docs
+// silently lost their CLI reference and told the reader to run a build that was
+// already done.
+const CLI_DIST = pathToFileURL(join(ROOT, 'packages', 'cli', 'dist', 'index.js')).href;
+
 async function generateCliReference() {
   // Import the CLI program to walk its command tree
-  const { createProgram } = await import(join(ROOT, 'packages', 'cli', 'dist', 'index.js'));
+  const { createProgram } = await import(CLI_DIST);
   const program = createProgram();
 
   const lines = [
@@ -184,7 +197,7 @@ async function generateMcpReference(cliAnchorLookup = new Map()) {
   // Read tool definitions by importing the server module
   let toolDefinitions;
   try {
-    const cliModule = await import(join(ROOT, 'packages', 'cli', 'dist', 'index.js'));
+    const cliModule = await import(CLI_DIST);
     toolDefinitions = cliModule.getToolDefinitions?.() || cliModule.TOOL_DEFINITIONS;
   } catch {
     // Fallback: parse the source files for tool metadata

--- a/scripts/generate-persona-workflows.mjs
+++ b/scripts/generate-persona-workflows.mjs
@@ -11,16 +11,8 @@
 import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { existsSync } from 'node:fs';
-
 const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
-const tsx = join(repoRoot, 'node_modules', '.bin', 'tsx');
 const cliEntry = join(repoRoot, 'packages', 'cli', 'src', 'bin', 'harness.ts');
-
-if (!existsSync(tsx)) {
-  console.error(`Missing tsx at ${tsx}. Run \`pnpm install\` first.`);
-  process.exit(1);
-}
 
 const isCheck = process.argv.includes('--check');
 // This repo dogfoods the workspace runner (builds the CLI from source) and wires
@@ -29,7 +21,13 @@ const args = [cliEntry, 'persona', 'sync-workflows', '--runner', 'workspace', '-
 if (isCheck) args.push('--check');
 
 try {
-  execFileSync(tsx, args, { stdio: 'inherit', cwd: repoRoot });
+  // `node --import tsx`, not `node_modules/.bin/tsx` -- Windows cannot execute
+  // the extensionless POSIX shim pnpm writes there, and the `existsSync` guard
+  // that used to sit above found it anyway. See generate-agent-setup-prompt.mjs.
+  execFileSync(process.execPath, ['--import', 'tsx', ...args], {
+    stdio: 'inherit',
+    cwd: repoRoot,
+  });
 } catch {
   process.exit(1);
 }

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -30,7 +30,6 @@ import { fileURLToPath } from 'node:url';
 import { getConfig, STANDARD_HOOKS } from './lib/plugin-config.mjs';
 
 const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
-const tsx = join(repoRoot, 'node_modules', '.bin', 'tsx');
 const prettier = join(repoRoot, 'node_modules', 'prettier', 'bin', 'prettier.cjs');
 const cliEntry = join(repoRoot, 'packages', 'cli', 'src', 'bin', 'harness.ts');
 
@@ -49,15 +48,16 @@ if (!target) {
 const config = getConfig(target);
 const isCheck = process.argv.includes('--check');
 
-if (!existsSync(tsx)) {
-  console.error(`Missing tsx at ${tsx}. Run \`pnpm install\` first.`);
-  process.exit(1);
-}
-
 const pluginRoot = join(repoRoot, config.pluginDir);
 
 function runCli(args) {
-  execFileSync(tsx, [cliEntry, ...args], { stdio: 'inherit', cwd: repoRoot });
+  // `node --import tsx`, not `node_modules/.bin/tsx` -- Windows cannot execute
+  // the extensionless POSIX shim pnpm writes there, and the `existsSync` guard
+  // that used to sit above found it anyway. See generate-agent-setup-prompt.mjs.
+  execFileSync(process.execPath, ['--import', 'tsx', cliEntry, ...args], {
+    stdio: 'inherit',
+    cwd: repoRoot,
+  });
 }
 
 function prettierWrite(targetPath) {

--- a/scripts/generate-tool-catalog.mjs
+++ b/scripts/generate-tool-catalog.mjs
@@ -30,6 +30,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { tmpdir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 
@@ -88,7 +89,12 @@ function sortKeysDeep(value) {
  * first (same precondition as generate-docs.mjs's CLI/MCP references).
  */
 async function loadToolDefinitions() {
-  const cliModule = await import(join(ROOT, 'packages', 'cli', 'dist', 'index.js'));
+  // `pathToFileURL`, NOT a bare absolute path: the ESM loader reads the
+  // Windows drive letter as a URL scheme and rejects it with "Received
+  // protocol 'c:'". POSIX absolute paths start with `/` and happen to work,
+  // which is why this survived. Same fix as generate-docs.mjs.
+  const cliDist = pathToFileURL(join(ROOT, 'packages', 'cli', 'dist', 'index.js')).href;
+  const cliModule = await import(cliDist);
   const defs = cliModule.getToolDefinitions?.() ?? cliModule.TOOL_DEFINITIONS;
   if (!Array.isArray(defs) || defs.length === 0) {
     throw new Error(


### PR DESCRIPTION
## Summary

`pnpm run generate-docs` fails on every Windows machine, and with it the pre-push hook that runs it. Three defects, all POSIX assumptions, each one hidden behind the last.

**They were only discoverable in sequence.** Fixing the `.bin` spawn let `generate-docs` run, which revealed the bare absolute `import()`, which let the CLI reference generate, which revealed that the generated docs are platform-specific, which turned the drift gate red — and only then did the hook reach `generate-tool-catalog.mjs`, which had the same `import()` bug again.

## 1. `execFileSync(node_modules/.bin/tsx, …)` → ENOENT

pnpm writes three shims there: `tsx` (a POSIX shell script), `tsx.CMD` and `tsx.ps1`. Windows cannot execute the extensionless one:

```
Error: spawn ...\node_modules\.bin\tsx ENOENT
```

Three scripts did this — `generate-agent-setup-prompt.mjs`, `generate-persona-workflows.mjs`, `generate-plugin.mjs`.

**The guard made it worse.** Each checked `existsSync(tsx)` first and exited with *"Missing tsx at … Run `pnpm install` first."* The POSIX shim **is** present, so the check passed, gave false confidence, and the real failure landed later and far less legibly than the message the guard existed to produce. Presence is not executability.

Fixed with `node --import tsx <entry>` rather than by resolving `tsx.CMD`: the `.CMD` route works but then needs `shell: true`, which needs every path quoted, on a repo whose checkout path may contain spaces. `--import` removes the shim from the picture — one code path, no shell, no quoting, identical on all three platforms. Output verified identical.

## 2. `await import(join(ROOT, …))` → "Received protocol 'c:'"

```
Only URLs with a scheme in: file, data, and node are supported by the default
ESM loader. On Windows, absolute paths must be valid file:// URLs.
```

The loader reads the drive letter as a URL scheme. POSIX absolute paths start with `/` and happen to work, which is why this survived. Three sites: two in `generate-docs.mjs` (hoisted to one constant, since both imported the same file) and one in `generate-tool-catalog.mjs`.

**And its error pointed at the wrong fix.** The catch reports *"CLI reference skipped (build CLI first: `pnpm build`)"* — so on Windows the docs silently lost their CLI reference and told the reader to run a build that had already succeeded. `docs/reference/cli-commands.md` now generates.

## 3. `path.join` in option defaults → platform-specific generated docs

`distortion`'s `DEFAULT_INPUT` / `DEFAULT_MODEL_OUT` were `path.join('.harness', 'metrics', …)`. They are option defaults, so they are printed in `--help` and embedded verbatim in the reference:

```diff
- `--input` — Observations JSONL (default: .harness/metrics/ablation-replays.jsonl)
+ `--input` — Observations JSONL (default: .harness\metrics\ablation-replays.jsonl)
```

A Windows regeneration therefore failed the reference-docs drift gate. **This could never surface before, because generate-docs could not run on Windows at all** — the platform bug was concealing the platform-specific output.

Fixed at the source as POSIX literals rather than by normalising separators in the generator, which would have to tell a path from any other backslash in the text. Node's fs accepts forward slashes on Windows, so nothing is lost. Changeset included (this one touches `packages/cli/src`).

## Verification

On Windows (Node 22.23.2, the repo's pinned major):

- `pnpm run generate-docs` — **exit 1 → exit 0**, and writes `cli-commands.md`, `mcp-tools.md`, `skills-catalog.md`, `agent-setup/prompt.md`
- the regenerated `docs/reference/` is **byte-identical** to the committed Linux-generated copies
- `pnpm run generate:tool-catalog:check` — **exit 1 → exit 0**
- `grep` confirms no bare absolute `await import(join(…))` or `.bin/tsx` spawn remains under `scripts/`
- the **full pre-push hook now passes**, which is how this branch was pushed

## Reported separately, not fixed here

While getting the hook to run I hit two more Windows issues that are out of scope for this PR:

- `pnpm run check:changesets` is `BASE_REF=origin/main node …` — POSIX env-var-prefix syntax, which cmd.exe rejects (`'BASE_REF' is not recognized…`), so the hook needs `npm_config_script_shell` pointed at a POSIX shell. Unfiled; happy to open one.
- #2141 — the security scanner writes `timeline.json` with `JSON.stringify(…, 2)` while Prettier format-gates it, so a scan that appends an entry blocks every push until the file is hand-formatted.

Both are the same family as these: tooling that assumes a POSIX shell or a Linux runner. None of them are caught by CI, because doc generation and the pre-push hook only ever run on Linux there.
