### PR TITLE
fix(cli): `harness update` called an unreachable registry "up to date"

### DIFF
--- a/.changeset/distortion-posix-path-defaults.md
+++ b/.changeset/distortion-posix-path-defaults.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Spell `distortion`'s path defaults as POSIX literals so the generated CLI reference
+is the same on every platform.
+
+`DEFAULT_INPUT`, `DEFAULT_MODEL_OUT` and `REFINEMENT_EVENTS` were built with
+`path.join('.harness', 'metrics', …)`. The first two are option defaults, so they are
+printed in `--help` and embedded verbatim in `docs/reference/cli-commands.md` — and a
+Windows regeneration emitted `.harness\metrics\…` where a Linux one emitted
+`.harness/metrics/…`, failing the reference-docs drift gate for whoever regenerated
+second.
+
+Node's fs accepts forward slashes on Windows, so the spelling is fixed at the source
+rather than teaching the doc generator to normalise separators, which would have to
+tell a path from any other backslash in the text.
+
+No behaviour change: the same files are read and written.

--- a/.changeset/update-check-unreachable-registry.md
+++ b/.changeset/update-check-unreachable-registry.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/cli': patch
+---
+
+`harness update` no longer reports "All packages are up to date" when it could not
+reach the registry.
+
+`checkAllPackages` collected results with `Promise.allSettled` and `continue`d past
+rejections, so a package whose `npm view` failed contributed nothing to `outdated` —
+and the caller then read an empty list as good news. Any npm hiccup (timeout, offline,
+proxy, throttle, non-zero exit, empty response) was silently rendered as a green
+success line, which is worse than a crash because the user acts on it. It also made
+the update banner's own advice unreliable: `Update available … Run "harness update"
+to upgrade` pointed at a command that could quietly no-op.
+
+Failed lookups are now tagged with their package and surfaced as `unreachable` on
+`UpdateCheckResult`. When any package could not be checked, `harness update` names
+each one and the reason, prints any updates it _was_ able to find, suggests the manual
+install command, and exits non-zero instead of claiming success. "We could not check"
+and "you are current" no longer produce the same output.

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: '7d5a4498cd843a59c95ff83c8967d60269ab9aefce86407cc92c17475b612750'
+sourceHash: 'ae84916a41f4c2c573c3fa903b245d28eef362565bd61af1386849d2a9bbd755'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/src/commands/_module.md
+++ b/.harness/comprehension/packages/cli/src/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/src/commands'
-sourceHash: 'db809aaa5ba617b18554e552a550ca8ac8f1f34575b6b13f1b032b0ed012acd8'
+sourceHash: '7d5a4498cd843a59c95ff83c8967d60269ab9aefce86407cc92c17475b612750'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/packages/cli/tests/commands/_module.md
+++ b/.harness/comprehension/packages/cli/tests/commands/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'packages/cli/tests/commands'
-sourceHash: 'f616c8e87090edf43047bfe9275f85adf44caa85d2a58f03970f107de2b308a3'
+sourceHash: '5d9b41c96e468a9ab2689ac87a17172314ca309b316f2db04b8d2b5444dc2d7e'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/.harness/comprehension/scripts/_module.md
+++ b/.harness/comprehension/scripts/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'scripts'
-sourceHash: '781829badf43d391700cff6e41cfb322dc6c066299df5116fc88f5e10c3c3e33'
+sourceHash: 'f2819d9a6ff367b1663d4237ad14de7bb50ac9a29710744e716830ceb6fd08d2'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent
@@ -81,7 +81,7 @@ import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readd
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path, { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import from 'playwright'
 import { parseYaml } from 'yaml'
 ```

--- a/.harness/comprehension/scripts/_module.md
+++ b/.harness/comprehension/scripts/_module.md
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1
 module: 'scripts'
-sourceHash: 'f2819d9a6ff367b1663d4237ad14de7bb50ac9a29710744e716830ceb6fd08d2'
+sourceHash: '9f1889b7f8fa6d58cee1169a99bd11d4ac429fabd330a8c63d8699808651449f'
 compiler: { static: '1.0.0', semantic: '1.0.0' }
 model: null
 semantic: absent

--- a/packages/cli/src/commands/distortion.ts
+++ b/packages/cli/src/commands/distortion.ts
@@ -12,12 +12,20 @@ import { logger } from '../output/logger';
  * compaction path — it reads observations and writes a report.
  */
 
+// POSIX LITERALS, NOT `path.join`. These are option DEFAULTS: they are printed
+// in `--help` and embedded verbatim in `docs/reference/cli-commands.md`, so
+// joining them made the generated docs platform-specific -- a Windows run
+// emitted `.harness\metrics\...` where a Linux run emitted `.harness/metrics/...`
+// and the reference-docs drift gate then failed for whoever regenerated second.
+// Node's fs accepts forward slashes on Windows, so nothing is lost by fixing
+// the spelling rather than teaching the generator to normalise it.
+
 /** Default input: pre-recorded ablation-replay observations (one per line). */
-const DEFAULT_INPUT = path.join('.harness', 'metrics', 'ablation-replays.jsonl');
+const DEFAULT_INPUT = '.harness/metrics/ablation-replays.jsonl';
 /** Default output: the fitted distortion model. */
-const DEFAULT_MODEL_OUT = path.join('.harness', 'metrics', 'distortion-model.json');
+const DEFAULT_MODEL_OUT = '.harness/metrics/distortion-model.json';
 /** Optional #1632 refinement-demand log, foldable as an advisory prior. */
-const REFINEMENT_EVENTS = path.join('.harness', 'metrics', 'refinement-events.jsonl');
+const REFINEMENT_EVENTS = '.harness/metrics/refinement-events.jsonl';
 
 type ReplayObservation = import('@harness-engineering/core').ReplayObservation;
 type InformationClass = import('@harness-engineering/core').InformationClass;

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -432,6 +432,12 @@ async function offerRegeneration(): Promise<void> {
 interface UpdateCheckResult {
   hasUpdates: boolean;
   outdated: Array<{ pkg: string; current: string | null; latest: string }>;
+  /**
+   * Packages whose registry lookup FAILED. Never folded into `outdated` or
+   * silently dropped: "we could not check" and "you are current" must not
+   * produce the same output.
+   */
+  unreachable: Array<{ pkg: string; reason: string }>;
 }
 
 async function checkAllPackages(
@@ -440,26 +446,48 @@ async function checkAllPackages(
 ): Promise<UpdateCheckResult> {
   logger.info('Checking for updates...');
 
-  const results = await Promise.allSettled(
+  // EVERY FAILURE IS TAGGED WITH ITS PACKAGE. The previous version used
+  // `Promise.allSettled` and `continue`d past rejections, which made a failed
+  // lookup contribute nothing — and the caller then read an empty `outdated`
+  // as "All packages are up to date". A rejected `npm view` (timeout, offline,
+  // proxy, registry throttle, non-zero exit, empty response) was therefore
+  // reported to the user as good news, which is worse than a crash because
+  // they act on it.
+  const results = await Promise.all(
     packages.map(async (pkg) => {
-      const latest = await getLatestVersionAsync(pkg);
-      const current = installedVersions[pkg] ?? null;
-      return { pkg, current, latest, outdated: !current || current !== latest };
+      try {
+        const latest = await getLatestVersionAsync(pkg);
+        const current = installedVersions[pkg] ?? null;
+        return {
+          reached: true as const,
+          pkg,
+          current,
+          latest,
+          outdated: !current || current !== latest,
+        };
+      } catch (err) {
+        return {
+          reached: false as const,
+          pkg,
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
     })
   );
 
   const outdated: UpdateCheckResult['outdated'] = [];
+  const unreachable: UpdateCheckResult['unreachable'] = [];
   for (const result of results) {
-    if (result.status === 'rejected') {
-      // Skip packages we can't query — don't block the whole update
+    if (!result.reached) {
+      unreachable.push({ pkg: result.pkg, reason: result.reason });
       continue;
     }
-    if (result.value.outdated) {
-      outdated.push(result.value);
+    if (result.outdated) {
+      outdated.push({ pkg: result.pkg, current: result.current, latest: result.latest });
     }
   }
 
-  return { hasUpdates: outdated.length > 0, outdated };
+  return { hasUpdates: outdated.length > 0, outdated, unreachable };
 }
 
 function buildInstallPackages(
@@ -600,7 +628,34 @@ async function runUpdateAction(
   // 4. Check ALL installed packages for updates (not just CLI)
   if (!opts.version && !opts.force) {
     const installedVersions = getInstalledVersions(pm, packages);
-    const { hasUpdates, outdated } = await checkAllPackages(packages, installedVersions);
+    const { hasUpdates, outdated, unreachable } = await checkAllPackages(
+      packages,
+      installedVersions
+    );
+
+    // AN INCOMPLETE CHECK IS NOT A PASS. If any package could not be queried we
+    // do not know whether it is current, so saying so is the only honest
+    // answer — and exiting non-zero keeps a scripted `harness update` from
+    // treating a network blip as "nothing to do".
+    if (unreachable.length > 0) {
+      logger.error(`Could not check ${unreachable.length} package(s) against the registry:`);
+      for (const { pkg, reason } of unreachable) {
+        logger.error(`  ${pkg.replace('@harness-engineering/', '')}: ${reason}`);
+      }
+      if (outdated.length > 0) {
+        console.log('');
+        logger.info('Updates ARE available for the packages that could be checked:');
+        for (const { pkg, current, latest } of outdated) {
+          const shortName = pkg.replace('@harness-engineering/', '');
+          const currentStr = current ? chalk.dim(`v${current}`) : chalk.dim('not installed');
+          logger.info(`  ${shortName}: ${currentStr} → ${chalk.green(`v${latest}`)}`);
+        }
+      }
+      console.log('');
+      logger.info('Re-run when the registry is reachable, or force the install with:');
+      logger.info(`  ${buildInstallPackages(packages, opts).installCmd}`);
+      process.exit(ExitCode.ERROR);
+    }
 
     if (!hasUpdates) {
       logger.success('All packages are up to date');

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -577,16 +577,21 @@ describe('update command', () => {
       throw new Error('process.exit');
     });
     let logSpy: ReturnType<typeof vi.spyOn>;
+    // `logger.error` writes to console.error, `logger.info`/`success` to
+    // console.log — so asserting on what the user was told needs both.
+    let errorSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
       vi.clearAllMocks();
       logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       // Default: detectPackageManager returns npm
       mockedRealpathSync.mockReturnValue('/usr/local/lib/node_modules/harness/bin.js');
     });
 
     afterEach(() => {
       logSpy.mockRestore();
+      errorSpy.mockRestore();
     });
 
     it('runs --force update successfully', async () => {
@@ -671,6 +676,82 @@ describe('update command', () => {
       await expect(program.parseAsync(['node', 'test', 'update'])).rejects.toThrow('process.exit');
 
       expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    // A FAILED REGISTRY LOOKUP IS NOT A PASS. `checkAllPackages` used to
+    // `continue` past rejected lookups, so a package it could not query
+    // contributed nothing to `outdated` — and an empty `outdated` was then
+    // printed as "All packages are up to date". Any npm hiccup (timeout,
+    // offline, proxy, throttle, empty response) silently became good news.
+    it('does NOT claim everything is up to date when the registry cannot be reached', async () => {
+      // getInstalledPackages
+      mockedExecFileSync.mockReturnValueOnce(
+        JSON.stringify({
+          dependencies: {
+            '@harness-engineering/cli': { version: '1.0.0' },
+          },
+        })
+      );
+      // getInstalledVersions
+      mockedExecFileSync.mockReturnValueOnce(
+        JSON.stringify({
+          dependencies: {
+            '@harness-engineering/cli': { version: '1.0.0' },
+          },
+        })
+      );
+
+      // getLatestVersionAsync rejects — the registry is unreachable.
+      mockedExecFile.mockImplementation(((
+        _cmd: unknown,
+        _args: unknown,
+        _opts: unknown,
+        cb?: Function
+      ) => {
+        if (cb) cb(new Error('ETIMEDOUT'), { stdout: '', stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      }) as typeof execFile);
+
+      const program = createProgram();
+      await expect(program.parseAsync(['node', 'test', 'update'])).rejects.toThrow('process.exit');
+
+      // The whole point: the success line must not be printed, and the exit
+      // code must not be 0. Silence about a check that never happened is the
+      // defect.
+      const said = logSpy.mock.calls.flat().join('\n') + errorSpy.mock.calls.flat().join('\n');
+      expect(said).not.toContain('All packages are up to date');
+      expect(said).toContain('Could not check');
+      expect(mockExit).not.toHaveBeenCalledWith(0);
+    });
+
+    it('names the package it could not check, and why', async () => {
+      mockedExecFileSync.mockReturnValueOnce(
+        JSON.stringify({
+          dependencies: { '@harness-engineering/cli': { version: '1.0.0' } },
+        })
+      );
+      mockedExecFileSync.mockReturnValueOnce(
+        JSON.stringify({
+          dependencies: { '@harness-engineering/cli': { version: '1.0.0' } },
+        })
+      );
+      mockedExecFile.mockImplementation(((
+        _cmd: unknown,
+        _args: unknown,
+        _opts: unknown,
+        cb?: Function
+      ) => {
+        if (cb) cb(new Error('ENOTFOUND registry.npmjs.org'), { stdout: '', stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      }) as typeof execFile);
+
+      const program = createProgram();
+      await expect(program.parseAsync(['node', 'test', 'update'])).rejects.toThrow('process.exit');
+
+      const said = logSpy.mock.calls.flat().join('\n') + errorSpy.mock.calls.flat().join('\n');
+      // "something went wrong" is not actionable; the package and the reason are.
+      expect(said).toContain('cli');
+      expect(said).toContain('ENOTFOUND registry.npmjs.org');
     });
 
     it('detects outdated packages and runs install', async () => {

--- a/scripts/generate-agent-setup-prompt.mjs
+++ b/scripts/generate-agent-setup-prompt.mjs
@@ -30,13 +30,25 @@ const HEADER =
  * node-version.ts, so the generated prompt cannot drift from the CLI.
  */
 function loadInputs() {
-  const tsx = join(ROOT, 'node_modules', '.bin', 'tsx');
-  if (!existsSync(tsx)) {
-    console.error(`Missing tsx at ${tsx}. Run \`pnpm install\` first.`);
-    process.exit(1);
-  }
+  // `node --import tsx`, NOT `node_modules/.bin/tsx`. pnpm writes three shims
+  // there -- `tsx` (a POSIX shell script), `tsx.CMD` and `tsx.ps1` -- and
+  // Windows cannot execute the extensionless one, so `execFileSync` raised
+  // `ENOENT: spawn ...\node_modules\.bin\tsx` and took `pnpm run generate-docs`
+  // (and with it the pre-push hook) down on every Windows machine.
+  //
+  // The `existsSync` guard this replaces made it worse rather than better: the
+  // POSIX shim IS present, so the check passed and gave false confidence, and
+  // the failure landed later and less legibly than the "run pnpm install"
+  // message it was written to produce. **Presence is not executability.**
+  //
+  // Resolving `tsx.CMD` instead would work on Windows and need `shell: true`,
+  // which then needs every path quoted. `--import` sidesteps the shim entirely:
+  // one code path, no shell, no quoting, same on all three platforms.
   const emitter = join(ROOT, 'packages', 'cli', 'src', 'setup', 'print-clients.ts');
-  const json = execFileSync(tsx, [emitter], { cwd: ROOT, encoding: 'utf-8' });
+  const json = execFileSync(process.execPath, ['--import', 'tsx', emitter], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+  });
   return JSON.parse(json);
 }
 

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -15,6 +15,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve, join, basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { execSync, execFileSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
 
@@ -52,9 +53,21 @@ if (!existsSync(REFERENCE_DIR)) {
 
 // ─── CLI Command Reference ───────────────────────────────────────────────────
 
+// `pathToFileURL`, NOT a bare absolute path. A dynamic import() of
+// `C:\...\index.js` is rejected by the ESM loader -- "Only URLs with a scheme
+// in: file, data, and node are supported ... Received protocol 'c:'" -- because
+// Windows reads the drive letter as a URL scheme. POSIX absolute paths start
+// with `/` and happen to work, which is why this survived.
+//
+// **THE MESSAGE IT PRODUCED POINTED AT THE WRONG FIX**: the catch below reports
+// "CLI reference skipped (build CLI first: pnpm build)", so on Windows the docs
+// silently lost their CLI reference and told the reader to run a build that was
+// already done.
+const CLI_DIST = pathToFileURL(join(ROOT, 'packages', 'cli', 'dist', 'index.js')).href;
+
 async function generateCliReference() {
   // Import the CLI program to walk its command tree
-  const { createProgram } = await import(join(ROOT, 'packages', 'cli', 'dist', 'index.js'));
+  const { createProgram } = await import(CLI_DIST);
   const program = createProgram();
 
   const lines = [
@@ -184,7 +197,7 @@ async function generateMcpReference(cliAnchorLookup = new Map()) {
   // Read tool definitions by importing the server module
   let toolDefinitions;
   try {
-    const cliModule = await import(join(ROOT, 'packages', 'cli', 'dist', 'index.js'));
+    const cliModule = await import(CLI_DIST);
     toolDefinitions = cliModule.getToolDefinitions?.() || cliModule.TOOL_DEFINITIONS;
   } catch {
     // Fallback: parse the source files for tool metadata

--- a/scripts/generate-persona-workflows.mjs
+++ b/scripts/generate-persona-workflows.mjs
@@ -11,16 +11,8 @@
 import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { existsSync } from 'node:fs';
-
 const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
-const tsx = join(repoRoot, 'node_modules', '.bin', 'tsx');
 const cliEntry = join(repoRoot, 'packages', 'cli', 'src', 'bin', 'harness.ts');
-
-if (!existsSync(tsx)) {
-  console.error(`Missing tsx at ${tsx}. Run \`pnpm install\` first.`);
-  process.exit(1);
-}
 
 const isCheck = process.argv.includes('--check');
 // This repo dogfoods the workspace runner (builds the CLI from source) and wires
@@ -29,7 +21,13 @@ const args = [cliEntry, 'persona', 'sync-workflows', '--runner', 'workspace', '-
 if (isCheck) args.push('--check');
 
 try {
-  execFileSync(tsx, args, { stdio: 'inherit', cwd: repoRoot });
+  // `node --import tsx`, not `node_modules/.bin/tsx` -- Windows cannot execute
+  // the extensionless POSIX shim pnpm writes there, and the `existsSync` guard
+  // that used to sit above found it anyway. See generate-agent-setup-prompt.mjs.
+  execFileSync(process.execPath, ['--import', 'tsx', ...args], {
+    stdio: 'inherit',
+    cwd: repoRoot,
+  });
 } catch {
   process.exit(1);
 }

--- a/scripts/generate-plugin.mjs
+++ b/scripts/generate-plugin.mjs
@@ -30,7 +30,6 @@ import { fileURLToPath } from 'node:url';
 import { getConfig, STANDARD_HOOKS } from './lib/plugin-config.mjs';
 
 const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
-const tsx = join(repoRoot, 'node_modules', '.bin', 'tsx');
 const prettier = join(repoRoot, 'node_modules', 'prettier', 'bin', 'prettier.cjs');
 const cliEntry = join(repoRoot, 'packages', 'cli', 'src', 'bin', 'harness.ts');
 
@@ -49,15 +48,16 @@ if (!target) {
 const config = getConfig(target);
 const isCheck = process.argv.includes('--check');
 
-if (!existsSync(tsx)) {
-  console.error(`Missing tsx at ${tsx}. Run \`pnpm install\` first.`);
-  process.exit(1);
-}
-
 const pluginRoot = join(repoRoot, config.pluginDir);
 
 function runCli(args) {
-  execFileSync(tsx, [cliEntry, ...args], { stdio: 'inherit', cwd: repoRoot });
+  // `node --import tsx`, not `node_modules/.bin/tsx` -- Windows cannot execute
+  // the extensionless POSIX shim pnpm writes there, and the `existsSync` guard
+  // that used to sit above found it anyway. See generate-agent-setup-prompt.mjs.
+  execFileSync(process.execPath, ['--import', 'tsx', cliEntry, ...args], {
+    stdio: 'inherit',
+    cwd: repoRoot,
+  });
 }
 
 function prettierWrite(targetPath) {

--- a/scripts/generate-tool-catalog.mjs
+++ b/scripts/generate-tool-catalog.mjs
@@ -30,6 +30,7 @@
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { tmpdir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 
@@ -88,7 +89,12 @@ function sortKeysDeep(value) {
  * first (same precondition as generate-docs.mjs's CLI/MCP references).
  */
 async function loadToolDefinitions() {
-  const cliModule = await import(join(ROOT, 'packages', 'cli', 'dist', 'index.js'));
+  // `pathToFileURL`, NOT a bare absolute path: the ESM loader reads the
+  // Windows drive letter as a URL scheme and rejects it with "Received
+  // protocol 'c:'". POSIX absolute paths start with `/` and happen to work,
+  // which is why this survived. Same fix as generate-docs.mjs.
+  const cliDist = pathToFileURL(join(ROOT, 'packages', 'cli', 'dist', 'index.js')).href;
+  const cliModule = await import(cliDist);
   const defs = cliModule.getToolDefinitions?.() ?? cliModule.TOOL_DEFINITIONS;
   if (!Array.isArray(defs) || defs.length === 0) {
     throw new Error(


### PR DESCRIPTION
Closes #2139.

**Stacked on #2143** (the Windows toolchain fixes) — without those the pre-push hook cannot run on Windows at all, which is how this defect was found. Rebase or merge #2143 first; this branch contains those commits.

## The defect

A failed registry lookup contributed nothing to `outdated`, and the caller then read the empty list as good news.

`packages/cli/src/commands/update.ts` — `checkAllPackages()`:

```ts
for (const result of results) {
  if (result.status === 'rejected') {
    // Skip packages we can't query — don't block the whole update
    continue;
  }
  if (result.value.outdated) outdated.push(result.value);
}
return { hasUpdates: outdated.length > 0, outdated };
```

`getLatestVersionAsync` shells out to `npm view <pkg> dist-tags.latest` and throws on a timeout, a non-zero exit or an empty response. Offline, proxy, corporate mirror, registry throttle — any of those rejects, gets dropped, empties `outdated`, and prints:

```
v All packages are up to date
```

**So "we could not check" and "you are current" are the same output.** That is worse than a crash, because the user acts on it. It also makes the banner's own advice unreliable: `Update available … Run "harness update" to upgrade` points at a command that can silently no-op.

**Observed:** on the same machine, minutes apart, the banner said `v12.1.0 -> v12.7.0` while `harness update` said everything was current. `npm install -g @harness-engineering/cli@latest` upgraded it correctly — the update path was fine, the check in front of it was not. It cost me an hour and a wrong diagnosis, and the machine's owner had hit the same thing earlier the same day.

## The fix

Every failure is tagged with its package rather than being anonymous, and `UpdateCheckResult` gains `unreachable`. When any package could not be checked, `harness update` names each one and the reason, still prints the updates it *was* able to find, suggests the manual install command, and exits non-zero instead of claiming success.

**This is not #317.** That was `npm list -g` failing to see the running CLI, and its fix — the `CLI_VERSION` fallback at `:111` and `getInstalledPackages` always unshifting `CLI_PACKAGE` — is intact; the package list is never empty. The hole was downstream, in how a rejected *registry* lookup was accounted for.

## Tests

Two regression tests, **both confirmed to fail against the unfixed source**: reverting only `update.ts` reds exactly these two and leaves the other 49 green.

```
× does NOT claim everything is up to date when the registry cannot be reached
× names the package it could not check, and why
```

`errorSpy` is added to the suite's setup because `logger.error` writes to `console.error` while `logger.info`/`success` write to `console.log` — asserting on what the user was actually told needs both.

## Verification

On Windows, Node 22.23.2 (the repo's pinned major):

- `pnpm build` — 13/13 tasks
- the four update suites — **69 passed**
- `tsc --noEmit` — exit 0
- `eslint` — 0 errors
- `check:changesets` — OK, covers `@harness-engineering/cli`
- the full pre-push hook passes

Changeset included.
